### PR TITLE
Add Vehicle List resource type

### DIFF
--- a/src/components/BundleManager.tsx
+++ b/src/components/BundleManager.tsx
@@ -4,11 +4,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Search, Upload, Filter, Database, Cpu, HardDrive, Zap, FileText, AlertCircle } from "lucide-react";
+import { Search, Upload, Filter, Database, Cpu, HardDrive, Zap, FileText, AlertCircle, Car } from "lucide-react";
 import { toast } from "sonner";
 import { parseBundle, getPlatformName, getMemoryTypeName, getFlagNames, extractResourceSize, formatResourceId, type ParsedBundle, type ResourceEntry } from "@/lib/bundleParser";
 import { getResourceType, getResourceTypeColor } from "@/lib/resourceTypes";
 import { parseDebugData, findDebugResourceById, type DebugResource } from "@/lib/debugDataParser";
+import { parseVehicleList, type VehicleListEntry } from "@/lib/vehicleListParser";
 
 // Converted resource interface for UI display
 interface UIResource {
@@ -51,6 +52,7 @@ export const BundleManager = () => {
   const [loadedBundle, setLoadedBundle] = useState<ParsedBundle | null>(null);
   const [resources, setResources] = useState<UIResource[]>([]);
   const [debugResources, setDebugResources] = useState<DebugResource[]>([]);
+  const [vehicleList, setVehicleList] = useState<VehicleListEntry[] | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -114,9 +116,18 @@ export const BundleManager = () => {
       }
 
       // Convert resources to UI format
-      const uiResources = bundle.resources.map(resource => 
+      const uiResources = bundle.resources.map(resource =>
         convertResourceToUI(resource, bundle, debugData)
       );
+
+      // Parse vehicle list if present
+      const vehicleResource = bundle.resources.find(r => r.resourceTypeId === 0x00010005);
+      if (vehicleResource) {
+        const vehicles = parseVehicleList(arrayBuffer, vehicleResource);
+        setVehicleList(vehicles);
+      } else {
+        setVehicleList(null);
+      }
 
       setLoadedBundle(bundle);
       setResources(uiResources);
@@ -221,6 +232,26 @@ export const BundleManager = () => {
                       <div className="font-medium">{debugResources.length > 0 ? 'Available' : 'None'}</div>
                     </div>
                   </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {vehicleList && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Car className="w-5 h-5" />
+                    Vehicle List
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <ul className="grid grid-cols-2 md:grid-cols-3 gap-2">
+                    {vehicleList.map(v => (
+                      <li key={v.id} className="text-sm">
+                        {v.vehicleName || v.id}
+                      </li>
+                    ))}
+                  </ul>
                 </CardContent>
               </Card>
             )}

--- a/src/lib/resourceTypes.ts
+++ b/src/lib/resourceTypes.ts
@@ -30,6 +30,7 @@ export const RESOURCE_TYPES: Record<number, ResourceType> = {
   0x00000012: { id: 0x00000012, name: 'Navigation', description: 'AI navigation data', category: 'Data' },
   0x00000013: { id: 0x00000013, name: 'UI', description: 'User interface elements', category: 'Graphics' },
   0x00000014: { id: 0x00000014, name: 'Skybox', description: 'Sky/environment textures', category: 'Graphics' },
+  0x00010005: { id: 0x00010005, name: 'Vehicle List', description: 'List of available vehicles', category: 'Data' },
 };
 
 export function getResourceType(typeId: number): ResourceType {

--- a/src/lib/vehicleListParser.ts
+++ b/src/lib/vehicleListParser.ts
@@ -1,0 +1,67 @@
+import { extractResourceSize, type ResourceEntry } from './bundleParser';
+
+export interface VehicleListEntry {
+  id: string;
+  parentId: string;
+  vehicleName: string;
+  manufacturer: string;
+  wheelName: string;
+}
+
+function decodeCgsId(bytes: Uint8Array): string {
+  let result = '';
+  for (let i = 0; i < 8; i++) {
+    const b = bytes[i];
+    if (b === 0) break;
+    result += String.fromCharCode(b);
+  }
+  return result;
+}
+
+function decodeString(bytes: Uint8Array): string {
+  let end = bytes.indexOf(0);
+  if (end === -1) end = bytes.length;
+  return new TextDecoder().decode(bytes.slice(0, end));
+}
+
+function getResourceData(buffer: ArrayBuffer, resource: ResourceEntry): Uint8Array {
+  for (let i = 0; i < 3; i++) {
+    const size = extractResourceSize(resource.sizeAndAlignmentOnDisk[i]);
+    if (size > 0) {
+      const offset = resource.diskOffsets[i];
+      return new Uint8Array(buffer, offset, size);
+    }
+  }
+  return new Uint8Array();
+}
+
+export function parseVehicleList(buffer: ArrayBuffer, resource: ResourceEntry): VehicleListEntry[] {
+  const data = getResourceData(buffer, resource);
+  if (data.byteLength === 0) return [];
+
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  let numVehicles = view.getUint32(0, true);
+
+  // Detect 64-bit layout where the first field is a pointer
+  if (numVehicles > 1000) {
+    numVehicles = view.getUint32(8, true);
+  }
+
+  const entries: VehicleListEntry[] = [];
+  const entrySize = 0x108; // 264 bytes per entry
+  const offset = 0x10; // entries start after resource header
+
+  for (let i = 0; i < numVehicles; i++) {
+    const base = offset + i * entrySize;
+    const entryBytes = new Uint8Array(data.buffer, data.byteOffset + base, entrySize);
+    const id = decodeCgsId(entryBytes.subarray(0, 8));
+    const parentId = decodeCgsId(entryBytes.subarray(8, 16));
+    const wheelName = decodeString(entryBytes.subarray(0x10, 0x10 + 32));
+    const vehicleName = decodeString(entryBytes.subarray(0x30, 0x30 + 64));
+    const manufacturer = decodeString(entryBytes.subarray(0x70, 0x70 + 32));
+
+    entries.push({ id, parentId, wheelName, vehicleName, manufacturer });
+  }
+
+  return entries;
+}


### PR DESCRIPTION
## Summary
- support Vehicle List bundle by defining a dedicated resource type
- parse Vehicle List resources to extract and display vehicle entries

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: @typescript-eslint/no-empty-object-type and @typescript-eslint/no-require-imports)


------
https://chatgpt.com/codex/tasks/task_e_6890c48549ac8327884a5d4ebe96761a