### PR TITLE
Specify Node 20 runtime requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A web-based tool for exploring and managing Burnout Paradise bundle files, provi
 ## Getting Started
 
 ### Prerequisites
-- Node.js 18+ and npm
+- Node.js 20+ and npm
 - Modern web browser with WebGL support
 
 ### Installation

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- declare a Node.js >=20 engine requirement in package.json so Nixpacks selects a supported runtime
- update the README prerequisites to reference Node.js 20+

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e38b77cd4c832785ee6bf22d834cbe