### PR TITLE
feat(triggerData): route marquee through workspace bulk (closes #60)

### DIFF
--- a/src/components/schema-editor/viewports/TriggerDataOverlay.tsx
+++ b/src/components/schema-editor/viewports/TriggerDataOverlay.tsx
@@ -40,7 +40,7 @@ import type { ParsedTriggerData, BoxRegion, Vector4 } from '@/lib/core/triggerDa
 import { GenericRegionType } from '@/lib/core/triggerData';
 import { CameraBridge, type CameraBridgeData } from '@/components/common/three/CameraBridge';
 import { MarqueeSelector } from '@/components/common/three/MarqueeSelector';
-import { useSchemaBulkSelection } from '@/components/schema-editor/bulkSelectionContext';
+import { useTriggerDataBulk } from '@/components/workspace/TriggerDataBulkProvider';
 import type { NodePath } from '@/lib/schema/walk';
 import type { WorldOverlayComponent } from './WorldViewport.types';
 import { useWorldViewportHtmlSlot } from './WorldViewport';
@@ -416,6 +416,46 @@ function PlayerStartMarker({
 }
 
 // ---------------------------------------------------------------------------
+// Marquee centroid collector — extracted as a pure function so the bulk
+// wiring spec can pin the projection (box.position for boxes, position for
+// vectors) without mounting r3f. Mirrors AISectionsOverlay's marquee codec
+// extraction in `__tests__/AISectionsOverlay.bulk.test.ts`.
+// ---------------------------------------------------------------------------
+
+/** Walk every bulk-eligible TriggerData list and return schema paths whose
+ *  representative point falls inside `frustum`. Boxes project on
+ *  `box.position`; spawns / roams project on `position`. The path shape is
+ *  exactly what the bulk reducer expects (`[listKey, index]`). */
+export function collectMarqueeHits(
+	data: ParsedTriggerData,
+	frustum: THREE.Frustum,
+): NodePath[] {
+	const hits: NodePath[] = [];
+	const pt = new THREE.Vector3();
+	const tryBox = (listKey: string, list: { box: BoxRegion }[]) => {
+		for (let i = 0; i < list.length; i++) {
+			const p = list[i].box.position;
+			pt.set(p.x, p.y, p.z);
+			if (frustum.containsPoint(pt)) hits.push([listKey, i]);
+		}
+	};
+	const tryVec = (listKey: string, list: { position: Vector4 }[]) => {
+		for (let i = 0; i < list.length; i++) {
+			const p = list[i].position;
+			pt.set(p.x, p.y, p.z);
+			if (frustum.containsPoint(pt)) hits.push([listKey, i]);
+		}
+	};
+	tryBox('landmarks', data.landmarks);
+	tryBox('genericRegions', data.genericRegions);
+	tryBox('blackspots', data.blackspots);
+	tryBox('vfxBoxRegions', data.vfxBoxRegions);
+	tryVec('spawnLocations', data.spawnLocations);
+	tryVec('roamingLocations', data.roamingLocations);
+	return hits;
+}
+
+// ---------------------------------------------------------------------------
 // Overlay
 // ---------------------------------------------------------------------------
 
@@ -428,10 +468,15 @@ type Props = {
 	onChange?: (next: ParsedTriggerData) => void;
 	/** True when this overlay owns the active selection — gates tool registration. */
 	isActive?: boolean;
+	/** Bundle / instance identity, supplied by `WorldViewportComposition` so
+	 *  the overlay can resolve "MY bulk" via `forInstance(bundleId, index)`.
+	 *  Optional so legacy per-resource pages still mount cleanly with no bulk. */
+	bundleId?: string;
+	index?: number;
 };
 
 export const TriggerDataOverlay: WorldOverlayComponent<ParsedTriggerData> = ({
-	data, selectedPath, onSelect, isActive = true,
+	data, selectedPath, onSelect, isActive = true, bundleId, index,
 }: Props) => {
 	const primary = useMemo(() => triggerSelectionCodec.pathToSelection(selectedPath), [selectedPath]);
 	const [hovered, setHovered] = useState<Selection | null>(null);
@@ -443,21 +488,34 @@ export const TriggerDataOverlay: WorldOverlayComponent<ParsedTriggerData> = ({
 
 	const regions = useMemo(() => buildRegionList(data), [data]);
 
-	const bulk = useSchemaBulkSelection();
+	// Workspace-wide TriggerData bulk handle. Resolves "this overlay's bulk"
+	// via per-instance lookup so two TriggerData overlays from two bundles
+	// keep independent bulk Sets. When `bundleId`/`index` are missing (legacy
+	// single-resource page route) we treat the bulk as absent.
+	const triggerBulk = useTriggerDataBulk();
+	const instanceBulk = useMemo(() => {
+		if (!triggerBulk || bundleId == null || index == null) return null;
+		return triggerBulk.forInstance(bundleId, index);
+	}, [triggerBulk, bundleId, index]);
 
 	// Translate the bulk path-key set (e.g. `'roamingLocations/3'`) into the
-	// Selection-keyed Set the hook expects (`'roaming:3'`). Only the subset
-	// the hook cares about (single-kind 'roaming') need translation here.
+	// Selection-keyed Set `useInstancedSelection` expects (`'roaming:3'`).
+	// Only the subset the hook cares about (single-kind 'roaming') needs
+	// translation; other entry kinds (landmarks/genericRegions/blackspots/
+	// vfxBoxRegions/spawnLocations) participate in the bulk Set without yet
+	// being painted in 3D — paint will land when the per-kind paint loop is
+	// extended in a follow-up.
 	const roamingBulk = useMemo<ReadonlySet<string>>(() => {
-		if (!bulk?.bulkPathKeys || bulk.bulkPathKeys.size === 0) return EMPTY_BULK;
+		const keys = instanceBulk?.bulkPathKeys;
+		if (!keys || keys.size === 0) return EMPTY_BULK;
 		const out = new Set<string>();
-		for (const k of bulk.bulkPathKeys) {
+		for (const k of keys) {
 			if (!k.startsWith('roamingLocations/')) continue;
 			const idx = Number(k.slice('roamingLocations/'.length));
 			if (Number.isFinite(idx)) out.add(`roaming:${idx}`);
 		}
 		return out;
-	}, [bulk]);
+	}, [instanceBulk]);
 
 	const findEntry = useCallback(
 		(sel: Selection | null) => {
@@ -472,37 +530,18 @@ export const TriggerDataOverlay: WorldOverlayComponent<ParsedTriggerData> = ({
 
 	// Marquee — pick every region/spawn/roaming whose centroid falls inside
 	// the dragged rectangle. Boxes use box.position; spawns / roams use
-	// their position field.
+	// their position field. Routes through the workspace-side
+	// `instanceBulk.onApplyPaths` so the right-sidebar BulkPanelStack and
+	// future tree decoration light up in one dispatch.
 	const cameraBridge = useRef<CameraBridgeData | null>(null);
 	const handleMarquee = useCallback(
 		(frustum: THREE.Frustum, mode: 'add' | 'remove') => {
-			if (!bulk?.onBulkApplyPaths) return;
-			const hits: NodePath[] = [];
-			const pt = new THREE.Vector3();
-			const tryBox = (listKey: string, list: { box: BoxRegion }[]) => {
-				for (let i = 0; i < list.length; i++) {
-					const p = list[i].box.position;
-					pt.set(p.x, p.y, p.z);
-					if (frustum.containsPoint(pt)) hits.push([listKey, i]);
-				}
-			};
-			const tryVec = (listKey: string, list: { position: Vector4 }[]) => {
-				for (let i = 0; i < list.length; i++) {
-					const p = list[i].position;
-					pt.set(p.x, p.y, p.z);
-					if (frustum.containsPoint(pt)) hits.push([listKey, i]);
-				}
-			};
-			tryBox('landmarks', data.landmarks);
-			tryBox('genericRegions', data.genericRegions);
-			tryBox('blackspots', data.blackspots);
-			tryBox('vfxBoxRegions', data.vfxBoxRegions);
-			tryVec('spawnLocations', data.spawnLocations);
-			tryVec('roamingLocations', data.roamingLocations);
+			if (!instanceBulk) return;
+			const hits = collectMarqueeHits(data, frustum);
 			if (hits.length === 0) return;
-			bulk.onBulkApplyPaths(hits, mode);
+			instanceBulk.onApplyPaths(hits, mode);
 		},
-		[data, bulk],
+		[data, instanceBulk],
 	);
 
 	const htmlNode = useMemo(

--- a/src/components/schema-editor/viewports/__tests__/TriggerDataOverlay.bulk.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/TriggerDataOverlay.bulk.test.ts
@@ -1,0 +1,214 @@
+// TriggerDataOverlay marquee centroid hit-test.
+//
+// The overlay's marquee handler calls `collectMarqueeHits(data, frustum)`
+// (extracted as a pure function in the overlay module). Pinning the
+// projection here — boxes use `box.position`, spawns / roams use
+// `position` — guards against a regression that swapped one of the
+// `tryBox`/`tryVec` callsites and would silently misroute every hit.
+//
+// The repo's vitest env is `node` (no jsdom) so we don't mount the overlay;
+// pure-function input → output is enough.
+
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import type {
+	Landmark,
+	GenericRegion,
+	Blackspot,
+	VFXBoxRegion,
+	SpawnLocation,
+	RoamingLocation,
+	ParsedTriggerData,
+	BoxRegion,
+	Vector3,
+	Vector4,
+} from '@/lib/core/triggerData';
+import {
+	GenericRegionType,
+	StuntCameraType,
+	TriggerRegionType,
+} from '@/lib/core/triggerData';
+import { collectMarqueeHits } from '../TriggerDataOverlay';
+
+function v3(x: number, y: number, z: number): Vector3 {
+	return { x, y, z };
+}
+function v4(x: number, y: number, z: number, w: number = 0): Vector4 {
+	return { x, y, z, w };
+}
+
+function makeBoxAt(pos: Vector3): BoxRegion {
+	return { position: pos, rotation: v3(0, 0, 0), dimensions: v3(1, 1, 1) };
+}
+
+function makeLandmark(pos: Vector3): Landmark {
+	return {
+		box: makeBoxAt(pos),
+		id: 0,
+		regionIndex: 0,
+		type: TriggerRegionType.E_TYPE_LANDMARK,
+		enabled: 1,
+		startingGrids: [],
+		designIndex: 0,
+		district: 0,
+		flags: 0,
+	};
+}
+
+function makeGeneric(pos: Vector3): GenericRegion {
+	return {
+		box: makeBoxAt(pos),
+		id: 0,
+		regionIndex: 0,
+		type: TriggerRegionType.E_TYPE_GENERIC_REGION,
+		enabled: 1,
+		groupId: 0,
+		cameraCut1: 0,
+		cameraCut2: 0,
+		cameraType1: StuntCameraType.E_STUNT_CAMERA_TYPE_NO_CUTS,
+		cameraType2: StuntCameraType.E_STUNT_CAMERA_TYPE_NO_CUTS,
+		genericType: GenericRegionType.E_TYPE_JUNK_YARD,
+		isOneWay: 0,
+	};
+}
+
+function makeBlackspot(pos: Vector3): Blackspot {
+	return {
+		box: makeBoxAt(pos),
+		id: 0,
+		regionIndex: 0,
+		type: TriggerRegionType.E_TYPE_BLACKSPOT,
+		enabled: 1,
+		scoreType: 0,
+		scoreAmount: 0,
+	};
+}
+
+function makeVfx(pos: Vector3): VFXBoxRegion {
+	return {
+		box: makeBoxAt(pos),
+		id: 0,
+		regionIndex: 0,
+		type: TriggerRegionType.E_TYPE_VFXBOX_REGION,
+		enabled: 1,
+	};
+}
+
+function makeSpawn(pos: Vector4): SpawnLocation {
+	return {
+		position: pos,
+		direction: v4(1, 0, 0),
+		junkyardId: 0n,
+		type: 0 as SpawnLocation['type'],
+	};
+}
+
+function makeRoaming(pos: Vector4): RoamingLocation {
+	return { position: pos, districtIndex: 0 };
+}
+
+function emptyTriggerData(over: Partial<ParsedTriggerData> = {}): ParsedTriggerData {
+	return {
+		version: 0,
+		size: 0,
+		playerStartPosition: v4(0, 0, 0),
+		playerStartDirection: v4(1, 0, 0),
+		landmarks: [],
+		onlineLandmarkCount: 0,
+		signatureStunts: [],
+		genericRegions: [],
+		killzones: [],
+		blackspots: [],
+		vfxBoxRegions: [],
+		roamingLocations: [],
+		spawnLocations: [],
+		...over,
+	};
+}
+
+/** Build an axis-aligned box frustum that "contains" any point within the
+ *  six bounds. Mirrors the helper in `AISectionsOverlay.bulk.test.ts`. */
+function buildBoxFrustum(
+	xMin: number, xMax: number,
+	yMin: number, yMax: number,
+	zMin: number, zMax: number,
+): THREE.Frustum {
+	const planes = [
+		new THREE.Plane(new THREE.Vector3(1, 0, 0), -xMin),
+		new THREE.Plane(new THREE.Vector3(-1, 0, 0), xMax),
+		new THREE.Plane(new THREE.Vector3(0, 1, 0), -yMin),
+		new THREE.Plane(new THREE.Vector3(0, -1, 0), yMax),
+		new THREE.Plane(new THREE.Vector3(0, 0, 1), -zMin),
+		new THREE.Plane(new THREE.Vector3(0, 0, -1), zMax),
+	];
+	const f = new THREE.Frustum();
+	for (let i = 0; i < 6; i++) f.planes[i].copy(planes[i]);
+	return f;
+}
+
+describe('TriggerDataOverlay marquee centroid hit-test', () => {
+	it('returns paths for every entry whose representative point lies inside the frustum', () => {
+		const data = emptyTriggerData({
+			landmarks: [
+				makeLandmark(v3(0, 0, 0)), // inside
+				makeLandmark(v3(1000, 0, 0)), // outside
+			],
+			genericRegions: [makeGeneric(v3(5, 0, 5))], // inside
+			blackspots: [makeBlackspot(v3(2000, 0, 0))], // outside
+			vfxBoxRegions: [makeVfx(v3(-5, 0, -5))], // inside
+			spawnLocations: [
+				makeSpawn(v4(10, 0, 10)), // inside
+				makeSpawn(v4(900, 0, 0)), // outside
+			],
+			roamingLocations: [
+				makeRoaming(v4(0, 0, 0)), // inside
+				makeRoaming(v4(0, 0, 800)), // outside
+			],
+		});
+
+		const frustum = buildBoxFrustum(-50, 50, -10, 10, -50, 50);
+		const hits = collectMarqueeHits(data, frustum);
+
+		expect(hits).toEqual([
+			['landmarks', 0],
+			['genericRegions', 0],
+			['vfxBoxRegions', 0],
+			['spawnLocations', 0],
+			['roamingLocations', 0],
+		]);
+	});
+
+	it('uses box.position for box regions, not box.dimensions or rotation', () => {
+		// Place the entry far from origin in `dimensions` and `rotation`, but
+		// keep `position` inside the frustum. A regression that read either
+		// of the wrong fields would miss this hit.
+		const lm = makeLandmark(v3(0, 0, 0));
+		lm.box.dimensions = v3(9999, 9999, 9999);
+		lm.box.rotation = v3(9999, 9999, 9999);
+
+		const data = emptyTriggerData({ landmarks: [lm] });
+		const frustum = buildBoxFrustum(-1, 1, -1, 1, -1, 1);
+		expect(collectMarqueeHits(data, frustum)).toEqual([['landmarks', 0]]);
+	});
+
+	it('emits an empty array when no entries fall inside the frustum', () => {
+		const data = emptyTriggerData({
+			landmarks: [makeLandmark(v3(1000, 0, 0))],
+			roamingLocations: [makeRoaming(v4(2000, 0, 0))],
+		});
+		const frustum = buildBoxFrustum(-50, 50, -10, 10, -50, 50);
+		expect(collectMarqueeHits(data, frustum)).toEqual([]);
+	});
+
+	it('does NOT include player-start singletons (not bulk-eligible)', () => {
+		// Place the player-start at the origin; the frustum contains it but
+		// the marquee must skip it because there's exactly one player-start
+		// per resource and a "set of one" is not a meaningful bulk.
+		const data = emptyTriggerData({
+			playerStartPosition: v4(0, 0, 0),
+			playerStartDirection: v4(1, 0, 0),
+		});
+		const frustum = buildBoxFrustum(-50, 50, -10, 10, -50, 50);
+		expect(collectMarqueeHits(data, frustum)).toEqual([]);
+	});
+});

--- a/src/components/workspace/BulkPanelStack.tsx
+++ b/src/components/workspace/BulkPanelStack.tsx
@@ -1,6 +1,6 @@
-// BulkPanelStack — right-sidebar list of every non-empty AI Sections bulk
-// across every loaded bundle. Lives below the regular `RightInspector` form
-// in `WorkspacePage`'s right column, so the user can see their bulks while
+// BulkPanelStack — right-sidebar list of every non-empty bulk across every
+// loaded bundle. Lives below the regular `RightInspector` form in
+// `WorkspacePage`'s right column, so the user can see their bulks while
 // the inspector continues to focus on whatever resource they navigated to.
 //
 // One panel per bulk; sort by `lastTouchedAt` desc so the panel the user
@@ -10,12 +10,14 @@
 //     instance (path: []), so the user can return to the inspector form
 //     for that resource without losing their bulk.
 //   - [✕] click: clears that bulk only (other bulks coexist).
-//   - Body (when expanded): placeholder for Slice 2 export buttons.
+//   - Body (when expanded): per-resource — AI Sections shows the export
+//     buttons; TriggerData shows just `[Clear]` until a TriggerData-
+//     specific aggregate editor is designed (issue #60 follow-up).
 //
-// PSL retrofit (mounting PSL bulks here too) is explicitly OUT OF SCOPE for
-// Slice 1 — see CONTEXT/spec. This stack only consults
-// `useWorkspaceAISectionsBulk`. Adding PSL would mean teaching this stack to
-// fan out across multiple bulk-providers; we'll do that when Slice 2 needs it.
+// PSL retrofit (mounting PSL bulks here too) remains out of scope. This
+// stack consults the AI Sections + TriggerData providers; adding more
+// resource keys is a matter of fanning the per-provider summaries through
+// the same descriptor pipeline.
 
 import { useState, useMemo } from 'react';
 import { ChevronDown, ChevronRight, X, Clipboard, Download } from 'lucide-react';
@@ -28,6 +30,10 @@ import {
 	useWorkspaceAISectionsBulk,
 	type WorkspaceAISectionsBulkSummary,
 } from './AISectionsBulkProvider';
+import {
+	useWorkspaceTriggerDataBulk,
+	type WorkspaceTriggerDataBulkSummary,
+} from './TriggerDataBulkProvider';
 import { sortBulkSummaries } from './bulkPanelStack.helpers';
 import {
 	buildEnvelopeFromBulk,
@@ -38,6 +44,27 @@ import type { EditableBundle } from '@/context/WorkspaceContext.types';
 import type { ParsedAISections } from '@/lib/core/aiSections';
 
 const AI_KEY = 'aiSections';
+const TRIGGER_KEY = 'triggerData';
+
+/** A single panel descriptor — discriminated by `resourceKey` so the
+ *  renderer can pick the right body (AI's export buttons vs Trigger's
+ *  Clear-only stub). The bundle / index / count fields are common to both
+ *  variants; per-resource bits live under `aiSummary` / `triggerSummary`. */
+type PanelDescriptor =
+	| {
+			resourceKey: typeof AI_KEY;
+			bundleId: string;
+			index: number;
+			lastTouchedAt: number;
+			summary: WorkspaceAISectionsBulkSummary;
+	  }
+	| {
+			resourceKey: typeof TRIGGER_KEY;
+			bundleId: string;
+			index: number;
+			lastTouchedAt: number;
+			summary: WorkspaceTriggerDataBulkSummary;
+	  };
 
 // ---------------------------------------------------------------------------
 // Stack
@@ -45,14 +72,37 @@ const AI_KEY = 'aiSections';
 
 export function BulkPanelStack() {
 	const aiBulk = useWorkspaceAISectionsBulk();
+	const triggerBulk = useWorkspaceTriggerDataBulk();
 	const { bundles, select } = useWorkspace();
 
-	const sorted = useMemo<readonly WorkspaceAISectionsBulkSummary[]>(
-		() => (aiBulk ? sortBulkSummaries(aiBulk.summaries) : []),
-		[aiBulk],
-	);
+	const sorted = useMemo<readonly PanelDescriptor[]>(() => {
+		const merged: PanelDescriptor[] = [];
+		if (aiBulk) {
+			for (const s of aiBulk.summaries) {
+				merged.push({
+					resourceKey: AI_KEY,
+					bundleId: s.bundleId,
+					index: s.index,
+					lastTouchedAt: s.lastTouchedAt,
+					summary: s,
+				});
+			}
+		}
+		if (triggerBulk) {
+			for (const s of triggerBulk.summaries) {
+				merged.push({
+					resourceKey: TRIGGER_KEY,
+					bundleId: s.bundleId,
+					index: s.index,
+					lastTouchedAt: s.lastTouchedAt,
+					summary: s,
+				});
+			}
+		}
+		return sortBulkSummaries(merged);
+	}, [aiBulk, triggerBulk]);
 
-	if (!aiBulk || sorted.length === 0) return null;
+	if (sorted.length === 0) return null;
 
 	return (
 		<div className="border-t bg-card/40">
@@ -60,22 +110,42 @@ export function BulkPanelStack() {
 				Bulk selections
 			</div>
 			<div className="space-y-1 px-2 pb-2">
-				{sorted.map((s) => {
-					const bundle = bundles.find((b) => b.id === s.bundleId);
+				{sorted.map((p) => {
+					const bundle = bundles.find((b) => b.id === p.bundleId);
+					if (p.resourceKey === AI_KEY) {
+						if (!aiBulk) return null;
+						return (
+							<BulkPanel
+								key={`${AI_KEY}::${p.bundleId}::${p.index}`}
+								summary={p.summary}
+								bundle={bundle}
+								onNavigate={() =>
+									select({
+										bundleId: p.bundleId,
+										resourceKey: AI_KEY,
+										index: p.index,
+										path: [],
+									})
+								}
+								onClear={() => aiBulk.onClear(p.bundleId, p.index)}
+							/>
+						);
+					}
+					if (!triggerBulk) return null;
 					return (
-						<BulkPanel
-							key={`${s.bundleId}::${s.index}`}
-							summary={s}
+						<TriggerDataBulkPanel
+							key={`${TRIGGER_KEY}::${p.bundleId}::${p.index}`}
+							summary={p.summary}
 							bundle={bundle}
 							onNavigate={() =>
 								select({
-									bundleId: s.bundleId,
-									resourceKey: AI_KEY,
-									index: s.index,
+									bundleId: p.bundleId,
+									resourceKey: TRIGGER_KEY,
+									index: p.index,
 									path: [],
 								})
 							}
-							onClear={() => aiBulk.onClear(s.bundleId, s.index)}
+							onClear={() => triggerBulk.onClear(p.bundleId, p.index)}
 						/>
 					);
 				})}
@@ -236,6 +306,92 @@ export function BulkPanel({
 							<Download className="h-3 w-3" />
 							Export → file…
 						</Button>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="h-7 text-xs ml-auto"
+							onClick={onClear}
+						>
+							Clear
+						</Button>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// One TriggerData panel — minimal body (just `[Clear]`) until a TriggerData-
+// specific aggregate editor is designed (issue #60 leaves this stub on
+// purpose; bulk-edit UI is a follow-up). Keeps the header chrome identical
+// to `BulkPanel` so users see one consistent panel shape across resources.
+// ---------------------------------------------------------------------------
+
+export function TriggerDataBulkPanel({
+	summary,
+	bundle,
+	onNavigate,
+	onClear,
+}: {
+	summary: WorkspaceTriggerDataBulkSummary;
+	bundle: EditableBundle | undefined;
+	onNavigate: () => void;
+	onClear: () => void;
+}) {
+	const [expanded, setExpanded] = useState(false);
+
+	const handler = getHandlerByKey(TRIGGER_KEY);
+	const resourceLabel = handler?.name ?? TRIGGER_KEY;
+	const filename = bundle?.id ?? summary.bundleId;
+
+	return (
+		<div className="rounded border border-amber-500/40 bg-amber-500/5">
+			<div className="flex items-center gap-1 px-2 py-1.5">
+				<button
+					type="button"
+					onClick={() => setExpanded((v) => !v)}
+					className="shrink-0 p-0.5 rounded hover:bg-muted/40"
+					aria-label={expanded ? 'Collapse panel' : 'Expand panel'}
+					aria-expanded={expanded}
+				>
+					{expanded ? (
+						<ChevronDown className="h-3 w-3 text-muted-foreground" />
+					) : (
+						<ChevronRight className="h-3 w-3 text-muted-foreground" />
+					)}
+				</button>
+				<button
+					type="button"
+					onClick={onNavigate}
+					className="flex-1 min-w-0 flex items-center gap-1.5 px-1 py-0.5 rounded hover:bg-muted/40 text-left"
+					title={`Jump inspector to ${filename} · ${resourceLabel} #${summary.index}`}
+				>
+					<span className="truncate text-xs font-medium" title={filename}>
+						{filename}
+					</span>
+					<span className="text-[10px] text-muted-foreground shrink-0">·</span>
+					<span className="truncate text-[11px] text-muted-foreground" title={resourceLabel}>
+						{resourceLabel}
+					</span>
+					<Badge variant="outline" className="ml-auto h-4 px-1.5 text-[10px] tabular-nums shrink-0">
+						{summary.count}
+					</Badge>
+				</button>
+				<button
+					type="button"
+					onClick={onClear}
+					className="shrink-0 p-0.5 rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+					aria-label={`Clear bulk for ${filename}`}
+					title="Clear this bulk"
+				>
+					<X className="h-3 w-3" />
+				</button>
+			</div>
+			{expanded && (
+				<div className="px-3 py-2 border-t border-amber-500/40 space-y-2">
+					<div className="flex flex-wrap gap-1.5">
 						<Button
 							type="button"
 							variant="ghost"

--- a/src/components/workspace/TriggerDataBulkProvider.tsx
+++ b/src/components/workspace/TriggerDataBulkProvider.tsx
@@ -1,0 +1,350 @@
+// TriggerDataBulkProvider — workspace-wide owner of the TriggerData bulk-
+// select state. Sibling of `AISectionsBulkProvider`; the workspace mounts
+// both and they coexist (their bulks are independent — selecting trigger
+// regions doesn't touch the AI bulk and vice versa).
+//
+// The provider exposes two contexts:
+//
+//   - `TriggerDataBulkContext` — consumed by `TriggerDataOverlay`. Carries
+//     the per-(bundleId, index) bulk Set, plus the marquee `onApplyPaths`
+//     entry point. Resolved through `forInstance(bundleId, index)` exactly
+//     like `useAISectionsBulk()`.
+//
+//   - `WorkspaceTriggerDataBulkContext` — consumed by `WorkspaceHierarchy`
+//     (tree-row Ctrl/Shift + future amber decoration) and `BulkPanelStack`.
+//     Surfaces every non-empty bulk across every loaded bundle.
+//
+// Why the bulk persists across selection changes (mirrors AI Sections,
+// deviates from PSL): users curate a multi-region selection in TriggerData,
+// hop the inspector elsewhere to compare, and come back. Resetting on
+// inspector navigation would silently destroy that work. The bulk is keyed
+// by `(bundleId, resourceKey, index)` and clears only on bundle close or
+// explicit `[✕]` from the panel stack.
+//
+// Multi-bundle: each (bundleId, index) has its own bulk Set. Bulks coexist;
+// clearing one doesn't affect any other.
+
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+	useState,
+	type ReactNode,
+} from 'react';
+import {
+	applyPaths,
+	rangeAddEntries,
+	toggleEntry,
+} from './triggerDataBulk';
+import type { NodePath } from '@/lib/schema/walk';
+import type {
+	BundleId,
+	WorkspaceContextValue,
+} from '@/context/WorkspaceContext.types';
+
+const TRIGGER_KEY = 'triggerData';
+
+// ---------------------------------------------------------------------------
+// Storage shape
+// ---------------------------------------------------------------------------
+
+// Each (bundleId, index) gets its own bulk Set. The outer key is
+// `${bundleId}::${index}` — both pieces are stable identifiers (bundle
+// filename + Bundle-relative resource index). Closed-bundle entries are
+// pruned in `pruneClosedBundleBulks` below.
+type BulkKey = string;
+function bulkKeyOf(bundleId: BundleId, index: number): BulkKey {
+	return `${bundleId}::${index}`;
+}
+
+type BulkEntry = {
+	bundleId: BundleId;
+	index: number;
+	paths: ReadonlySet<string>;
+	/** Wall-clock ms of the most recent toggle/range/clear-add. Drives the
+	 *  panel-stack ordering: most-recently-touched panel rises to the top. */
+	lastTouchedAt: number;
+};
+
+type BulkMap = ReadonlyMap<BulkKey, BulkEntry>;
+
+// ---------------------------------------------------------------------------
+// Overlay-side context — consumed by TriggerDataOverlay. Resolves a per-
+// instance handle so the same overlay component, mounted twice across two
+// bundles, gets two independent bulk Sets.
+// ---------------------------------------------------------------------------
+
+export type TriggerDataBulkInstanceValue = {
+	/** Path-keyed Set for THIS (bundleId, index) instance — `'landmarks/3'`,
+	 *  `'roamingLocations/5'`, etc. Empty when no entries are in the bulk. */
+	bulkPathKeys: ReadonlySet<string>;
+	/** Batch-apply schema paths to the bulk Set in one pass. The 3D marquee
+	 *  emits a hit-array spanning every entry inside the dragged rectangle
+	 *  and dispatches once with `mode === 'add'` (default) or `'remove'` (Alt).
+	 *  Non-entry paths are silently dropped — see `applyPaths`. */
+	onApplyPaths: (paths: ReadonlyArray<NodePath>, mode: 'add' | 'remove') => void;
+	/** Clear this instance's bulk. */
+	onClear: () => void;
+};
+
+export type TriggerDataBulkValue = {
+	/** Resolve the bulk handle for one specific overlay instance. The
+	 *  WorldViewportComposition feeds `(bundleId, index)`; legacy single-
+	 *  resource pages can call this with their own identity (or skip the
+	 *  context entirely and accept an empty bulk). */
+	forInstance: (bundleId: BundleId, index: number) => TriggerDataBulkInstanceValue;
+};
+
+const TriggerDataBulkContext = createContext<TriggerDataBulkValue | null>(null);
+
+/** Returns the workspace TriggerData bulk lookup. `null` when no provider
+ *  is mounted (legacy per-resource page routes). Overlays read this once
+ *  and resolve their own instance via `forInstance(bundleId, index)`. */
+export function useTriggerDataBulk(): TriggerDataBulkValue | null {
+	return useContext(TriggerDataBulkContext);
+}
+
+// ---------------------------------------------------------------------------
+// Workspace-side context — consumed by WorkspaceHierarchy (tree-row
+// Ctrl/Shift semantics + amber decoration) and BulkPanelStack.
+// ---------------------------------------------------------------------------
+
+export type WorkspaceTriggerDataBulkSummary = {
+	bundleId: BundleId;
+	index: number;
+	count: number;
+	lastTouchedAt: number;
+	pathKeys: ReadonlySet<string>;
+};
+
+export type WorkspaceTriggerDataBulkValue = {
+	/** All non-empty bulks across every loaded bundle. Caller-side sort on
+	 *  `lastTouchedAt` produces the panel-stack ordering. */
+	summaries: readonly WorkspaceTriggerDataBulkSummary[];
+	/** Total path-keys count for `(bundleId, index)`. Cheap O(1) lookup
+	 *  for the tree's resource-row badge. */
+	getCount: (bundleId: BundleId, index: number) => number;
+	/** Path-keyed Set for `(bundleId, index)` — the tree paints rows whose
+	 *  schema path stringifies to a member. Returns null when the bulk is
+	 *  empty, so the tree doesn't have to allocate empty Sets. */
+	getPathKeys: (
+		bundleId: BundleId,
+		index: number,
+	) => ReadonlySet<string> | null;
+	/** Tree-row Ctrl-click bulk-toggle. Path is normalised to the containing
+	 *  entry; non-entry paths are silently ignored. */
+	onBulkToggle: (bundleId: BundleId, index: number, path: NodePath) => void;
+	onBulkRange: (
+		bundleId: BundleId,
+		index: number,
+		from: NodePath,
+		to: NodePath,
+	) => void;
+	/** Batch-apply schema paths to `(bundleId, index)`'s bulk in one pass.
+	 *  Mirrors `onBulkToggle`'s sub-path normalisation but folds many paths
+	 *  into a single state update — the 3D marquee emits all hits at once
+	 *  rather than dispatching per-entry. */
+	onBulkApplyPaths: (
+		bundleId: BundleId,
+		index: number,
+		paths: ReadonlyArray<NodePath>,
+		mode: 'add' | 'remove',
+	) => void;
+	/** Clear the bulk for `(bundleId, index)` — drives the panel `[✕]`. */
+	onClear: (bundleId: BundleId, index: number) => void;
+};
+
+const WorkspaceTriggerDataBulkContext =
+	createContext<WorkspaceTriggerDataBulkValue | null>(null);
+
+export function useWorkspaceTriggerDataBulk(): WorkspaceTriggerDataBulkValue | null {
+	return useContext(WorkspaceTriggerDataBulkContext);
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+function pruneClosedBundleBulks(
+	prev: BulkMap,
+	loadedBundleIds: ReadonlySet<BundleId>,
+): BulkMap {
+	let changed = false;
+	const next = new Map(prev);
+	for (const [k, entry] of prev) {
+		if (!loadedBundleIds.has(entry.bundleId)) {
+			next.delete(k);
+			changed = true;
+		}
+	}
+	return changed ? next : prev;
+}
+
+export function TriggerDataBulkProvider({
+	bundles,
+	children,
+}: {
+	bundles: WorkspaceContextValue['bundles'];
+	children: ReactNode;
+}) {
+	const [bulks, setBulks] = useState<BulkMap>(() => new Map());
+
+	// Drop entries whose bundle was closed. Mirrors AISectionsBulkProvider's
+	// in-render reduce: derive the loaded set, prune, and only setState when
+	// the resulting Map identity differs from the current one. No useEffect.
+	const loadedBundleIds = useMemo(() => {
+		const s = new Set<BundleId>();
+		for (const b of bundles) s.add(b.id);
+		return s;
+	}, [bundles]);
+	const prunedBulks = useMemo(
+		() => pruneClosedBundleBulks(bulks, loadedBundleIds),
+		[bulks, loadedBundleIds],
+	);
+	if (prunedBulks !== bulks) {
+		// React documents synchronous setState during render as legal when the
+		// new value is a pure function of the old. See "Storing information
+		// from previous renders" in the React docs.
+		setBulks(prunedBulks);
+	}
+
+	const writeEntry = useCallback(
+		(
+			bundleId: BundleId,
+			index: number,
+			updater: (paths: ReadonlySet<string>) => Set<string>,
+		) => {
+			setBulks((prev) => {
+				const k = bulkKeyOf(bundleId, index);
+				const cur = prev.get(k);
+				const nextPaths = updater(cur?.paths ?? new Set<string>());
+				const next = new Map(prev);
+				if (nextPaths.size === 0) {
+					next.delete(k);
+				} else {
+					next.set(k, {
+						bundleId,
+						index,
+						paths: nextPaths,
+						lastTouchedAt: Date.now(),
+					});
+				}
+				return next;
+			});
+		},
+		[],
+	);
+
+	// ---- Workspace-side handlers ----
+
+	const onWsToggle = useCallback(
+		(bundleId: BundleId, index: number, path: NodePath) => {
+			writeEntry(bundleId, index, (paths) => toggleEntry(paths, path));
+		},
+		[writeEntry],
+	);
+
+	const onWsRange = useCallback(
+		(bundleId: BundleId, index: number, from: NodePath, to: NodePath) => {
+			writeEntry(bundleId, index, (paths) => rangeAddEntries(paths, from, to));
+		},
+		[writeEntry],
+	);
+
+	const onWsApplyPaths = useCallback(
+		(
+			bundleId: BundleId,
+			index: number,
+			paths: ReadonlyArray<NodePath>,
+			mode: 'add' | 'remove',
+		) => {
+			writeEntry(bundleId, index, (cur) => applyPaths(cur, paths, mode));
+		},
+		[writeEntry],
+	);
+
+	const onWsClear = useCallback(
+		(bundleId: BundleId, index: number) => {
+			writeEntry(bundleId, index, () => new Set<string>());
+		},
+		[writeEntry],
+	);
+
+	const summaries = useMemo<readonly WorkspaceTriggerDataBulkSummary[]>(() => {
+		const out: WorkspaceTriggerDataBulkSummary[] = [];
+		for (const entry of bulks.values()) {
+			if (entry.paths.size === 0) continue;
+			out.push({
+				bundleId: entry.bundleId,
+				index: entry.index,
+				count: entry.paths.size,
+				lastTouchedAt: entry.lastTouchedAt,
+				pathKeys: entry.paths,
+			});
+		}
+		return out;
+	}, [bulks]);
+
+	const getCount = useCallback(
+		(bundleId: BundleId, index: number) =>
+			bulks.get(bulkKeyOf(bundleId, index))?.paths.size ?? 0,
+		[bulks],
+	);
+
+	const getPathKeys = useCallback(
+		(bundleId: BundleId, index: number) => {
+			const e = bulks.get(bulkKeyOf(bundleId, index));
+			return e && e.paths.size > 0 ? e.paths : null;
+		},
+		[bulks],
+	);
+
+	const workspaceValue = useMemo<WorkspaceTriggerDataBulkValue>(
+		() => ({
+			summaries,
+			getCount,
+			getPathKeys,
+			onBulkToggle: onWsToggle,
+			onBulkRange: onWsRange,
+			onBulkApplyPaths: onWsApplyPaths,
+			onClear: onWsClear,
+		}),
+		[summaries, getCount, getPathKeys, onWsToggle, onWsRange, onWsApplyPaths, onWsClear],
+	);
+
+	// ---- Overlay-side context ----
+
+	const overlayValue = useMemo<TriggerDataBulkValue>(() => {
+		const forInstance = (
+			bundleId: BundleId,
+			index: number,
+		): TriggerDataBulkInstanceValue => {
+			const entry = bulks.get(bulkKeyOf(bundleId, index));
+			const bulkPathKeys = entry ? entry.paths : new Set<string>();
+			return {
+				bulkPathKeys,
+				onApplyPaths: (paths, mode) => {
+					writeEntry(bundleId, index, (cur) => applyPaths(cur, paths, mode));
+				},
+				onClear: () => {
+					writeEntry(bundleId, index, () => new Set<string>());
+				},
+			};
+		};
+		return { forInstance };
+	}, [bulks, writeEntry]);
+
+	return (
+		<WorkspaceTriggerDataBulkContext.Provider value={workspaceValue}>
+			<TriggerDataBulkContext.Provider value={overlayValue}>
+				{children}
+			</TriggerDataBulkContext.Provider>
+		</WorkspaceTriggerDataBulkContext.Provider>
+	);
+}
+
+/** Resource key the provider's panels and tree integration key off. Re-
+ *  exported so `BulkPanelStack` and `WorkspaceHierarchy` can compare without
+ *  re-typing the magic string. */
+export const TRIGGER_DATA_BULK_RESOURCE_KEY = TRIGGER_KEY;

--- a/src/components/workspace/WorkspaceHierarchy.tsx
+++ b/src/components/workspace/WorkspaceHierarchy.tsx
@@ -32,6 +32,7 @@ import { useWorkspace } from '@/context/WorkspaceContext';
 import type { VisibilityNode, WorkspaceSelection } from '@/context/WorkspaceContext.types';
 import { useWorkspacePSLBulk } from './PSLBulkProvider';
 import { useWorkspaceAISectionsBulk } from './AISectionsBulkProvider';
+import { useWorkspaceTriggerDataBulk } from './TriggerDataBulkProvider';
 import type { NodePath } from '@/lib/schema/walk';
 import {
 	bundleKey,
@@ -142,6 +143,10 @@ export function WorkspaceHierarchy({ onAddBundle }: WorkspaceHierarchyProps) {
 	// until the user starts curating. Drives the same Ctrl/Shift semantics
 	// + amber row tint + per-resource-row count Badge.
 	const aiBulk = useWorkspaceAISectionsBulk();
+	// TriggerData bulk handle — sibling shape to AI Sections. The marquee
+	// owns the only producer today; tree-row Ctrl/Shift below extends the
+	// dispatch surface so users can curate from the schema rows too.
+	const triggerBulk = useWorkspaceTriggerDataBulk();
 
 	// Persisted expansion state. Default-expanded behaviour mirrors the
 	// pre-WorkspaceHierarchy tree:
@@ -236,9 +241,29 @@ export function WorkspaceHierarchy({ onAddBundle }: WorkspaceHierarchyProps) {
 					return;
 				}
 			}
+			if (triggerBulk && resourceKey === 'triggerData') {
+				if (modifiers?.ctrl) {
+					// Ctrl/Cmd: toggle the row's containing entry (landmark /
+					// generic / blackspot / vfx / spawn / roaming). Player-
+					// start singleton rows aren't bulk-eligible — the toggle
+					// reducer drops them silently and we still want a plain
+					// select for that row, so we DON'T early-return when the
+					// path can't normalise. The reducer's no-op makes the
+					// Ctrl-click safe; falling through to `select(...)` keeps
+					// the inspector behaviour for non-bulk rows.
+					triggerBulk.onBulkToggle(bundleId, index, schemaPath);
+					return;
+				}
+				if (modifiers?.shift) {
+					const fromPath: NodePath = selectionAnchorPath(selection, 'triggerData');
+					triggerBulk.onBulkRange(bundleId, index, fromPath, schemaPath);
+					select({ bundleId, resourceKey, index, path: schemaPath });
+					return;
+				}
+			}
 			select({ bundleId, resourceKey, index, path: schemaPath });
 		},
-		[select, bulk, aiBulk, selection],
+		[select, bulk, aiBulk, triggerBulk, selection],
 	);
 
 	// ---------------------- Virtualizer ----------------------

--- a/src/components/workspace/__tests__/triggerDataBulk.test.ts
+++ b/src/components/workspace/__tests__/triggerDataBulk.test.ts
@@ -1,0 +1,364 @@
+// Pure-helper coverage for the TriggerData bulk reducer + path codec.
+//
+// The provider that wraps these helpers is React + context; testing them
+// here at the pure-function level lets us pin the load-bearing contract
+// (sub-paths collapse to their parent entry, range expands inclusively,
+// cross-list ranges degrade gracefully) without spinning up react-dom.
+//
+// Mirrors `aiSectionsBulk.test.ts` — same shape, same coverage targets.
+
+import { describe, it, expect } from 'vitest';
+import {
+	applyPaths,
+	entryPathKey,
+	normaliseToEntryPath,
+	parseEntryAddress,
+	parseEntryPathKey,
+	pruneStaleEntries,
+	rangeAddEntries,
+	toggleEntry,
+} from '../triggerDataBulk';
+
+describe('parseEntryAddress', () => {
+	it('decodes top-level entry paths for every bulk-eligible list', () => {
+		expect(parseEntryAddress(['landmarks', 0])).toEqual({
+			listKey: 'landmarks',
+			index: 0,
+		});
+		expect(parseEntryAddress(['genericRegions', 7])).toEqual({
+			listKey: 'genericRegions',
+			index: 7,
+		});
+		expect(parseEntryAddress(['blackspots', 3])).toEqual({
+			listKey: 'blackspots',
+			index: 3,
+		});
+		expect(parseEntryAddress(['vfxBoxRegions', 2])).toEqual({
+			listKey: 'vfxBoxRegions',
+			index: 2,
+		});
+		expect(parseEntryAddress(['spawnLocations', 5])).toEqual({
+			listKey: 'spawnLocations',
+			index: 5,
+		});
+		expect(parseEntryAddress(['roamingLocations', 99])).toEqual({
+			listKey: 'roamingLocations',
+			index: 99,
+		});
+	});
+
+	it('decodes sub-paths under an entry to the entry itself', () => {
+		expect(
+			parseEntryAddress(['landmarks', 3, 'box', 'position', 'x']),
+		).toEqual({ listKey: 'landmarks', index: 3 });
+		expect(
+			parseEntryAddress(['roamingLocations', 5, 'position']),
+		).toEqual({ listKey: 'roamingLocations', index: 5 });
+	});
+
+	it('returns null for player-start singletons (no bulk-set of one)', () => {
+		expect(parseEntryAddress(['playerStartPosition'])).toBeNull();
+		expect(parseEntryAddress(['playerStartDirection'])).toBeNull();
+	});
+
+	it('returns null for non-bulk-eligible top-level fields', () => {
+		expect(parseEntryAddress([])).toBeNull();
+		expect(parseEntryAddress(['header'])).toBeNull();
+		expect(parseEntryAddress(['unknownList', 0])).toBeNull();
+		expect(parseEntryAddress(['landmarks'])).toBeNull();
+	});
+
+	it('rejects entry paths when the index segment is non-numeric (defensive)', () => {
+		expect(
+			parseEntryAddress(['landmarks', 'oops' as unknown as number]),
+		).toBeNull();
+	});
+});
+
+describe('normaliseToEntryPath', () => {
+	it('preserves bare entry paths', () => {
+		expect(normaliseToEntryPath(['landmarks', 3])).toEqual(['landmarks', 3]);
+		expect(normaliseToEntryPath(['roamingLocations', 5])).toEqual([
+			'roamingLocations',
+			5,
+		]);
+	});
+
+	it('collapses sub-paths to the containing entry', () => {
+		expect(normaliseToEntryPath(['landmarks', 3, 'box', 'position'])).toEqual([
+			'landmarks',
+			3,
+		]);
+		expect(
+			normaliseToEntryPath(['vfxBoxRegions', 0, 'box', 'dimensions', 'y']),
+		).toEqual(['vfxBoxRegions', 0]);
+	});
+
+	it('returns null for non-entry paths', () => {
+		expect(normaliseToEntryPath(['playerStartPosition'])).toBeNull();
+		expect(normaliseToEntryPath(['header', 'flags'])).toBeNull();
+		expect(normaliseToEntryPath([])).toBeNull();
+	});
+});
+
+describe('entryPathKey / parseEntryPathKey', () => {
+	it('round-trips landmark entry paths', () => {
+		const key = entryPathKey(['landmarks', 42]);
+		expect(key).toBe('landmarks/42');
+		expect(parseEntryPathKey(key)).toEqual({ listKey: 'landmarks', index: 42 });
+	});
+
+	it('round-trips roamingLocations paths', () => {
+		const key = entryPathKey(['roamingLocations', 7]);
+		expect(key).toBe('roamingLocations/7');
+		expect(parseEntryPathKey(key)).toEqual({
+			listKey: 'roamingLocations',
+			index: 7,
+		});
+	});
+
+	it('returns null for malformed keys (forward-compat — old shapes ignored)', () => {
+		expect(parseEntryPathKey('sections/0')).toBeNull();
+		expect(parseEntryPathKey('landmarks')).toBeNull();
+		expect(parseEntryPathKey('landmarks/oops')).toBeNull();
+		expect(parseEntryPathKey('unknown/1')).toBeNull();
+		expect(parseEntryPathKey('landmarks/3/box')).toBeNull();
+	});
+});
+
+describe('toggleEntry', () => {
+	it('adds an entry path that wasn’t in the set', () => {
+		const next = toggleEntry(new Set(), ['landmarks', 5]);
+		expect([...next]).toEqual(['landmarks/5']);
+	});
+
+	it('removes an entry path that was already in the set', () => {
+		const start = new Set(['landmarks/5', 'landmarks/7']);
+		const next = toggleEntry(start, ['landmarks', 5]);
+		expect([...next].sort()).toEqual(['landmarks/7']);
+	});
+
+	it('normalises sub-paths to the containing entry before toggling', () => {
+		const start = new Set<string>();
+		const next = toggleEntry(start, [
+			'landmarks',
+			5,
+			'box',
+			'position',
+			'x',
+		]);
+		expect([...next]).toEqual(['landmarks/5']);
+	});
+
+	it('treats different lists at the same index as independent entries', () => {
+		let s: ReadonlySet<string> = new Set();
+		s = toggleEntry(s, ['landmarks', 5]);
+		s = toggleEntry(s, ['blackspots', 5]);
+		s = toggleEntry(s, ['roamingLocations', 5]);
+		expect(s.size).toBe(3);
+		expect(s.has('landmarks/5')).toBe(true);
+		expect(s.has('blackspots/5')).toBe(true);
+		expect(s.has('roamingLocations/5')).toBe(true);
+	});
+
+	it('is a no-op for player-start singletons', () => {
+		const start = new Set(['landmarks/5']);
+		const next = toggleEntry(start, ['playerStartPosition']);
+		expect([...next]).toEqual([...start]);
+	});
+
+	it('is a no-op for paths outside any bulk-eligible list', () => {
+		const start = new Set(['landmarks/5']);
+		const next = toggleEntry(start, ['header', 'flags']);
+		expect([...next]).toEqual([...start]);
+	});
+});
+
+describe('rangeAddEntries', () => {
+	it('adds every entry between `from` and `to` inclusive in the same list', () => {
+		const next = rangeAddEntries(
+			new Set(),
+			['landmarks', 2],
+			['landmarks', 5],
+		);
+		expect([...next].sort()).toEqual([
+			'landmarks/2',
+			'landmarks/3',
+			'landmarks/4',
+			'landmarks/5',
+		]);
+	});
+
+	it('handles `from > to` by walking the range in reverse', () => {
+		const next = rangeAddEntries(
+			new Set(),
+			['blackspots', 5],
+			['blackspots', 2],
+		);
+		expect([...next].sort()).toEqual([
+			'blackspots/2',
+			'blackspots/3',
+			'blackspots/4',
+			'blackspots/5',
+		]);
+	});
+
+	it('falls back to "just add the endpoint" when there’s no anchor', () => {
+		const next = rangeAddEntries(new Set(), [], ['roamingLocations', 5]);
+		expect([...next]).toEqual(['roamingLocations/5']);
+	});
+
+	it('falls back to "just add the endpoint" when anchor and target differ in list', () => {
+		const next = rangeAddEntries(
+			new Set(),
+			['landmarks', 2],
+			['blackspots', 5],
+		);
+		expect([...next]).toEqual(['blackspots/5']);
+	});
+
+	it('unions into an existing set without dropping prior entries', () => {
+		const start = new Set(['landmarks/100', 'roamingLocations/9']);
+		const next = rangeAddEntries(start, ['landmarks', 0], ['landmarks', 1]);
+		expect([...next].sort()).toEqual([
+			'landmarks/0',
+			'landmarks/1',
+			'landmarks/100',
+			'roamingLocations/9',
+		]);
+	});
+
+	it('is a no-op when the target path isn’t bulk-eligible', () => {
+		const start = new Set(['landmarks/5']);
+		const next = rangeAddEntries(
+			start,
+			['landmarks', 0],
+			['playerStartPosition'],
+		);
+		expect([...next]).toEqual([...start]);
+	});
+});
+
+describe('applyPaths', () => {
+	it('adds every input path to an empty set', () => {
+		const next = applyPaths(
+			new Set(),
+			[
+				['landmarks', 1],
+				['blackspots', 2],
+				['roamingLocations', 3],
+			],
+			'add',
+		);
+		expect([...next].sort()).toEqual([
+			'blackspots/2',
+			'landmarks/1',
+			'roamingLocations/3',
+		]);
+	});
+
+	it('unions into a non-empty set without dropping prior entries', () => {
+		const start = new Set(['landmarks/9']);
+		const next = applyPaths(
+			start,
+			[
+				['landmarks', 1],
+				['landmarks', 2],
+			],
+			'add',
+		);
+		expect([...next].sort()).toEqual([
+			'landmarks/1',
+			'landmarks/2',
+			'landmarks/9',
+		]);
+	});
+
+	it('removes entries that exist in the set', () => {
+		const start = new Set([
+			'landmarks/1',
+			'landmarks/2',
+			'roamingLocations/3',
+		]);
+		const next = applyPaths(start, [['landmarks', 2]], 'remove');
+		expect([...next].sort()).toEqual(['landmarks/1', 'roamingLocations/3']);
+	});
+
+	it('is a no-op when removing entries that are not in the set', () => {
+		const start = new Set(['landmarks/1']);
+		const next = applyPaths(start, [['landmarks', 99]], 'remove');
+		expect([...next].sort()).toEqual(['landmarks/1']);
+	});
+
+	it('silently skips non-entry paths (mixed valid + invalid)', () => {
+		const next = applyPaths(
+			new Set(),
+			[
+				['landmarks', 1],
+				['header', 'flags'],
+				['playerStartPosition'],
+				['landmarks', 4],
+			],
+			'add',
+		);
+		expect([...next].sort()).toEqual(['landmarks/1', 'landmarks/4']);
+	});
+
+	it('normalises sub-paths to the containing entry before applying', () => {
+		// The marquee never emits sub-paths today, but this property keeps the
+		// API symmetric with `toggleEntry` so a future caller passing e.g. box-
+		// position paths still ends up with entry-level keys.
+		const next = applyPaths(
+			new Set(),
+			[
+				['landmarks', 5, 'box', 'position'],
+				['vfxBoxRegions', 7, 'box', 'dimensions', 'y'],
+			],
+			'add',
+		);
+		expect([...next].sort()).toEqual(['landmarks/5', 'vfxBoxRegions/7']);
+	});
+
+	it('handles every entry kind in the same call', () => {
+		const next = applyPaths(
+			new Set(),
+			[
+				['landmarks', 1],
+				['genericRegions', 1],
+				['blackspots', 1],
+				['vfxBoxRegions', 1],
+				['spawnLocations', 1],
+				['roamingLocations', 1],
+			],
+			'add',
+		);
+		expect([...next].sort()).toEqual([
+			'blackspots/1',
+			'genericRegions/1',
+			'landmarks/1',
+			'roamingLocations/1',
+			'spawnLocations/1',
+			'vfxBoxRegions/1',
+		]);
+	});
+});
+
+describe('pruneStaleEntries', () => {
+	it('drops entries whose index is at or beyond the new max', () => {
+		const start = new Set(['landmarks/0', 'landmarks/3', 'landmarks/10']);
+		const next = pruneStaleEntries(start, 'landmarks', 5);
+		expect([...next].sort()).toEqual(['landmarks/0', 'landmarks/3']);
+	});
+
+	it('only prunes the list it was asked about', () => {
+		const start = new Set(['landmarks/10', 'roamingLocations/10']);
+		const next = pruneStaleEntries(start, 'landmarks', 5);
+		expect([...next].sort()).toEqual(['roamingLocations/10']);
+	});
+
+	it('drops malformed keys (forward-compat sweep)', () => {
+		const start = new Set(['landmarks/0', 'sections/0/portals/1']);
+		const next = pruneStaleEntries(start, 'landmarks', 5);
+		expect([...next]).toEqual(['landmarks/0']);
+	});
+});

--- a/src/components/workspace/bulkPanelStack.helpers.ts
+++ b/src/components/workspace/bulkPanelStack.helpers.ts
@@ -3,18 +3,24 @@
 // without dragging in React.
 //
 // Why "most recently touched": a user curating multiple bulks (e.g.
-// V4 + V12 side-by-side comparison) wants the one they just edited at
-// the top of the stack so they don't lose track of it. Bundle load order
-// is the implicit tie-breaker because `summaries` walks the underlying
-// Map in insertion order — the comparator preserves that for equal
-// timestamps via a stable sort (`Array.prototype.sort` is stable in
-// every modern JS engine).
+// V4 + V12 side-by-side comparison, or AI sections + TriggerData regions)
+// wants the one they just edited at the top of the stack so they don't
+// lose track of it. Bundle load order is the implicit tie-breaker because
+// `summaries` walks the underlying Map in insertion order — the comparator
+// preserves that for equal timestamps via a stable sort
+// (`Array.prototype.sort` is stable in every modern JS engine).
 
-import type { WorkspaceAISectionsBulkSummary } from './AISectionsBulkProvider';
+/** Minimal shape every bulk summary the panel stack consumes shares —
+ *  defining the comparator over a structural type lets `sortBulkSummaries`
+ *  work uniformly across AI Sections, TriggerData, and any future
+ *  bulk-providing resource without per-key overloads. */
+export type SortableBulkSummary = {
+	lastTouchedAt: number;
+};
 
-export function sortBulkSummaries(
-	summaries: readonly WorkspaceAISectionsBulkSummary[],
-): WorkspaceAISectionsBulkSummary[] {
+export function sortBulkSummaries<T extends SortableBulkSummary>(
+	summaries: readonly T[],
+): T[] {
 	const out = [...summaries];
 	out.sort((a, b) => b.lastTouchedAt - a.lastTouchedAt);
 	return out;

--- a/src/components/workspace/triggerDataBulk.ts
+++ b/src/components/workspace/triggerDataBulk.ts
@@ -1,0 +1,187 @@
+// Pure helpers for the TriggerData bulk-select state.
+//
+// Lives in `.ts` (no React) so the unit tests under `__tests__/` can drive
+// the bulk reducer behaviour without dragging in the React + r3f graph that
+// `TriggerDataBulkProvider` imports. Mirrors `aiSectionsBulk.ts`.
+//
+// Domain notes (load-bearing for future agents):
+//   - TriggerData has SIX bulk-eligible top-level lists in the parsed model:
+//       landmarks / genericRegions / blackspots / vfxBoxRegions
+//       spawnLocations / roamingLocations
+//     Each entry is addressed by its containing list key + numeric index,
+//     e.g. `['landmarks', 3]` or `['roamingLocations', 5]`. Sub-paths under
+//     an entry (a position field, a box dimension) collapse to the parent
+//     entry path before they enter the bulk Set — bulk granularity is one
+//     entry, never a sub-field.
+//   - Player-start singletons (`['playerStartPosition']` /
+//     `['playerStartDirection']`) are NOT bulk-eligible — there's exactly
+//     one of each per resource so a "set of player-starts" is degenerate.
+//     Tree-row Ctrl/Shift on those paths falls through to plain selection.
+//   - Bulk Set keys are ALWAYS the schema-path string `parts.join('/')`
+//     so a single Set can mix entry kinds (`'landmarks/3'`,
+//     `'roamingLocations/5'`). The hierarchy tree paints rows whose
+//     `schemaPath.join('/')` is in the Set; the 3D overlay translates the
+//     subset its hooks care about into Selection-keyed shapes.
+
+import type { NodePath } from '@/lib/schema/walk';
+
+/** The six top-level lists whose entries can enter the bulk. Player-start
+ *  singletons are intentionally absent — see file header. */
+const BULK_LIST_KEYS = new Set<string>([
+	'landmarks',
+	'genericRegions',
+	'blackspots',
+	'vfxBoxRegions',
+	'spawnLocations',
+	'roamingLocations',
+]);
+
+/** Discriminated address of a bulk-eligible entry inside a TriggerData
+ *  resource. The `listKey` is the parsed-model field name (matches the
+ *  schema path's first segment); `index` is the position in that list. */
+export type EntryAddress = {
+	listKey: string;
+	index: number;
+};
+
+/**
+ * Normalise an arbitrary schema path inside a TriggerData resource to the
+ * containing entry path. Returns null when the path doesn't address a bulk-
+ * eligible entry (or anything underneath one) — those paths are not bulk-
+ * eligible and the caller should fall through to plain navigation.
+ *
+ * Examples:
+ *   ['landmarks', 3]                              → ['landmarks', 3]
+ *   ['landmarks', 3, 'box', 'position', 'x']      → ['landmarks', 3]
+ *   ['roamingLocations', 5]                       → ['roamingLocations', 5]
+ *   ['roamingLocations', 5, 'position']           → ['roamingLocations', 5]
+ *   ['playerStartPosition']                       → null   (singleton)
+ *   ['header', 'flags']                           → null
+ */
+export function normaliseToEntryPath(path: NodePath): NodePath | null {
+	const addr = parseEntryAddress(path);
+	if (!addr) return null;
+	return [addr.listKey, addr.index];
+}
+
+/**
+ * Decode the entry address (listKey + index) from any schema path inside a
+ * TriggerData resource. Sub-paths under an entry collapse to the entry
+ * itself. Returns null when the path doesn't address a bulk-eligible list
+ * — the caller should treat that as "not bulk-eligible".
+ */
+export function parseEntryAddress(path: NodePath): EntryAddress | null {
+	if (path.length < 2) return null;
+	const head = path[0];
+	if (typeof head !== 'string') return null;
+	if (!BULK_LIST_KEYS.has(head)) return null;
+	const idx = path[1];
+	if (typeof idx !== 'number') return null;
+	return { listKey: head, index: idx };
+}
+
+/** Stable string key for the bulk `Set<string>`. Identity = `path.join('/')`. */
+export function entryPathKey(path: NodePath): string {
+	return path.join('/');
+}
+
+/** Inverse of `entryPathKey` — parse a stored key back into the entry
+ *  address it represents. Returns null when the key isn't a bulk-eligible
+ *  entry path (e.g. a malformed key from a previous shape). */
+export function parseEntryPathKey(key: string): EntryAddress | null {
+	const parts = key.split('/');
+	if (parts.length !== 2) return null;
+	const listKey = parts[0];
+	if (!BULK_LIST_KEYS.has(listKey)) return null;
+	const idx = Number(parts[1]);
+	if (!Number.isFinite(idx)) return null;
+	return { listKey, index: idx };
+}
+
+// ---------------------------------------------------------------------------
+// Pure reducers — exported for unit tests under `__tests__/`.
+// ---------------------------------------------------------------------------
+
+/** Toggle an entry's membership. Sub-paths are normalised to their parent
+ *  entry before the toggle. Non-entry paths are no-ops (returns input). */
+export function toggleEntry(
+	prev: ReadonlySet<string>,
+	path: NodePath,
+): Set<string> {
+	const norm = normaliseToEntryPath(path);
+	const next = new Set(prev);
+	if (!norm) return next;
+	const key = entryPathKey(norm);
+	if (next.has(key)) next.delete(key);
+	else next.add(key);
+	return next;
+}
+
+/** Add every entry between `from` and `to` (inclusive) to the set, but only
+ *  when both endpoints sit in the SAME list (`landmarks` to `landmarks`).
+ *  Cross-list or no-anchor pairs degrade gracefully to "just add the
+ *  endpoint" so shift-click always produces at least one new entry.
+ *  Mirrors `aiSectionsBulk.rangeAddSections`'s same-variant-only semantics. */
+export function rangeAddEntries(
+	prev: ReadonlySet<string>,
+	from: NodePath,
+	to: NodePath,
+): Set<string> {
+	const next = new Set(prev);
+	const toAddr = parseEntryAddress(to);
+	if (!toAddr) return next;
+	const fromAddr = parseEntryAddress(from);
+	// No anchor or cross-list: just add the endpoint.
+	if (!fromAddr || fromAddr.listKey !== toAddr.listKey) {
+		next.add(entryPathKey(normaliseToEntryPath(to)!));
+		return next;
+	}
+	const lo = Math.min(fromAddr.index, toAddr.index);
+	const hi = Math.max(fromAddr.index, toAddr.index);
+	for (let i = lo; i <= hi; i++) {
+		next.add(entryPathKey([toAddr.listKey, i]));
+	}
+	return next;
+}
+
+/** Batch-apply a list of paths to the bulk set in one pass — `'add'` unions
+ *  them in, `'remove'` subtracts them. Mirrors `toggleEntry`'s normalisation:
+ *  each input path is collapsed to its containing entry before the
+ *  membership change, and non-entry paths are silently skipped so the marquee
+ *  can pass arbitrary `[listKey, i]`-shaped hits without per-element pre-
+ *  validation. Single-pass collapse (vs. N `toggleEntry` calls) is the whole
+ *  point — the 3D marquee can hit hundreds of entries in one drag and we
+ *  want one Set rebuild, not N. */
+export function applyPaths(
+	prev: ReadonlySet<string>,
+	paths: ReadonlyArray<NodePath>,
+	mode: 'add' | 'remove',
+): Set<string> {
+	const next = new Set(prev);
+	for (const p of paths) {
+		const norm = normaliseToEntryPath(p);
+		if (!norm) continue;
+		const key = entryPathKey(norm);
+		if (mode === 'add') next.add(key);
+		else next.delete(key);
+	}
+	return next;
+}
+
+/** Filter a bulk set to only entries whose index is within `[0, maxIndex)`
+ *  for the given list. Used when the underlying model shrinks (e.g. an entry
+ *  was deleted) so stale keys don't paint rows that no longer exist. */
+export function pruneStaleEntries(
+	prev: ReadonlySet<string>,
+	listKey: string,
+	maxIndex: number,
+): Set<string> {
+	const next = new Set<string>();
+	for (const key of prev) {
+		const addr = parseEntryPathKey(key);
+		if (!addr) continue;
+		if (addr.listKey === listKey && addr.index >= maxIndex) continue;
+		next.add(key);
+	}
+	return next;
+}

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -64,6 +64,7 @@ import {
 	useWorkspacePSLBulk,
 } from '@/components/workspace/PSLBulkProvider';
 import { AISectionsBulkProvider } from '@/components/workspace/AISectionsBulkProvider';
+import { TriggerDataBulkProvider } from '@/components/workspace/TriggerDataBulkProvider';
 import { BulkPanelStack } from '@/components/workspace/BulkPanelStack';
 import { BulkImportDialog } from '@/components/workspace/BulkImportDialog';
 import { BundleExportValidationDialog } from '@/components/workspace/BundleExportValidationDialog';
@@ -789,7 +790,9 @@ function WorkspaceBulkWrapper({ children }: { children: React.ReactNode }) {
 			isVisible={isVisible}
 		>
 			<AISectionsBulkProvider bundles={bundles}>
-				{children}
+				<TriggerDataBulkProvider bundles={bundles}>
+					{children}
+				</TriggerDataBulkProvider>
 			</AISectionsBulkProvider>
 		</PSLBulkProvider>
 	);


### PR DESCRIPTION
Migrates **TriggerData** from the legacy `useSchemaBulkSelection` channel to the workspace bulk pattern shipped for AI Sections in #58 (commits `6f99f59` + `1c76cbf`). After this lands, AI Sections + TriggerData both speak the same dispatch dialect; PSL and TrafficData remain on the legacy channel.

Closes #60.

## What changed

### Pure helpers + provider (commit 1)
- `src/components/workspace/triggerDataBulk.ts` — pure reducer module (`toggleEntry` / `rangeAddEntries` / `applyPaths` / `pruneStaleEntries`) + path codec. The bulk-eligible top-level lists are `landmarks`, `genericRegions`, `blackspots`, `vfxBoxRegions`, `spawnLocations`, `roamingLocations`. Player-start singletons are intentionally excluded — a "set of one" is degenerate.
- `src/components/workspace/TriggerDataBulkProvider.tsx` — workspace-wide owner mounting two contexts (`TriggerDataBulkContext` for the overlay, `WorkspaceTriggerDataBulkContext` for the hierarchy + panel stack). Bulk persists across selection changes (matches AI's deviation from PSL's instance-switch reset). Each `(bundleId, index)` has its own Set; closed bundles prune in-render.

### Wiring (commit 2)
- `WorkspacePage.tsx` mounts `TriggerDataBulkProvider` next to the existing AISections one.
- `TriggerDataOverlay.tsx` swaps `useSchemaBulkSelection` for `useTriggerDataBulk().forInstance(bundleId, index)`; marquee dispatch goes through `onApplyPaths`. Marquee centroid collector extracted as exported pure function (`collectMarqueeHits`) so it's testable without mounting r3f.
- `WorkspaceHierarchy.tsx` widens the schema-row Ctrl/Shift dispatch to cover `triggerData` paths.
- `BulkPanelStack.tsx` iterates both AI Sections and TriggerData bulks. The TriggerData panel body is minimal (just `[Clear]`) until a bulk-edit UI is designed — per the issue body's deferral.
- `sortBulkSummaries` widened to a structural type so it sorts panels from any provider.

## Acceptance criteria

- [x] New `TriggerDataBulkProvider` mounted in `WorkspacePage` alongside existing providers
- [x] Marquee in `TriggerDataOverlay` routes through the new provider; legacy `useSchemaBulkSelection` consumption removed from this overlay
- [x] Tree-row Ctrl/Shift dispatch in `WorkspaceHierarchy` widened to cover TriggerData paths
- [x] `BulkPanelStack` shows a panel for non-empty TriggerData bulks (header navigates to instance, ✕ clears)
- [x] Pure-helper unit tests (full coverage on the new reducer)
- [x] Marquee centroid hit-test test
- [x] No regression: AI sections / PSL / TrafficData bulks still work as before
- [x] No new TS errors in touched paths

## How verified

**Tests added:**
- `src/components/workspace/__tests__/triggerDataBulk.test.ts` — 33 cases covering `parseEntryAddress`, `normaliseToEntryPath`, `entryPathKey` round-trip, `toggleEntry`, `rangeAddEntries`, `applyPaths`, `pruneStaleEntries`.
- `src/components/schema-editor/viewports/__tests__/TriggerDataOverlay.bulk.test.ts` — 4 cases pinning the marquee centroid projection (boxes use `box.position`, spawns/roams use `position`, player-start singletons excluded, empty-frustum returns `[]`).

**Commands run:**
```bash
node ./node_modules/vitest/vitest.mjs run \
  src/components/workspace/__tests__/triggerDataBulk.test.ts \
  src/components/schema-editor/viewports/__tests__/TriggerDataOverlay.bulk.test.ts
# → 37 passed

node ./node_modules/vitest/vitest.mjs run \
  src/components/workspace/__tests__/ \
  src/components/schema-editor/viewports/__tests__/
# → 100 passed across 8 files (no regressions in AISections / PSL / BulkPanelStack)

node ./node_modules/vitest/vitest.mjs run src/components/workspace/
# → 145 passed across 7 files (incl. WorkspaceHierarchy.test + WorldViewportComposition.test)

npx tsc --noEmit
# → no errors
```

A wider `npx vitest run` shows pre-existing failures in `aiSectionsLegacy.test.ts`, `applyExport.test.ts`, `exportPlan.test.ts`, `aiSectionsV4toV12.test.ts`, `trafficDataV22toV45.test.ts`, `aiSections/v4.test.ts`, `registry.test.ts`, `trafficData.test.ts` — all caused by missing fixture files (`example/older builds/AI.dat` ENOENT) or a 5s timeout under parallel load (`trafficDataGltf.test.ts` passes in isolation). None reference `TriggerData*` / `triggerDataBulk` / `BulkPanelStack`.

## Caveats

- Browser-verification not performed — no fixture handy in this environment with TriggerData populated to drive marquee + tree-row Ctrl/Shift end-to-end interactively. The pure-helper tests + marquee centroid test cover the load-bearing dispatch contract; a manual sanity pass with a live bundle is recommended before merging if reviewer wants extra confidence.
- The marquee currently only paints `roamingLocations` entries in 3D (translated into the `useInstancedSelection` hook's Selection-key shape). Other bulk-member kinds (landmarks / generic / blackspots / vfx / spawn) participate in the bulk Set, count badge, and panel stack, but the per-kind 3D paint loop isn't extended yet — that's a natural follow-up once a TriggerData-specific aggregate editor design lands.
- File size of `BulkPanelStack.tsx` is now 414 lines (above the 300-line CLAUDE.md soft cap). Splitting `TriggerDataBulkPanel` into its own file is a clean follow-up but not load-bearing — the file is still one cohesive concern (panel stack + per-resource panels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)