### PR TITLE
refactor(schema-editor): narrow SchemaExtensionProps to NodePath-rooted view (closes #56)

### DIFF
--- a/src/components/schema-editor/InspectorPanel.tsx
+++ b/src/components/schema-editor/InspectorPanel.tsx
@@ -290,7 +290,8 @@ function CustomExtensionGroup({
 	path: NodePath;
 	value: unknown;
 }) {
-	const { data, resource, updateAtPath, setAtPath, getExtension } = useSchemaEditor();
+	const { data, resource, updateAtPath, setAtPath, getExtension, selectPath } =
+		useSchemaEditor();
 	const Component = getExtension(componentName);
 	if (!Component) {
 		return (
@@ -304,6 +305,7 @@ function CustomExtensionGroup({
 			path={path}
 			value={value}
 			setValue={(next) => updateAtPath(path, () => next)}
+			selectChild={(rel) => selectPath([...path, ...rel])}
 			setData={(next) => setAtPath([], next)}
 			data={data}
 			resource={resource}

--- a/src/components/schema-editor/context.tsx
+++ b/src/components/schema-editor/context.tsx
@@ -23,27 +23,57 @@ import {
 // Extension registry
 // ---------------------------------------------------------------------------
 
-// Props passed to any React component registered as a custom field renderer
-// via schema.kind === 'custom' or propertyGroup.component. Same mental model
-// as visual-react's EditingExtensionProps — the extension gets the value at
-// its path, a setter, and the full root for cross-ref lookups.
-export type SchemaExtensionProps = {
+// Props passed to a schema-editor extension component (registered via
+// `{ kind: 'custom', component }` on a field, or `propertyGroup.component`
+// on a record). The default contract is deliberately narrow: an extension
+// gets a path-rooted view of one node and the means to mutate / navigate
+// inside it.
+//
+// If an extension genuinely owns the whole resource (e.g., a list-of-X tab
+// that pages through siblings the schema can't address from a single node),
+// type its props as `WholeResourceExtensionProps` and add a comment line
+// justifying why the wider surface is needed. Don't widen
+// `SchemaExtensionProps` itself — the narrow form is the default for a
+// reason: every extra field on the prop bag is friction for whoever writes
+// the next extension.
+export type SchemaExtensionProps<T = unknown> = {
 	/** Path to the value this extension owns. */
 	path: NodePath;
 	/** Current value at `path`. */
-	value: unknown;
+	value: T;
 	/** Replace the value at `path`. */
-	setValue: (next: unknown) => void;
-	/** Replace the entire resource root. Useful for legacy tab adapters
-	 * whose contract is `(data, onChange(data)) => JSX`. */
-	setData: (next: unknown) => void;
+	setValue: (next: T) => void;
+	/** Move the editor's selection to a node relative to this extension's
+	 * `path` (`rel` is appended to `path`). Pass `[]` to re-select this
+	 * extension's own node. */
+	selectChild: (rel: NodePath) => void;
+};
+
+// Props for extensions that genuinely operate on the resource as a whole
+// — typically root-level tabs whose pre-schema contract was
+// `(data, onChange(data)) => JSX`, or list tabs that need to walk sibling
+// arrays the schema can't reach from a single node. Each call site that
+// uses this type should justify it with a one-line comment.
+export type WholeResourceExtensionProps<T = unknown> = SchemaExtensionProps<T> & {
 	/** Full resource root — read-only for cross-reference lookups. */
 	data: unknown;
+	/** Replace the entire resource root. Mirrors the legacy tab contract
+	 * `(data, onChange(data)) => JSX`. */
+	setData: (next: unknown) => void;
 	/** The resource schema — for ref target resolution. */
 	resource: ResourceSchema;
 };
 
-export type SchemaExtension = React.ComponentType<SchemaExtensionProps>;
+// The registry stores components in their type-erased form. Runtime
+// always hands them the full `WholeResourceExtensionProps` prop bag;
+// each component's declared props (narrow or wide) decide what's
+// observed on the consumer side. Using `any` for `value` lets us put
+// both `React.FC<SchemaExtensionProps<ChallengeListEntry>>` and
+// `React.FC<WholeResourceExtensionProps>` in the same map without
+// fighting variance.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- variance escape hatch for the heterogeneous registry; see comment above.
+export type SchemaExtension = React.ComponentType<WholeResourceExtensionProps<any>>;
 export type ExtensionRegistry = Record<string, SchemaExtension>;
 
 // ---------------------------------------------------------------------------

--- a/src/components/schema-editor/extensions/__tests__/extensionContract.test.ts
+++ b/src/components/schema-editor/extensions/__tests__/extensionContract.test.ts
@@ -1,0 +1,170 @@
+// Spec test for the schema-editor extension contract.
+//
+// These tests are about the registry shape and the narrow-vs-whole-resource
+// type distinction — not the rendered output (vitest runs in a node env
+// without jsdom in this repo). Each registry below is the exact map every
+// production page passes to <SchemaEditorProvider extensions={...}>; the
+// goal here is a lightweight regression net: if someone renames a key or
+// drops an extension by accident, the per-resource expectation list catches
+// it before the schema page silently shows "Extension not registered".
+//
+// Why the leaflet stub: the triggerDataExtensions registry imports
+// RegionsMap, which pulls in leaflet, which touches `window` at module
+// load time. The repo's vitest env is `node`, so we shim those before
+// the registries are imported.
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Stub leaflet + react-leaflet so triggerDataExtensions' RegionsMap import
+// doesn't blow up at module-load time in a node env.
+vi.mock('leaflet', () => ({ default: {}, Icon: class {}, latLngBounds: () => ({}) }));
+vi.mock('react-leaflet', () => ({
+	MapContainer: () => null,
+	TileLayer: () => null,
+	Rectangle: () => null,
+	useMap: () => ({}),
+	Marker: () => null,
+	Popup: () => null,
+}));
+
+// Imports below must happen after the vi.mock calls; vitest hoists them
+// automatically but we still keep the order tidy for readability.
+import { aiSectionsExtensions } from '../aiSectionsExtensions';
+import { challengeListExtensions } from '../challengeListExtensions';
+import { polygonSoupListExtensions } from '../collisionTagExtension';
+import { renderableExtensions } from '../renderableExtensions';
+import { streetDataExtensions } from '../streetDataExtensions';
+import { trafficDataExtensions } from '../trafficDataExtensions';
+import { triggerDataExtensions } from '../triggerDataExtensions';
+import { vehicleListExtensions } from '../vehicleListExtensions';
+import type {
+	SchemaExtensionProps,
+	WholeResourceExtensionProps,
+} from '../../context';
+
+describe('schema-editor extension registries', () => {
+	const registries = {
+		aiSections: aiSectionsExtensions,
+		challengeList: challengeListExtensions,
+		polygonSoupList: polygonSoupListExtensions,
+		renderable: renderableExtensions,
+		streetData: streetDataExtensions,
+		trafficData: trafficDataExtensions,
+		triggerData: triggerDataExtensions,
+		vehicleList: vehicleListExtensions,
+	};
+
+	// Minimum keys each page needs the registry to expose. If a key is
+	// missing the schema's `customRenderer` / `propertyGroup.component`
+	// fall-through path renders a yellow warning — see CustomField.tsx —
+	// which would silently regress the UI. This test makes the link
+	// explicit.
+	const expectedKeysByResource: Record<keyof typeof registries, string[]> = {
+		aiSections: [
+			'AISectionsOverview',
+			'AISectionsList',
+			'AISectionsResetPairs',
+			'AISectionEdges',
+		],
+		challengeList: [
+			'ChallengeOverviewTab',
+			'ChallengeAction1Tab',
+			'ChallengeAction2Tab',
+		],
+		polygonSoupList: ['collisionTag'],
+		renderable: ['RenderableCard', 'RenderableMeshCard'],
+		streetData: [
+			'StreetDataOverviewTab',
+			'StreetsTab',
+			'JunctionsTab',
+			'RoadsTab',
+			'ChallengesTab',
+		],
+		trafficData: [
+			'SectionsTab',
+			'LaneRungsTab',
+			'FlowTypesTab',
+			'PaintColoursTab',
+			'OverviewTab',
+			'KillZonesTab',
+			'VehiclesTab',
+			'TrafficLightsTab',
+		],
+		triggerData: [
+			'HeaderTab',
+			'RegionsMapTab',
+			'LandmarksTab',
+			'GenericRegionsTab',
+			'BlackspotsTab',
+			'VfxTab',
+			'SignatureStuntsTab',
+			'KillzonesTab',
+			'RoamingTab',
+			'SpawnsTab',
+		],
+		vehicleList: ['VehicleEditorTab'],
+	};
+
+	for (const [resourceKey, registry] of Object.entries(registries) as [
+		keyof typeof registries,
+		(typeof registries)[keyof typeof registries],
+	][]) {
+		const expected = expectedKeysByResource[resourceKey];
+		it(`${resourceKey}: registers exactly the expected keys`, () => {
+			expect(Object.keys(registry).sort()).toEqual([...expected].sort());
+		});
+
+		it(`${resourceKey}: every entry is a function-typed component`, () => {
+			for (const [key, component] of Object.entries(registry)) {
+				expect(typeof component, `${resourceKey}.${key}`).toBe('function');
+			}
+		});
+	}
+
+	// Total count surfaces in the PR review summary. If a future change
+	// adds or removes an extension, this number changes and the diff is
+	// obvious. Not a load-bearing assertion — drop / bump as needed.
+	it('total registered extension count is 34', () => {
+		const total = Object.values(registries).reduce(
+			(acc, reg) => acc + Object.keys(reg).length,
+			0,
+		);
+		expect(total).toBe(34);
+	});
+});
+
+describe('SchemaExtensionProps / WholeResourceExtensionProps relationship', () => {
+	// These are compile-time spec checks. The body is a pure type assertion;
+	// at runtime the test just verifies the values pass through. The point
+	// is that someone refactoring the types has to keep these compiling.
+	it('WholeResourceExtensionProps satisfies SchemaExtensionProps (subtype)', () => {
+		const wide: WholeResourceExtensionProps<number> = {
+			path: ['x', 1],
+			value: 42,
+			setValue: () => {},
+			selectChild: () => {},
+			data: null,
+			setData: () => {},
+			resource: { rootType: 'X', registry: {} } as never,
+		};
+		// If WholeResourceExtensionProps<T> is a structural superset of
+		// SchemaExtensionProps<T>, this assignment compiles. If someone
+		// drops a narrow field from the wide variant, this line will fail
+		// to type-check.
+		const narrow: SchemaExtensionProps<number> = wide;
+		expect(narrow.value).toBe(42);
+	});
+
+	it('SchemaExtensionProps default value type is unknown', () => {
+		// Default generic should be `unknown` — preserves type safety
+		// while letting extensions that don't care about value still
+		// type-check without specifying the parameter.
+		const narrow: SchemaExtensionProps = {
+			path: [],
+			value: 'anything',
+			setValue: () => {},
+			selectChild: () => {},
+		};
+		expect(narrow.value).toBe('anything');
+	});
+});

--- a/src/components/schema-editor/extensions/aiSectionsExtensions.tsx
+++ b/src/components/schema-editor/extensions/aiSectionsExtensions.tsx
@@ -1,16 +1,21 @@
 // Adapters that wrap the legacy AISections tab components as schema-editor
 // extensions. Each adapter translates between:
-//   - the schema editor's `(path, value, setValue, setData, data, resource)`
-//     extension contract, and
+//   - the schema editor's narrow / whole-resource extension contracts, and
 //   - the tabs' original `(data, onChange, ...)` props.
 //
 // This is what lets the schema-driven page reuse the existing Overview +
 // SectionsList + ResetPairsTable UIs verbatim while the schema still owns
 // tree navigation, per-section inspection, and round-trip walks.
+//
+// Most adapters here are `WholeResourceExtensionProps` because the legacy
+// tabs were authored against the resource root — they fan out across
+// `sections`, `sectionResetPairs`, etc. The per-section edges adapter
+// genuinely needs the root too (it cross-references other sections to
+// resolve duplicate-edge targets) so it stays whole-resource even though
+// `path` points at a single section.
 
 import React, { useRef, useState } from 'react';
-import type { SchemaExtensionProps, ExtensionRegistry } from '../context';
-import { useSchemaEditor } from '../context';
+import type { WholeResourceExtensionProps, ExtensionRegistry } from '../context';
 import type { ParsedAISectionsV12, AISection } from '@/lib/core/aiSections';
 import { AISectionsOverview } from '@/components/aisections/AISectionsOverview';
 import { ResetPairsTable } from '@/components/aisections/ResetPairsTable';
@@ -22,7 +27,11 @@ import { EdgesList } from '@/components/aisections/EdgesList';
 // Overview — root-level propertyGroup extension
 // ---------------------------------------------------------------------------
 
-export const AISectionsOverviewExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => (
+// WholeResource: legacy overview tab that operates on the full root.
+export const AISectionsOverviewExtension: React.FC<WholeResourceExtensionProps> = ({
+	data,
+	setData,
+}) => (
 	<AISectionsOverview
 		data={data as ParsedAISectionsV12}
 		onChange={setData as (next: ParsedAISectionsV12) => void}
@@ -37,8 +46,15 @@ export const AISectionsOverviewExtension: React.FC<SchemaExtensionProps> = ({ da
 // modal dialog; under the schema editor it navigates the tree selection
 // to the clicked section instead, so the inspector takes over with the
 // Identity / Portals / NoGo Lines / Corners tabs declared on AISection.
-export const AISectionsListExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => {
-	const { selectPath } = useSchemaEditor();
+//
+// WholeResource: list tab needs the full sections array; selectChild is
+// relative to the extension's path (which is the root for a property-group
+// tab) so `['sections', i]` lands on the right section.
+export const AISectionsListExtension: React.FC<WholeResourceExtensionProps> = ({
+	data,
+	setData,
+	selectChild,
+}) => {
 	const scrollToIndexRef = useRef<((index: number) => void) | null>(null);
 	const [addOpen, setAddOpen] = useState(false);
 
@@ -50,7 +66,7 @@ export const AISectionsListExtension: React.FC<SchemaExtensionProps> = ({ data, 
 		onChange({ ...parsed, sections: [...parsed.sections, section] });
 		// Select the freshly added section so the inspector jumps to it.
 		requestAnimationFrame(() => {
-			selectPath(['sections', newIndex]);
+			selectChild(['sections', newIndex]);
 		});
 	};
 
@@ -60,7 +76,7 @@ export const AISectionsListExtension: React.FC<SchemaExtensionProps> = ({ data, 
 				data={parsed}
 				onChange={onChange}
 				onAddClick={() => setAddOpen(true)}
-				onDetailClick={(i) => selectPath(['sections', i])}
+				onDetailClick={(i) => selectChild(['sections', i])}
 				scrollToIndexRef={scrollToIndexRef}
 			/>
 			<AddSectionDialog open={addOpen} onOpenChange={setAddOpen} onAdd={handleAdd} />
@@ -72,7 +88,11 @@ export const AISectionsListExtension: React.FC<SchemaExtensionProps> = ({ data, 
 // Reset pairs — customRenderer on root.sectionResetPairs
 // ---------------------------------------------------------------------------
 
-export const AISectionsResetPairsExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => (
+// WholeResource: legacy reset-pairs tab operates on the full root.
+export const AISectionsResetPairsExtension: React.FC<WholeResourceExtensionProps> = ({
+	data,
+	setData,
+}) => (
 	<ResetPairsTable
 		data={data as ParsedAISectionsV12}
 		onChange={setData as (next: ParsedAISectionsV12) => void}
@@ -92,7 +112,12 @@ export const AISectionsResetPairsExtension: React.FC<SchemaExtensionProps> = ({ 
 // srcIdx]`. We pull `srcIdx` from the path rather than counting indices in
 // the parent, so the operation stays correct regardless of how the user
 // got here (tree click, breadcrumb, programmatic selection).
-export const AISectionEdgesExtension: React.FC<SchemaExtensionProps> = ({ path, value, data }) => {
+//
+// WholeResource: the EdgesList resolves duplicate-edge targets across
+// other sections, so the full `ParsedAISectionsV12` model is required.
+export const AISectionEdgesExtension: React.FC<
+	WholeResourceExtensionProps<AISection | undefined>
+> = ({ path, value, data }) => {
 	if (path.length < 2 || path[0] !== 'sections' || typeof path[1] !== 'number') {
 		return (
 			<div className="text-xs text-muted-foreground">
@@ -101,7 +126,7 @@ export const AISectionEdgesExtension: React.FC<SchemaExtensionProps> = ({ path, 
 		);
 	}
 	const srcIdx = path[1];
-	const section = value as AISection | undefined;
+	const section = value;
 	const model = data as ParsedAISectionsV12;
 	if (!section) {
 		return <div className="text-xs text-muted-foreground">No section selected.</div>;

--- a/src/components/schema-editor/extensions/challengeListExtensions.tsx
+++ b/src/components/schema-editor/extensions/challengeListExtensions.tsx
@@ -20,7 +20,11 @@
 // root — structural sharing keeps siblings untouched.
 
 import React, { useMemo } from 'react';
-import type { SchemaExtensionProps, ExtensionRegistry } from '../context';
+import type {
+	SchemaExtensionProps,
+	WholeResourceExtensionProps,
+	ExtensionRegistry,
+} from '../context';
 import type {
 	ChallengeListEntry,
 	ChallengeListEntryAction,
@@ -117,7 +121,10 @@ function computeStats(data: ParsedChallengeList): OverviewStats {
 // Root-level extension — overview statistics
 // ---------------------------------------------------------------------------
 
-export const ChallengeOverviewExtension: React.FC<SchemaExtensionProps> = ({ data }) => {
+// WholeResource: this is a root-level overview that aggregates stats across
+// every challenge in the resource — the narrow per-node view doesn't reach
+// siblings.
+export const ChallengeOverviewExtension: React.FC<WholeResourceExtensionProps> = ({ data }) => {
 	const typed = data as ParsedChallengeList;
 	const stats = useMemo(() => computeStats(typed), [typed]);
 	return <ChallengeOverview data={typed} stats={stats} />;
@@ -133,9 +140,12 @@ type ActionExtensionFactoryOptions = {
 
 function makeActionExtension(
 	{ actionIndex }: ActionExtensionFactoryOptions,
-): React.FC<SchemaExtensionProps> {
-	const Component: React.FC<SchemaExtensionProps> = ({ value, setValue }) => {
-		const challenge = value as ChallengeListEntry | undefined;
+): React.FC<SchemaExtensionProps<ChallengeListEntry | undefined>> {
+	const Component: React.FC<SchemaExtensionProps<ChallengeListEntry | undefined>> = ({
+		value,
+		setValue,
+	}) => {
+		const challenge = value;
 		if (!challenge || !Array.isArray(challenge.actions)) {
 			return (
 				<div className="text-sm text-muted-foreground">

--- a/src/components/schema-editor/extensions/collisionTagExtension.tsx
+++ b/src/components/schema-editor/extensions/collisionTagExtension.tsx
@@ -203,7 +203,10 @@ export function FlagCheckbox({ label, value, onChange, disabled }: FlagCheckboxP
 // Main extension — decoded inspector for a single polygon's collisionTag
 // ---------------------------------------------------------------------------
 
-export const CollisionTagExtension: React.FC<SchemaExtensionProps> = ({ value, setValue }) => {
+export const CollisionTagExtension: React.FC<SchemaExtensionProps<number>> = ({
+	value,
+	setValue,
+}) => {
 	const raw = (typeof value === 'number' ? value : 0) >>> 0;
 	const decoded = decodeCollisionTag(raw);
 

--- a/src/components/schema-editor/extensions/renderableExtensions.tsx
+++ b/src/components/schema-editor/extensions/renderableExtensions.tsx
@@ -353,6 +353,9 @@ function NotDecodedHint() {
 // ---------------------------------------------------------------------------
 
 // Full-renderable view — shows every mesh's card stacked vertically.
+// Narrow: reads `path` to look up its renderable in the decoded-renderable
+// React context, which is separate from the schema editor's `data`. No
+// cross-tree access needed.
 export const RenderableCardExtension: React.FC<SchemaExtensionProps> = ({ path }) => {
 	const ctx = useRenderableDecoded();
 	const wi = path[0] === 'renderables' && typeof path[1] === 'number' ? (path[1] as number) : null;
@@ -385,7 +388,8 @@ export const RenderableCardExtension: React.FC<SchemaExtensionProps> = ({ path }
 	);
 };
 
-// Single-mesh view — like the full card but scoped to one mesh row.
+// Single-mesh view — like the full card but scoped to one mesh row. Narrow
+// for the same reason as RenderableCardExtension above.
 export const RenderableMeshCardExtension: React.FC<SchemaExtensionProps> = ({ path }) => {
 	const ctx = useRenderableDecoded();
 	const wi = path[0] === 'renderables' && typeof path[1] === 'number' ? (path[1] as number) : null;

--- a/src/components/schema-editor/extensions/streetDataExtensions.tsx
+++ b/src/components/schema-editor/extensions/streetDataExtensions.tsx
@@ -4,14 +4,13 @@
 // inlined inside StreetDataEditor.tsx) so the schema editor can reuse them
 // as custom renderers without rewriting the per-row edit logic.
 //
-// The contract is identical to trafficDataExtensions.tsx — an adapter
-// receives `(path, value, setValue, setData, data, resource)` and delegates
-// to a classic `{ data, onChange }` tab by passing `setData` through as
-// `onChange`. Tabs only ever mutate their own list, so behavior matches
-// the pre-schema editor.
+// All five adapters take `WholeResourceExtensionProps`: the legacy tabs
+// were authored against the resource root (`{ data, onChange }`) and
+// fan out across multiple sibling arrays, which the narrow per-node view
+// can't reach.
 
 import React from 'react';
-import type { SchemaExtensionProps, ExtensionRegistry } from '../context';
+import type { WholeResourceExtensionProps, ExtensionRegistry } from '../context';
 import type { ParsedStreetData } from '@/lib/core/streetData';
 
 import { OverviewTab } from '@/components/streetdata/OverviewTab';
@@ -21,10 +20,10 @@ import { RoadsTab } from '@/components/streetdata/RoadsTab';
 import { ChallengesTab } from '@/components/streetdata/ChallengesTab';
 
 // ---------------------------------------------------------------------------
-// Adapters
+// Adapters — every one is WholeResource (legacy whole-tree tabs).
 // ---------------------------------------------------------------------------
 
-export const StreetDataOverviewExtension: React.FC<SchemaExtensionProps> = ({
+export const StreetDataOverviewExtension: React.FC<WholeResourceExtensionProps> = ({
 	data,
 	setData,
 }) => (
@@ -34,28 +33,28 @@ export const StreetDataOverviewExtension: React.FC<SchemaExtensionProps> = ({
 	/>
 );
 
-export const StreetsExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => (
+export const StreetsExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<StreetsTab
 		data={data as ParsedStreetData}
 		onChange={setData as (next: ParsedStreetData) => void}
 	/>
 );
 
-export const JunctionsExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => (
+export const JunctionsExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<JunctionsTab
 		data={data as ParsedStreetData}
 		onChange={setData as (next: ParsedStreetData) => void}
 	/>
 );
 
-export const RoadsExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => (
+export const RoadsExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<RoadsTab
 		data={data as ParsedStreetData}
 		onChange={setData as (next: ParsedStreetData) => void}
 	/>
 );
 
-export const ChallengesExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => (
+export const ChallengesExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<ChallengesTab
 		data={data as ParsedStreetData}
 		onChange={setData as (next: ParsedStreetData) => void}

--- a/src/components/schema-editor/extensions/trafficDataExtensions.tsx
+++ b/src/components/schema-editor/extensions/trafficDataExtensions.tsx
@@ -20,7 +20,7 @@
 // at mutation time.
 
 import React, { useRef } from 'react';
-import type { SchemaExtensionProps, ExtensionRegistry } from '../context';
+import type { WholeResourceExtensionProps, ExtensionRegistry } from '../context';
 import type { ParsedTrafficDataRetail } from '@/lib/core/trafficData';
 import type { TrafficDataSelection } from '@/components/trafficdata/useTrafficSelection';
 import { useSchemaEditor } from '../context';
@@ -82,51 +82,58 @@ function useTabSelectionBridge() {
 }
 
 // ---------------------------------------------------------------------------
-// Root-level adapters — tab owns full ParsedTrafficDataRetail
+// Root-level adapters — tab owns full ParsedTrafficDataRetail.
+// All TrafficData adapters are WholeResource: the legacy tabs were authored
+// against `{ data, onChange }` and read across `hulls`, `flowTypes`,
+// `paintColours`, etc. simultaneously. The narrow per-node view can't see
+// past one path.
 // ---------------------------------------------------------------------------
 
-export const FlowTypesExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => (
+export const FlowTypesExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<FlowTypesTab
 		data={data as ParsedTrafficDataRetail}
 		onChange={setData as (next: ParsedTrafficDataRetail) => void}
 	/>
 );
 
-export const PaintColoursExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => (
+export const PaintColoursExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<PaintColoursTab
 		data={data as ParsedTrafficDataRetail}
 		onChange={setData as (next: ParsedTrafficDataRetail) => void}
 	/>
 );
 
-// Overview — onHullClick routes through the schema editor's tree selection
-// so clicking a hull in the summary jumps to that hull node.
-export const OverviewExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => {
-	const { selectPath } = useSchemaEditor();
-	return (
-		<OverviewTab
-			data={data as ParsedTrafficDataRetail}
-			onChange={setData as (next: ParsedTrafficDataRetail) => void}
-			onHullClick={(i) => selectPath(['hulls', i])}
-		/>
-	);
-};
+// Overview — onHullClick routes through the editor's tree selection so
+// clicking a hull in the summary jumps to that hull node. `selectChild`
+// from the root resolves to the absolute path because the extension's
+// `path` is `[]` (it's a root-level property group).
+export const OverviewExtension: React.FC<WholeResourceExtensionProps> = ({
+	data,
+	setData,
+	selectChild,
+}) => (
+	<OverviewTab
+		data={data as ParsedTrafficDataRetail}
+		onChange={setData as (next: ParsedTrafficDataRetail) => void}
+		onHullClick={(i) => selectChild(['hulls', i])}
+	/>
+);
 
-export const KillZonesExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => (
+export const KillZonesExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<KillZonesTab
 		data={data as ParsedTrafficDataRetail}
 		onChange={setData as (next: ParsedTrafficDataRetail) => void}
 	/>
 );
 
-export const VehiclesExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => (
+export const VehiclesExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<VehiclesTab
 		data={data as ParsedTrafficDataRetail}
 		onChange={setData as (next: ParsedTrafficDataRetail) => void}
 	/>
 );
 
-export const TrafficLightsExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => (
+export const TrafficLightsExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<TrafficLightsTab
 		data={data as ParsedTrafficDataRetail}
 		onChange={setData as (next: ParsedTrafficDataRetail) => void}
@@ -145,7 +152,13 @@ function hullIndexFromPath(path: NodePath): number {
 	return idx;
 }
 
-export const SectionsExtension: React.FC<SchemaExtensionProps> = ({ path, data, setData }) => {
+// WholeResource: SectionsTab needs the full `data` to walk parallel arrays
+// (sections + flows) per hull, and the legacy `onChange` replaces the root.
+export const SectionsExtension: React.FC<WholeResourceExtensionProps> = ({
+	path,
+	data,
+	setData,
+}) => {
 	const hullIndex = hullIndexFromPath(path);
 	const { selected, onSelect, scrollToIndexRef } = useTabSelectionBridge();
 	return (
@@ -160,7 +173,13 @@ export const SectionsExtension: React.FC<SchemaExtensionProps> = ({ path, data, 
 	);
 };
 
-export const LaneRungsExtension: React.FC<SchemaExtensionProps> = ({ path, data, setData }) => {
+// WholeResource: same reasoning as SectionsExtension — LaneRungsTab walks
+// per-hull arrays from the root.
+export const LaneRungsExtension: React.FC<WholeResourceExtensionProps> = ({
+	path,
+	data,
+	setData,
+}) => {
 	const hullIndex = hullIndexFromPath(path);
 	const { scrollToIndexRef } = useTabSelectionBridge();
 	return (

--- a/src/components/schema-editor/extensions/triggerDataExtensions.tsx
+++ b/src/components/schema-editor/extensions/triggerDataExtensions.tsx
@@ -28,8 +28,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Search } from 'lucide-react';
 
-import type { SchemaExtensionProps, ExtensionRegistry } from '../context';
-import { useSchemaEditor } from '../context';
+import type { WholeResourceExtensionProps, ExtensionRegistry } from '../context';
 import type { NodePath } from '@/lib/schema/walk';
 import type {
 	ParsedTriggerData,
@@ -153,8 +152,10 @@ function makeScrollPosRef() {
 // Map the "Edit Box" button click onto a schema selection. In the old
 // editor, the button opened a modal dialog. In the schema editor we let
 // the inspector handle the box form — just navigate the selection.
-function useBoxNavigator() {
-	const { selectPath } = useSchemaEditor();
+//
+// Callers pass their `selectChild`; for these root-level extensions the
+// extension's `path` is `[]`, so child paths are effectively absolute.
+function makeBoxNavigator(selectChild: (rel: NodePath) => void) {
 	return (kind: 'landmark' | 'generic' | 'blackspot' | 'vfx', index: number) => {
 		const pathByKind: Record<typeof kind, NodePath> = {
 			landmark: ['landmarks', index, 'box'],
@@ -162,7 +163,7 @@ function useBoxNavigator() {
 			blackspot: ['blackspots', index, 'box'],
 			vfx: ['vfxBoxRegions', index, 'box'],
 		};
-		selectPath(pathByKind[kind]);
+		selectChild(pathByKind[kind]);
 	};
 }
 
@@ -203,7 +204,8 @@ function FilterBar({
 // Header extension — wraps HeaderEditor for the TriggerData root form
 // ---------------------------------------------------------------------------
 
-export const HeaderExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => (
+// WholeResource: legacy header tab operates on the resource root.
+export const HeaderExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<Card>
 		<CardHeader>
 			<CardTitle className="text-sm">Header</CardTitle>
@@ -221,7 +223,8 @@ export const HeaderExtension: React.FC<SchemaExtensionProps> = ({ data, setData 
 // Regions 2D map — read-only leaflet view of every region
 // ---------------------------------------------------------------------------
 
-export const RegionsMapExtension: React.FC<SchemaExtensionProps> = ({ data }) => (
+// WholeResource: 2D map renders every region in the resource at once.
+export const RegionsMapExtension: React.FC<WholeResourceExtensionProps> = ({ data }) => (
 	<Card>
 		<CardHeader>
 			<CardTitle className="text-sm">Region Map (2D)</CardTitle>
@@ -236,7 +239,13 @@ export const RegionsMapExtension: React.FC<SchemaExtensionProps> = ({ data }) =>
 // Complex list extensions — virtualized tables with filter + clone / add
 // ---------------------------------------------------------------------------
 
-export const LandmarksExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => {
+// WholeResource: list tab walks the full landmarks array; box-edit
+// navigation jumps to other root-level paths via selectChild.
+export const LandmarksExtension: React.FC<WholeResourceExtensionProps> = ({
+	data,
+	setData,
+	selectChild,
+}) => {
 	const td = data as ParsedTriggerData;
 	const onChange = setData as (next: ParsedTriggerData) => void;
 	const [filterQuery, setFilterQuery] = useState('');
@@ -246,7 +255,7 @@ export const LandmarksExtension: React.FC<SchemaExtensionProps> = ({ data, setDa
 		() => buildFilteredIndices(td.landmarks as unknown as Record<string, unknown>[], filterQuery),
 		[td.landmarks, filterQuery],
 	);
-	const navigateToBox = useBoxNavigator();
+	const navigateToBox = makeBoxNavigator(selectChild);
 
 	const addLandmark = () => {
 		const lm: Landmark = {
@@ -306,7 +315,12 @@ export const LandmarksExtension: React.FC<SchemaExtensionProps> = ({ data, setDa
 	);
 };
 
-export const GenericRegionsExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => {
+// WholeResource: same shape as LandmarksExtension above.
+export const GenericRegionsExtension: React.FC<WholeResourceExtensionProps> = ({
+	data,
+	setData,
+	selectChild,
+}) => {
 	const td = data as ParsedTriggerData;
 	const onChange = setData as (next: ParsedTriggerData) => void;
 	const [filterQuery, setFilterQuery] = useState('');
@@ -320,7 +334,7 @@ export const GenericRegionsExtension: React.FC<SchemaExtensionProps> = ({ data, 
 			),
 		[td.genericRegions, filterQuery],
 	);
-	const navigateToBox = useBoxNavigator();
+	const navigateToBox = makeBoxNavigator(selectChild);
 
 	const addGeneric = () => {
 		const gr: GenericRegion = {
@@ -386,7 +400,12 @@ export const GenericRegionsExtension: React.FC<SchemaExtensionProps> = ({ data, 
 	);
 };
 
-export const BlackspotsExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => {
+// WholeResource: same shape as LandmarksExtension above.
+export const BlackspotsExtension: React.FC<WholeResourceExtensionProps> = ({
+	data,
+	setData,
+	selectChild,
+}) => {
 	const td = data as ParsedTriggerData;
 	const onChange = setData as (next: ParsedTriggerData) => void;
 	const [filterQuery, setFilterQuery] = useState('');
@@ -397,7 +416,7 @@ export const BlackspotsExtension: React.FC<SchemaExtensionProps> = ({ data, setD
 			buildFilteredIndices(td.blackspots as unknown as Record<string, unknown>[], filterQuery),
 		[td.blackspots, filterQuery],
 	);
-	const navigateToBox = useBoxNavigator();
+	const navigateToBox = makeBoxNavigator(selectChild);
 
 	const addBlackspot = () => {
 		const bs: Blackspot = {
@@ -458,7 +477,12 @@ export const BlackspotsExtension: React.FC<SchemaExtensionProps> = ({ data, setD
 	);
 };
 
-export const VfxExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => {
+// WholeResource: same shape as LandmarksExtension above.
+export const VfxExtension: React.FC<WholeResourceExtensionProps> = ({
+	data,
+	setData,
+	selectChild,
+}) => {
 	const td = data as ParsedTriggerData;
 	const onChange = setData as (next: ParsedTriggerData) => void;
 	const [filterQuery, setFilterQuery] = useState('');
@@ -472,7 +496,7 @@ export const VfxExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) 
 			),
 		[td.vfxBoxRegions, filterQuery],
 	);
-	const navigateToBox = useBoxNavigator();
+	const navigateToBox = makeBoxNavigator(selectChild);
 
 	const addVfx = () => {
 		const v: VFXBoxRegion = {
@@ -533,7 +557,8 @@ export const VfxExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) 
 // shape, so the extension just wires up a filter bar + add handler.
 // ---------------------------------------------------------------------------
 
-export const SignatureStuntsExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => {
+// WholeResource: list tab walks the full signatureStunts array.
+export const SignatureStuntsExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => {
 	const td = data as ParsedTriggerData;
 	const onChange = setData as (next: ParsedTriggerData) => void;
 	const [filterQuery, setFilterQuery] = useState('');
@@ -569,7 +594,8 @@ export const SignatureStuntsExtension: React.FC<SchemaExtensionProps> = ({ data,
 	);
 };
 
-export const KillzonesExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => {
+// WholeResource: list tab walks the full killzones array.
+export const KillzonesExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => {
 	const td = data as ParsedTriggerData;
 	const onChange = setData as (next: ParsedTriggerData) => void;
 	const [filterQuery, setFilterQuery] = useState('');
@@ -602,7 +628,8 @@ export const KillzonesExtension: React.FC<SchemaExtensionProps> = ({ data, setDa
 	);
 };
 
-export const RoamingExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => {
+// WholeResource: list tab walks the full roamingLocations array.
+export const RoamingExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => {
 	const td = data as ParsedTriggerData;
 	const onChange = setData as (next: ParsedTriggerData) => void;
 	const [filterQuery, setFilterQuery] = useState('');
@@ -638,7 +665,8 @@ export const RoamingExtension: React.FC<SchemaExtensionProps> = ({ data, setData
 	);
 };
 
-export const SpawnsExtension: React.FC<SchemaExtensionProps> = ({ data, setData }) => {
+// WholeResource: list tab walks the full spawnLocations array.
+export const SpawnsExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => {
 	const td = data as ParsedTriggerData;
 	const onChange = setData as (next: ParsedTriggerData) => void;
 	const [filterQuery, setFilterQuery] = useState('');

--- a/src/components/schema-editor/extensions/vehicleListExtensions.tsx
+++ b/src/components/schema-editor/extensions/vehicleListExtensions.tsx
@@ -11,7 +11,9 @@ import type { SchemaExtensionProps, ExtensionRegistry } from '../context';
 import type { VehicleListEntry } from '@/lib/core/vehicleList';
 import { VehicleEditorForm } from '@/components/VehicleEditorForm';
 
-export const VehicleEditorExtension: React.FC<SchemaExtensionProps> = ({ value, setValue }) => {
+export const VehicleEditorExtension: React.FC<
+	SchemaExtensionProps<VehicleListEntry | undefined>
+> = ({ value, setValue }) => {
 	if (!value || typeof value !== 'object') {
 		return (
 			<div className="text-xs text-muted-foreground">
@@ -19,12 +21,7 @@ export const VehicleEditorExtension: React.FC<SchemaExtensionProps> = ({ value, 
 			</div>
 		);
 	}
-	return (
-		<VehicleEditorForm
-			vehicle={value as VehicleListEntry}
-			onChange={(next) => setValue(next)}
-		/>
-	);
+	return <VehicleEditorForm vehicle={value} onChange={(next) => setValue(next)} />;
 };
 
 export const vehicleListExtensions: ExtensionRegistry = {

--- a/src/components/schema-editor/fields/CustomField.tsx
+++ b/src/components/schema-editor/fields/CustomField.tsx
@@ -10,8 +10,14 @@ type Props = FieldRendererProps<unknown> & {
 // Escape hatch — looks up a component by name in the editor extension
 // registry and embeds it with the standard extension props. If the
 // extension is not registered, renders a soft warning without crashing.
+//
+// Extensions typed as the narrow `SchemaExtensionProps` will only observe
+// `path / value / setValue / selectChild`; ones typed as
+// `WholeResourceExtensionProps` additionally observe `data / setData /
+// resource`. Runtime always hands them the full prop bag — TypeScript on
+// the consumer side decides what's visible.
 export function CustomField({ label, value, onChange, meta, schema, path }: Props) {
-	const { getExtension, data, resource, setAtPath } = useSchemaEditor();
+	const { getExtension, data, resource, setAtPath, selectPath } = useSchemaEditor();
 	const Component = getExtension(schema.component);
 	return (
 		<FieldShell label={label} description={meta?.description} warning={meta?.warning}>
@@ -20,6 +26,7 @@ export function CustomField({ label, value, onChange, meta, schema, path }: Prop
 					path={path}
 					value={value}
 					setValue={onChange}
+					selectChild={(rel) => selectPath([...path, ...rel])}
 					setData={(next) => setAtPath([], next)}
 					data={data}
 					resource={resource}


### PR DESCRIPTION
## Summary

`SchemaExtensionProps` previously exposed `path / value / setValue / setData / data / resource` to every registered extension — the entire schema editor's mutation surface. Most extensions ignored most of it; the wide seam was a hold-over from the legacy `(data, onChange) => JSX` tab contract. Adding a new extension required learning what each of those six fields means before writing any code.

This PR splits the contract into a narrow default and an explicit wider opt-in.

## New types

```ts
// Default — narrow, NodePath-rooted
type SchemaExtensionProps<T = unknown> = {
  path: NodePath;
  value: T;
  setValue: (next: T) => void;
  selectChild: (rel: NodePath) => void;  // joins onto extension's own path
};

// Opt-in for legacy whole-tree tabs
type WholeResourceExtensionProps<T = unknown> = SchemaExtensionProps<T> & {
  data: unknown;
  setData: (next: unknown) => void;
  resource: ResourceSchema;
};
```

The narrow type is the default. Widening is the explicit opt-in — no parallel "isWide?" flag at the registration layer; the prop type *is* the contract.

## Categorisation table

| Extension file | Extensions | Narrow | WholeResource |
|---|---|---|---|
| `aiSectionsExtensions.tsx` | 4 | 0 | 4 |
| `challengeListExtensions.tsx` | 3 | 2 (Action1, Action2) | 1 (Overview) |
| `collisionTagExtension.tsx` | 1 | 1 | 0 |
| `renderableExtensions.tsx` | 2 | 2 | 0 |
| `streetDataExtensions.tsx` | 5 | 0 | 5 |
| `trafficDataExtensions.tsx` | 8 | 0 | 8 |
| `triggerDataExtensions.tsx` | 10 | 0 | 10 |
| `vehicleListExtensions.tsx` | 1 | 1 | 0 |
| **Total** | **34** | **6** | **28** |

Narrow extensions own a single node and never reach across the resource: `ChallengeAction1Extension` / `ChallengeAction2Extension` (per-challenge), `CollisionTagExtension` (per-polygon u32 field), `RenderableCardExtension` / `RenderableMeshCardExtension` (per-renderable; pull data from a sibling React context), `VehicleEditorExtension` (per-vehicle form).

WholeResource extensions wrap legacy tabs that read across multiple sibling arrays simultaneously — exactly the shape the narrow view can't represent. Each one carries an inline comment justifying the wider surface (e.g. "WholeResource: legacy reset-pairs tab operates on the full root").

## Internal call-site changes

- `fields/CustomField.tsx` and `InspectorPanel.tsx::CustomExtensionGroup` now compute `selectChild` from the extension's own path. They still hand the full `WholeResourceExtensionProps` bag to every component; the consumer's declared type decides what's observed.
- `triggerDataExtensions::useBoxNavigator` became `makeBoxNavigator(selectChild)` — no longer pulls from `useSchemaEditor()`.
- `aiSectionsExtensions::AISectionsListExtension` and `trafficDataExtensions::OverviewExtension` route navigation through `selectChild` instead of the editor context's `selectPath`.

## Why "less context to add a new extension"

Before:
```ts
export const FooExtension: React.FC<SchemaExtensionProps> = ({
  path, value, setValue, setData, data, resource,
}) => { /* … */ };
```
A new contributor had to learn what `setData` vs `setValue` vs `data` vs `resource` means before writing one line. The narrow default makes the common case literally three properties:

```ts
export const FooExtension: React.FC<SchemaExtensionProps<MyType>> = ({
  path, value, setValue, selectChild,
}) => { /* … */ };
```

If a contributor needs the wider surface they pick `WholeResourceExtensionProps` and write a one-line comment saying why — visible at the point of decision, not buried in the prop bag.

## How verified

**Tests** (run with `node ./node_modules/vitest/vitest.mjs run`):
- New: `src/components/schema-editor/extensions/__tests__/extensionContract.test.ts` (19 tests)
  - asserts each per-resource registry exposes exactly the keys the schema references via `customRenderer` / `propertyGroup.component` (catches accidental drops before the UI silently shows "Extension not registered")
  - asserts `WholeResourceExtensionProps<T>` is a structural superset of `SchemaExtensionProps<T>` so future refactors can't quietly drop a narrow field from the wide variant
- Schema-editor suite: 92 → 111 tests, all passing
- Full suite: 1417 / 1417 passing (3 skipped, baseline unchanged)
- `tsc -p tsconfig.app.json --noEmit` introduces no new errors (a few pre-existing `PvsCellSelection` errors in `TrafficDataViewport`/`SectionsTab` that are out of scope for this PR remain; they're identical against `origin/main`).

**Browser** (Vite dev server at localhost:8080, loaded `example/B5TRAFFIC.BNDL`):
- TrafficData root tabs render: Overview, Header, World, Flow Types, Vehicles, Kill Zones, Lights, Paint
- `OverviewExtension` → click hull row 28 → `selectChild(['hulls', 28])` → editor selection updates, breadcrumb shows `root > hulls > [28]`, inspector now shows `TrafficHull` record
- `SectionsExtension` and `LaneRungsExtension` both render under the per-hull tabs with their tabular UIs intact (18 sections, 203 rungs visible)
- Console: no schema-editor regressions; the only console warnings (`Function components cannot be given refs` from `Badge`/`CapabilityBadge` in `ResourceCard`) are pre-existing and unrelated.

**Coverage caveat**: I exercised TrafficData end-to-end in the browser. The other five resources (AISections, StreetData, TriggerData, ChallengeList, VehicleList, PolygonSoupList) share the same `CustomField` / `CustomExtensionGroup` glue, and the per-resource extension contract tests assert their registries are intact. I did not load each of those bundles in the browser within reasonable session effort — the registry tests + the shared call sites give confidence, but a browser walkthrough of each resource type would close that gap if needed.

## Files touched

- `src/components/schema-editor/context.tsx` (type definitions + registry)
- `src/components/schema-editor/InspectorPanel.tsx` (CustomExtensionGroup wiring)
- `src/components/schema-editor/fields/CustomField.tsx` (selectChild computation)
- `src/components/schema-editor/extensions/*.tsx` (all 8 extension files)
- `src/components/schema-editor/extensions/__tests__/extensionContract.test.ts` (new)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)