### PR TITLE
chore(tests): move World viewport overlay tests into __tests__/ (closes #53)

### DIFF
--- a/src/components/schema-editor/viewports/__tests__/AISectionsLegacyOverlay.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/AISectionsLegacyOverlay.test.ts
@@ -13,7 +13,7 @@ import {
 	legacyAISectionMarkerPath,
 	legacyAISectionSelectionCodec,
 	buildBatchedLegacySections,
-} from './AISectionsLegacyOverlay';
+} from '../AISectionsLegacyOverlay';
 import type { LegacyAISection } from '@/lib/core/aiSections';
 import { LegacyDangerRating } from '@/lib/core/aiSections';
 import type { NodePath } from '@/lib/schema/walk';

--- a/src/components/schema-editor/viewports/__tests__/AISectionsOverlay.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/AISectionsOverlay.test.ts
@@ -18,7 +18,7 @@ import {
 	aiSectionMarkerPath,
 	aiSectionSelectionCodec,
 	edgeContextMenuRootStyle,
-} from './AISectionsOverlay';
+} from '../AISectionsOverlay';
 import type { NodePath } from '@/lib/schema/walk';
 
 describe('AISectionsOverlay', () => {

--- a/src/components/schema-editor/viewports/__tests__/PolygonSoupListOverlay.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/PolygonSoupListOverlay.test.ts
@@ -16,7 +16,7 @@ import {
 	polygonSoupSelectionCodec,
 	soupPolyAddressPath,
 	soupPolyPathAddress,
-} from './PolygonSoupListOverlay';
+} from '../PolygonSoupListOverlay';
 import type { NodePath } from '@/lib/schema/walk';
 
 describe('PolygonSoupListOverlay', () => {

--- a/src/components/schema-editor/viewports/__tests__/StreetDataOverlay.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/StreetDataOverlay.test.ts
@@ -24,7 +24,7 @@ import {
 	streetSelectionCodec,
 	streetPathMarker,
 	streetMarkerPath,
-} from './StreetDataOverlay';
+} from '../StreetDataOverlay';
 import type { NodePath } from '@/lib/schema/walk';
 
 describe('StreetDataOverlay', () => {

--- a/src/components/schema-editor/viewports/__tests__/TrafficDataOverlay.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/TrafficDataOverlay.test.ts
@@ -14,7 +14,7 @@ import {
 	trafficPathSelection,
 	trafficSelectionCodec,
 	trafficSelectionPath,
-} from './TrafficDataOverlay';
+} from '../TrafficDataOverlay';
 import type { NodePath } from '@/lib/schema/walk';
 
 describe('TrafficDataOverlay', () => {

--- a/src/components/schema-editor/viewports/__tests__/TriggerDataOverlay.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/TriggerDataOverlay.test.ts
@@ -17,7 +17,7 @@ import {
 	triggerMarkerPath,
 	triggerPathMarker,
 	triggerSelectionCodec,
-} from './TriggerDataOverlay';
+} from '../TriggerDataOverlay';
 import type { NodePath } from '@/lib/schema/walk';
 
 describe('TriggerDataOverlay', () => {

--- a/src/components/schema-editor/viewports/__tests__/ZoneListOverlay.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/ZoneListOverlay.test.ts
@@ -27,7 +27,7 @@ import {
 	zoneIndexPath,
 	zonePathIndex,
 	zoneSelectionCodec,
-} from './ZoneListOverlay';
+} from '../ZoneListOverlay';
 import type { ParsedZoneList, Zone } from '@/lib/core/zoneList';
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #53.

Project convention (per the issue body):
> Tests live in a \`__tests__/\` subfolder **inside the feature folder**.
> **Never** co-locate \`*.test.ts\` next to the source file.

Seven World viewport overlay tests were still co-located alongside their source files. PR #63 already placed three bulk-selection tests under \`src/components/schema-editor/viewports/__tests__/\`; this PR brings the rest in line.

## What changed

All seven tests moved via \`git mv\` (history preserved) from \`src/components/schema-editor/viewports/\` into \`src/components/schema-editor/viewports/__tests__/\`. The single \`./<Overlay>\` relative import in each file was rewritten to \`../<Overlay>\`. No source files were modified.

| File | From | To |
|---|---|---|
| \`AISectionsOverlay.test.ts\` | \`viewports/\` | \`viewports/__tests__/\` |
| \`AISectionsLegacyOverlay.test.ts\` | \`viewports/\` | \`viewports/__tests__/\` |
| \`StreetDataOverlay.test.ts\` | \`viewports/\` | \`viewports/__tests__/\` |
| \`TrafficDataOverlay.test.ts\` | \`viewports/\` | \`viewports/__tests__/\` |
| \`TriggerDataOverlay.test.ts\` | \`viewports/\` | \`viewports/__tests__/\` |
| \`ZoneListOverlay.test.ts\` | \`viewports/\` | \`viewports/__tests__/\` |
| \`PolygonSoupListOverlay.test.ts\` | \`viewports/\` | \`viewports/__tests__/\` |

\`git diff --stat\` summary: 7 files renamed, 7 insertions / 7 deletions (the import-path rewrite).

## Test counts

\`node ./node_modules/vitest/vitest.mjs run src/components/schema-editor/viewports\`

| | Test files | Tests |
|---|---|---|
| Before | 14 | 88 |
| After  | 14 | 88 |

All passing in both runs.

## Acceptance criteria

- [x] All 7 overlay test files moved to \`src/components/schema-editor/viewports/__tests__/\`
- [x] Relative imports updated (\`./X\` → \`../X\`)
- [x] Test count unchanged; all pass
- [x] No source files modified beyond the test moves themselves

🤖 Generated with [Claude Code](https://claude.com/claude-code)