### PR TITLE
feat(aiSections): V6 → V12 migration + accept V6 sources in paradise-pc-retail (#40)

### DIFF
--- a/scripts/investigate-aiSections-v6-to-v12.ts
+++ b/scripts/investigate-aiSections-v6-to-v12.ts
@@ -1,0 +1,301 @@
+// Fixture triangulation for AI Sections V6 → V12 migration (issue #40).
+//
+// Reads the available V6 prototype + V12 retail fixtures and prints the
+// distributions and spatial joins that the migration code's defaulted /
+// lossy lists need to be calibrated against. Run with:
+//
+//   tsx scripts/investigate-aiSections-v6-to-v12.ts
+//
+// Findings get folded back into the migration JSDoc and the PR description.
+//
+// V6 vs V4 deltas the migration cares about:
+//   - V6 carries `spanIndex` (i32, -1 = none), so we don't synthesise it
+//     like V4 — it can pass straight through.
+//   - V6 carries `district` (u8, 0..4). Always 0 in retail PC/PS3 so V12's
+//     `district` slot can take it verbatim.
+//   - V6 has a documented flag set (IS_IN_AIR / IS_SHORTCUT / IS_JUNCTION).
+//     V12's flag set has cognate bits (IN_AIR / SHORTCUT / JUNCTION) so the
+//     mapping looks 1:1 in name; we want to confirm spatially.
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+	parseAISectionsData,
+	type ParsedAISectionsV12,
+	type ParsedAISectionsV6,
+	AISectionFlag,
+	SectionSpeed,
+	LegacyDangerRating,
+	LegacyAISectionFlagV6,
+	LegacyEDistrict,
+} from '../src/lib/core/aiSections';
+import { parseBundle } from '../src/lib/core/bundle';
+import { RESOURCE_TYPE_IDS } from '../src/lib/core/types';
+import { extractResourceSize, isCompressed, decompressData } from '../src/lib/core/resourceManager';
+
+const HERE = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const V6_PATH = resolve(HERE, 'example/older builds/AI v6.DAT');
+const V12_PC_PATH = resolve(HERE, 'example/AI.DAT');
+const V12_PS3_PATH = resolve(HERE, 'example/ps3/AI.DAT');
+
+function loadResourceBytes(fixturePath: string): Uint8Array {
+	const raw = readFileSync(fixturePath);
+	const bytes = new Uint8Array(raw.byteLength);
+	bytes.set(raw);
+	const buffer = bytes.buffer;
+	const bundle = parseBundle(buffer);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === RESOURCE_TYPE_IDS.AI_SECTIONS);
+	if (!resource) throw new Error(`Fixture ${fixturePath} missing AI Sections resource`);
+	for (let bi = 0; bi < 3; bi++) {
+		const size = extractResourceSize(resource.sizeAndAlignmentOnDisk[bi]);
+		if (size <= 0) continue;
+		const base = bundle.header.resourceDataOffsets[bi] >>> 0;
+		const rel = resource.diskOffsets[bi] >>> 0;
+		const start = (base + rel) >>> 0;
+		let slice: Uint8Array = new Uint8Array(buffer.slice(start, start + size));
+		if (isCompressed(slice)) slice = decompressData(slice);
+		return slice;
+	}
+	throw new Error(`No populated data block in AI Sections resource of ${fixturePath}`);
+}
+
+function parseFile(path: string, littleEndian: boolean) {
+	const slice = loadResourceBytes(path);
+	return parseAISectionsData(slice, littleEndian);
+}
+
+function distribution<K extends string | number>(items: Iterable<K>): Map<K, number> {
+	const out = new Map<K, number>();
+	for (const item of items) out.set(item, (out.get(item) ?? 0) + 1);
+	return out;
+}
+
+function fmtMap<K>(label: string, map: Map<K, number>, total: number, name?: (k: K) => string) {
+	console.log(`\n  ${label} (n=${total}):`);
+	const entries = [...map.entries()].sort((a, b) => Number(a[0]) - Number(b[0]));
+	for (const [k, v] of entries) {
+		const pct = ((v / total) * 100).toFixed(1).padStart(5);
+		const name_ = name ? name(k) : String(k);
+		console.log(`    ${name_.padEnd(28)} ${String(v).padStart(6)}  ${pct}%`);
+	}
+}
+
+function sectionCentroid(section: { cornersX: number[]; cornersZ: number[] }): { x: number; z: number } {
+	const x = (section.cornersX[0] + section.cornersX[1] + section.cornersX[2] + section.cornersX[3]) / 4;
+	const z = (section.cornersZ[0] + section.cornersZ[1] + section.cornersZ[2] + section.cornersZ[3]) / 4;
+	return { x, z };
+}
+
+function v12Centroid(section: { corners: { x: number; y: number }[] }): { x: number; z: number } {
+	let x = 0, z = 0;
+	for (const c of section.corners) { x += c.x; z += c.y; }
+	return { x: x / 4, z: z / 4 };
+}
+
+function nearestV12Section(point: { x: number; z: number }, v12: ParsedAISectionsV12): { idx: number; dist: number } {
+	let best = -1, bestD = Infinity;
+	for (let i = 0; i < v12.sections.length; i++) {
+		const c = v12Centroid(v12.sections[i]);
+		const d = (c.x - point.x) ** 2 + (c.z - point.z) ** 2;
+		if (d < bestD) { bestD = d; best = i; }
+	}
+	return { idx: best, dist: Math.sqrt(bestD) };
+}
+
+function bbox(points: { x: number; z: number }[]) {
+	let minX = Infinity, maxX = -Infinity, minZ = Infinity, maxZ = -Infinity;
+	for (const p of points) {
+		if (p.x < minX) minX = p.x; if (p.x > maxX) maxX = p.x;
+		if (p.z < minZ) minZ = p.z; if (p.z > maxZ) maxZ = p.z;
+	}
+	return { minX, maxX, minZ, maxZ };
+}
+
+console.log('=== AI Sections V6 → V12 fixture triangulation ===');
+
+const v6 = parseFile(V6_PATH, false) as ParsedAISectionsV6;
+const v12pc = parseFile(V12_PC_PATH, true) as ParsedAISectionsV12;
+const v12ps3 = parseFile(V12_PS3_PATH, false) as ParsedAISectionsV12;
+
+console.log(`\nV6 (X360 BE, 2007-02-22 prototype): kind=${v6.kind} sections=${v6.legacy.sections.length} headerVersion=${v6.legacy.headerVersion}`);
+console.log(`V12 PC retail:                       kind=${v12pc.kind} sections=${v12pc.sections.length} resetPairs=${v12pc.sectionResetPairs.length}`);
+console.log(`V12 PS3 retail:                      kind=${v12ps3.kind} sections=${v12ps3.sections.length} resetPairs=${v12ps3.sectionResetPairs.length}`);
+
+console.log(`\n--- Per-speed limits in V12 (the values V6 has no equivalent for) ---`);
+console.log(`  sectionMinSpeeds (PC):  [${v12pc.sectionMinSpeeds.map(v => v.toFixed(2)).join(', ')}]`);
+console.log(`  sectionMaxSpeeds (PC):  [${v12pc.sectionMaxSpeeds.map(v => v.toFixed(2)).join(', ')}]`);
+console.log(`  sectionMinSpeeds (PS3): [${v12ps3.sectionMinSpeeds.map(v => v.toFixed(2)).join(', ')}]`);
+console.log(`  sectionMaxSpeeds (PS3): [${v12ps3.sectionMaxSpeeds.map(v => v.toFixed(2)).join(', ')}]`);
+
+console.log(`\n--- V6 dangerRating distribution ---`);
+const v6Dangers = v6.legacy.sections.map(s => s.dangerRating);
+fmtMap('dangerRating', distribution(v6Dangers), v6Dangers.length, k =>
+	`${k}=${LegacyDangerRating[k as number] ?? '?'}`);
+
+console.log(`\n--- V12 PC speed distribution ---`);
+const v12Speeds = v12pc.sections.map(s => s.speed);
+fmtMap('speed', distribution(v12Speeds), v12Speeds.length, k =>
+	`${k}=${SectionSpeed[k as number] ?? '?'}`);
+
+console.log(`\n--- V6 flags distribution (raw u8 byte) ---`);
+const v6Flags = v6.legacy.sections.map(s => s.flags);
+fmtMap('flags (raw u8)', distribution(v6Flags), v6Flags.length, k => `0x${(k as number).toString(16).padStart(2, '0')}`);
+
+console.log(`\n--- V6 flags distribution (per-bit) ---`);
+const v6BitCounts = new Map<string, number>();
+for (const s of v6.legacy.sections) {
+	for (const [name, mask] of Object.entries(LegacyAISectionFlagV6)) {
+		if (typeof mask !== 'number' || mask === 0) continue;
+		if (s.flags & mask) v6BitCounts.set(name, (v6BitCounts.get(name) ?? 0) + 1);
+	}
+}
+console.log(`\n  bit set counts (n=${v6.legacy.sections.length}):`);
+for (const [name, count] of v6BitCounts) {
+	const pct = ((count / v6.legacy.sections.length) * 100).toFixed(1);
+	console.log(`    ${name.padEnd(20)} ${String(count).padStart(6)}  ${pct}%`);
+}
+
+console.log(`\n--- V6 spanIndex distribution ---`);
+const v6SpanCounts = { negative: 0, zero: 0, positive: 0 };
+for (const s of v6.legacy.sections) {
+	const sp = s.spanIndex ?? -1;
+	if (sp < 0) v6SpanCounts.negative++;
+	else if (sp === 0) v6SpanCounts.zero++;
+	else v6SpanCounts.positive++;
+}
+console.log(`  spanIndex: ${v6SpanCounts.negative} <0, ${v6SpanCounts.zero} =0, ${v6SpanCounts.positive} >0  (n=${v6.legacy.sections.length})`);
+
+console.log(`\n--- V6 district distribution ---`);
+const v6Districts = v6.legacy.sections.map(s => s.district ?? 0);
+fmtMap('district', distribution(v6Districts), v6Districts.length, k =>
+	`${k}=${LegacyEDistrict[k as number] ?? '?'}`);
+
+console.log(`\n--- V12 PC flags distribution (per-bit) ---`);
+const v12FlagBitCounts = new Map<string, number>();
+for (const s of v12pc.sections) {
+	for (const [name, mask] of Object.entries(AISectionFlag)) {
+		if (typeof mask !== 'number') continue;
+		if (s.flags & mask) v12FlagBitCounts.set(name, (v12FlagBitCounts.get(name) ?? 0) + 1);
+	}
+}
+console.log(`\n  bit set counts (n=${v12pc.sections.length}):`);
+for (const [name, count] of v12FlagBitCounts) {
+	const pct = ((count / v12pc.sections.length) * 100).toFixed(1);
+	console.log(`    ${name.padEnd(20)} ${String(count).padStart(6)}  ${pct}%`);
+}
+
+console.log(`\n--- V12 PC district / spanIndex distribution ---`);
+const v12Districts = v12pc.sections.map(s => s.district);
+fmtMap('district', distribution(v12Districts), v12Districts.length);
+const v12SpanCounts = { negative: 0, zero: 0, positive: 0 };
+for (const s of v12pc.sections) {
+	if (s.spanIndex < 0) v12SpanCounts.negative++;
+	else if (s.spanIndex === 0) v12SpanCounts.zero++;
+	else v12SpanCounts.positive++;
+}
+console.log(`  spanIndex: ${v12SpanCounts.negative} <0, ${v12SpanCounts.zero} =0, ${v12SpanCounts.positive} >0  (n=${v12pc.sections.length})`);
+
+console.log(`\n--- V6 vs V12 spatial overlap (centroid bbox) ---`);
+const v6Centroids = v6.legacy.sections.map(sectionCentroid);
+const v12Centroids = v12pc.sections.map(v12Centroid);
+console.log(`  V6 centroid bbox:  ${JSON.stringify(bbox(v6Centroids))}`);
+console.log(`  V12 centroid bbox: ${JSON.stringify(bbox(v12Centroids))}`);
+
+console.log(`\n--- Spatial correlation: V6 dangerRating → nearest V12 speed ---`);
+const PROXIMITY_THRESHOLD = 50;
+const joint = new Map<string, number>();
+let matched = 0;
+for (let i = 0; i < v6.legacy.sections.length; i++) {
+	const s = v6.legacy.sections[i];
+	const { idx, dist } = nearestV12Section(v6Centroids[i], v12pc);
+	if (dist > PROXIMITY_THRESHOLD) continue;
+	matched++;
+	const key = `dr=${s.dangerRating} → speed=${v12pc.sections[idx].speed}`;
+	joint.set(key, (joint.get(key) ?? 0) + 1);
+}
+console.log(`  Matched ${matched}/${v6.legacy.sections.length} V6 sections within ${PROXIMITY_THRESHOLD} units of a V12 section.`);
+const sortedJoint = [...joint.entries()].sort((a, b) => b[1] - a[1]);
+for (const [key, count] of sortedJoint) {
+	console.log(`    ${key.padEnd(28)} ${count}`);
+}
+
+console.log(`\n--- Spatial correlation: V6 IS_IN_AIR → nearest V12 IN_AIR? ---`);
+const v6InAir = v6.legacy.sections
+	.map((s, i) => ({ s, i }))
+	.filter(({ s }) => s.flags & LegacyAISectionFlagV6.IS_IN_AIR);
+console.log(`  V6 sections with IS_IN_AIR set: ${v6InAir.length}`);
+let inAirHits = 0, otherHits = 0, far = 0;
+for (const { i } of v6InAir) {
+	const { idx, dist } = nearestV12Section(v6Centroids[i], v12pc);
+	if (dist > PROXIMITY_THRESHOLD) { far++; continue; }
+	const f = v12pc.sections[idx].flags;
+	if (f & AISectionFlag.IN_AIR) inAirHits++;
+	else otherHits++;
+}
+console.log(`  matched in V12 IN_AIR: ${inAirHits}`);
+console.log(`  matched other:          ${otherHits}`);
+console.log(`  too far:                ${far}`);
+
+console.log(`\n--- Spatial correlation: V6 IS_SHORTCUT → nearest V12 SHORTCUT? ---`);
+const v6Shortcut = v6.legacy.sections
+	.map((s, i) => ({ s, i }))
+	.filter(({ s }) => s.flags & LegacyAISectionFlagV6.IS_SHORTCUT);
+console.log(`  V6 sections with IS_SHORTCUT set: ${v6Shortcut.length}`);
+let scHits = 0, scAi = 0, scOther = 0, scFar = 0;
+for (const { i } of v6Shortcut) {
+	const { idx, dist } = nearestV12Section(v6Centroids[i], v12pc);
+	if (dist > PROXIMITY_THRESHOLD) { scFar++; continue; }
+	const f = v12pc.sections[idx].flags;
+	if (f & AISectionFlag.SHORTCUT) scHits++;
+	else if (f & AISectionFlag.AI_SHORTCUT) scAi++;
+	else scOther++;
+}
+console.log(`  matched V12 SHORTCUT:     ${scHits}`);
+console.log(`  matched V12 AI_SHORTCUT:  ${scAi}`);
+console.log(`  matched V12 other:        ${scOther}`);
+console.log(`  too far:                  ${scFar}`);
+
+console.log(`\n--- Spatial correlation: V6 IS_JUNCTION → nearest V12 JUNCTION? ---`);
+const v6Junction = v6.legacy.sections
+	.map((s, i) => ({ s, i }))
+	.filter(({ s }) => s.flags & LegacyAISectionFlagV6.IS_JUNCTION);
+console.log(`  V6 sections with IS_JUNCTION set: ${v6Junction.length}`);
+let jHits = 0, jOther = 0, jFar = 0;
+for (const { i } of v6Junction) {
+	const { idx, dist } = nearestV12Section(v6Centroids[i], v12pc);
+	if (dist > PROXIMITY_THRESHOLD) { jFar++; continue; }
+	const f = v12pc.sections[idx].flags;
+	if (f & AISectionFlag.JUNCTION) jHits++;
+	else jOther++;
+}
+console.log(`  matched V12 JUNCTION: ${jHits}`);
+console.log(`  matched V12 other:    ${jOther}`);
+console.log(`  too far:              ${jFar}`);
+
+console.log(`\n--- V6 portal/noGo characteristics ---`);
+let v6Portals = 0, v6NoGos = 0, v6PortalBLs = 0;
+let v6PortalNonZeroW = 0;
+for (const s of v6.legacy.sections) {
+	v6Portals += s.portals.length;
+	v6NoGos += s.noGoLines.length;
+	for (const p of s.portals) {
+		v6PortalBLs += p.boundaryLines.length;
+		if (p.midPosition.w !== 0) v6PortalNonZeroW++;
+	}
+}
+console.log(`  total portals: ${v6Portals}, total portal BLs: ${v6PortalBLs}, total noGoLines: ${v6NoGos}`);
+console.log(`  portals with non-zero midPosition.w (structural pad): ${v6PortalNonZeroW}`);
+
+console.log(`\n--- V6 spanIndex co-occurrence with district ---`);
+let spanWithDistrictNonZero = 0, spanZeroDistrictNonZero = 0;
+for (const s of v6.legacy.sections) {
+	if ((s.district ?? 0) !== 0) {
+		if ((s.spanIndex ?? -1) >= 0) spanWithDistrictNonZero++;
+		else spanZeroDistrictNonZero++;
+	}
+}
+console.log(`  district != 0 with spanIndex >= 0: ${spanWithDistrictNonZero}`);
+console.log(`  district != 0 with spanIndex < 0:  ${spanZeroDistrictNonZero}`);
+
+console.log('\nDone.\n');

--- a/src/lib/conversion/__tests__/exportPlan.test.ts
+++ b/src/lib/conversion/__tests__/exportPlan.test.ts
@@ -15,6 +15,7 @@ import {
 import { getTargetPreset } from '../targets';
 
 const V4_FIXTURE = path.resolve(__dirname, '../../../../example/older builds/AI.dat');
+const V6_FIXTURE = path.resolve(__dirname, '../../../../example/older builds/AI v6.DAT');
 const V12_PC_FIXTURE = path.resolve(__dirname, '../../../../example/AI.DAT');
 
 function loadEditableBundle(fixturePath: string) {
@@ -36,6 +37,41 @@ describe('analyzeExport — V4 bundle against paradise-pc-retail', () => {
 			currentKind: 'v4',
 			targetKind: 'v12',
 		});
+	});
+});
+
+describe('analyzeExport — V6 bundle against paradise-pc-retail (issue #40)', () => {
+	it('plans exactly one V6 → V12 AI Sections migration with no blockers', () => {
+		const bundle = loadEditableBundle(V6_FIXTURE);
+		const preset = getTargetPreset('paradise-pc-retail')!;
+		const analysis = analyzeExport(bundle, preset);
+
+		expect(analysis.blockers).toEqual([]);
+		expect(analysis.migrations).toHaveLength(1);
+		expect(analysis.migrations[0]).toMatchObject({
+			resourceKey: 'aiSections',
+			currentKind: 'v6',
+			targetKind: 'v12',
+		});
+	});
+
+	it('runs the V6 → V12 migration end-to-end (V6 fixture → V12 model)', () => {
+		const bundle = loadEditableBundle(V6_FIXTURE);
+		const preset = getTargetPreset('paradise-pc-retail')!;
+		const analysis = analyzeExport(bundle, preset);
+		const result = runMigrations(analysis.migrations);
+
+		expect(result.runs).toHaveLength(1);
+		expect(result.runs[0].migration.resourceKey).toBe('aiSections');
+		const migrated = result.runs[0].result as { kind: string; version: number };
+		expect(migrated.kind).toBe('v12');
+		expect(migrated.version).toBe(12);
+		// V6 → V12 has lossy entries — the export dialog uses this to show
+		// the pre-export confirmation modal.
+		expect(result.lossy.length).toBeGreaterThan(0);
+		for (const entry of result.lossy) {
+			expect(entry.startsWith('aiSections: ')).toBe(true);
+		}
 	});
 });
 

--- a/src/lib/conversion/migrations/__tests__/aiSectionsV6toV12.test.ts
+++ b/src/lib/conversion/migrations/__tests__/aiSectionsV6toV12.test.ts
@@ -1,0 +1,483 @@
+// Tests for the V6 → V12 AI Sections migration (issue #40).
+//
+// Mirrors the V4 → V12 test layout from #36 — fixture-driven structural
+// round-trip on the real V6 prototype bundle, synthetic-section
+// dangerRating / flag-mapping coverage, profile wiring assertion, and
+// stability checks. The V6 prototype bundle is the 2007-02-22 X360 build
+// (3,900 sections); we also exercise the synthetic V6 model from
+// `aiSectionsLegacy.test.ts` to keep coverage stable if the real fixture
+// is ever moved.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '@/lib/core/bundle';
+import { extractResourceSize, isCompressed, decompressData } from '@/lib/core/resourceManager';
+import { RESOURCE_TYPE_IDS } from '@/lib/core/types';
+import {
+	parseAISectionsData,
+	writeAISectionsData,
+	SectionSpeed,
+	AISectionFlag,
+	LegacyAISectionFlagV6,
+	LegacyEDistrict,
+	LegacyDangerRating,
+	type ParsedAISectionsV6,
+	type ParsedAISectionsV12,
+	type LegacyAISection,
+	type LegacyAISectionsData,
+} from '@/lib/core/aiSections';
+import { migrateV6toV12, migrateSectionV6toV12 } from '../aiSectionsV6toV12';
+import { aiSectionsV6Profile } from '@/lib/editor/profiles/aiSections';
+
+const V6_FIXTURE = path.resolve(__dirname, '../../../../../example/older builds/AI v6.DAT');
+
+function loadResourceBytes(fixturePath: string): Uint8Array {
+	const raw = fs.readFileSync(fixturePath);
+	const bytes = new Uint8Array(raw.byteLength);
+	bytes.set(raw);
+	const buffer = bytes.buffer;
+	const bundle = parseBundle(buffer);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === RESOURCE_TYPE_IDS.AI_SECTIONS);
+	if (!resource) throw new Error(`Fixture ${fixturePath} missing AI Sections resource`);
+	for (let bi = 0; bi < 3; bi++) {
+		const size = extractResourceSize(resource.sizeAndAlignmentOnDisk[bi]);
+		if (size <= 0) continue;
+		const base = bundle.header.resourceDataOffsets[bi] >>> 0;
+		const rel = resource.diskOffsets[bi] >>> 0;
+		const start = (base + rel) >>> 0;
+		let slice: Uint8Array = new Uint8Array(buffer.slice(start, start + size));
+		if (isCompressed(slice)) slice = decompressData(slice);
+		return slice;
+	}
+	throw new Error('No populated data block in AI Sections resource');
+}
+
+function parseV6Fixture(): ParsedAISectionsV6 {
+	const slice = loadResourceBytes(V6_FIXTURE);
+	const parsed = parseAISectionsData(slice, /* littleEndian */ false);
+	if (parsed.kind !== 'v6') {
+		throw new Error(`Expected V6 fixture, got ${parsed.kind}`);
+	}
+	return parsed;
+}
+
+function legacyCounts(legacy: LegacyAISectionsData) {
+	let portals = 0, portalBLs = 0, noGoLines = 0;
+	for (const s of legacy.sections) {
+		portals += s.portals.length;
+		noGoLines += s.noGoLines.length;
+		for (const p of s.portals) portalBLs += p.boundaryLines.length;
+	}
+	return {
+		sections: legacy.sections.length,
+		portals,
+		portalBLs,
+		noGoLines,
+	};
+}
+
+function v12Counts(model: ParsedAISectionsV12) {
+	let portals = 0, portalBLs = 0, noGoLines = 0;
+	for (const s of model.sections) {
+		portals += s.portals.length;
+		noGoLines += s.noGoLines.length;
+		for (const p of s.portals) portalBLs += p.boundaryLines.length;
+	}
+	return {
+		sections: model.sections.length,
+		portals,
+		portalBLs,
+		noGoLines,
+	};
+}
+
+describe('migrateV6toV12 — fixture-driven structural round-trip', () => {
+	const v6 = parseV6Fixture();
+	const { result, defaulted, lossy } = migrateV6toV12(v6);
+
+	it('produces a v12-shaped result with retail defaults filled in', () => {
+		expect(result.kind).toBe('v12');
+		expect(result.version).toBe(12);
+		expect(result.sectionMinSpeeds).toHaveLength(5);
+		expect(result.sectionMaxSpeeds).toHaveLength(5);
+		expect(result.sectionMinSpeeds[0]).toBeCloseTo(67.05, 1);
+		expect(result.sectionMaxSpeeds[4]).toBeCloseTo(80.45, 1);
+		expect(result.sectionResetPairs).toEqual([]);
+	});
+
+	it('preserves section / portal / boundary-line / nogo counts', () => {
+		const before = legacyCounts(v6.legacy);
+		const after = v12Counts(result);
+		expect(after.sections).toBe(before.sections);
+		expect(after.portals).toBe(before.portals);
+		expect(after.portalBLs).toBe(before.portalBLs);
+		expect(after.noGoLines).toBe(before.noGoLines);
+	});
+
+	it('writes through the V12 writer and re-parses with identical counts', () => {
+		const bytes = writeAISectionsData(result, /* littleEndian */ true);
+		const reparsed = parseAISectionsData(bytes, /* littleEndian */ true);
+		if (reparsed.kind !== 'v12') {
+			throw new Error(`Expected v12 after round-trip, got ${reparsed.kind}`);
+		}
+		expect(v12Counts(reparsed)).toEqual(v12Counts(result));
+		expect(reparsed.sectionMinSpeeds).toEqual(result.sectionMinSpeeds);
+		expect(reparsed.sectionMaxSpeeds).toEqual(result.sectionMaxSpeeds);
+	});
+
+	it('synthesises sequential ids (0..N-1) and passes spanIndex/district through', () => {
+		for (let i = 0; i < result.sections.length; i++) {
+			const s = result.sections[i];
+			expect(s.id).toBe(i);
+			// V6 carries spanIndex/district verbatim — assert pass-through
+			// against the source legacy section. (The V6 fixture has 3,900
+			// district=0 sections, so the district pass-through is a no-op
+			// in practice but the assertion guards against a future regression
+			// that would default it.)
+			const src = v6.legacy.sections[i];
+			expect(s.spanIndex).toBe(src.spanIndex ?? -1);
+			expect(s.district).toBe(src.district ?? 0);
+		}
+	});
+
+	it('reports the documented defaulted field paths', () => {
+		// V6 — unlike V4 — does NOT default sections[].spanIndex or
+		// sections[].district because the V6 schema carries them.
+		expect(defaulted).toEqual([
+			'sectionMaxSpeeds',
+			'sectionMinSpeeds',
+			'sectionResetPairs',
+			'sections[].id',
+		]);
+	});
+
+	it('reports the documented lossy field paths on the real V6 fixture', () => {
+		// The V6 fixture has dangerRating across all sections, V6 flag bits
+		// set on 1,449 of 3,900 sections, and 8,906 portals (so portal-W
+		// drops are flagged).
+		expect(lossy).toEqual([
+			'sections[].flags (V6 IS_IN_AIR/IS_SHORTCUT/IS_JUNCTION mapped to V12 cognate bits)',
+			'sections[].portals[].position (V6 midPosition.w dropped — vpu::Vector3 structural padding)',
+			'sections[].speed (from dangerRating)',
+		]);
+	});
+});
+
+describe('migrateV6toV12 — synthetic section coverage', () => {
+	function syntheticV6(sections: LegacyAISection[]): ParsedAISectionsV6 {
+		return {
+			kind: 'v6',
+			version: 6,
+			legacy: { version: 6, sections },
+		};
+	}
+
+	function makeSection(overrides: Partial<LegacyAISection> = {}): LegacyAISection {
+		return {
+			portals: [],
+			noGoLines: [],
+			cornersX: [0, 1, 1, 0],
+			cornersZ: [0, 0, 1, 1],
+			dangerRating: LegacyDangerRating.E_DANGER_RATING_NORMAL,
+			flags: 0,
+			spanIndex: -1,
+			district: 0,
+			...overrides,
+		};
+	}
+
+	it('maps Freeway → Very Fast (modal pick from V6 fixture spatial join)', () => {
+		const { result } = migrateV6toV12(syntheticV6([makeSection({ dangerRating: 0 })]));
+		expect(result.sections[0].speed).toBe(SectionSpeed.E_SECTION_SPEED_VERY_FAST);
+	});
+
+	it('maps Normal → Normal', () => {
+		const { result } = migrateV6toV12(syntheticV6([makeSection({ dangerRating: 1 })]));
+		expect(result.sections[0].speed).toBe(SectionSpeed.E_SECTION_SPEED_NORMAL);
+	});
+
+	it('maps Dangerous → Normal (the V4/V6 axis was retired in V12)', () => {
+		const { result } = migrateV6toV12(syntheticV6([makeSection({ dangerRating: 2 })]));
+		expect(result.sections[0].speed).toBe(SectionSpeed.E_SECTION_SPEED_NORMAL);
+	});
+
+	it('falls back to Normal for an out-of-range dangerRating value', () => {
+		const { result } = migrateV6toV12(syntheticV6([makeSection({ dangerRating: 99 })]));
+		expect(result.sections[0].speed).toBe(SectionSpeed.E_SECTION_SPEED_NORMAL);
+	});
+
+	it('passes V6 spanIndex through verbatim', () => {
+		const { result } = migrateV6toV12(syntheticV6([
+			makeSection({ spanIndex: 12345 }),
+			makeSection({ spanIndex: -1 }),
+			makeSection({ spanIndex: 0 }),
+		]));
+		expect(result.sections[0].spanIndex).toBe(12345);
+		expect(result.sections[1].spanIndex).toBe(-1);
+		expect(result.sections[2].spanIndex).toBe(0);
+	});
+
+	it('passes V6 district through verbatim (non-zero districts survive)', () => {
+		const { result } = migrateV6toV12(syntheticV6([
+			makeSection({ district: LegacyEDistrict.E_DISTRICT_CITY }),
+			makeSection({ district: LegacyEDistrict.E_DISTRICT_AIRPORT }),
+		]));
+		expect(result.sections[0].district).toBe(LegacyEDistrict.E_DISTRICT_CITY);
+		expect(result.sections[1].district).toBe(LegacyEDistrict.E_DISTRICT_AIRPORT);
+	});
+
+	it('maps V6 IS_IN_AIR → V12 IN_AIR', () => {
+		const { result } = migrateV6toV12(syntheticV6([
+			makeSection({ flags: LegacyAISectionFlagV6.IS_IN_AIR }),
+		]));
+		expect(result.sections[0].flags).toBe(AISectionFlag.IN_AIR);
+	});
+
+	it('maps V6 IS_SHORTCUT → V12 SHORTCUT', () => {
+		const { result } = migrateV6toV12(syntheticV6([
+			makeSection({ flags: LegacyAISectionFlagV6.IS_SHORTCUT }),
+		]));
+		expect(result.sections[0].flags).toBe(AISectionFlag.SHORTCUT);
+	});
+
+	it('maps V6 IS_JUNCTION → V12 JUNCTION', () => {
+		const { result } = migrateV6toV12(syntheticV6([
+			makeSection({ flags: LegacyAISectionFlagV6.IS_JUNCTION }),
+		]));
+		expect(result.sections[0].flags).toBe(AISectionFlag.JUNCTION);
+	});
+
+	it('maps a combined V6 flag mask to the union of V12 cognate bits', () => {
+		const combined = LegacyAISectionFlagV6.IS_IN_AIR
+			| LegacyAISectionFlagV6.IS_SHORTCUT
+			| LegacyAISectionFlagV6.IS_JUNCTION;
+		const { result } = migrateV6toV12(syntheticV6([makeSection({ flags: combined })]));
+		expect(result.sections[0].flags).toBe(
+			AISectionFlag.IN_AIR | AISectionFlag.SHORTCUT | AISectionFlag.JUNCTION,
+		);
+	});
+
+	it('does not flag the flag-bit lossy entry when no V6 section sets a flag', () => {
+		const { lossy } = migrateV6toV12(syntheticV6([makeSection({ flags: 0 })]));
+		expect(lossy).not.toContain(
+			'sections[].flags (V6 IS_IN_AIR/IS_SHORTCUT/IS_JUNCTION mapped to V12 cognate bits)',
+		);
+	});
+
+	it('does flag the flag-bit lossy entry when at least one V6 section sets any bit', () => {
+		const { lossy } = migrateV6toV12(syntheticV6([
+			makeSection({ flags: 0 }),
+			makeSection({ flags: LegacyAISectionFlagV6.IS_SHORTCUT }),
+		]));
+		expect(lossy).toContain(
+			'sections[].flags (V6 IS_IN_AIR/IS_SHORTCUT/IS_JUNCTION mapped to V12 cognate bits)',
+		);
+	});
+
+	it('does not flag the portal-W lossy entry on a portal-less section', () => {
+		const { lossy } = migrateV6toV12(syntheticV6([makeSection()]));
+		expect(lossy).not.toContain(
+			'sections[].portals[].position (V6 midPosition.w dropped — vpu::Vector3 structural padding)',
+		);
+	});
+
+	it('packs cornersX/cornersZ into Vector2[4] with x=worldX, y=worldZ', () => {
+		const v6 = syntheticV6([makeSection({
+			cornersX: [10, 20, 30, 40],
+			cornersZ: [100, 200, 300, 400],
+		})]);
+		const { result } = migrateV6toV12(v6);
+		expect(result.sections[0].corners).toEqual([
+			{ x: 10, y: 100 },
+			{ x: 20, y: 200 },
+			{ x: 30, y: 300 },
+			{ x: 40, y: 400 },
+		]);
+	});
+
+	it('drops portal midPosition.w (vpu::Vector3 padding) on conversion', () => {
+		const v6 = syntheticV6([makeSection({
+			portals: [{
+				midPosition: { x: 1, y: 2, z: 3, w: 999 },
+				boundaryLines: [],
+				linkSection: 7,
+			}],
+		})]);
+		const { result, lossy } = migrateV6toV12(v6);
+		expect(result.sections[0].portals[0].position).toEqual({ x: 1, y: 2, z: 3 });
+		expect(result.sections[0].portals[0].linkSection).toBe(7);
+		expect(lossy).toContain(
+			'sections[].portals[].position (V6 midPosition.w dropped — vpu::Vector3 structural padding)',
+		);
+	});
+
+	it('round-trips the synthetic V6 model from aiSectionsLegacy.test.ts', () => {
+		// Mirrors acceptance criterion: synthetic V6 → migrate → V12 writer
+		// → re-parse → assert structural shape preserved.
+		const synthetic: ParsedAISectionsV6 = {
+			kind: 'v6',
+			version: 6,
+			legacy: {
+				version: 6,
+				sections: [
+					{
+						portals: [
+							{
+								midPosition: { x: 1, y: 2, z: 3, w: 0 },
+								boundaryLines: [
+									{ verts: { x: 10, y: 20, z: 30, w: 40 } },
+									{ verts: { x: 11, y: 21, z: 31, w: 41 } },
+								],
+								linkSection: 7,
+							},
+							{
+								midPosition: { x: -100.5, y: 50.25, z: -200.75, w: 0 },
+								boundaryLines: [{ verts: { x: 0, y: 0, z: 0, w: 0 } }],
+								linkSection: 0,
+							},
+						],
+						noGoLines: [
+							{ verts: { x: 1, y: 2, z: 3, w: 4 } },
+							{ verts: { x: 5, y: 6, z: 7, w: 8 } },
+							{ verts: { x: 9, y: 10, z: 11, w: 12 } },
+						],
+						cornersX: [-10, 10, 10, -10],
+						cornersZ: [-20, -20, 20, 20],
+						dangerRating: LegacyDangerRating.E_DANGER_RATING_DANGEROUS,
+						flags: LegacyAISectionFlagV6.IS_SHORTCUT | LegacyAISectionFlagV6.IS_JUNCTION,
+						spanIndex: 42,
+						district: LegacyEDistrict.E_DISTRICT_CITY,
+					},
+					{
+						portals: [],
+						noGoLines: [],
+						cornersX: [0, 1, 2, 3],
+						cornersZ: [4, 5, 6, 7],
+						dangerRating: LegacyDangerRating.E_DANGER_RATING_FREEWAY,
+						flags: LegacyAISectionFlagV6.NONE,
+						spanIndex: -1,
+						district: LegacyEDistrict.E_DISTRICT_SUBURBS,
+					},
+				],
+			},
+		};
+
+		const { result } = migrateV6toV12(synthetic);
+		expect(result.sections).toHaveLength(2);
+		// Section 0: spanIndex passes through, district passes through,
+		// flags map cognate-name.
+		expect(result.sections[0].spanIndex).toBe(42);
+		expect(result.sections[0].district).toBe(LegacyEDistrict.E_DISTRICT_CITY);
+		expect(result.sections[0].flags).toBe(AISectionFlag.SHORTCUT | AISectionFlag.JUNCTION);
+		expect(result.sections[0].speed).toBe(SectionSpeed.E_SECTION_SPEED_NORMAL); // Dangerous → Normal
+		// Section 1: empty portals/noGo branch.
+		expect(result.sections[1].portals).toHaveLength(0);
+		expect(result.sections[1].noGoLines).toHaveLength(0);
+		expect(result.sections[1].speed).toBe(SectionSpeed.E_SECTION_SPEED_VERY_FAST); // Freeway → VERY_FAST
+		expect(result.sections[1].flags).toBe(0);
+
+		// Writer accepts it; re-parse keeps counts.
+		const bytes = writeAISectionsData(result, /* littleEndian */ true);
+		const reparsed = parseAISectionsData(bytes, /* littleEndian */ true);
+		if (reparsed.kind !== 'v12') throw new Error('expected v12 after round-trip');
+		expect(reparsed.sections).toHaveLength(2);
+		expect(reparsed.sections[0].spanIndex).toBe(42);
+		expect(reparsed.sections[0].district).toBe(LegacyEDistrict.E_DISTRICT_CITY);
+		expect(reparsed.sections[0].flags).toBe(AISectionFlag.SHORTCUT | AISectionFlag.JUNCTION);
+	});
+});
+
+describe('migrateSectionV6toV12 — per-section helper', () => {
+	function makeSection(overrides: Partial<LegacyAISection> = {}): LegacyAISection {
+		return {
+			portals: [],
+			noGoLines: [],
+			cornersX: [0, 1, 1, 0],
+			cornersZ: [0, 0, 1, 1],
+			dangerRating: LegacyDangerRating.E_DANGER_RATING_NORMAL,
+			flags: 0,
+			spanIndex: -1,
+			district: 0,
+			...overrides,
+		};
+	}
+
+	it('produces a V12 section with the destinationIndex placeholder id', () => {
+		const { section } = migrateSectionV6toV12(makeSection(), { destinationIndex: 42 });
+		expect(section.id).toBe(42);
+	});
+
+	it('passes spanIndex/district through (NOT defaulted on V6, unlike V4)', () => {
+		const { section, report } = migrateSectionV6toV12(
+			makeSection({ spanIndex: 99, district: LegacyEDistrict.E_DISTRICT_AIRPORT }),
+			{ destinationIndex: 0 },
+		);
+		expect(section.spanIndex).toBe(99);
+		expect(section.district).toBe(LegacyEDistrict.E_DISTRICT_AIRPORT);
+		expect(report.defaulted.has('sections[].spanIndex')).toBe(false);
+		expect(report.defaulted.has('sections[].district')).toBe(false);
+	});
+
+	it('reports sections[].id as defaulted (V6 has no AISectionId)', () => {
+		const { report } = migrateSectionV6toV12(makeSection(), { destinationIndex: 0 });
+		expect(report.defaulted.has('sections[].id')).toBe(true);
+	});
+
+	it('reports the dangerRating-axis lossy entry on every section', () => {
+		const { report } = migrateSectionV6toV12(makeSection(), { destinationIndex: 0 });
+		expect(report.lossy.has('sections[].speed (from dangerRating)')).toBe(true);
+	});
+
+	it('omits the flag lossy entry when no V6 flag bits are set', () => {
+		const { report } = migrateSectionV6toV12(makeSection({ flags: 0 }), { destinationIndex: 0 });
+		expect(report.lossy.has(
+			'sections[].flags (V6 IS_IN_AIR/IS_SHORTCUT/IS_JUNCTION mapped to V12 cognate bits)',
+		)).toBe(false);
+	});
+
+	it('flags the flag lossy entry when any V6 flag bit is set', () => {
+		const { report } = migrateSectionV6toV12(
+			makeSection({ flags: LegacyAISectionFlagV6.IS_JUNCTION }),
+			{ destinationIndex: 0 },
+		);
+		expect(report.lossy.has(
+			'sections[].flags (V6 IS_IN_AIR/IS_SHORTCUT/IS_JUNCTION mapped to V12 cognate bits)',
+		)).toBe(true);
+	});
+});
+
+describe('aiSectionsV6Profile.conversions.v12 wiring', () => {
+	it('exposes migrateV6toV12 under conversions.v12.migrate (acceptance criterion)', () => {
+		const conversion = aiSectionsV6Profile.conversions?.v12;
+		expect(conversion).toBeDefined();
+		expect(conversion?.label).toMatch(/v12/i);
+		expect(conversion?.migrate).toBe(migrateV6toV12);
+	});
+});
+
+describe('migrateV6toV12 — stability', () => {
+	it('produces identical output on repeated calls (deterministic)', () => {
+		const v6 = parseV6Fixture();
+		const a = migrateV6toV12(v6);
+		const b = migrateV6toV12(v6);
+		expect(a.result).toEqual(b.result);
+		expect(a.defaulted).toEqual(b.defaulted);
+		expect(a.lossy).toEqual(b.lossy);
+	});
+
+	it('writer is stable: write → parse → write produces identical bytes', () => {
+		const v6 = parseV6Fixture();
+		const { result } = migrateV6toV12(v6);
+		const bytes1 = writeAISectionsData(result, /* littleEndian */ true);
+		const reparsed = parseAISectionsData(bytes1, /* littleEndian */ true);
+		const bytes2 = writeAISectionsData(reparsed, /* littleEndian */ true);
+		expect(bytes2.byteLength).toBe(bytes1.byteLength);
+		for (let i = 0; i < bytes1.byteLength; i++) {
+			if (bytes1[i] !== bytes2[i]) {
+				throw new Error(`Stable-writer mismatch at byte ${i}`);
+			}
+		}
+	});
+});

--- a/src/lib/conversion/migrations/aiSectionsV6toV12.ts
+++ b/src/lib/conversion/migrations/aiSectionsV6toV12.ts
@@ -1,0 +1,319 @@
+// AI Sections V6 → V12 migration (issue #40).
+//
+// Converts a Burnout 5 2007-02-22 prototype V6 AI Sections payload into the
+// retail V12 shape. Pure: same input → same output, no I/O.
+//
+// === Investigation findings (see scripts/investigate-aiSections-v6-to-v12.ts) ===
+//
+// V6 carries strictly more information than V4 — `spanIndex` (i32),
+// `district` (u8 enum), and a documented three-bit flag set
+// (IS_IN_AIR / IS_SHORTCUT / IS_JUNCTION). That trims the defaulted list
+// (V12's spanIndex / district come straight across) and adds a real flag
+// mapping rather than V4's "drop everything".
+//
+// Defaulted fields (V12 additive — V6 has no equivalent):
+//
+//   - sectionMinSpeeds / sectionMaxSpeeds — V6 has no per-speed limits.
+//     Both retail PC and PS3 fixtures ship identical values; we use them
+//     as a stable default. See `RETAIL_SPEED_*` below. Same constants as
+//     V4→V12 (#36) — kept duplicated rather than shared so the V6
+//     migration is auditable as a single self-contained file.
+//   - sectionResetPairs — V6 has no reset table. Defaulted to empty.
+//   - sections[].id — V6 sections have no AISectionId (V12 uses a u32).
+//     We synthesise the index (0..N-1) so the IDs are deterministic and
+//     round-trip-stable; V6 had no GameDB hashes either, so any choice is
+//     invented. Same approach as V4→V12.
+//
+// Pass-through fields (V6 carries them directly, no synthesis):
+//
+//   - sections[].spanIndex — V6 `i32` widens cleanly into V12's `i16`
+//     storage in practice (each section can reference one span; with
+//     section counts in the low thousands the index never approaches
+//     32767). Pass through verbatim. The V6 fixture's 3,900 sections
+//     produced 2,250 positive spanIndex values, all within i16 range.
+//   - sections[].district — always 0 across the V6 fixture (3,900/3,900)
+//     and the V12 PC retail fixture (8,780/8,780). Pass through verbatim;
+//     the byte will be 0 in any practical input. The enum values for
+//     non-zero districts (1..4) survive untouched if a synthetic V6 ever
+//     uses them.
+//
+// Lossy fields (V6 carries information that V12 maps with a semantic
+// change — see the JSDoc on `migrateV6toV12` for the per-field rationale):
+//
+//   - sections[].speed (from dangerRating) — Same modal mapping derived
+//     in #36's V4 investigation (the V6 axis is the same enum). Spatial
+//     join on the V6 fixture vs V12 PC retail confirmed the modal
+//     mapping holds: dr=0 (Freeway) → VERY_FAST is the 1st-place mode
+//     (214/493 within 50 units, vs 209 NORMAL — close call but
+//     consistent with V4's much stronger dominance). dr=1 (Normal) →
+//     NORMAL (1798/2293). dr=2 (Dangerous) → NORMAL (975/1026). The
+//     dangerRating axis was retired in V12; this is a documented guess.
+//   - sections[].flags (V6 → V12 cognate name mapping) — V6's three flag
+//     bits map onto V12's same-name bits via a 1:1 rename (V6 IS_IN_AIR →
+//     V12 IN_AIR, V6 IS_SHORTCUT → V12 SHORTCUT, V6 IS_JUNCTION → V12
+//     JUNCTION). Spatial-join correlation against V12 PC retail:
+//     SHORTCUT 70.4% direct hit (722/1025, with 147 more hitting the
+//     adjacent AI_SHORTCUT bit), JUNCTION 59% direct hit (199/336),
+//     IN_AIR 30% direct hit (15/50 — small sample). Cognate names are
+//     the natural mapping; topology shifts between the V6 prototype map
+//     and the V12 retail map account for the imperfect correlation.
+//   - sections[].portals[].position (V6 midPosition.w dropped — same
+//     vpu::Vector3 structural padding as V4). All 8,906 portals in the
+//     V6 fixture have w=0, but the parser preserves the field verbatim
+//     for round-trip fidelity, and a non-zero W on a synthetic V6 would
+//     silently vanish here, so we flag it as lossy when at least one
+//     section has portals.
+//
+// Dropped fields (V6 has, V12 doesn't):
+//
+//   - sections[].dangerRating — superseded by `speed`; the V6 enum value
+//     is consumed via DANGER_TO_SPEED, not preserved.
+//
+// V12 has but V6 → V12 doesn't synthesise (left at zero):
+//
+//   - V12 flag bits NO_RESET / SPLIT / TERMINATOR / AI_SHORTCUT /
+//     AI_INTERSTATE_EXIT — the V6 model has no fields that signal these.
+//     Users who want them set must edit the V12 result by hand.
+
+import type {
+	ParsedAISectionsV6,
+	ParsedAISectionsV12,
+	AISection,
+	Portal,
+	BoundaryLine,
+	LegacyAISection,
+} from '@/lib/core/aiSections';
+import {
+	SectionSpeed,
+	AISectionFlag,
+	LegacyAISectionFlagV6,
+	CORNERS_PER_SECTION,
+} from '@/lib/core/aiSections';
+import type { ConversionResult } from '@/lib/editor/types';
+
+// ---------------------------------------------------------------------------
+// Defaults sourced from retail PC/PS3 fixtures. Identical to V4→V12 (#36) —
+// duplicated here so the V6 migration is self-contained and auditable.
+// ---------------------------------------------------------------------------
+
+const RETAIL_SPEED_MIN: readonly number[] = [
+	67.05000305175781,
+	24.583332061767578,
+	26.81666374206543,
+	29.05000114440918,
+	31.28333282470703,
+];
+
+const RETAIL_SPEED_MAX: readonly number[] = [
+	71.51666259765625,
+	58.11666488647461,
+	71.51666259765625,
+	75.98332977294922,
+	80.44999694824219,
+];
+
+// ---------------------------------------------------------------------------
+// dangerRating → speed (lossy, modal mapping). Same axis values as V4 — kept
+// duplicated rather than imported from `aiSectionsV4toV12.ts` so the V6
+// migration's investigation findings are documented in one place.
+//
+// V6 fixture vs V12 PC retail spatial-join distribution (within 50 world
+// units, 3,786/3,900 sections matched):
+//
+//   Freeway   (0):  214 → VERY_FAST, 209 → NORMAL, 65 → FAST   (n=493)
+//   Normal    (1): 1798 → NORMAL, 393 → FAST, 31 → SLOW, ...   (n=2293)
+//   Dangerous (2):  975 → NORMAL, 42 → FAST, 7 → VERY_SLOW, …  (n=1026)
+//
+// Same modal pick as V4. The Freeway → VERY_FAST mode is closer to a tie
+// in V6 than V4, but VERY_FAST stays the 1st-place pick on the spatial
+// join.
+// ---------------------------------------------------------------------------
+
+const DANGER_TO_SPEED: Record<number, SectionSpeed> = {
+	0: SectionSpeed.E_SECTION_SPEED_VERY_FAST, // Freeway   → Very Fast
+	1: SectionSpeed.E_SECTION_SPEED_NORMAL,    // Normal    → Normal
+	2: SectionSpeed.E_SECTION_SPEED_NORMAL,    // Dangerous → Normal (the V4/V6 axis was retired in V12)
+};
+
+// ---------------------------------------------------------------------------
+// V6 flag-bit → V12 flag-bit table. Cognate name mapping; see file header
+// for the spatial-correlation rationale. Two-tuple `[v6Mask, v12Mask]`
+// keeps the table grep-able for the bit values.
+// ---------------------------------------------------------------------------
+
+const V6_TO_V12_FLAG_MAP: readonly { v6: number; v12: number }[] = [
+	{ v6: LegacyAISectionFlagV6.IS_IN_AIR,   v12: AISectionFlag.IN_AIR },
+	{ v6: LegacyAISectionFlagV6.IS_SHORTCUT, v12: AISectionFlag.SHORTCUT },
+	{ v6: LegacyAISectionFlagV6.IS_JUNCTION, v12: AISectionFlag.JUNCTION },
+];
+
+function mapV6Flags(v6Flags: number): number {
+	let v12 = 0;
+	for (const { v6, v12: v12Bit } of V6_TO_V12_FLAG_MAP) {
+		if (v6Flags & v6) v12 |= v12Bit;
+	}
+	return v12;
+}
+
+// ---------------------------------------------------------------------------
+// Per-section migration — same Set-of-paths bookkeeping shape as V4→V12 so
+// callers that mix per-resource and per-section reports get a consistent
+// surface.
+// ---------------------------------------------------------------------------
+
+type ReportSet = Set<string>;
+
+/** Per-section migration report — the set of `defaulted` / `lossy` field
+ *  paths recorded while migrating ONE V6 section. */
+export type SectionMigrationReportV6 = {
+	defaulted: ReadonlySet<string>;
+	lossy: ReadonlySet<string>;
+};
+
+/**
+ * Migrate a single V6 legacy AI section to its V12 shape. Pure function.
+ *
+ * `destinationIndex` is used for the placeholder `id` value — for the
+ * whole-resource migration path, this doubles as the canonical sequential
+ * id. Bulk-import callers can overwrite the id after the call.
+ *
+ * Unlike the V4 path, V6 sections carry their own `spanIndex`, `district`,
+ * and a documented three-bit flag set, so they are NOT defaulted — they
+ * pass through (with the V6→V12 flag mapping applied).
+ *
+ * @param v6 The V6 section to migrate. The `LegacyAISection` shape declares
+ *   `spanIndex` / `district` as optional because the same type is used by
+ *   the V4 parser; on a V6 section both are guaranteed populated.
+ * @param options.destinationIndex Placeholder section id; bulk-import
+ *   callers can overwrite this after the call.
+ */
+export function migrateSectionV6toV12(
+	v6: LegacyAISection,
+	options: { destinationIndex: number },
+): { section: AISection; report: SectionMigrationReportV6 } {
+	const defaulted: ReportSet = new Set();
+	const lossy: ReportSet = new Set();
+	const section = migrateSection(v6, options.destinationIndex, defaulted, lossy);
+	return { section, report: { defaulted, lossy } };
+}
+
+function migrateSection(
+	v6: LegacyAISection,
+	index: number,
+	defaulted: ReportSet,
+	lossy: ReportSet,
+): AISection {
+	// V6 corners — same parallel cornersX / cornersZ f32[4] layout as V4;
+	// V12 packs them as Vector2[4] with x=worldX, y=worldZ.
+	const corners = Array.from({ length: CORNERS_PER_SECTION }, (_, c) => ({
+		x: v6.cornersX[c] ?? 0,
+		y: v6.cornersZ[c] ?? 0,
+	}));
+
+	const portals: Portal[] = v6.portals.map((p) => {
+		// midPosition.w is structural padding (vpu::Vector3 → 4 bytes pad);
+		// V12 portals are packed vec3, so W is unconditionally dropped.
+		// Tracked as lossy even when W is 0 because the V6 parser preserves
+		// it verbatim; a non-zero W on a synthetic V6 would silently vanish.
+		return {
+			position: { x: p.midPosition.x, y: p.midPosition.y, z: p.midPosition.z },
+			boundaryLines: p.boundaryLines.map((bl): BoundaryLine => ({
+				verts: { x: bl.verts.x, y: bl.verts.y, z: bl.verts.z, w: bl.verts.w },
+			})),
+			linkSection: p.linkSection,
+		};
+	});
+
+	const noGoLines: BoundaryLine[] = v6.noGoLines.map((bl) => ({
+		verts: { x: bl.verts.x, y: bl.verts.y, z: bl.verts.z, w: bl.verts.w },
+	}));
+
+	const speedFromDanger = DANGER_TO_SPEED[v6.dangerRating];
+	const speed = speedFromDanger ?? SectionSpeed.E_SECTION_SPEED_NORMAL;
+
+	const v12Flags = mapV6Flags(v6.flags);
+
+	defaulted.add('sections[].id');
+	lossy.add('sections[].speed (from dangerRating)');
+	if (v6.flags !== 0) {
+		// Only flag this as lossy when at least one V6 bit was actually set
+		// on the section — if no bits are set, no information was lost.
+		lossy.add('sections[].flags (V6 IS_IN_AIR/IS_SHORTCUT/IS_JUNCTION mapped to V12 cognate bits)');
+	}
+	if (v6.portals.length > 0) {
+		lossy.add('sections[].portals[].position (V6 midPosition.w dropped — vpu::Vector3 structural padding)');
+	}
+
+	return {
+		portals,
+		noGoLines,
+		corners,
+		// Sequential index — V6 has no AISectionId. Stable, deterministic,
+		// cheap; same choice as V4→V12. Bulk-import callers can overwrite.
+		id: index >>> 0,
+		// V6 carries spanIndex (i32, -1 = none); pass through. The V12
+		// writer truncates to i16, but in practice V6 spanIndex values
+		// stay within i16 range (one entry per section, section counts
+		// are in the low thousands).
+		spanIndex: v6.spanIndex ?? -1,
+		speed,
+		// V6 carries district; pass through. Always 0 in retail-equivalent
+		// V6 data — the V6 fixture has 3,900/3,900 sections at
+		// E_DISTRICT_SUBURBS.
+		district: v6.district ?? 0,
+		flags: v12Flags,
+	};
+}
+
+/**
+ * Convert a Burnout 5 2007-02-22 prototype V6 AI Sections payload to the
+ * retail Paradise V12 shape. Pure function.
+ *
+ * V6 has more direct overlap with V12 than V4: `spanIndex` and `district`
+ * pass through verbatim, the V6 flag bits map cognate-name onto V12 flag
+ * bits (IS_IN_AIR → IN_AIR, IS_SHORTCUT → SHORTCUT, IS_JUNCTION →
+ * JUNCTION). The migration still has to default V12's per-speed limits
+ * tables and reset-pair table (V6 has no equivalent) and synthesise
+ * sequential section ids (V6 has no GameDB hashes). Three V6 fields
+ * remain lossy: `dangerRating` is collapsed into V12's `speed` enum, the
+ * V6 flag-bit cognate mapping is a documented guess (spatial correlation
+ * 30–70%), and the portal `midPosition.w` structural-padding word is
+ * dropped.
+ *
+ * @param v6 The V6 model to migrate.
+ * @returns `result` = a fully-formed V12 model the writer can serialise;
+ *          `defaulted` = field paths filled from defaults;
+ *          `lossy` = field paths whose V6 source had no clean V12 equivalent.
+ */
+export function migrateV6toV12(v6: ParsedAISectionsV6): ConversionResult<ParsedAISectionsV12> {
+	const defaulted = new Set<string>();
+	const lossy = new Set<string>();
+
+	defaulted.add('sectionMinSpeeds');
+	defaulted.add('sectionMaxSpeeds');
+	defaulted.add('sectionResetPairs');
+
+	const sections: AISection[] = v6.legacy.sections.map((s, i) => {
+		const { section, report } = migrateSectionV6toV12(s, { destinationIndex: i });
+		for (const f of report.defaulted) defaulted.add(f);
+		for (const f of report.lossy) lossy.add(f);
+		return section;
+	});
+
+	const result: ParsedAISectionsV12 = {
+		kind: 'v12',
+		version: 12,
+		sectionMinSpeeds: [...RETAIL_SPEED_MIN],
+		sectionMaxSpeeds: [...RETAIL_SPEED_MAX],
+		sections,
+		sectionResetPairs: [],
+	};
+
+	return {
+		result,
+		defaulted: [...defaulted].sort(),
+		lossy: [...lossy].sort(),
+	};
+}
+
+export type { ParsedAISectionsV6, ParsedAISectionsV12 };

--- a/src/lib/editor/profiles/aiSections.ts
+++ b/src/lib/editor/profiles/aiSections.ts
@@ -27,6 +27,7 @@ import { aiSectionsV4ResourceSchema } from '@/lib/schema/resources/aiSections/v4
 import { aiSectionsV6ResourceSchema } from '@/lib/schema/resources/aiSections/v6';
 import { freezeSchema } from '@/lib/schema/freeze';
 import { migrateV4toV12 } from '@/lib/conversion/migrations/aiSectionsV4toV12';
+import { migrateV6toV12 } from '@/lib/conversion/migrations/aiSectionsV6toV12';
 
 export const aiSectionsV12Profile = defineProfile<ParsedAISectionsV12>({
 	kind: 'v12',
@@ -61,11 +62,21 @@ export const aiSectionsV6Profile = defineProfile<ParsedAISectionsV6>({
 	kind: 'v6',
 	displayName: 'v6 prototype',
 	// Same freeze treatment as V4 — the V6 prototype data is read-only in the
-	// inspector for now (no migration / edit-op coverage yet). The 3D overlay
-	// binding (`AISectionsLegacyOverlay`) already accepts the V4 | V6 union,
-	// so registering this profile lights up the same viewport rendering V4
-	// gets, plus the schema inspector with the V6-specific spanIndex/district
-	// fields surfaced.
+	// inspector. The 3D overlay binding (`AISectionsLegacyOverlay`) already
+	// accepts the V4 | V6 union, so registering this profile lights up the
+	// same viewport rendering V4 gets, plus the schema inspector with the
+	// V6-specific spanIndex/district fields surfaced.
 	schema: freezeSchema(aiSectionsV6ResourceSchema),
 	matches: (model) => (model as ParsedAISections).kind === 'v6',
+	conversions: {
+		// Reachable via `pickProfile(0x10001, v6Model).conversions.v12.migrate`.
+		// Issue #40 — the paradise-pc-retail preset (#37) accepts V6 sources
+		// because of this entry; V6 → V12 has lossy mappings (dangerRating →
+		// speed, V6 flag-bit cognate name mapping, portal-W drop) so the
+		// export dialog will show the pre-export confirmation.
+		v12: {
+			label: 'Convert to v12 (Paradise PC Retail)',
+			migrate: migrateV6toV12,
+		},
+	},
 });


### PR DESCRIPTION
## Summary

Adds `migrateV6toV12` paralleling V4→V12 (#36). V6 carries more V12-cognate information than V4 — `spanIndex` and `district` pass through verbatim rather than being defaulted, and the V6 flag set maps cognate-name onto V12's flag bits. Wires V6 EditorProfile's `conversions.v12` so the `paradise-pc-retail` preset accepts V6 sources end-to-end.

Closes #40.

## Investigation findings

Pass run against the 3,900-section `example/older builds/AI v6.DAT` fixture vs V12 PC retail (8,780 sections), produced by [`scripts/investigate-aiSections-v6-to-v12.ts`](scripts/investigate-aiSections-v6-to-v12.ts).

**Defaulted (V12 has, V6 lacks):**
- `sectionMinSpeeds` / `sectionMaxSpeeds` — retail PC and PS3 ship identical values; same defaults as V4→V12
- `sectionResetPairs` — empty
- `sections[].id` — synthesised as sequential index (no GameDB hashes in V6)

**Pass-through (V6 carries directly, no synthesis):**
- `spanIndex` — V6 fixture's positive values stay within i16 range that V12 storage uses
- `district` — always 0 in V6 retail (3,900/3,900) and V12 PC retail (8,780/8,780)

**Lossy:**
- `dangerRating → speed` — same modal mapping as V4 (Freeway → VERY_FAST, Normal → NORMAL, Dangerous → NORMAL); spatial join confirms VERY_FAST is the 1st-place pick for Freeway in the V6 map (214 vs 209 for NORMAL — close call but consistent with V4 dominance)
- V6 flag bits → V12 cognate names (1:1 rename): IS_IN_AIR → IN_AIR, IS_SHORTCUT → SHORTCUT, IS_JUNCTION → JUNCTION. Spatial correlation: SHORTCUT 70% direct hit (722/1025, +147 hitting AI_SHORTCUT), JUNCTION 59% (199/336), IN_AIR 30% (15/50, small sample). Topology shifts between the prototype and retail maps account for the imperfect correlation
- `portals[].position` (midPosition.w dropped) — all 8,906 V6 portals have w=0 in the fixture, but flagged for round-trip safety on synthetic V6 inputs

## Files

- [`src/lib/conversion/migrations/aiSectionsV6toV12.ts`](src/lib/conversion/migrations/aiSectionsV6toV12.ts) — `migrateV6toV12` + per-section helper
- [`src/lib/conversion/migrations/__tests__/aiSectionsV6toV12.test.ts`](src/lib/conversion/migrations/__tests__/aiSectionsV6toV12.test.ts) — 31 tests: fixture round-trip, synthetic dangerRating + flag-bit + spanIndex/district pass-through coverage, profile wiring, stability
- [`src/lib/editor/profiles/aiSections.ts`](src/lib/editor/profiles/aiSections.ts) — V6 EditorProfile gets `conversions.v12` wired up
- [`src/lib/conversion/__tests__/exportPlan.test.ts`](src/lib/conversion/__tests__/exportPlan.test.ts) — two new fixture-driven tests pin the V6 → preset path
- [`scripts/investigate-aiSections-v6-to-v12.ts`](scripts/investigate-aiSections-v6-to-v12.ts) — investigation script

## Test plan

- [x] V6→V12 migration tests pass (31/31)
- [x] V6 fixture round-trips through V12 writer with identical section/portal/boundary-line counts
- [x] V6 EditorProfile.conversions.v12.migrate === migrateV6toV12 (acceptance criterion)
- [x] paradise-pc-retail preset accepts V6 source: `analyzeExport(v6Bundle, preset)` plans exactly one V6→V12 migration with no blockers
- [x] V4→V12 path unchanged (no edits to `aiSectionsV4toV12.ts`); pre-existing test failures on this checkout are V4-fixture-availability issues, not regressions
- [x] Synthetic V6 round-trip from `aiSectionsLegacy.test.ts` migrates and round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)