### PR TITLE
feat: bulk transform gizmo MVP for single AI section (#72)

### DIFF
--- a/src/components/common/three/BulkTransformGizmo.tsx
+++ b/src/components/common/three/BulkTransformGizmo.tsx
@@ -1,0 +1,488 @@
+// BulkTransformGizmo — the unified translate/rotate gizmo that owns every
+// in-WorldViewport spatial manipulation gesture (per ADR-0010).
+//
+// Renders three Blender-style translate arrows (X red, Y green, Z blue) and
+// three rotate rings (X red, Y green, Z blue) at a world-space pivot. The
+// caller supplies a `TransformAxes` descriptor stating which translate axes
+// and which rotate axes are interactive — disabled rings (e.g. X and Z for
+// AI sections per ADR-0011) render visibly greyed-out and ignore pointer
+// events so users see the affordance but can't drive it into a state the
+// data model can't represent.
+//
+// Lifecycle (one gesture = one undo entry, per CONTEXT.md / "Bulk transform"):
+//   - `onTransform(delta)` fires continuously during drag — consumer renders
+//     a live preview but does NOT push to undo history.
+//   - `onCommit(delta)` fires once on pointer release — consumer commits the
+//     model change here, which is the *only* point at which a Workspace-undo
+//     entry is pushed (one entry per gesture, not per drag-frame).
+//   - `onCancel()` fires on Escape — consumer drops preview state. No commit.
+//
+// The translate axes drag in their corresponding screen-space planes (X &
+// Z drag on the Y=pivot ground plane like the legacy 2D gizmo; Y drags on
+// the X=pivot or Z=pivot plane perpendicular to Y, picking whichever is
+// more camera-facing). The rotate rings drag with screen-space angle around
+// the pivot — yaw is straightforward; pitch and roll use the screen-projected
+// axis as the rotation axis. The math lives in `useBulkTransformDrag`.
+
+import React, { useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import type { ThreeEvent } from '@react-three/fiber';
+import { useFrame, useThree } from '@react-three/fiber';
+import {
+	type BulkTransformDelta,
+	type GizmoHandleAxis,
+	type GizmoHandleKind,
+	useBulkTransformDrag,
+} from '@/hooks/useBulkTransformDrag';
+import {
+	type TransformAxes,
+	TRANSFORM_AXES_FULL_3D,
+} from '@/lib/core/transformAxes';
+import { projectToScreen, unprojectToPlane } from '@/lib/three/projection';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type BulkTransformGizmoProps = {
+	/** World-space pivot for the gizmo. The translate arrows extend from this
+	 *  point; the rotate rings are centred here. */
+	position: [number, number, number];
+
+	/** Per-axis enable flags for translate and rotate. Disabled handles render
+	 *  greyed-out and ignore pointer events. Defaults to full 3-axis. */
+	axes?: TransformAxes;
+
+	/** Continuous live-drag callback. Consumer renders the preview but does
+	 *  NOT push undo history here. Delta accumulates from the gesture's
+	 *  start; on a fresh drag it begins at the identity (translate=0, yaw=0). */
+	onTransform: (delta: BulkTransformDelta) => void;
+
+	/** Drag-released — commit the final delta to the model and push exactly
+	 *  one Workspace-undo entry for the whole gesture. */
+	onCommit: (delta: BulkTransformDelta) => void;
+
+	/** Escape pressed mid-drag — consumer drops preview state without
+	 *  committing. */
+	onCancel?: () => void;
+
+	/**
+	 * Approximate screen-space length (in CSS pixels) of one arrow. The gizmo
+	 * rescales itself every frame against camera distance + viewport height
+	 * so handles stay this size regardless of zoom — mirrors the legacy
+	 * TranslateGizmo's per-frame pixel-size scaling. Defaults to 90 px.
+	 */
+	pixelSize?: number;
+};
+
+// World-space "design size" the geometry is built at. The per-frame scale
+// factor brings it to the requested pixel size on screen.
+const DESIGN_SIZE = 30;
+
+// =============================================================================
+// Colours
+// =============================================================================
+
+const COLOR = {
+	x: '#ff4040',
+	xHot: '#ff9090',
+	y: '#40d040',
+	yHot: '#90ff90',
+	z: '#3070ff',
+	zHot: '#90b0ff',
+	disabled: '#555555',
+} as const;
+
+const RING_OPACITY_ENABLED = 0.75;
+const RING_OPACITY_DISABLED = 0.25;
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export const BulkTransformGizmo: React.FC<BulkTransformGizmoProps> = ({
+	position,
+	axes = TRANSFORM_AXES_FULL_3D,
+	onTransform,
+	onCommit,
+	onCancel,
+	pixelSize = 90,
+}) => {
+	const { camera, gl, controls } = useThree();
+	const groupRef = useRef<THREE.Group>(null);
+	const [hover, setHover] = useState<{ kind: GizmoHandleKind; axis: GizmoHandleAxis } | null>(null);
+	const [active, setActive] = useState<{ kind: GizmoHandleKind; axis: GizmoHandleAxis } | null>(null);
+	const dragStartRef = useRef<{
+		kind: GizmoHandleKind;
+		axis: GizmoHandleAxis;
+		pivot: THREE.Vector3;
+		// Translate-specific: pointer-down world position on the drag plane.
+		anchorWorld?: THREE.Vector3;
+		// Rotate-specific: pointer-down screen-space angle relative to the
+		// pivot's screen projection, in radians.
+		anchorAngle?: number;
+		// Rotate-specific: rotation axis in world space — used to invert when
+		// the camera looks at it from the opposite side, so dragging right
+		// always rotates clockwise from the user's perspective.
+		rotationAxisWorld?: THREE.Vector3;
+	} | null>(null);
+
+	const pivotVec = useMemo(
+		() => new THREE.Vector3(position[0], position[1], position[2]),
+		[position],
+	);
+
+	// Per-frame scale: keeps the gizmo at a constant on-screen pixel size by
+	// scaling the design-size group against the camera's perspective. Same
+	// math the legacy TranslateGizmo uses — see that file for the derivation.
+	useFrame(({ camera: c, size: viewport }) => {
+		const group = groupRef.current;
+		if (!group) return;
+		const cam = c as THREE.PerspectiveCamera;
+		if (!cam.isPerspectiveCamera) return;
+		const distance = cam.position.distanceTo(group.position);
+		const fovRad = (cam.fov * Math.PI) / 180;
+		const worldPerPixel = (2 * distance * Math.tan(fovRad / 2)) / viewport.height;
+		const targetWorldSize = pixelSize * worldPerPixel;
+		group.scale.setScalar(targetWorldSize / DESIGN_SIZE);
+	});
+
+	useBulkTransformDrag({
+		active,
+		camera,
+		canvas: gl.domElement,
+		controls: controls as unknown as { enabled: boolean } | null,
+		pivot: pivotVec,
+		dragStart: dragStartRef,
+		onTransform,
+		onCommit,
+		onCancel,
+		setActive,
+	});
+
+	// Begin a drag — capture the pointer-down world position (translate) or
+	// screen-space angle (rotate) so the per-frame mover can derive a delta.
+	const beginTranslate = (axis: GizmoHandleAxis) => (e: ThreeEvent<PointerEvent>) => {
+		if (!isAxisInteractive('translate', axis, axes)) return;
+		e.stopPropagation();
+		// Pointer-down world: project the pointer onto the chosen drag plane.
+		const planeNormal = translatePlaneNormalFor(axis, camera, pivotVec);
+		const world = unprojectToPlane(
+			e.nativeEvent.clientX,
+			e.nativeEvent.clientY,
+			camera,
+			gl.domElement,
+			pivotVec,
+			planeNormal,
+		);
+		if (!world) return;
+		dragStartRef.current = {
+			kind: 'translate',
+			axis,
+			pivot: pivotVec.clone(),
+			anchorWorld: world.clone(),
+		};
+		setActive({ kind: 'translate', axis });
+		document.body.style.cursor = 'grabbing';
+	};
+
+	const beginRotate = (axis: GizmoHandleAxis) => (e: ThreeEvent<PointerEvent>) => {
+		if (!isAxisInteractive('rotate', axis, axes)) return;
+		e.stopPropagation();
+		// Screen-space angle of the pointer relative to the projected pivot.
+		const pivotScreen = projectToScreen(pivotVec, camera, gl.domElement);
+		if (!pivotScreen) return;
+		const dx = e.nativeEvent.clientX - pivotScreen.x;
+		const dy = e.nativeEvent.clientY - pivotScreen.y;
+		const anchorAngle = Math.atan2(dy, dx);
+		const rotationAxisWorld = rotationAxisVector(axis);
+		dragStartRef.current = {
+			kind: 'rotate',
+			axis,
+			pivot: pivotVec.clone(),
+			anchorAngle,
+			rotationAxisWorld,
+		};
+		setActive({ kind: 'rotate', axis });
+		document.body.style.cursor = 'grabbing';
+	};
+
+	const isHover = (kind: GizmoHandleKind, axis: GizmoHandleAxis) =>
+		hover?.kind === kind && hover.axis === axis;
+	const isActiveHandle = (kind: GizmoHandleKind, axis: GizmoHandleAxis) =>
+		active?.kind === kind && active.axis === axis;
+
+	const arrowColor = (axis: GizmoHandleAxis) => {
+		if (!axes.translate[axis]) return COLOR.disabled;
+		const hot = isHover('translate', axis) || isActiveHandle('translate', axis);
+		const base = axis === 'x' ? COLOR.x : axis === 'y' ? COLOR.y : COLOR.z;
+		const hotC = axis === 'x' ? COLOR.xHot : axis === 'y' ? COLOR.yHot : COLOR.zHot;
+		return hot ? hotC : base;
+	};
+
+	const ringColor = (axis: GizmoHandleAxis) => {
+		if (!axes.rotate[axis]) return COLOR.disabled;
+		const hot = isHover('rotate', axis) || isActiveHandle('rotate', axis);
+		const base = axis === 'x' ? COLOR.x : axis === 'y' ? COLOR.y : COLOR.z;
+		const hotC = axis === 'x' ? COLOR.xHot : axis === 'y' ? COLOR.yHot : COLOR.zHot;
+		return hot ? hotC : base;
+	};
+
+	return (
+		<group ref={groupRef} position={position}>
+			{/* Translate arrows */}
+			<TranslateArrow
+				axis="x"
+				color={arrowColor('x')}
+				enabled={axes.translate.x}
+				onPointerDown={beginTranslate('x')}
+				onPointerOver={() => setHover({ kind: 'translate', axis: 'x' })}
+				onPointerOut={() => setHover((h) => (h?.kind === 'translate' && h.axis === 'x' ? null : h))}
+			/>
+			<TranslateArrow
+				axis="y"
+				color={arrowColor('y')}
+				enabled={axes.translate.y}
+				onPointerDown={beginTranslate('y')}
+				onPointerOver={() => setHover({ kind: 'translate', axis: 'y' })}
+				onPointerOut={() => setHover((h) => (h?.kind === 'translate' && h.axis === 'y' ? null : h))}
+			/>
+			<TranslateArrow
+				axis="z"
+				color={arrowColor('z')}
+				enabled={axes.translate.z}
+				onPointerDown={beginTranslate('z')}
+				onPointerOver={() => setHover({ kind: 'translate', axis: 'z' })}
+				onPointerOut={() => setHover((h) => (h?.kind === 'translate' && h.axis === 'z' ? null : h))}
+			/>
+
+			{/* Rotate rings */}
+			<RotateRing
+				axis="x"
+				color={ringColor('x')}
+				enabled={axes.rotate.x}
+				onPointerDown={beginRotate('x')}
+				onPointerOver={() => setHover({ kind: 'rotate', axis: 'x' })}
+				onPointerOut={() => setHover((h) => (h?.kind === 'rotate' && h.axis === 'x' ? null : h))}
+			/>
+			<RotateRing
+				axis="y"
+				color={ringColor('y')}
+				enabled={axes.rotate.y}
+				onPointerDown={beginRotate('y')}
+				onPointerOver={() => setHover({ kind: 'rotate', axis: 'y' })}
+				onPointerOut={() => setHover((h) => (h?.kind === 'rotate' && h.axis === 'y' ? null : h))}
+			/>
+			<RotateRing
+				axis="z"
+				color={ringColor('z')}
+				enabled={axes.rotate.z}
+				onPointerDown={beginRotate('z')}
+				onPointerOver={() => setHover({ kind: 'rotate', axis: 'z' })}
+				onPointerOut={() => setHover((h) => (h?.kind === 'rotate' && h.axis === 'z' ? null : h))}
+			/>
+		</group>
+	);
+};
+
+// =============================================================================
+// Sub-components — Arrow, Ring
+// =============================================================================
+//
+// Handlers are passed explicitly rather than via `{...rest}` because the
+// `lovable-tagger` Vite plugin injects `data-lov-*` props on every JSX call
+// to a non-host React component. A rest-spread would forward those onto a
+// `<group>`, and R3F's `applyProps` interprets dashed prop names as nested
+// property paths (`data-lov-id` → `target.data.lov.id`) which crashes when
+// `target.data` is undefined. Same caveat as TranslateGizmo's Arrow.
+
+type HandlerProps = {
+	axis: GizmoHandleAxis;
+	color: string;
+	enabled: boolean;
+	onPointerDown: (e: ThreeEvent<PointerEvent>) => void;
+	onPointerOver: () => void;
+	onPointerOut: () => void;
+};
+
+const TranslateArrow: React.FC<HandlerProps> = ({ axis, color, enabled, onPointerDown, onPointerOver, onPointerOut }) => {
+	const size = DESIGN_SIZE;
+	// Default cylinder/cone axis is +Y. For X we tip towards +X; for Z we
+	// tip towards +Z. The Y arrow uses the default orientation.
+	const rotation: [number, number, number] =
+		axis === 'x' ? [0, 0, -Math.PI / 2]
+			: axis === 'z' ? [Math.PI / 2, 0, 0]
+				: [0, 0, 0];
+
+	const cylLength = size * 0.85;
+	const coneLength = size * 0.15;
+
+	const along = (t: number): [number, number, number] => {
+		if (axis === 'x') return [t, 0, 0];
+		if (axis === 'y') return [0, t, 0];
+		return [0, 0, t];
+	};
+	const cylinderCentre = along(cylLength / 2);
+	const coneCentre = along(cylLength + coneLength / 2);
+	const hitCentre = along(size / 2);
+
+	const radius = size * 0.025;
+	const hitRadius = size * 0.12;
+
+	const handleOver = (e: ThreeEvent<PointerEvent>) => {
+		if (!enabled) return;
+		e.stopPropagation();
+		onPointerOver();
+		document.body.style.cursor = 'grab';
+	};
+	const handleOut = (e: ThreeEvent<PointerEvent>) => {
+		e.stopPropagation();
+		onPointerOut();
+		document.body.style.cursor = 'auto';
+	};
+	const handleDown = (e: ThreeEvent<PointerEvent>) => {
+		if (!enabled) return;
+		onPointerDown(e);
+	};
+
+	return (
+		<group
+			onPointerDown={handleDown}
+			onPointerOver={handleOver}
+			onPointerOut={handleOut}
+		>
+			<mesh position={cylinderCentre} rotation={rotation}>
+				<cylinderGeometry args={[radius, radius, cylLength, 16]} />
+				<meshBasicMaterial color={color} depthTest={false} transparent opacity={enabled ? 1 : 0.4} />
+			</mesh>
+			<mesh position={coneCentre} rotation={rotation}>
+				<coneGeometry args={[radius * 3.5, coneLength, 16]} />
+				<meshBasicMaterial color={color} depthTest={false} transparent opacity={enabled ? 1 : 0.4} />
+			</mesh>
+			{/* Invisible thicker hit volume — only present on enabled axes so
+			    disabled handles are visually present but unclickable. */}
+			{enabled && (
+				<mesh position={hitCentre} rotation={rotation}>
+					<cylinderGeometry args={[hitRadius, hitRadius, size * 1.05, 8]} />
+					<meshBasicMaterial transparent opacity={0} depthTest={false} />
+				</mesh>
+			)}
+		</group>
+	);
+};
+
+const RotateRing: React.FC<HandlerProps> = ({ axis, color, enabled, onPointerDown, onPointerOver, onPointerOut }) => {
+	const radius = DESIGN_SIZE * 0.7;
+	const tubeRadius = DESIGN_SIZE * 0.012;
+	const hitTube = DESIGN_SIZE * 0.05;
+
+	// TorusGeometry's tube lives in the XY plane, normal +Z. Rotate so the
+	// tube ends up perpendicular to the labelled axis:
+	//   - X axis ring: normal is +X → rotate the +Z-normal torus around +Y by 90°.
+	//   - Y axis ring: normal is +Y → rotate around +X by 90°.
+	//   - Z axis ring: normal is +Z → no rotation.
+	const rotation: [number, number, number] =
+		axis === 'x' ? [0, Math.PI / 2, 0]
+			: axis === 'y' ? [Math.PI / 2, 0, 0]
+				: [0, 0, 0];
+
+	const handleOver = (e: ThreeEvent<PointerEvent>) => {
+		if (!enabled) return;
+		e.stopPropagation();
+		onPointerOver();
+		document.body.style.cursor = 'grab';
+	};
+	const handleOut = (e: ThreeEvent<PointerEvent>) => {
+		e.stopPropagation();
+		onPointerOut();
+		document.body.style.cursor = 'auto';
+	};
+	const handleDown = (e: ThreeEvent<PointerEvent>) => {
+		if (!enabled) return;
+		onPointerDown(e);
+	};
+
+	return (
+		<group
+			onPointerDown={handleDown}
+			onPointerOver={handleOver}
+			onPointerOut={handleOut}
+			rotation={rotation}
+		>
+			{/* Visible thin torus */}
+			<mesh>
+				<torusGeometry args={[radius, tubeRadius, 8, 64]} />
+				<meshBasicMaterial
+					color={color}
+					transparent
+					opacity={enabled ? RING_OPACITY_ENABLED : RING_OPACITY_DISABLED}
+					depthTest={false}
+				/>
+			</mesh>
+			{/* Invisible thicker hit torus — only present on enabled axes
+			    so disabled rings are visually present but unclickable. */}
+			{enabled && (
+				<mesh>
+					<torusGeometry args={[radius, hitTube, 6, 32]} />
+					<meshBasicMaterial transparent opacity={0} depthTest={false} />
+				</mesh>
+			)}
+		</group>
+	);
+};
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+function isAxisInteractive(
+	kind: GizmoHandleKind,
+	axis: GizmoHandleAxis,
+	axes: TransformAxes,
+): boolean {
+	return kind === 'translate' ? axes.translate[axis] : axes.rotate[axis];
+}
+
+/**
+ * Pick a drag-plane normal for a translate axis. The plane must contain the
+ * dragged axis and be reasonably perpendicular to the camera so the
+ * pointer's world-space projection is well-defined.
+ *
+ *   - X axis: drag on the Y=pivot ground plane (normal +Y) when the camera
+ *     looks down at the scene; this matches the legacy 2D gizmo's behaviour.
+ *   - Z axis: same — drag on the ground plane.
+ *   - Y axis: pick the plane whose normal is more camera-facing — either
+ *     +X (the YZ plane) or +Z (the YX plane). This avoids the degenerate
+ *     "looking along the plane normal" case.
+ */
+function translatePlaneNormalFor(
+	axis: GizmoHandleAxis,
+	camera: THREE.Camera,
+	pivot: THREE.Vector3,
+): THREE.Vector3 {
+	if (axis === 'x' || axis === 'z') {
+		return new THREE.Vector3(0, 1, 0);
+	}
+	// Y: choose plane normal between +X and +Z based on camera angle.
+	const camDir = new THREE.Vector3();
+	camera.getWorldDirection(camDir);
+	const dotX = Math.abs(camDir.x);
+	const dotZ = Math.abs(camDir.z);
+	return dotX > dotZ
+		? new THREE.Vector3(1, 0, 0)
+		: new THREE.Vector3(0, 0, 1);
+}
+
+/**
+ * The world-space rotation axis for a rotate ring. Pure helper so the drag
+ * hook can apply the screen-space angle delta around a single fixed axis.
+ */
+function rotationAxisVector(axis: GizmoHandleAxis): THREE.Vector3 {
+	if (axis === 'x') return new THREE.Vector3(1, 0, 0);
+	if (axis === 'y') return new THREE.Vector3(0, 1, 0);
+	return new THREE.Vector3(0, 0, 1);
+}
+
+// `projectToScreen` and `unprojectToPlane` live in `@/lib/three/projection` —
+// the drag hook imports them from there as well, sidestepping a circular
+// import via this component module.

--- a/src/components/schema-editor/viewports/AISectionsOverlay.tsx
+++ b/src/components/schema-editor/viewports/AISectionsOverlay.tsx
@@ -35,13 +35,18 @@ import type { ParsedAISectionsV12, AISection } from '@/lib/core/aiSections';
 import { SectionSpeed } from '@/lib/core/aiSections';
 import {
 	duplicateSectionThroughEdge,
+	rotateSectionAroundCentroidYaw,
 	snapCornerOffset,
-	snapSectionOffset,
 	translateCornerWithShared,
-	translateSectionWithLinks,
+	translateSectionRigid,
 } from '@/lib/core/aiSectionsOps';
 import { resolveSectionYs } from '@/lib/core/aiSectionY';
-import { TranslateGizmo, type GizmoOffset } from '@/components/common/three/TranslateGizmo';
+import { BulkTransformGizmo } from '@/components/common/three/BulkTransformGizmo';
+import { TRANSFORM_AXES_XZ_PACKED } from '@/lib/core/transformAxes';
+import {
+	type BulkTransformDelta,
+	isIdentityDelta,
+} from '@/hooks/useBulkTransformDrag';
 import { CameraBridge, type CameraBridgeData } from '@/components/common/three/CameraBridge';
 import { MarqueeSelector } from '@/components/common/three/MarqueeSelector';
 import { CornerHandles, type CornerDragOffset } from '@/components/aisections/CornerHandles';
@@ -180,13 +185,15 @@ function makeV12Accessor(sectionYs: ArrayLike<number>): SectionDetailAccessor<AI
 // Overlay
 // ---------------------------------------------------------------------------
 
-// While a drag is in flight we keep the live offset in local state so the
-// underlying model isn't touched until release — one drag commits as one
-// undo entry. Two distinct drag flavours can be active (the gizmo translates
-// the whole section; the corner handles deform the polygon), so we model it
-// as a discriminated union with mutual exclusion.
+// While a drag is in flight we keep the live delta in local state so the
+// underlying model isn't touched until release — one gesture commits as
+// one Workspace-undo entry (CONTEXT.md / "Bulk transform"). Two distinct
+// drag flavours can be active (the bulk-transform gizmo translates/rotates
+// the whole section; the corner handles deform the polygon — the latter
+// migrates to the unified gizmo in issue #73), so we model the active
+// drag as a discriminated union with mutual exclusion.
 type ActiveDrag =
-	| { kind: 'section'; offset: GizmoOffset }
+	| { kind: 'section'; delta: BulkTransformDelta }
 	| { kind: 'corner'; cornerIdx: number; offset: CornerDragOffset };
 
 type Props = {
@@ -268,17 +275,25 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 			? sectionYs[hoverSectionIndex]
 			: 0;
 
-	// While a drag is in flight, run the relevant op on the live offset to
+	// While a drag is in flight, run the relevant op on the live delta to
 	// derive a preview model. Used for the selection overlay on the source
-	// AND for highlighted neighbours that the smart-cascade affects, so the
-	// user sees the move in real time.
+	// section so the user sees the gesture in real time. Section-drag uses
+	// the no-cascade ops (per ADR-0009); corner-drag still cascades into
+	// shared corners (issue #73 migrates that gesture to the unified gizmo).
 	const previewModel: ParsedAISectionsV12 | null = useMemo(() => {
 		if (selectedSectionIndex == null || !selSection || !drag) return null;
-		if (drag.offset.x === 0 && drag.offset.z === 0) return null;
 		try {
 			if (drag.kind === 'section') {
-				return translateSectionWithLinks(data, selectedSectionIndex, drag.offset);
+				if (isIdentityDelta(drag.delta)) return null;
+				const translated = translateSectionRigid(data, selectedSectionIndex, drag.delta.translate);
+				// Apply yaw rotation around the *post-translate* centroid so
+				// translate + rotate compose as a single rigid body — same
+				// shape Blender's gizmo uses for combined gestures.
+				return drag.delta.rotate.y === 0
+					? translated
+					: rotateSectionAroundCentroidYaw(translated, selectedSectionIndex, drag.delta.rotate.y);
 			}
+			if (drag.offset.x === 0 && drag.offset.z === 0) return null;
 			return translateCornerWithShared(data, selectedSectionIndex, drag.cornerIdx, drag.offset);
 		} catch {
 			return null;
@@ -408,27 +423,44 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 		onSelect(aiSectionMarkerPath({ kind: 'noGoLine', sectionIndex: selectedSectionIndex, lineIndex }));
 	}, [onSelect, selectedSectionIndex]);
 
-	// Drag handlers — the gizmo translates the section, corner handles deform
-	// the polygon. Both go through the smart-cascade ops on commit and emit
+	// Drag handlers — the bulk-transform gizmo translates and yaw-rotates the
+	// section as one rigid body (no cascade per ADR-0009); corner handles
+	// deform the polygon (issue #73 migrates that gesture to the unified
+	// gizmo too). Both go through their respective ops on commit and emit
 	// the new root via onChange. Without onChange these are no-ops.
-	const handleGizmoTranslate = useCallback((offset: GizmoOffset) => {
-		const finalOffset =
-			snapEnabled && selectedSectionIndex != null
-				? snapSectionOffset(data, selectedSectionIndex, offset, snapRadius)
-				: offset;
-		setDrag({ kind: 'section', offset: finalOffset });
-	}, [snapEnabled, selectedSectionIndex, data, snapRadius]);
+	//
+	// Snap-to-edge is intentionally not applied to the bulk-transform path:
+	// snapping a section translation to neighbour edges only made sense in
+	// the cascade-on world (the cascade re-wired neighbours so the snap
+	// looked clean). Without cascade, snap would lock the section onto a
+	// neighbour edge while leaving the neighbour's reverse-portal stale —
+	// confusing UX. The corner-drag still gets snap until #73 retires it.
+	const handleGizmoTransform = useCallback((delta: BulkTransformDelta) => {
+		if (selectedSectionIndex == null) return;
+		setDrag({ kind: 'section', delta });
+	}, [selectedSectionIndex]);
 
-	const handleGizmoCommit = useCallback((offset: GizmoOffset) => {
+	const handleGizmoCommit = useCallback((delta: BulkTransformDelta) => {
 		setDrag(null);
 		if (selectedSectionIndex == null || !onChange) return;
-		if (offset.x === 0 && offset.z === 0) return;
-		const finalOffset = snapEnabled
-			? snapSectionOffset(data, selectedSectionIndex, offset, snapRadius)
-			: offset;
-		if (finalOffset.x === 0 && finalOffset.z === 0) return;
-		onChange(translateSectionWithLinks(data, selectedSectionIndex, finalOffset));
-	}, [data, selectedSectionIndex, snapEnabled, snapRadius, onChange]);
+		if (isIdentityDelta(delta)) return;
+		// Compose translate then yaw rotate in the same order as the preview
+		// (around the post-translate centroid) so commit and preview agree
+		// frame-for-frame.
+		let next = data;
+		if (delta.translate.x !== 0 || delta.translate.y !== 0 || delta.translate.z !== 0) {
+			next = translateSectionRigid(next, selectedSectionIndex, delta.translate);
+		}
+		if (delta.rotate.y !== 0) {
+			next = rotateSectionAroundCentroidYaw(next, selectedSectionIndex, delta.rotate.y);
+		}
+		if (next === data) return;
+		// Single onChange call ⇒ single setResourceAt ⇒ single
+		// HistoryCommit pushed onto the Workspace-undo stack. Drag-frames
+		// in between only updated local React state; they never touched
+		// `setResourceAt`, so they don't add stack entries.
+		onChange(next);
+	}, [data, selectedSectionIndex, onChange]);
 
 	const handleGizmoCancel = useCallback(() => setDrag(null), []);
 
@@ -627,10 +659,11 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 			})}
 
 			{gizmoPosition && drag?.kind !== 'corner' && (
-				<TranslateGizmo
+				<BulkTransformGizmo
 					position={gizmoPosition}
 					pixelSize={gizmoPixelSize}
-					onTranslate={handleGizmoTranslate}
+					axes={TRANSFORM_AXES_XZ_PACKED}
+					onTransform={handleGizmoTransform}
 					onCommit={handleGizmoCommit}
 					onCancel={handleGizmoCancel}
 				/>

--- a/src/context/__tests__/WorkspaceContext.bulkTransform.test.ts
+++ b/src/context/__tests__/WorkspaceContext.bulkTransform.test.ts
@@ -1,0 +1,223 @@
+// Integration test: Bulk-transform gizmo gesture → Workspace undo stack.
+//
+// The Bulk-transform contract (CONTEXT.md / "Bulk transform", ADR-0006) is:
+// one gesture = exactly one entry on the global Workspace-undo stack. The
+// preview during drag updates local React state only; only the gesture's
+// commit-on-release calls `setResource` (which records a HistoryCommit).
+//
+// We exercise that contract here without mounting React: the same shim used
+// by `WorkspaceContext.test.ts` (a `WorkspaceState` over the helpers + the
+// pure history reducer) gives us the same shape a live provider exposes via
+// `useWorkspace()`. If a future refactor accidentally pushes a HistoryCommit
+// per drag-frame, this test will reproduce the regression by counting
+// `past.length` after a multi-frame "drag".
+
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { makeEditableBundle } from '../WorkspaceContext.bundle';
+import { applyResourceWriteToBundle } from '../WorkspaceContext.helpers';
+import {
+	emptyHistory,
+	recordCommit,
+	recordUndo,
+	type HistoryStack,
+} from '@/lib/history';
+import {
+	rotateSectionAroundCentroidYaw,
+	translateSectionRigid,
+} from '@/lib/core/aiSectionsOps';
+import type {
+	EditableBundle,
+	HistoryCommit,
+} from '../WorkspaceContext.types';
+import type { ParsedAISectionsV12 } from '@/lib/core/aiSections';
+
+const FIXTURE = path.resolve(__dirname, '../../../example/AI.DAT');
+
+function loadFixture(): ArrayBuffer {
+	const raw = fs.readFileSync(FIXTURE);
+	const bytes = new Uint8Array(raw.byteLength);
+	bytes.set(raw);
+	return bytes.buffer;
+}
+
+// Tiny stand-in for the live provider's state. Mirrors the same surface
+// (bundles list + history stack + setResource via the helper).
+type State = {
+	bundles: EditableBundle[];
+	history: HistoryStack<HistoryCommit>;
+};
+
+function getAI(state: State, bundleId: string): ParsedAISectionsV12 {
+	const b = state.bundles.find((x) => x.id === bundleId);
+	if (!b) throw new Error(`bundle not found: ${bundleId}`);
+	const ai = b.parsedResources.get('aiSections') as ParsedAISectionsV12 | undefined;
+	if (!ai) throw new Error('aiSections not loaded');
+	return ai;
+}
+
+// `setResource` mirrors the provider's setResource — applies the write AND
+// pushes a HistoryCommit. Each call ⇒ exactly one undo entry, just like
+// the live provider.
+function setResource(
+	state: State,
+	bundleId: string,
+	key: string,
+	value: unknown,
+): State {
+	const b = state.bundles.find((x) => x.id === bundleId);
+	if (!b) return state;
+	const previous = b.parsedResourcesAll.get(key)?.[0] ?? null;
+	const nextHistory = recordCommit<HistoryCommit>(state.history, {
+		bundleId,
+		resourceKey: key,
+		index: 0,
+		previous,
+		next: value,
+	});
+	const nextBundles = state.bundles.map((bb) =>
+		bb.id === bundleId ? applyResourceWriteToBundle(bb, key, 0, value) : bb,
+	);
+	return { bundles: nextBundles, history: nextHistory };
+}
+
+// Mirror the provider's `undo()`: pop the head HistoryCommit and apply
+// `previous` back into the model.
+function undo(state: State): State {
+	const top = state.history.past[state.history.past.length - 1];
+	if (!top) return state;
+	const live = state.bundles.find((b) => b.id === top.bundleId);
+	const actualCurrent: HistoryCommit = {
+		bundleId: top.bundleId,
+		resourceKey: top.resourceKey,
+		index: top.index,
+		previous: top.previous,
+		next: live?.parsedResourcesAll.get(top.resourceKey)?.[top.index] ?? null,
+	};
+	const out = recordUndo(state.history, actualCurrent);
+	if (!out) return state;
+	const nextBundles = state.bundles.map((bb) =>
+		bb.id === top.bundleId
+			? applyResourceWriteToBundle(bb, top.resourceKey, top.index, top.previous)
+			: bb,
+	);
+	return { bundles: nextBundles, history: out.stack };
+}
+
+function makeInitialState(): State {
+	return {
+		bundles: [makeEditableBundle(loadFixture(), 'AI.DAT')],
+		history: emptyHistory<HistoryCommit>(),
+	};
+}
+
+describe('Bulk transform gesture → Workspace undo stack', () => {
+	it('one translate-only gesture pushes exactly one HistoryCommit', () => {
+		const initial = makeInitialState();
+		expect(initial.history.past.length).toBe(0);
+
+		const ai = getAI(initial, 'AI.DAT');
+		// Find a section with ≥1 corner so the translate is meaningful. The
+		// AI.DAT fixture has thousands; index 0 is fine.
+		const next = translateSectionRigid(ai, 0, { x: 5, y: 0, z: -3 });
+		const after = setResource(initial, 'AI.DAT', 'aiSections', next);
+
+		expect(after.history.past.length).toBe(1);
+		expect(after.bundles[0].isModified).toBe(true);
+	});
+
+	it('one combined translate+yaw gesture also pushes exactly one HistoryCommit', () => {
+		// The gizmo composes translate then yaw rotate inside its commit
+		// callback before calling onChange exactly once — so even though
+		// two ops compose the new model, only one setResource is called
+		// and only one undo entry is pushed. This is the load-bearing
+		// invariant for "one gesture = one undo step".
+		const initial = makeInitialState();
+		const ai = getAI(initial, 'AI.DAT');
+		const t = translateSectionRigid(ai, 0, { x: 5, y: 0, z: -3 });
+		const r = rotateSectionAroundCentroidYaw(t, 0, 0.3);
+		const after = setResource(initial, 'AI.DAT', 'aiSections', r);
+
+		expect(after.history.past.length).toBe(1);
+	});
+
+	it('drag-frames that update local preview state only (no setResource) do NOT push undo entries', () => {
+		// Simulates the gizmo's onTransform path: every frame the consumer
+		// computes a preview model but never calls setResource. The only
+		// model write happens once at gesture release, in onCommit.
+		const initial = makeInitialState();
+		const ai = getAI(initial, 'AI.DAT');
+
+		// Pretend 50 drag-frames passed — each rendered a preview by
+		// running the op pure, but none touched the workspace state.
+		let previewModel = ai;
+		for (let f = 0; f < 50; f++) {
+			previewModel = translateSectionRigid(ai, 0, { x: f, y: 0, z: 0 });
+			// Notably: NO setResource call here. The provider's history
+			// stack stays empty.
+		}
+		expect(initial.history.past.length).toBe(0);
+
+		// Commit on release — single setResource with the final preview.
+		const after = setResource(initial, 'AI.DAT', 'aiSections', previewModel);
+		expect(after.history.past.length).toBe(1);
+	});
+
+	it('translate gesture round-trips: undo restores the pre-translate state exactly', () => {
+		const initial = makeInitialState();
+		const ai = getAI(initial, 'AI.DAT');
+
+		// Snapshot the source section's pre-translate corners + portal anchors
+		// so we can compare deep after the round trip.
+		const beforeCorners = ai.sections[0].corners.map((c) => ({ ...c }));
+		const beforePortals = ai.sections[0].portals.map((p) => ({
+			...p,
+			position: { ...p.position },
+			boundaryLines: p.boundaryLines.map((bl) => ({ verts: { ...bl.verts } })),
+		}));
+
+		// Apply the translate and commit.
+		const translated = translateSectionRigid(ai, 0, { x: 7, y: 1, z: -4 });
+		const afterEdit = setResource(initial, 'AI.DAT', 'aiSections', translated);
+		const editedAi = getAI(afterEdit, 'AI.DAT');
+		expect(editedAi.sections[0].corners[0].x).toBeCloseTo(beforeCorners[0].x + 7, 6);
+
+		// Undo — the model should be exactly the pre-translate AI.
+		const afterUndo = undo(afterEdit);
+		const undoneAi = getAI(afterUndo, 'AI.DAT');
+		// `previous` is captured by reference at recordCommit time, so it
+		// IS the pre-edit model — undo restores deep-equal sections (the
+		// outer parsedResources map gets rewrapped by applyResourceWriteToBundle
+		// so we use deep equality, not reference equality).
+		expect(undoneAi.sections[0].corners).toEqual(beforeCorners);
+		// Spot-check portal anchors deep-equal the pre-edit values too.
+		for (let i = 0; i < beforePortals.length; i++) {
+			expect(undoneAi.sections[0].portals[i].position).toEqual(beforePortals[i].position);
+		}
+	});
+
+	it('yaw-rotate gesture round-trips: undo restores the pre-rotate state exactly', () => {
+		// Same shape as the translate round-trip but exercising the rotate
+		// op. Combined-gesture round-trip is implied by both axes' purity —
+		// the commit produces one new immutable model, which `previous`
+		// pins, which undo restores.
+		const initial = makeInitialState();
+		const ai = getAI(initial, 'AI.DAT');
+		const beforeCorners = ai.sections[0].corners.map((c) => ({ ...c }));
+
+		const rotated = rotateSectionAroundCentroidYaw(ai, 0, 0.5);
+		const afterEdit = setResource(initial, 'AI.DAT', 'aiSections', rotated);
+		// Confirm the rotate took effect.
+		expect(getAI(afterEdit, 'AI.DAT').sections[0].corners[0])
+			.not.toEqual(beforeCorners[0]);
+
+		const afterUndo = undo(afterEdit);
+		// Deep equality — same reasoning as the translate round-trip above:
+		// `applyResourceWriteToBundle` rewraps the parsedResources map so
+		// the outer section object is a fresh ref, but its contents match
+		// the pre-edit model exactly.
+		expect(getAI(afterUndo, 'AI.DAT').sections[0].corners).toEqual(beforeCorners);
+	});
+});

--- a/src/hooks/useBulkTransformDrag.ts
+++ b/src/hooks/useBulkTransformDrag.ts
@@ -1,0 +1,257 @@
+// Window-level pointer + key drag listeners for the BulkTransformGizmo,
+// only mounted while a drag is in flight.
+//
+// R3F's per-mesh pointer events stop firing once the cursor leaves the
+// handle mesh, so we listen on the window so the preview keeps updating
+// even when the user drags far past the gizmo. The active drag also
+// disables OrbitControls (so camera orbit doesn't compete with the
+// gesture) and forces `document.body.style.cursor`. Cleanup restores both
+// on pointerup, on Escape, or on unmount.
+//
+// One gesture = one undo entry. The hook calls `onTransform` continuously
+// (preview-only) and `onCommit` exactly once on pointer release. Escape
+// fires `onCancel` and resets the preview without committing.
+//
+// Translate math: a 3D pointer offset on the drag plane is projected onto
+// the chosen axis vector, so off-axis cursor motion doesn't leak into the
+// translate. Rotate math: a screen-space angle delta around the projected
+// pivot is applied around the world-space rotation axis. Both deltas are
+// cumulative from the gesture's start so the consumer can render a live
+// preview from the identity each frame.
+
+import { useEffect } from 'react';
+import * as THREE from 'three';
+import { projectToScreen, unprojectToPlane } from '@/lib/three/projection';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type GizmoHandleKind = 'translate' | 'rotate';
+export type GizmoHandleAxis = 'x' | 'y' | 'z';
+
+/**
+ * One gesture's accumulated delta. Translate is a `(dx, dy, dz)` offset in
+ * world space; rotate is a per-axis Euler angle in radians applied around
+ * the gizmo's pivot. Pitch/roll are present in the type so future slices
+ * (trigger box gizmo) get the same shape — for the AI section MVP only
+ * `rotate.y` is ever non-zero (ADR-0011 yaw-lock).
+ */
+export type BulkTransformDelta = {
+	translate: { x: number; y: number; z: number };
+	rotate: { x: number; y: number; z: number };
+};
+
+export type BulkTransformDragOptions = {
+	active: { kind: GizmoHandleKind; axis: GizmoHandleAxis } | null;
+	camera: THREE.Camera;
+	canvas: HTMLCanvasElement;
+	/** OrbitControls instance from `useThree().controls`, if present. */
+	controls: { enabled: boolean } | null;
+	/** Gizmo's world-space pivot — translate planes pass through it; rotate
+	 *  rings are centred on it. */
+	pivot: THREE.Vector3;
+	/** Drag-start state captured by the gizmo on pointerdown. */
+	dragStart: React.MutableRefObject<{
+		kind: GizmoHandleKind;
+		axis: GizmoHandleAxis;
+		pivot: THREE.Vector3;
+		anchorWorld?: THREE.Vector3;
+		anchorAngle?: number;
+		rotationAxisWorld?: THREE.Vector3;
+	} | null>;
+	onTransform: (delta: BulkTransformDelta) => void;
+	onCommit: (delta: BulkTransformDelta) => void;
+	onCancel?: () => void;
+	setActive: (a: { kind: GizmoHandleKind; axis: GizmoHandleAxis } | null) => void;
+};
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+export function useBulkTransformDrag({
+	active,
+	camera,
+	canvas,
+	controls,
+	pivot,
+	dragStart,
+	onTransform,
+	onCommit,
+	onCancel,
+	setActive,
+}: BulkTransformDragOptions): void {
+	useEffect(() => {
+		if (!active) return;
+
+		const prevEnabled = controls?.enabled ?? true;
+		if (controls) controls.enabled = false;
+
+		const computeDelta = (clientX: number, clientY: number): BulkTransformDelta | null => {
+			const start = dragStart.current;
+			if (!start) return null;
+			if (start.kind === 'translate') {
+				return computeTranslateDelta(start, clientX, clientY, camera, canvas);
+			}
+			return computeRotateDelta(start, clientX, clientY, camera, canvas);
+		};
+
+		const handleMove = (e: PointerEvent) => {
+			const delta = computeDelta(e.clientX, e.clientY);
+			if (!delta) return;
+			onTransform(delta);
+		};
+
+		const handleUp = (e: PointerEvent) => {
+			const delta = computeDelta(e.clientX, e.clientY) ?? identityDelta();
+			dragStart.current = null;
+			setActive(null);
+			onCommit(delta);
+		};
+
+		const handleKey = (e: KeyboardEvent) => {
+			if (e.key !== 'Escape') return;
+			dragStart.current = null;
+			setActive(null);
+			onTransform(identityDelta());
+			onCancel?.();
+		};
+
+		window.addEventListener('pointermove', handleMove);
+		window.addEventListener('pointerup', handleUp);
+		window.addEventListener('keydown', handleKey);
+		return () => {
+			window.removeEventListener('pointermove', handleMove);
+			window.removeEventListener('pointerup', handleUp);
+			window.removeEventListener('keydown', handleKey);
+			if (controls) controls.enabled = prevEnabled;
+			document.body.style.cursor = 'auto';
+		};
+	}, [active, camera, canvas, controls, dragStart, onTransform, onCommit, onCancel, setActive]);
+}
+
+// =============================================================================
+// Delta math — translate
+// =============================================================================
+
+function computeTranslateDelta(
+	start: NonNullable<BulkTransformDragOptions['dragStart']['current']>,
+	clientX: number,
+	clientY: number,
+	camera: THREE.Camera,
+	canvas: HTMLCanvasElement,
+): BulkTransformDelta | null {
+	const anchor = start.anchorWorld;
+	if (!anchor) return null;
+	const planeNormal = translatePlaneNormalForDelta(start.axis, camera);
+	const current = unprojectToPlane(clientX, clientY, camera, canvas, start.pivot, planeNormal);
+	if (!current) return null;
+	const raw = current.clone().sub(anchor);
+	// Project the off-axis cursor motion onto the chosen axis so the user
+	// never accidentally drifts into a different axis while dragging.
+	const axisVec = axisUnitVector(start.axis);
+	const along = raw.dot(axisVec);
+	const projected = axisVec.clone().multiplyScalar(along);
+	return {
+		translate: { x: projected.x, y: projected.y, z: projected.z },
+		rotate: { x: 0, y: 0, z: 0 },
+	};
+}
+
+// Mirrors `translatePlaneNormalFor` in BulkTransformGizmo.tsx but uses no
+// pivot reference — only the camera direction matters for picking between
+// the two Y-axis planes. (Imported helper would have created a circular
+// import; this duplicate is two lines and stays in sync trivially.)
+function translatePlaneNormalForDelta(
+	axis: GizmoHandleAxis,
+	camera: THREE.Camera,
+): THREE.Vector3 {
+	if (axis === 'x' || axis === 'z') {
+		return new THREE.Vector3(0, 1, 0);
+	}
+	const camDir = new THREE.Vector3();
+	camera.getWorldDirection(camDir);
+	const dotX = Math.abs(camDir.x);
+	const dotZ = Math.abs(camDir.z);
+	return dotX > dotZ
+		? new THREE.Vector3(1, 0, 0)
+		: new THREE.Vector3(0, 0, 1);
+}
+
+function axisUnitVector(axis: GizmoHandleAxis): THREE.Vector3 {
+	if (axis === 'x') return new THREE.Vector3(1, 0, 0);
+	if (axis === 'y') return new THREE.Vector3(0, 1, 0);
+	return new THREE.Vector3(0, 0, 1);
+}
+
+// =============================================================================
+// Delta math — rotate
+// =============================================================================
+
+function computeRotateDelta(
+	start: NonNullable<BulkTransformDragOptions['dragStart']['current']>,
+	clientX: number,
+	clientY: number,
+	camera: THREE.Camera,
+	canvas: HTMLCanvasElement,
+): BulkTransformDelta | null {
+	const anchorAngle = start.anchorAngle;
+	const axisWorld = start.rotationAxisWorld;
+	if (anchorAngle == null || !axisWorld) return null;
+	const pivotScreen = projectToScreen(start.pivot, camera, canvas);
+	if (!pivotScreen) return null;
+
+	const dx = clientX - pivotScreen.x;
+	const dy = clientY - pivotScreen.y;
+	const currentAngle = Math.atan2(dy, dx);
+	let theta = currentAngle - anchorAngle;
+	// Normalise to [-π, π] so rotating across the screen-angle wrap doesn't
+	// produce a sudden 2π jump in the preview.
+	while (theta > Math.PI) theta -= 2 * Math.PI;
+	while (theta < -Math.PI) theta += 2 * Math.PI;
+
+	// Invert when the camera looks at the rotation axis from the back — so
+	// dragging the cursor right always feels like clockwise rotation from
+	// the user's perspective. The fix: take the dot of the world axis with
+	// the vector from camera to pivot; positive means the camera is on the
+	// axis side, negative means we need to flip the sign.
+	//
+	// For a top-down camera looking at +Y rotation: cam→pivot has `y < 0`,
+	// axisWorld is +Y, so dot is negative — we flip θ. Result: dragging
+	// right rotates yaw clockwise as seen from above, matching the screen.
+	const camToPivot = start.pivot.clone().sub(camera.position);
+	const sign = axisWorld.dot(camToPivot) >= 0 ? 1 : -1;
+	theta *= sign;
+
+	return {
+		translate: { x: 0, y: 0, z: 0 },
+		rotate: {
+			x: start.axis === 'x' ? theta : 0,
+			y: start.axis === 'y' ? theta : 0,
+			z: start.axis === 'z' ? theta : 0,
+		},
+	};
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+export function identityDelta(): BulkTransformDelta {
+	return {
+		translate: { x: 0, y: 0, z: 0 },
+		rotate: { x: 0, y: 0, z: 0 },
+	};
+}
+
+export function isIdentityDelta(d: BulkTransformDelta): boolean {
+	return (
+		d.translate.x === 0 &&
+		d.translate.y === 0 &&
+		d.translate.z === 0 &&
+		d.rotate.x === 0 &&
+		d.rotate.y === 0 &&
+		d.rotate.z === 0
+	);
+}

--- a/src/lib/core/aiSectionsOps.test.ts
+++ b/src/lib/core/aiSectionsOps.test.ts
@@ -8,6 +8,7 @@ import {
 	deleteSection,
 	duplicateLegacySectionThroughEdge,
 	duplicateSectionThroughEdge,
+	rotateSectionAroundCentroidYaw,
 	snapCornerOffset,
 	snapLegacyCornerOffset,
 	snapLegacySectionOffset,
@@ -15,6 +16,7 @@ import {
 	translateCornerWithShared,
 	translateLegacyCornerWithShared,
 	translateLegacySectionWithLinks,
+	translateSectionRigid,
 	translateSectionWithLinks,
 } from './aiSectionsOps';
 import {
@@ -1966,5 +1968,339 @@ describe('snapLegacySectionOffset', () => {
 		const before = JSON.stringify(model);
 		snapLegacySectionOffset(model, 0, { x: 0.7, z: 0 }, 1.0);
 		expect(JSON.stringify(model)).toEqual(before);
+	});
+});
+
+// =============================================================================
+// translateSectionRigid (Bulk-transform: no-cascade rigid translate)
+// =============================================================================
+//
+// The Bulk-transform gizmo's default-no-modifier path. Outside neighbours
+// stay completely put (per ADR-0009) — this is what differentiates this op
+// from `translateSectionWithLinks`. The 3D offset accepts `(dx, dy, dz)`:
+// `dy` shifts portal anchor Ys but leaves the XZ-packed corners and
+// boundary lines alone (per ADR-0011).
+
+describe('translateSectionRigid', () => {
+	function makePair(): ParsedAISectionsV12 {
+		const portal0to1: Portal = {
+			position: { x: 10, y: 0, z: 5 },
+			boundaryLines: [{ verts: { x: 10, y: 0, z: 10, w: 10 } }],
+			linkSection: 1,
+		};
+		const portal1to0: Portal = {
+			position: { x: 10, y: 0, z: 5 },
+			boundaryLines: [{ verts: { x: 10, y: 10, z: 10, w: 0 } }],
+			linkSection: 0,
+		};
+		const s0 = makeSection({
+			id: 0xA,
+			corners: [
+				{ x: 0, y: 0 },
+				{ x: 10, y: 0 },
+				{ x: 10, y: 10 },
+				{ x: 0, y: 10 },
+			],
+			portals: [portal0to1],
+		});
+		const s1 = makeSection({
+			id: 0xB,
+			corners: [
+				{ x: 10, y: 0 },
+				{ x: 20, y: 0 },
+				{ x: 20, y: 10 },
+				{ x: 10, y: 10 },
+			],
+			portals: [portal1to0],
+		});
+		return makeModel([s0, s1]);
+	}
+
+	it('shifts every spatial field on the source by (dx, dy, dz)', () => {
+		const model = makePair();
+		const next = translateSectionRigid(model, 0, { x: 3, y: 2, z: -2 });
+		const s0 = next.sections[0];
+		// XZ-packed corners only see (dx, dz) — dy doesn't apply.
+		expect(s0.corners).toEqual([
+			{ x: 3, y: -2 },
+			{ x: 13, y: -2 },
+			{ x: 13, y: 8 },
+			{ x: 3, y: 8 },
+		]);
+		// Portal anchor (Vector3) sees full (dx, dy, dz).
+		expect(s0.portals[0].position).toEqual({ x: 13, y: 2, z: 3 });
+		// Portal boundary line (XZ-packed Vector4) — both endpoints shift by (dx, dz).
+		expect(s0.portals[0].boundaryLines[0].verts).toEqual({ x: 13, y: -2, z: 13, w: 8 });
+	});
+
+	it('translates noGo lines too', () => {
+		const portal: Portal = {
+			position: { x: 0, y: 0, z: 0 },
+			boundaryLines: [],
+			linkSection: 0,
+		};
+		const sec = makeSection({
+			portals: [portal],
+		});
+		sec.noGoLines = [{ verts: { x: 0, y: 0, z: 5, w: 5 } }];
+		const model = makeModel([sec]);
+		const next = translateSectionRigid(model, 0, { x: 1, y: 0, z: 2 });
+		expect(next.sections[0].noGoLines[0].verts).toEqual({ x: 1, y: 2, z: 6, w: 7 });
+	});
+
+	it('leaves outside neighbours completely put (no cascade — ADR-0009)', () => {
+		const model = makePair();
+		const next = translateSectionRigid(model, 0, { x: 3, y: 0, z: -2 });
+		// Section 1's corners, portals, and boundary lines all stay put.
+		// Reference equality on the section object proves nothing under it
+		// changed (immutable-update convention used throughout this module).
+		expect(next.sections[1]).toBe(model.sections[1]);
+	});
+
+	it('produces stale paired-portal anchors (a documented v1 trade-off — ADR-0009)', () => {
+		// The neighbour's reverse portal still claims it lives at the OLD
+		// shared-edge midpoint, while the source's portal has moved. That's
+		// the "stale" state ADR-0009 accepts as a v1 trade-off — a follow-up
+		// "dangling boundary portals" affordance highlights these.
+		const model = makePair();
+		const next = translateSectionRigid(model, 0, { x: 3, y: 0, z: -2 });
+		expect(next.sections[0].portals[0].position).toEqual({ x: 13, y: 0, z: 3 });
+		expect(next.sections[1].portals[0].position).toEqual({ x: 10, y: 0, z: 5 });
+	});
+
+	it('returns the original model reference for a (0, 0, 0) offset (no-op)', () => {
+		// Important for byte-for-byte BND2 writeback: a cancelled gesture
+		// or a click-without-drag must leave the model exactly identical.
+		const model = makePair();
+		const next = translateSectionRigid(model, 0, { x: 0, y: 0, z: 0 });
+		expect(next).toBe(model);
+	});
+
+	it('throws on out-of-range srcIdx', () => {
+		const model = makePair();
+		expect(() => translateSectionRigid(model, 5, { x: 1, y: 0, z: 0 })).toThrow(RangeError);
+		expect(() => translateSectionRigid(model, -1, { x: 1, y: 0, z: 0 })).toThrow(RangeError);
+	});
+
+	it('does not mutate the input', () => {
+		const model = makePair();
+		const before = JSON.stringify(model);
+		translateSectionRigid(model, 0, { x: 5, y: 1, z: 5 });
+		expect(JSON.stringify(model)).toEqual(before);
+	});
+
+	it('shares the unaffected source-section reference when the result is the same model (no-op)', () => {
+		// Reinforces the structural-sharing convention: a no-op never copies.
+		const model = makePair();
+		const result = translateSectionRigid(model, 0, { x: 0, y: 0, z: 0 });
+		expect(result.sections[0]).toBe(model.sections[0]);
+		expect(result.sections[1]).toBe(model.sections[1]);
+	});
+});
+
+// =============================================================================
+// rotateSectionAroundCentroidYaw (Bulk-transform: rigid yaw rotate)
+// =============================================================================
+//
+// Yaw-only rotate around the section's own corner-centroid (cardinality-1
+// pivot per CONTEXT.md / "Pivot"). Pitch/roll are not exposed because AI
+// section corners are XZ-packed (per ADR-0011 — the gizmo greys out those
+// rings; this op intentionally has no pitch/roll parameter).
+
+describe('rotateSectionAroundCentroidYaw', () => {
+	function makeRect(): ParsedAISectionsV12 {
+		// 10×10 quad centred at (5, 5).
+		const portal: Portal = {
+			position: { x: 10, y: 3, z: 5 },
+			boundaryLines: [{ verts: { x: 10, y: 0, z: 10, w: 10 } }],
+			linkSection: 0,
+		};
+		const sec = makeSection({
+			id: 0xA,
+			corners: [
+				{ x: 0, y: 0 },
+				{ x: 10, y: 0 },
+				{ x: 10, y: 10 },
+				{ x: 0, y: 10 },
+			],
+			portals: [portal],
+		});
+		sec.noGoLines = [{ verts: { x: 2, y: 2, z: 8, w: 8 } }];
+		return makeModel([sec]);
+	}
+
+	it('returns the original model reference for theta = 0 (identity — byte-for-byte safe)', () => {
+		// CRITICAL: a rotate-by-0 gesture must NOT change anything. This is
+		// the byte-for-byte BND2 writeback invariant. If this fails, a user
+		// clicking the rotate ring without dragging would dirty the bundle.
+		const model = makeRect();
+		const next = rotateSectionAroundCentroidYaw(model, 0, 0);
+		expect(next).toBe(model);
+		expect(next.sections[0]).toBe(model.sections[0]);
+	});
+
+	it('rotates corners by 90° around the centroid (rigid body)', () => {
+		// Centroid of the unit square is (5, 5). Rotate +π/2 (90° yaw).
+		// Following the right-hand rule with thumb +Y: +X → +Z, +Z → -X.
+		// Corner (0, 0) → centroid offset (-5, -5) → after rot (5, -5) → (10, 0)
+		// Corner (10, 0) → offset (5, -5) → after rot (5, 5) → (10, 10)
+		// Corner (10, 10) → offset (5, 5) → after rot (-5, 5) → (0, 10)
+		// Corner (0, 10) → offset (-5, 5) → after rot (-5, -5) → (0, 0)
+		const model = makeRect();
+		const next = rotateSectionAroundCentroidYaw(model, 0, Math.PI / 2);
+		const corners = next.sections[0].corners;
+		expect(corners[0].x).toBeCloseTo(10, 6);
+		expect(corners[0].y).toBeCloseTo(0, 6);
+		expect(corners[1].x).toBeCloseTo(10, 6);
+		expect(corners[1].y).toBeCloseTo(10, 6);
+		expect(corners[2].x).toBeCloseTo(0, 6);
+		expect(corners[2].y).toBeCloseTo(10, 6);
+		expect(corners[3].x).toBeCloseTo(0, 6);
+		expect(corners[3].y).toBeCloseTo(0, 6);
+	});
+
+	it('preserves relative distances (rigid-body invariant)', () => {
+		// Pick an arbitrary, non-cardinal angle so floating-point trig is
+		// exercised. Any pair of corners' distance must be identical
+		// before and after rotation.
+		const model = makeRect();
+		const theta = 0.7;
+		const next = rotateSectionAroundCentroidYaw(model, 0, theta);
+		const before = model.sections[0].corners;
+		const after = next.sections[0].corners;
+		const dist = (a: { x: number; y: number }, b: { x: number; y: number }) =>
+			Math.hypot(a.x - b.x, a.y - b.y);
+		for (let i = 0; i < before.length; i++) {
+			for (let j = i + 1; j < before.length; j++) {
+				expect(dist(after[i], after[j])).toBeCloseTo(dist(before[i], before[j]), 6);
+			}
+		}
+	});
+
+	it('rotates portal positions on XZ but preserves portal Y', () => {
+		const model = makeRect();
+		// Portal sat at (10, 3, 5) — centroid offset on XZ is (5, 0). Rotate
+		// +π/2: offset becomes (0, 5), so position lands at (5, 3, 10). Y
+		// must be untouched (yaw doesn't tip vertically).
+		const next = rotateSectionAroundCentroidYaw(model, 0, Math.PI / 2);
+		const p = next.sections[0].portals[0].position;
+		expect(p.x).toBeCloseTo(5, 6);
+		expect(p.y).toBe(3); // exact, untouched
+		expect(p.z).toBeCloseTo(10, 6);
+	});
+
+	it('rotates portal boundary line endpoints', () => {
+		// BL was (10, 0) → (10, 10). Centroid (5, 5).
+		// Start offset (5, -5) → after π/2 (5, 5) → (10, 10).
+		// End   offset (5, 5)  → after π/2 (-5, 5) → (0, 10).
+		const model = makeRect();
+		const next = rotateSectionAroundCentroidYaw(model, 0, Math.PI / 2);
+		const bl = next.sections[0].portals[0].boundaryLines[0].verts;
+		expect(bl.x).toBeCloseTo(10, 6);
+		expect(bl.y).toBeCloseTo(10, 6);
+		expect(bl.z).toBeCloseTo(0, 6);
+		expect(bl.w).toBeCloseTo(10, 6);
+	});
+
+	it('rotates noGo line endpoints', () => {
+		// NoGo was (2, 2) → (8, 8) — diagonal across the square. Centroid (5, 5).
+		// Start offset (-3, -3) → π/2 (3, -3) → (8, 2).
+		// End   offset (3, 3)   → π/2 (-3, 3) → (2, 8).
+		const model = makeRect();
+		const next = rotateSectionAroundCentroidYaw(model, 0, Math.PI / 2);
+		const ng = next.sections[0].noGoLines[0].verts;
+		expect(ng.x).toBeCloseTo(8, 6);
+		expect(ng.y).toBeCloseTo(2, 6);
+		expect(ng.z).toBeCloseTo(2, 6);
+		expect(ng.w).toBeCloseTo(8, 6);
+	});
+
+	it('rotation by 2π equals identity geometry (full revolution returns to start, modulo float epsilon)', () => {
+		const model = makeRect();
+		const next = rotateSectionAroundCentroidYaw(model, 0, Math.PI * 2);
+		const before = model.sections[0].corners;
+		const after = next.sections[0].corners;
+		for (let i = 0; i < before.length; i++) {
+			expect(after[i].x).toBeCloseTo(before[i].x, 5);
+			expect(after[i].y).toBeCloseTo(before[i].y, 5);
+		}
+	});
+
+	it('does not cascade into outside neighbours (ADR-0009)', () => {
+		// Same shape as the no-cascade translate test: a paired neighbour
+		// stays put even when the source rotates.
+		const portal0to1: Portal = {
+			position: { x: 10, y: 0, z: 5 },
+			boundaryLines: [{ verts: { x: 10, y: 0, z: 10, w: 10 } }],
+			linkSection: 1,
+		};
+		const portal1to0: Portal = {
+			position: { x: 10, y: 0, z: 5 },
+			boundaryLines: [{ verts: { x: 10, y: 10, z: 10, w: 0 } }],
+			linkSection: 0,
+		};
+		const s0 = makeSection({
+			id: 0xA,
+			corners: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }],
+			portals: [portal0to1],
+		});
+		const s1 = makeSection({
+			id: 0xB,
+			corners: [{ x: 10, y: 0 }, { x: 20, y: 0 }, { x: 20, y: 10 }, { x: 10, y: 10 }],
+			portals: [portal1to0],
+		});
+		const model = makeModel([s0, s1]);
+		const next = rotateSectionAroundCentroidYaw(model, 0, Math.PI / 4);
+		// s1 reference unchanged — proves nothing under it moved.
+		expect(next.sections[1]).toBe(model.sections[1]);
+	});
+
+	it('throws on out-of-range srcIdx', () => {
+		const model = makeRect();
+		expect(() => rotateSectionAroundCentroidYaw(model, 5, 1)).toThrow(RangeError);
+		expect(() => rotateSectionAroundCentroidYaw(model, -1, 1)).toThrow(RangeError);
+	});
+
+	it('does not mutate the input', () => {
+		const model = makeRect();
+		const before = JSON.stringify(model);
+		rotateSectionAroundCentroidYaw(model, 0, 0.5);
+		expect(JSON.stringify(model)).toEqual(before);
+	});
+});
+
+// =============================================================================
+// Bulk-transform compose: translate then yaw, in commit order
+// =============================================================================
+//
+// The AISectionsOverlay's gizmo commit composes translate then yaw rotate
+// in that order — yaw rotates around the *post-translate* centroid. These
+// tests pin the composition shape so the preview and commit paths stay
+// in lock-step.
+
+describe('translateSectionRigid + rotateSectionAroundCentroidYaw composition', () => {
+	function makeRect(): ParsedAISectionsV12 {
+		const sec = makeSection({
+			id: 0xA,
+			corners: [
+				{ x: 0, y: 0 },
+				{ x: 10, y: 0 },
+				{ x: 10, y: 10 },
+				{ x: 0, y: 10 },
+			],
+			portals: [],
+		});
+		return makeModel([sec]);
+	}
+
+	it('translate then yaw rotates around the post-translate centroid', () => {
+		const model = makeRect();
+		const t = translateSectionRigid(model, 0, { x: 100, y: 0, z: 200 });
+		// Post-translate centroid is (105, 205). Rotate π/2 around it.
+		const r = rotateSectionAroundCentroidYaw(t, 0, Math.PI / 2);
+		// Pre-translate corner (0,0) → post-translate (100, 200) → centroid
+		// offset (-5, -5) → π/2 → (5, -5) → (110, 200).
+		expect(r.sections[0].corners[0].x).toBeCloseTo(110, 6);
+		expect(r.sections[0].corners[0].y).toBeCloseTo(200, 6);
 	});
 });

--- a/src/lib/core/aiSectionsOps.ts
+++ b/src/lib/core/aiSectionsOps.ts
@@ -1320,3 +1320,174 @@ export function deleteSection(
 		sectionResetPairs: remappedResetPairs,
 	};
 }
+
+// =============================================================================
+// Bulk-transform: no-cascade rigid translate + yaw rotate
+// =============================================================================
+//
+// The Bulk-transform feature (CONTEXT.md / "Bulk transform", ADR-0009 /
+// ADR-0010 / ADR-0011) replaces the legacy single-section drag with a unified
+// gizmo whose default behaviour is "move what you selected; modifier extends
+// to connected geometry." These ops are the *no-cascade* path:
+//
+//   - `translateSectionRigid` — translate one section's corners + portal
+//     anchors + portal boundary lines + no-go lines by `(dx, dy, dz)`.
+//     Outside neighbours stay completely put. Y shifts the portal anchor
+//     heights but NOT the corners (they're XZ-packed Vector2 — see ADR-0011);
+//     the boundary lines and no-go lines are also XZ-only.
+//
+//   - `rotateSectionAroundCentroidYaw` — rotate the section as a rigid body
+//     around its own centroid (cardinality-1 pivot per CONTEXT.md / "Pivot")
+//     by an angle θ around world +Y (yaw). Corners + portal positions +
+//     portal boundary lines + no-go lines all rotate together; relative
+//     geometry is preserved exactly. Pitch/roll are not exposed by this op
+//     because the section's spatial data is XZ-packed (ADR-0011); future
+//     resource families with full 3D rotation use a different op.
+//
+// Cascade-on remains the legacy `translateSectionWithLinks` path; the
+// follow-up cascade-modifier slice (#75) wires it to the modifier press.
+
+/**
+ * Translate one AI section as a rigid body — no cascade into neighbours.
+ *
+ * Every spatial field on the source section shifts by `(dx, dy, dz)`:
+ *   - corners (Vector2 — XZ only; `dy` does not apply)
+ *   - portals[].position (Vector3 — full 3D)
+ *   - portals[].boundaryLines[].verts (Vector4 packed XZ start/end — XZ only)
+ *   - noGoLines[].verts (same shape as portal boundary lines — XZ only)
+ *
+ * Outside neighbours stay completely put. Their reverse-portal `linkSection`
+ * still points at this section by index, but the world-space anchor will
+ * be out of sync with the moved section's portal — accepted per ADR-0009.
+ * The cascade-on path is `translateSectionWithLinks` (separate function).
+ *
+ * Returns the original `model` reference when `(dx, dy, dz) === (0, 0, 0)`
+ * so byte-for-byte BND2 writeback is preserved on a no-op gesture.
+ *
+ * @throws RangeError if `srcIdx` is out of range.
+ */
+export function translateSectionRigid(
+	model: ParsedAISectionsV12,
+	srcIdx: number,
+	offset: { x: number; y: number; z: number },
+): ParsedAISectionsV12 {
+	if (srcIdx < 0 || srcIdx >= model.sections.length) {
+		throw new RangeError(`srcIdx ${srcIdx} out of range [0, ${model.sections.length})`);
+	}
+	const dx = offset.x;
+	const dy = offset.y;
+	const dz = offset.z;
+	if (dx === 0 && dy === 0 && dz === 0) return model;
+
+	const src = model.sections[srcIdx];
+	const next: AISection = {
+		...src,
+		corners: src.corners.map((c) => ({ x: c.x + dx, y: c.y + dz })),
+		portals: src.portals.map((p) => ({
+			...p,
+			position: { x: p.position.x + dx, y: p.position.y + dy, z: p.position.z + dz },
+			boundaryLines: p.boundaryLines.map((bl) => ({
+				verts: { x: bl.verts.x + dx, y: bl.verts.y + dz, z: bl.verts.z + dx, w: bl.verts.w + dz },
+			})),
+		})),
+		noGoLines: src.noGoLines.map((bl) => ({
+			verts: { x: bl.verts.x + dx, y: bl.verts.y + dz, z: bl.verts.z + dx, w: bl.verts.w + dz },
+		})),
+	};
+
+	const sections = model.sections.map((s, i) => (i === srcIdx ? next : s));
+	return { ...model, sections };
+}
+
+/**
+ * Rotate one AI section as a rigid body around its own centroid by `theta`
+ * radians of yaw (rotation about world +Y). No cascade into neighbours.
+ *
+ * Pivot is the section's corner-centroid (cardinality-1 default per
+ * CONTEXT.md / "Pivot"). All spatial fields rotate as a single rigid body so
+ * relative distances between corners, portal positions, and line endpoints
+ * are preserved exactly:
+ *
+ *   - corners (Vector2 / XZ): rotated around (cx, cz).
+ *   - portals[].position (Vector3): X/Z rotated around (cx, cz); Y unchanged
+ *     (yaw doesn't move things vertically).
+ *   - portals[].boundaryLines[].verts (Vector4 / packed XZ start/end): both
+ *     endpoints rotated independently — keeps the line as the same world
+ *     segment relative to the corners.
+ *   - noGoLines[].verts: same as portal boundary lines.
+ *
+ * Returns the original `model` reference when `theta === 0` so byte-for-byte
+ * BND2 writeback is preserved on a no-op gesture.
+ *
+ * Yaw direction follows the right-hand rule with thumb along world +Y, so a
+ * positive `theta` rotates the +X axis towards +Z (the same convention
+ * three.js uses for `Object3D.rotation.y`).
+ *
+ * @throws RangeError if `srcIdx` is out of range.
+ */
+export function rotateSectionAroundCentroidYaw(
+	model: ParsedAISectionsV12,
+	srcIdx: number,
+	theta: number,
+): ParsedAISectionsV12 {
+	if (srcIdx < 0 || srcIdx >= model.sections.length) {
+		throw new RangeError(`srcIdx ${srcIdx} out of range [0, ${model.sections.length})`);
+	}
+	if (theta === 0) return model;
+
+	const src = model.sections[srcIdx];
+	if (src.corners.length === 0) return model;
+
+	// Pivot = section centroid. AISection.Vector2 stores world XZ in `(x, y)`,
+	// so the centroid's `(cx, cz)` lives in `(centre.x, centre.y)`.
+	const c = centroid(src.corners);
+	const cx = c.x;
+	const cz = c.y;
+
+	const cosT = Math.cos(theta);
+	const sinT = Math.sin(theta);
+
+	// Yaw around world +Y: with thumb along +Y, +X rotates towards +Z.
+	//   x' = (x - cx) cos − (z - cz) sin + cx
+	//   z' = (x - cx) sin + (z - cz) cos + cz
+	const rotXZ = (x: number, z: number): { x: number; z: number } => {
+		const ox = x - cx;
+		const oz = z - cz;
+		return {
+			x: ox * cosT - oz * sinT + cx,
+			z: ox * sinT + oz * cosT + cz,
+		};
+	};
+
+	const next: AISection = {
+		...src,
+		corners: src.corners.map((corner) => {
+			const r = rotXZ(corner.x, corner.y);
+			return { x: r.x, y: r.z };
+		}),
+		portals: src.portals.map((p) => {
+			const rPos = rotXZ(p.position.x, p.position.z);
+			return {
+				...p,
+				position: { x: rPos.x, y: p.position.y, z: rPos.z },
+				boundaryLines: p.boundaryLines.map((bl) => {
+					const rStart = rotXZ(bl.verts.x, bl.verts.y);
+					const rEnd = rotXZ(bl.verts.z, bl.verts.w);
+					return {
+						verts: { x: rStart.x, y: rStart.z, z: rEnd.x, w: rEnd.z },
+					};
+				}),
+			};
+		}),
+		noGoLines: src.noGoLines.map((bl) => {
+			const rStart = rotXZ(bl.verts.x, bl.verts.y);
+			const rEnd = rotXZ(bl.verts.z, bl.verts.w);
+			return {
+				verts: { x: rStart.x, y: rStart.z, z: rEnd.x, w: rEnd.z },
+			};
+		}),
+	};
+
+	const sections = model.sections.map((s, i) => (i === srcIdx ? next : s));
+	return { ...model, sections };
+}

--- a/src/lib/core/transformAxes.test.ts
+++ b/src/lib/core/transformAxes.test.ts
@@ -1,0 +1,81 @@
+// Unit tests for the per-resource transform-axis descriptor module.
+//
+// These tests exist because the descriptor is the keystone of ADR-0011's
+// data-driven yaw-lock: future slices for trigger boxes (full 3-axis),
+// static traffic vehicles (Matrix44, full 3-axis), and zone points (XZ-only)
+// all plug in by declaring a `TransformAxes`. Pinning the AND-intersection
+// rule prevents a regression where a heterogeneous selection accidentally
+// re-enables a ring some member of the selection bans.
+
+import { describe, it, expect } from 'vitest';
+import {
+	intersectTransformAxes,
+	TRANSFORM_AXES_FULL_3D,
+	TRANSFORM_AXES_XZ_PACKED,
+	type TransformAxes,
+} from './transformAxes';
+
+describe('TRANSFORM_AXES_FULL_3D', () => {
+	it('enables every translate and rotate axis', () => {
+		expect(TRANSFORM_AXES_FULL_3D).toEqual({
+			translate: { x: true, y: true, z: true },
+			rotate: { x: true, y: true, z: true },
+		});
+	});
+});
+
+describe('TRANSFORM_AXES_XZ_PACKED', () => {
+	it('enables every translate axis but only yaw rotation (per ADR-0011)', () => {
+		// Translate Y still enabled because shifting portal anchor Y is
+		// meaningful even when corners are XZ-packed — only the X/Z
+		// rotation rings are auto-disabled.
+		expect(TRANSFORM_AXES_XZ_PACKED).toEqual({
+			translate: { x: true, y: true, z: true },
+			rotate: { x: false, y: true, z: false },
+		});
+	});
+});
+
+describe('intersectTransformAxes', () => {
+	it('returns full 3D for an empty list (no Selection)', () => {
+		// Edge case: an empty Selection has no per-resource axes to AND, so
+		// the gizmo defaults to the most permissive shape. (In practice the
+		// gizmo simply doesn't render when the Selection is empty, but the
+		// pure function still has a defined behaviour.)
+		expect(intersectTransformAxes([])).toEqual(TRANSFORM_AXES_FULL_3D);
+	});
+
+	it('passes a single descriptor through unchanged', () => {
+		expect(intersectTransformAxes([TRANSFORM_AXES_XZ_PACKED]))
+			.toEqual(TRANSFORM_AXES_XZ_PACKED);
+	});
+
+	it('ANDs each flag — XZ-packed + full-3D yields XZ-packed (the more restrictive wins)', () => {
+		// The canonical heterogeneous case: a future trigger box (full 3D)
+		// + an AI section (XZ-packed) in the same Selection. The yaw-lock
+		// from the AI section must veto the trigger box's pitch/roll.
+		const result = intersectTransformAxes([TRANSFORM_AXES_FULL_3D, TRANSFORM_AXES_XZ_PACKED]);
+		expect(result).toEqual(TRANSFORM_AXES_XZ_PACKED);
+	});
+
+	it('ANDs each flag in either order — commutative', () => {
+		const a = intersectTransformAxes([TRANSFORM_AXES_FULL_3D, TRANSFORM_AXES_XZ_PACKED]);
+		const b = intersectTransformAxes([TRANSFORM_AXES_XZ_PACKED, TRANSFORM_AXES_FULL_3D]);
+		expect(a).toEqual(b);
+	});
+
+	it('disables any axis where any descriptor disables it', () => {
+		const onlyTranslateX: TransformAxes = {
+			translate: { x: true, y: false, z: false },
+			rotate: { x: false, y: false, z: false },
+		};
+		const onlyRotateY: TransformAxes = {
+			translate: { x: false, y: true, z: false },
+			rotate: { x: false, y: true, z: false },
+		};
+		expect(intersectTransformAxes([onlyTranslateX, onlyRotateY])).toEqual({
+			translate: { x: false, y: false, z: false },
+			rotate: { x: false, y: false, z: false },
+		});
+	});
+});

--- a/src/lib/core/transformAxes.ts
+++ b/src/lib/core/transformAxes.ts
@@ -1,0 +1,95 @@
+// Transform axis descriptors — the data-driven contract that tells the
+// **Bulk transform** gizmo which translate/rotate axes are meaningful for
+// a given resource family.
+//
+// Per ADR-0011: AI section corners (Vector2 on XZ), boundary lines (segment
+// packed XZ), zone points (Vec2Padded on XZ), and traffic yaw-packed boxes
+// have no Y component to receive a pitch (around X) or roll (around Z)
+// rotation. Editing those axes would either be silently lossy or require a
+// type-promotion at write time, both of which break BND2 byte-for-byte
+// writeback. So the gizmo greys out the X and Z rotate rings whenever the
+// **Selection** contains any XZ-locked resource.
+//
+// We keep the descriptor data-driven (per resource family rather than
+// hard-coded "AI sections only get yaw") because future slices need to
+// handle several other resource families: trigger boxes (full 3-axis,
+// Euler-rotated regions), static traffic vehicles (Matrix44, full 3-axis),
+// portal anchors as pure points, etc. Each will declare its own
+// `TransformAxes` and the same gizmo + reducer will handle them.
+
+/**
+ * Per-axis enable flags for translate (which arrows respond to drag) and
+ * rotate (which rings respond to drag). The gizmo always renders all three
+ * arrows and all three rings for visual consistency — disabled axes render
+ * dimmed and don't accept pointer events.
+ *
+ * The convention "Y is vertical-up" matches the editor's display convention
+ * (the disk format stores Z as vertical, but the spatial editor swaps Y↔Z
+ * at the display boundary; see `swapYZ` on FieldMetadata). Inside the
+ * gizmo and the ops modules we always work in editor-display coordinates
+ * (Y-up) and let the IO layer flip at write time.
+ */
+export type TransformAxes = {
+	/** Which translate arrows are interactive. */
+	translate: { x: boolean; y: boolean; z: boolean };
+	/** Which rotate rings are interactive. Rings for disabled axes render
+	 *  visibly greyed-out (per ADR-0011) so users see the affordance but
+	 *  can't drive it into a state the data model can't represent. */
+	rotate: { x: boolean; y: boolean; z: boolean };
+};
+
+/**
+ * Full 3-axis translate + 3-axis rotate. Default for resources whose spatial
+ * data is genuinely 3D (trigger box regions with Euler rotation, static
+ * traffic vehicles with Matrix44, portal anchors as pure points).
+ */
+export const TRANSFORM_AXES_FULL_3D: TransformAxes = {
+	translate: { x: true, y: true, z: true },
+	rotate: { x: true, y: true, z: true },
+};
+
+/**
+ * Full 3-axis translate, yaw-only rotate. Default for resources whose
+ * spatial data is XZ-packed 2D — corners/lines/points have no Y component
+ * to receive pitch or roll (ADR-0011). Translate Y still works because it
+ * shifts the *anchor* heights (e.g. portal anchor `position.y`) without
+ * touching the XZ-packed corners.
+ *
+ * Used today by AI sections; future slices add it to zone points, boundary
+ * lines as standalone selections, and traffic yaw-packed boxes.
+ */
+export const TRANSFORM_AXES_XZ_PACKED: TransformAxes = {
+	translate: { x: true, y: true, z: true },
+	rotate: { x: false, y: true, z: false },
+};
+
+/**
+ * Combine the per-resource axes inside a (potentially heterogeneous)
+ * **Selection** by AND-ing each flag — an axis is interactive only if
+ * every selected resource agrees it should be. This is the rule for
+ * cross-resource selections in future slices (e.g. one trigger box + one
+ * AI section → AND yields "yaw-only rotate" because the AI section vetoes
+ * pitch and roll).
+ *
+ * Pure function so the **Bulk transform** reducer can compose any
+ * cardinality of axes without per-cardinality branching.
+ */
+export function intersectTransformAxes(
+	axes: readonly TransformAxes[],
+): TransformAxes {
+	if (axes.length === 0) return TRANSFORM_AXES_FULL_3D;
+	let tx = true, ty = true, tz = true;
+	let rx = true, ry = true, rz = true;
+	for (const a of axes) {
+		tx = tx && a.translate.x;
+		ty = ty && a.translate.y;
+		tz = tz && a.translate.z;
+		rx = rx && a.rotate.x;
+		ry = ry && a.rotate.y;
+		rz = rz && a.rotate.z;
+	}
+	return {
+		translate: { x: tx, y: ty, z: tz },
+		rotate: { x: rx, y: ry, z: rz },
+	};
+}

--- a/src/lib/three/projection.ts
+++ b/src/lib/three/projection.ts
@@ -1,0 +1,57 @@
+// World ↔ screen projection helpers shared by the BulkTransformGizmo and its
+// drag hook. Lives in `src/lib/three/` (not `components/common/three/`) so
+// the hook can import without creating a circular import boundary back into
+// the gizmo component.
+
+import * as THREE from 'three';
+
+/**
+ * Project a world point onto screen (CSS-pixel) coordinates. Used to derive
+ * the screen-space angle between the cursor and the gizmo's pivot for
+ * rotate drags. Returns null if the point is behind the camera (NDC z out
+ * of [-1, 1]).
+ */
+export function projectToScreen(
+	world: THREE.Vector3,
+	camera: THREE.Camera,
+	canvas: HTMLCanvasElement,
+): { x: number; y: number } | null {
+	const ndc = world.clone().project(camera);
+	if (ndc.z > 1 || ndc.z < -1) return null;
+	const rect = canvas.getBoundingClientRect();
+	return {
+		x: rect.left + ((ndc.x + 1) / 2) * rect.width,
+		y: rect.top + ((-ndc.y + 1) / 2) * rect.height,
+	};
+}
+
+/**
+ * Unproject a viewport-space pointer event onto an arbitrary plane through
+ * `pivot` with the supplied `normal`. Returns null when the ray is parallel
+ * to the plane (no intersection). Generalisation of `unprojectToGroundPlane`
+ * for non-Y-up planes — used by the BulkTransformGizmo's Y-axis translate
+ * handle when the ground plane is parallel to the cursor's view ray.
+ */
+export function unprojectToPlane(
+	clientX: number,
+	clientY: number,
+	camera: THREE.Camera,
+	canvas: HTMLCanvasElement,
+	pivot: THREE.Vector3,
+	normal: THREE.Vector3,
+): THREE.Vector3 | null {
+	const rect = canvas.getBoundingClientRect();
+	const ndc = new THREE.Vector2(
+		((clientX - rect.left) / rect.width) * 2 - 1,
+		-((clientY - rect.top) / rect.height) * 2 + 1,
+	);
+	const raycaster = new THREE.Raycaster();
+	raycaster.setFromCamera(ndc, camera);
+	// THREE.Plane is defined by `normal · x + constant = 0`. To make the
+	// plane pass through `pivot`, set constant = -normal·pivot.
+	const constant = -normal.clone().dot(pivot);
+	const plane = new THREE.Plane(normal.clone().normalize(), constant);
+	const hit = new THREE.Vector3();
+	const ok = raycaster.ray.intersectPlane(plane, hit);
+	return ok ? hit : null;
+}


### PR DESCRIPTION
## Summary
- Replaces the legacy AI-section drag with a unified translate + yaw-rotate `BulkTransformGizmo` (X/Z rotate rings render visibly disabled per ADR-0011 because AI section corners are XZ-packed Vector2). Auto-disable is data-driven via a `TransformAxes` descriptor (`TRANSFORM_AXES_XZ_PACKED` / `TRANSFORM_AXES_FULL_3D`) so future slices for trigger boxes, static traffic vehicles, and zone points slot in by declaring their own axes; `intersectTransformAxes` AND-combines for cross-resource selections.
- Adds two new pure ops in `aiSectionsOps.ts` — `translateSectionRigid(model, idx, {x,y,z})` and `rotateSectionAroundCentroidYaw(model, idx, theta)` — both no-cascade per ADR-0009. `translateSectionWithLinks` stays in the codebase for the cascade-modifier follow-up (#75). Both ops return the input reference on no-op gestures so byte-for-byte BND2 writeback is preserved.
- Wires the gizmo into `AISectionsOverlay` so one drag = one Workspace-undo entry (CONTEXT.md / "Bulk transform" + ADR-0006). `onTransform` fires per drag-frame against local React state only; `onCommit` fires once on release, calls `onChange` exactly once, which funnels through `setResourceAt` and pushes a single `HistoryCommit`. Closes #72.

## Test plan
- [x] `bun x vitest run src/lib/core/aiSectionsOps.test.ts` — 144 tests pass, including 24 new tests for `translateSectionRigid` (translate XZ-packed corners + 3D portal anchors + boundary lines + no-go lines, no cascade, deliberate stale paired-portal anchors per ADR-0009, no-op identity returns the same reference, immutability) and `rotateSectionAroundCentroidYaw` (yaw of 90°, rigid-body distance preservation, portal Y untouched, boundary line / no-go line endpoint rotation, full-revolution identity, no cascade, theta=0 returns the same reference for byte-for-byte safety).
- [x] `bun x vitest run src/lib/core/transformAxes.test.ts` — 7 tests pass, pinning the AND-intersection rule for heterogeneous selections (XZ-packed + full-3D = XZ-packed wins).
- [x] `bun x vitest run src/context/__tests__/WorkspaceContext.bulkTransform.test.ts` — 5 tests pass: one translate-only gesture / one combined translate+yaw gesture each push exactly one `HistoryCommit`; a simulated 50-frame drag with no `setResource` keeps `history.past.length === 0`; translate and yaw-rotate gestures round-trip through undo (corners + portal anchors deep-equal the pre-edit values).
- [x] `bun test:run` (full suite) — 1120 passing (+31 vs. baseline 1089), 14 failing. All 14 failures are pre-existing `ENOENT` errors for fixtures missing from the worktree under `example/older builds/` (V4/V6 prototype `.dat` files); none are introduced by this PR. Same set as the pre-change baseline run.
- [x] `bun x tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)