### PR TITLE
feat: cascade modifier for bulk transform gizmo (#75)

### DIFF
--- a/src/components/common/three/BulkTransformGizmo.tsx
+++ b/src/components/common/three/BulkTransformGizmo.tsx
@@ -91,10 +91,17 @@ const COLOR = {
 	z: '#3070ff',
 	zHot: '#90b0ff',
 	disabled: '#555555',
+	// **Cascade** visual cue: a magenta-ish accent that tints the handles
+	// when Shift is held at gesture start. Distinct from the per-axis hues
+	// so it reads as "different mode", not "different axis" (issue #75 +
+	// CONTEXT.md / "Cascade").
+	cascade: '#ff66cc',
+	cascadeHot: '#ffaadd',
 } as const;
 
 const RING_OPACITY_ENABLED = 0.75;
 const RING_OPACITY_DISABLED = 0.25;
+const CASCADE_HALO_OPACITY = 0.35;
 
 // =============================================================================
 // Component
@@ -125,7 +132,15 @@ export const BulkTransformGizmo: React.FC<BulkTransformGizmoProps> = ({
 		// the camera looks at it from the opposite side, so dragging right
 		// always rotates clockwise from the user's perspective.
 		rotationAxisWorld?: THREE.Vector3;
+		// **Cascade** opt-in captured at pointer-down. See `BulkTransformDelta.cascade`
+		// and CONTEXT.md / "Cascade" for the semantics: Shift held at gesture
+		// start enables cascade for the lifetime of that gesture; pressing or
+		// releasing Shift mid-drag does NOT switch modes.
+		cascade?: boolean;
 	} | null>(null);
+	// Tracks the cascade flag for the active gesture so the visual tint stays
+	// stable across re-renders (the ref above is mutable). Pure render state.
+	const [activeCascade, setActiveCascade] = useState(false);
 
 	const pivotVec = useMemo(
 		() => new THREE.Vector3(position[0], position[1], position[2]),
@@ -147,6 +162,14 @@ export const BulkTransformGizmo: React.FC<BulkTransformGizmoProps> = ({
 		group.scale.setScalar(targetWorldSize / DESIGN_SIZE);
 	});
 
+	// Wrap setActive so clearing the active gesture also clears the local
+	// cascade-tint state — keeps the gizmo colour back at the no-cascade
+	// default between gestures.
+	const setActiveAndCascade = (a: { kind: GizmoHandleKind; axis: GizmoHandleAxis } | null) => {
+		setActive(a);
+		if (a === null) setActiveCascade(false);
+	};
+
 	useBulkTransformDrag({
 		active,
 		camera,
@@ -157,11 +180,14 @@ export const BulkTransformGizmo: React.FC<BulkTransformGizmoProps> = ({
 		onTransform,
 		onCommit,
 		onCancel,
-		setActive,
+		setActive: setActiveAndCascade,
 	});
 
 	// Begin a drag — capture the pointer-down world position (translate) or
 	// screen-space angle (rotate) so the per-frame mover can derive a delta.
+	// Also captures the cascade modifier (Shift) at gesture start; the value
+	// is pinned for the lifetime of the gesture so users don't accidentally
+	// flip modes by tapping Shift mid-drag (per ADR-0009 + issue #75).
 	const beginTranslate = (axis: GizmoHandleAxis) => (e: ThreeEvent<PointerEvent>) => {
 		if (!isAxisInteractive('translate', axis, axes)) return;
 		e.stopPropagation();
@@ -176,12 +202,15 @@ export const BulkTransformGizmo: React.FC<BulkTransformGizmoProps> = ({
 			planeNormal,
 		);
 		if (!world) return;
+		const cascade = e.nativeEvent.shiftKey === true;
 		dragStartRef.current = {
 			kind: 'translate',
 			axis,
 			pivot: pivotVec.clone(),
 			anchorWorld: world.clone(),
+			cascade,
 		};
+		setActiveCascade(cascade);
 		setActive({ kind: 'translate', axis });
 		document.body.style.cursor = 'grabbing';
 	};
@@ -196,13 +225,16 @@ export const BulkTransformGizmo: React.FC<BulkTransformGizmoProps> = ({
 		const dy = e.nativeEvent.clientY - pivotScreen.y;
 		const anchorAngle = Math.atan2(dy, dx);
 		const rotationAxisWorld = rotationAxisVector(axis);
+		const cascade = e.nativeEvent.shiftKey === true;
 		dragStartRef.current = {
 			kind: 'rotate',
 			axis,
 			pivot: pivotVec.clone(),
 			anchorAngle,
 			rotationAxisWorld,
+			cascade,
 		};
+		setActiveCascade(cascade);
 		setActive({ kind: 'rotate', axis });
 		document.body.style.cursor = 'grabbing';
 	};
@@ -230,6 +262,35 @@ export const BulkTransformGizmo: React.FC<BulkTransformGizmoProps> = ({
 
 	return (
 		<group ref={groupRef} position={position}>
+			{/* Cascade visual cue — a translucent magenta halo encircling the
+			    gizmo when Shift was held at gesture start. Reads as "the
+			    transform will drag connected outside geometry along" per
+			    CONTEXT.md / "Cascade" + ADR-0009. Renders on top of the
+			    gizmo's normal handles, no depth test, so it's visible from
+			    any camera angle. */}
+			{activeCascade && (
+				<>
+					<mesh rotation={[Math.PI / 2, 0, 0]}>
+						<torusGeometry args={[DESIGN_SIZE * 0.95, DESIGN_SIZE * 0.025, 8, 64]} />
+						<meshBasicMaterial
+							color={COLOR.cascade}
+							transparent
+							opacity={CASCADE_HALO_OPACITY}
+							depthTest={false}
+						/>
+					</mesh>
+					<mesh>
+						<sphereGeometry args={[DESIGN_SIZE * 0.06, 12, 12]} />
+						<meshBasicMaterial
+							color={COLOR.cascade}
+							transparent
+							opacity={CASCADE_HALO_OPACITY * 1.5}
+							depthTest={false}
+						/>
+					</mesh>
+				</>
+			)}
+
 			{/* Translate arrows */}
 			<TranslateArrow
 				axis="x"

--- a/src/components/schema-editor/viewports/AISectionsOverlay.tsx
+++ b/src/components/schema-editor/viewports/AISectionsOverlay.tsx
@@ -36,9 +36,11 @@ import { SectionSpeed } from '@/lib/core/aiSections';
 import {
 	duplicateSectionThroughEdge,
 	rotateSectionAroundCentroidYaw,
+	rotateSectionWithLinksYaw,
 	snapCornerOffset,
 	translateCornerWithShared,
 	translateSectionRigid,
+	translateSectionWithLinks,
 } from '@/lib/core/aiSectionsOps';
 import { resolveSectionYs } from '@/lib/core/aiSectionY';
 import { BulkTransformGizmo } from '@/components/common/three/BulkTransformGizmo';
@@ -277,14 +279,33 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 
 	// While a drag is in flight, run the relevant op on the live delta to
 	// derive a preview model. Used for the selection overlay on the source
-	// section so the user sees the gesture in real time. Section-drag uses
-	// the no-cascade ops (per ADR-0009); corner-drag still cascades into
-	// shared corners (issue #73 migrates that gesture to the unified gizmo).
+	// section so the user sees the gesture in real time. Section-drag picks
+	// between no-cascade ops (the ADR-0009 default) and cascade-on ops
+	// (`translateSectionWithLinks` / `rotateSectionWithLinksYaw`) based on
+	// `delta.cascade` — captured at gesture start from Shift, per issue #75.
+	// Corner-drag still cascades into shared corners (issue #73 migrates that
+	// gesture to the unified gizmo).
 	const previewModel: ParsedAISectionsV12 | null = useMemo(() => {
 		if (selectedSectionIndex == null || !selSection || !drag) return null;
 		try {
 			if (drag.kind === 'section') {
 				if (isIdentityDelta(drag.delta)) return null;
+				if (drag.delta.cascade) {
+					// Cascade-on path: translateSectionWithLinks for translate
+					// (the legacy auto-cascade behaviour preserved as the
+					// modifier-on implementation per ADR-0009), then a yaw
+					// rotate that ALSO cascades around the same pivot. We
+					// compute the rotate pivot from the source centroid AFTER
+					// translate so combined gestures compose like Blender.
+					let next = translateSectionWithLinks(data, selectedSectionIndex, {
+						x: drag.delta.translate.x,
+						z: drag.delta.translate.z,
+					});
+					if (drag.delta.rotate.y !== 0) {
+						next = rotateSectionWithLinksYaw(next, selectedSectionIndex, drag.delta.rotate.y);
+					}
+					return next;
+				}
 				const translated = translateSectionRigid(data, selectedSectionIndex, drag.delta.translate);
 				// Apply yaw rotation around the *post-translate* centroid so
 				// translate + rotate compose as a single rigid body — same
@@ -444,21 +465,43 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 		setDrag(null);
 		if (selectedSectionIndex == null || !onChange) return;
 		if (isIdentityDelta(delta)) return;
-		// Compose translate then yaw rotate in the same order as the preview
-		// (around the post-translate centroid) so commit and preview agree
-		// frame-for-frame.
 		let next = data;
-		if (delta.translate.x !== 0 || delta.translate.y !== 0 || delta.translate.z !== 0) {
-			next = translateSectionRigid(next, selectedSectionIndex, delta.translate);
-		}
-		if (delta.rotate.y !== 0) {
-			next = rotateSectionAroundCentroidYaw(next, selectedSectionIndex, delta.rotate.y);
+		if (delta.cascade) {
+			// Cascade-on path (Shift held at gesture start per issue #75 +
+			// ADR-0009). Same op composition as the preview branch above —
+			// translate-with-links, then rotate-with-links — so commit and
+			// preview agree frame-for-frame. The yaw cascade pivots on the
+			// post-translate source centroid implicitly (the rotate-with-
+			// links op recomputes it from the section's current corners).
+			if (delta.translate.x !== 0 || delta.translate.z !== 0) {
+				next = translateSectionWithLinks(next, selectedSectionIndex, {
+					x: delta.translate.x,
+					z: delta.translate.z,
+				});
+			}
+			if (delta.rotate.y !== 0) {
+				next = rotateSectionWithLinksYaw(next, selectedSectionIndex, delta.rotate.y);
+			}
+		} else {
+			// Cascade-off path (the ADR-0009 default). Compose translate then
+			// yaw rotate in the same order as the preview (around the
+			// post-translate centroid) so commit and preview agree frame-for-
+			// frame.
+			if (delta.translate.x !== 0 || delta.translate.y !== 0 || delta.translate.z !== 0) {
+				next = translateSectionRigid(next, selectedSectionIndex, delta.translate);
+			}
+			if (delta.rotate.y !== 0) {
+				next = rotateSectionAroundCentroidYaw(next, selectedSectionIndex, delta.rotate.y);
+			}
 		}
 		if (next === data) return;
 		// Single onChange call ⇒ single setResourceAt ⇒ single
 		// HistoryCommit pushed onto the Workspace-undo stack. Drag-frames
 		// in between only updated local React state; they never touched
-		// `setResourceAt`, so they don't add stack entries.
+		// `setResourceAt`, so they don't add stack entries. Cascade-on
+		// paths preserve this invariant: even though the cascade-with-links
+		// ops mutate more sections per gesture, they still produce ONE
+		// resulting model committed via ONE onChange call.
 		onChange(next);
 	}, [data, selectedSectionIndex, onChange]);
 
@@ -686,9 +729,9 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 			<CameraBridge bridge={cameraBridge} />
 
 			{/* DOM siblings — snap toggle, marquee rectangle, edge context
-			    menu — registered into the chrome's HTML slot. The slot
-			    renders these outside the Canvas in React-DOM-land, avoiding
-			    cross-reconciler portal quirks. */}
+			    menu, cascade-on hint — registered into the chrome's HTML
+			    slot. The slot renders these outside the Canvas in React-
+			    DOM-land, avoiding cross-reconciler portal quirks. */}
 			<HtmlSiblings
 				isActive={isActive}
 				snapEnabled={snapEnabled}
@@ -698,6 +741,7 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 				edgeMenu={edgeMenu}
 				onDuplicateThroughEdge={handleDuplicateThroughEdge}
 				onCloseEdgeMenu={() => setEdgeMenu(null)}
+				cascadeActive={drag?.kind === 'section' && drag.delta.cascade}
 			/>
 		</>
 	);
@@ -716,6 +760,7 @@ function HtmlSiblings({
 	edgeMenu,
 	onDuplicateThroughEdge,
 	onCloseEdgeMenu,
+	cascadeActive,
 }: {
 	isActive: boolean;
 	snapEnabled: boolean;
@@ -725,6 +770,7 @@ function HtmlSiblings({
 	edgeMenu: { x: number; y: number; sectionIndex: number; edgeIdx: number } | null;
 	onDuplicateThroughEdge: () => void;
 	onCloseEdgeMenu: () => void;
+	cascadeActive: boolean;
 }) {
 	const node = useMemo(
 		() => (
@@ -785,9 +831,39 @@ function HtmlSiblings({
 						</button>
 					</EdgeContextMenu>
 				)}
+
+				{/* Cascade status hint — appears top-centre during a Shift-
+				    held bulk-transform gesture (CONTEXT.md / "Cascade",
+				    ADR-0009, issue #75). Magenta tint matches the gizmo's
+				    cascade halo so the two cues read as one mode. */}
+				{cascadeActive && (
+					<div
+						role="status"
+						aria-live="polite"
+						style={{
+							position: 'absolute',
+							top: 8,
+							left: '50%',
+							transform: 'translateX(-50%)',
+							padding: '4px 10px',
+							borderRadius: 6,
+							fontSize: 11,
+							fontFamily: 'monospace',
+							border: '1px solid #ff66cc',
+							background: 'rgba(255, 102, 204, 0.18)',
+							color: '#ffaadd',
+							pointerEvents: 'none',
+							userSelect: 'none',
+							boxShadow: '0 1px 3px rgba(0,0,0,0.4)',
+							whiteSpace: 'nowrap',
+						}}
+					>
+						Cascade ON · outside neighbours follow
+					</div>
+				)}
 			</>
 		),
-		[snapEnabled, toggleSnap, cameraBridge, onMarquee, edgeMenu, onDuplicateThroughEdge, onCloseEdgeMenu],
+		[snapEnabled, toggleSnap, cameraBridge, onMarquee, edgeMenu, onDuplicateThroughEdge, onCloseEdgeMenu, cascadeActive],
 	);
 	// Pass `null` when this overlay isn't the active resource so the chrome
 	// drops our marquee / snap / context menu — see ADR-0007 / issue #24.

--- a/src/context/__tests__/WorkspaceContext.bulkTransform.test.ts
+++ b/src/context/__tests__/WorkspaceContext.bulkTransform.test.ts
@@ -26,7 +26,9 @@ import {
 } from '@/lib/history';
 import {
 	rotateSectionAroundCentroidYaw,
+	rotateSectionWithLinksYaw,
 	translateSectionRigid,
+	translateSectionWithLinks,
 } from '@/lib/core/aiSectionsOps';
 import type {
 	EditableBundle,
@@ -219,5 +221,73 @@ describe('Bulk transform gesture → Workspace undo stack', () => {
 		// the outer section object is a fresh ref, but its contents match
 		// the pre-edit model exactly.
 		expect(getAI(afterUndo, 'AI.DAT').sections[0].corners).toEqual(beforeCorners);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Cascade-on path (issue #75): ONE undo entry per gesture, regardless of
+	// modifier state. The cascade-on op mutates more sections per call (the
+	// neighbour cascade), but the gizmo's commit still funnels through a
+	// single onChange → setResource call, so the Workspace-undo stack grows
+	// by exactly one entry per gesture.
+	// ---------------------------------------------------------------------------
+
+	it('cascade-on translate gesture pushes exactly one HistoryCommit (per ADR-0009 + issue #75)', () => {
+		const initial = makeInitialState();
+		const ai = getAI(initial, 'AI.DAT');
+		const next = translateSectionWithLinks(ai, 0, { x: 5, z: -3 });
+		const after = setResource(initial, 'AI.DAT', 'aiSections', next);
+		expect(after.history.past.length).toBe(1);
+		expect(after.bundles[0].isModified).toBe(true);
+	});
+
+	it('cascade-on combined translate+yaw gesture also pushes exactly one HistoryCommit', () => {
+		// The gizmo composes translate-with-links then rotate-with-links
+		// inside its commit callback before calling onChange exactly once —
+		// so even though both ops cascade into neighbours, only ONE
+		// setResource fires and only ONE undo entry lands.
+		const initial = makeInitialState();
+		const ai = getAI(initial, 'AI.DAT');
+		const t = translateSectionWithLinks(ai, 0, { x: 5, z: -3 });
+		const r = rotateSectionWithLinksYaw(t, 0, 0.3);
+		const after = setResource(initial, 'AI.DAT', 'aiSections', r);
+		expect(after.history.past.length).toBe(1);
+	});
+
+	it('cascade-on round-trip: undo restores neighbour sections too (not just the source)', () => {
+		// The cascade-on path mutates outside neighbours' reverse portals +
+		// shared corners. Undo's `previous` snapshot is the WHOLE ParsedAI
+		// model, so neighbour sections snap back deep-equal as well.
+		const initial = makeInitialState();
+		const ai = getAI(initial, 'AI.DAT');
+
+		// Pick a section that actually has at least one portal pointing
+		// somewhere else — AI.DAT has thousands; section 0 is a reasonable
+		// bet but we filter for a portal-having one to be safe.
+		const srcIdx = ai.sections.findIndex(
+			(s) => s.portals.length > 0 && s.portals[0].linkSection >= 0 && s.portals[0].linkSection < ai.sections.length && s.portals[0].linkSection !== ai.sections.indexOf(s),
+		);
+		if (srcIdx === -1) {
+			// Defensive guard — every fixture has at least one connected pair.
+			throw new Error('no cascading source in fixture');
+		}
+		const neighbourIdx = ai.sections[srcIdx].portals[0].linkSection;
+
+		const beforeNeighbourPortals = ai.sections[neighbourIdx].portals.map((p) => ({
+			...p,
+			position: { ...p.position },
+		}));
+
+		const next = translateSectionWithLinks(ai, srcIdx, { x: 7, z: -4 });
+		const afterEdit = setResource(initial, 'AI.DAT', 'aiSections', next);
+		// Confirm cascade took effect: the neighbour's reverse portal moved.
+		const editedNeighbour = getAI(afterEdit, 'AI.DAT').sections[neighbourIdx];
+		expect(editedNeighbour.portals).not.toEqual(beforeNeighbourPortals);
+
+		const afterUndo = undo(afterEdit);
+		const undoneNeighbour = getAI(afterUndo, 'AI.DAT').sections[neighbourIdx];
+		// Neighbour restored deep-equal to its pre-edit state.
+		expect(undoneNeighbour.portals.map((p) => p.position)).toEqual(
+			beforeNeighbourPortals.map((p) => p.position),
+		);
 	});
 });

--- a/src/hooks/__tests__/useBulkTransformDrag.cascade.test.ts
+++ b/src/hooks/__tests__/useBulkTransformDrag.cascade.test.ts
@@ -1,0 +1,93 @@
+// Unit test pinning the **Cascade** modifier semantics (issue #75) on the
+// `BulkTransformDelta` carrier and the `identityDelta` / `isIdentityDelta`
+// helpers. The full drag hook itself is window-event-driven and lives
+// inside an R3F component context — we exercise it end-to-end via the
+// AISectionsOverlay tests rather than here.
+//
+// What this file pins:
+//   - `BulkTransformDelta.cascade` exists on the type and is forwarded
+//     through `identityDelta(cascade)` so consumers always see a stable
+//     flag (cascade-off identity is the existing zero-delta shape; cascade-
+//     on identity carries the modifier through even when the spatial part
+//     is zero, so a Shift-tap that doesn't move the mouse still routes
+//     through the cascade-on commit path).
+//   - `isIdentityDelta` ignores cascade — it only cares about the spatial
+//     transform. A zero translate/rotate with cascade=true is still a no-op
+//     gesture (nothing to push to the undo stack).
+//
+// The "captured at gesture start, not continuously" invariant is asserted
+// at the source — `BulkTransformGizmo.beginTranslate` / `.beginRotate`
+// each read `e.nativeEvent.shiftKey` once on pointerdown and write it
+// into `dragStartRef.current.cascade`. The hook then propagates that
+// snapshot into every per-frame delta via `start.cascade` in both
+// `computeTranslateDelta` and `computeRotateDelta`. There is no code path
+// that re-reads the modifier state mid-gesture.
+
+import { describe, it, expect } from 'vitest';
+import {
+	identityDelta,
+	isIdentityDelta,
+	type BulkTransformDelta,
+} from '../useBulkTransformDrag';
+
+describe('BulkTransformDelta.cascade (issue #75)', () => {
+	it('identityDelta() defaults cascade to false', () => {
+		const d = identityDelta();
+		expect(d.cascade).toBe(false);
+		expect(d.translate).toEqual({ x: 0, y: 0, z: 0 });
+		expect(d.rotate).toEqual({ x: 0, y: 0, z: 0 });
+	});
+
+	it('identityDelta(true) carries cascade=true through to the consumer', () => {
+		const d = identityDelta(true);
+		expect(d.cascade).toBe(true);
+	});
+
+	it('isIdentityDelta ignores the cascade flag — only the spatial delta counts', () => {
+		// A Shift-tap on the gizmo with no mouse motion still produces a
+		// cascade=true identity delta. The consumer should treat it as a
+		// no-op gesture (don't push to undo stack) — same as cascade=false.
+		const cascadeOnNoMotion: BulkTransformDelta = {
+			translate: { x: 0, y: 0, z: 0 },
+			rotate: { x: 0, y: 0, z: 0 },
+			cascade: true,
+		};
+		expect(isIdentityDelta(cascadeOnNoMotion)).toBe(true);
+
+		const cascadeOffNoMotion: BulkTransformDelta = {
+			translate: { x: 0, y: 0, z: 0 },
+			rotate: { x: 0, y: 0, z: 0 },
+			cascade: false,
+		};
+		expect(isIdentityDelta(cascadeOffNoMotion)).toBe(true);
+	});
+
+	it('a non-zero translate with cascade=true is NOT an identity delta', () => {
+		const d: BulkTransformDelta = {
+			translate: { x: 5, y: 0, z: 0 },
+			rotate: { x: 0, y: 0, z: 0 },
+			cascade: true,
+		};
+		expect(isIdentityDelta(d)).toBe(false);
+	});
+
+	it('a non-zero rotate with cascade=true is NOT an identity delta', () => {
+		const d: BulkTransformDelta = {
+			translate: { x: 0, y: 0, z: 0 },
+			rotate: { x: 0, y: 0.3, z: 0 },
+			cascade: true,
+		};
+		expect(isIdentityDelta(d)).toBe(false);
+	});
+
+	it('the cascade field is required on the BulkTransformDelta type (compile-time-pinned at runtime via every consumer)', () => {
+		// This is a compile-time invariant — TypeScript guarantees every
+		// producer of BulkTransformDelta sets `cascade`. The runtime check
+		// is just that `identityDelta()` returns a value with the key
+		// physically present (not undefined) so consumers can branch on it
+		// without type-narrow gymnastics.
+		const d = identityDelta();
+		expect('cascade' in d).toBe(true);
+		expect(typeof d.cascade).toBe('boolean');
+	});
+});

--- a/src/hooks/useBulkTransformDrag.ts
+++ b/src/hooks/useBulkTransformDrag.ts
@@ -36,10 +36,20 @@ export type GizmoHandleAxis = 'x' | 'y' | 'z';
  * the gizmo's pivot. Pitch/roll are present in the type so future slices
  * (trigger box gizmo) get the same shape — for the AI section MVP only
  * `rotate.y` is ever non-zero (ADR-0011 yaw-lock).
+ *
+ * `cascade` is the **Cascade** opt-in flag (CONTEXT.md / "Cascade", ADR-0009
+ * and issue #75). Captured at gesture START — pressing or releasing the
+ * cascade modifier mid-drag does NOT flip the mode for consistent gesture
+ * semantics. When true, consumers should route to the cascade-on op variants
+ * (`translateSectionWithLinks`, `rotateSectionWithLinksYaw`, etc.) that drag
+ * outside-neighbour reverse portals and shared corners along with the
+ * selection; when false (the ADR-0009 default), consumers run the rigid /
+ * no-cascade ops and outside neighbours stay put.
  */
 export type BulkTransformDelta = {
 	translate: { x: number; y: number; z: number };
 	rotate: { x: number; y: number; z: number };
+	cascade: boolean;
 };
 
 export type BulkTransformDragOptions = {
@@ -59,6 +69,10 @@ export type BulkTransformDragOptions = {
 		anchorWorld?: THREE.Vector3;
 		anchorAngle?: number;
 		rotationAxisWorld?: THREE.Vector3;
+		/** **Cascade** opt-in flag captured at pointer-down. Stays fixed for
+		 *  the lifetime of the gesture — pressing or releasing the modifier
+		 *  mid-drag does NOT switch modes. See `BulkTransformDelta.cascade`. */
+		cascade?: boolean;
 	} | null>;
 	onTransform: (delta: BulkTransformDelta) => void;
 	onCommit: (delta: BulkTransformDelta) => void;
@@ -104,7 +118,8 @@ export function useBulkTransformDrag({
 		};
 
 		const handleUp = (e: PointerEvent) => {
-			const delta = computeDelta(e.clientX, e.clientY) ?? identityDelta();
+			const cascade = dragStart.current?.cascade === true;
+			const delta = computeDelta(e.clientX, e.clientY) ?? identityDelta(cascade);
 			dragStart.current = null;
 			setActive(null);
 			onCommit(delta);
@@ -112,9 +127,10 @@ export function useBulkTransformDrag({
 
 		const handleKey = (e: KeyboardEvent) => {
 			if (e.key !== 'Escape') return;
+			const cascade = dragStart.current?.cascade === true;
 			dragStart.current = null;
 			setActive(null);
-			onTransform(identityDelta());
+			onTransform(identityDelta(cascade));
 			onCancel?.();
 		};
 
@@ -156,6 +172,7 @@ function computeTranslateDelta(
 	return {
 		translate: { x: projected.x, y: projected.y, z: projected.z },
 		rotate: { x: 0, y: 0, z: 0 },
+		cascade: start.cascade === true,
 	};
 }
 
@@ -231,6 +248,7 @@ function computeRotateDelta(
 			y: start.axis === 'y' ? theta : 0,
 			z: start.axis === 'z' ? theta : 0,
 		},
+		cascade: start.cascade === true,
 	};
 }
 
@@ -238,14 +256,18 @@ function computeRotateDelta(
 // Helpers
 // =============================================================================
 
-export function identityDelta(): BulkTransformDelta {
+export function identityDelta(cascade = false): BulkTransformDelta {
 	return {
 		translate: { x: 0, y: 0, z: 0 },
 		rotate: { x: 0, y: 0, z: 0 },
+		cascade,
 	};
 }
 
 export function isIdentityDelta(d: BulkTransformDelta): boolean {
+	// `cascade` is metadata about *how* to apply the delta, not part of the
+	// spatial change itself — a cascade=true delta with zero translate/rotate
+	// is still a no-op gesture (nothing to push to the undo stack).
 	return (
 		d.translate.x === 0 &&
 		d.translate.y === 0 &&

--- a/src/lib/core/aiSectionsOps.test.ts
+++ b/src/lib/core/aiSectionsOps.test.ts
@@ -9,6 +9,8 @@ import {
 	duplicateLegacySectionThroughEdge,
 	duplicateSectionThroughEdge,
 	rotateSectionAroundCentroidYaw,
+	rotateSectionWithLinksYaw,
+	rotateSelectionWithLinksYaw,
 	snapCornerOffset,
 	snapLegacyCornerOffset,
 	snapLegacySectionOffset,
@@ -16,8 +18,10 @@ import {
 	translateCornerWithShared,
 	translateLegacyCornerWithShared,
 	translateLegacySectionWithLinks,
+	translatePortalAnchorWithMirror,
 	translateSectionRigid,
 	translateSectionWithLinks,
+	translateSelectionWithLinks,
 } from './aiSectionsOps';
 import {
 	AI_SECTIONS_VERSION,
@@ -2302,5 +2306,398 @@ describe('translateSectionRigid + rotateSectionAroundCentroidYaw composition', (
 		// offset (-5, -5) → π/2 → (5, -5) → (110, 200).
 		expect(r.sections[0].corners[0].x).toBeCloseTo(110, 6);
 		expect(r.sections[0].corners[0].y).toBeCloseTo(200, 6);
+	});
+});
+
+// =============================================================================
+// Cascade-modifier ops (issue #75): rotateSectionWithLinksYaw,
+// translatePortalAnchorWithMirror, translateSelectionWithLinks,
+// rotateSelectionWithLinksYaw
+// =============================================================================
+//
+// These exercise the cascade-on path the gizmo routes through when Shift is
+// held at gesture start. Cascade-off is exercised by the existing
+// translateSectionRigid + rotateSectionAroundCentroidYaw suite above; this
+// suite pins the "outside neighbours follow" semantics.
+
+describe('rotateSectionWithLinksYaw', () => {
+	// Same makePair shape as translateSectionWithLinks: two adjacent quads
+	// sharing the right edge of section 0 / left edge of section 1, with
+	// mirrored portals at the edge midpoint.
+	function makePair(): ParsedAISectionsV12 {
+		const portal0to1: Portal = {
+			position: { x: 10, y: 0, z: 5 },
+			boundaryLines: [{ verts: { x: 10, y: 0, z: 10, w: 10 } }],
+			linkSection: 1,
+		};
+		const portal1to0: Portal = {
+			position: { x: 10, y: 0, z: 5 },
+			boundaryLines: [{ verts: { x: 10, y: 10, z: 10, w: 0 } }],
+			linkSection: 0,
+		};
+		const s0 = makeSection({
+			id: 0xA,
+			corners: [
+				{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 },
+			],
+			portals: [portal0to1],
+		});
+		const s1 = makeSection({
+			id: 0xB,
+			corners: [
+				{ x: 10, y: 0 }, { x: 20, y: 0 }, { x: 20, y: 10 }, { x: 10, y: 10 },
+			],
+			portals: [portal1to0],
+		});
+		return makeModel([s0, s1]);
+	}
+
+	it('rotates the source section around its centroid like the rigid op', () => {
+		const model = makePair();
+		// Source centroid is (5, 5); π/2 rotates (0, 0) → centroid offset
+		// (-5, -5) → (5, -5) → (10, 0).
+		const next = rotateSectionWithLinksYaw(model, 0, Math.PI / 2);
+		expect(next.sections[0].corners[0].x).toBeCloseTo(10, 6);
+		expect(next.sections[0].corners[0].y).toBeCloseTo(0, 6);
+	});
+
+	it("rotates the neighbour's reverse portal around the source centroid", () => {
+		const model = makePair();
+		// Pre-rotate portal anchor is at (10, 5). Source centroid is (5, 5).
+		// π/2 rotation: offset (5, 0) → (0, 5) → world (5, 10).
+		const next = rotateSectionWithLinksYaw(model, 0, Math.PI / 2);
+		expect(next.sections[1].portals[0].position.x).toBeCloseTo(5, 6);
+		expect(next.sections[1].portals[0].position.y).toBe(0); // y unchanged
+		expect(next.sections[1].portals[0].position.z).toBeCloseTo(10, 6);
+	});
+
+	it('keeps source and neighbour portal positions equal after the rotate (lockstep)', () => {
+		const model = makePair();
+		const next = rotateSectionWithLinksYaw(model, 0, 0.7);
+		const sp = next.sections[0].portals[0].position;
+		const np = next.sections[1].portals[0].position;
+		expect(sp.x).toBeCloseTo(np.x, 6);
+		expect(sp.y).toBeCloseTo(np.y, 6);
+		expect(sp.z).toBeCloseTo(np.z, 6);
+	});
+
+	it('orbits the shared corners on the neighbour around the source centroid', () => {
+		const model = makePair();
+		// Shared corners are (10, 0) and (10, 10) — they were on the source's
+		// right edge and ARE the neighbour's left edge. After π/2 around
+		// (5, 5): (10, 0) → (5, -5)+(5,5) → (10, 0)? wait. Let's compute:
+		// offset (5, -5) → π/2 → (5, 5) → world (10, 10). And (10, 10) →
+		// offset (5, 5) → π/2 → (-5, 5) → world (0, 10).
+		const next = rotateSectionWithLinksYaw(model, 0, Math.PI / 2);
+		const s1 = next.sections[1];
+		// Pre-rotate s1 corners were [(10,0),(20,0),(20,10),(10,10)]. The
+		// shared corners at indexes 0 and 3 spin; the non-shared ones at
+		// indexes 1 and 2 stay put.
+		expect(s1.corners[0].x).toBeCloseTo(10, 6);
+		expect(s1.corners[0].y).toBeCloseTo(10, 6);
+		expect(s1.corners[3].x).toBeCloseTo(0, 6);
+		expect(s1.corners[3].y).toBeCloseTo(10, 6);
+		// Non-shared corners unchanged.
+		expect(s1.corners[1]).toEqual({ x: 20, y: 0 });
+		expect(s1.corners[2]).toEqual({ x: 20, y: 10 });
+	});
+
+	it('is a no-op for theta === 0', () => {
+		const model = makePair();
+		expect(rotateSectionWithLinksYaw(model, 0, 0)).toBe(model);
+	});
+
+	it('throws on out-of-range srcIdx', () => {
+		const model = makePair();
+		expect(() => rotateSectionWithLinksYaw(model, 5, 0.1)).toThrow(RangeError);
+		expect(() => rotateSectionWithLinksYaw(model, -1, 0.1)).toThrow(RangeError);
+	});
+
+	it('a full revolution (2π) returns a near-identity result', () => {
+		const model = makePair();
+		const next = rotateSectionWithLinksYaw(model, 0, 2 * Math.PI);
+		// Floats won't be exactly equal but should be machine-close.
+		expect(next.sections[0].corners[0].x).toBeCloseTo(0, 5);
+		expect(next.sections[0].corners[0].y).toBeCloseTo(0, 5);
+		expect(next.sections[1].portals[0].position.x).toBeCloseTo(10, 5);
+		expect(next.sections[1].portals[0].position.z).toBeCloseTo(5, 5);
+	});
+});
+
+describe('translatePortalAnchorWithMirror', () => {
+	function makePair(): ParsedAISectionsV12 {
+		const portal0to1: Portal = {
+			position: { x: 10, y: 3, z: 5 },
+			boundaryLines: [{ verts: { x: 10, y: 0, z: 10, w: 10 } }],
+			linkSection: 1,
+		};
+		const portal1to0: Portal = {
+			position: { x: 10, y: 3, z: 5 },
+			boundaryLines: [{ verts: { x: 10, y: 10, z: 10, w: 0 } }],
+			linkSection: 0,
+		};
+		const s0 = makeSection({ id: 0xA, portals: [portal0to1] });
+		const s1 = makeSection({
+			id: 0xB,
+			corners: [
+				{ x: 10, y: 0 }, { x: 20, y: 0 }, { x: 20, y: 10 }, { x: 10, y: 10 },
+			],
+			portals: [portal1to0],
+		});
+		return makeModel([s0, s1]);
+	}
+
+	it('translates the source portal and the mirror portal by the same delta', () => {
+		const model = makePair();
+		const next = translatePortalAnchorWithMirror(model, 0, 0, { x: 4, y: 0.5, z: -2 });
+		expect(next.sections[0].portals[0].position).toEqual({ x: 14, y: 3.5, z: 3 });
+		expect(next.sections[1].portals[0].position).toEqual({ x: 14, y: 3.5, z: 3 });
+	});
+
+	it('does NOT touch corners on either section', () => {
+		const model = makePair();
+		const next = translatePortalAnchorWithMirror(model, 0, 0, { x: 4, y: 0, z: -2 });
+		expect(next.sections[0].corners).toEqual(model.sections[0].corners);
+		expect(next.sections[1].corners).toEqual(model.sections[1].corners);
+	});
+
+	it('does NOT touch portal boundary lines on either section', () => {
+		const model = makePair();
+		const next = translatePortalAnchorWithMirror(model, 0, 0, { x: 4, y: 0, z: -2 });
+		expect(next.sections[0].portals[0].boundaryLines).toEqual(
+			model.sections[0].portals[0].boundaryLines,
+		);
+		expect(next.sections[1].portals[0].boundaryLines).toEqual(
+			model.sections[1].portals[0].boundaryLines,
+		);
+	});
+
+	it('is a no-op for a zero offset', () => {
+		const model = makePair();
+		expect(translatePortalAnchorWithMirror(model, 0, 0, { x: 0, y: 0, z: 0 })).toBe(model);
+	});
+
+	it('throws on out-of-range sectionIdx or portalIdx', () => {
+		const model = makePair();
+		expect(() => translatePortalAnchorWithMirror(model, 5, 0, { x: 1, y: 0, z: 0 })).toThrow(RangeError);
+		expect(() => translatePortalAnchorWithMirror(model, 0, 5, { x: 1, y: 0, z: 0 })).toThrow(RangeError);
+	});
+
+	it('still moves the source portal even when the mirror is missing (orphan link)', () => {
+		const orphan: AISection = makeSection({
+			id: 0xC,
+			portals: [{
+				position: { x: 1, y: 0, z: 2 },
+				boundaryLines: [],
+				linkSection: 999, // out of range
+			}],
+		});
+		const model = makeModel([orphan]);
+		const next = translatePortalAnchorWithMirror(model, 0, 0, { x: 5, y: 0, z: 0 });
+		expect(next.sections[0].portals[0].position).toEqual({ x: 6, y: 0, z: 2 });
+	});
+});
+
+describe('translateSelectionWithLinks', () => {
+	// Build a row of 3 sections so we can pick the middle two as a Selection
+	// and verify outside neighbours cascade while inside Selection members
+	// translate rigid-bodily.
+	function makeTrio(): ParsedAISectionsV12 {
+		// s0 — leftmost (outside Selection). Its right edge is (10, 0)–(10, 10)
+		// shared with s1.
+		const s0 = makeSection({
+			id: 0xA,
+			corners: [
+				{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 },
+			],
+			portals: [{
+				position: { x: 10, y: 0, z: 5 },
+				boundaryLines: [{ verts: { x: 10, y: 0, z: 10, w: 10 } }],
+				linkSection: 1,
+			}],
+		});
+		// s1 — middle. Has a portal to s0 on its left edge AND a portal to
+		// s2 on its right edge.
+		const s1 = makeSection({
+			id: 0xB,
+			corners: [
+				{ x: 10, y: 0 }, { x: 20, y: 0 }, { x: 20, y: 10 }, { x: 10, y: 10 },
+			],
+			portals: [
+				{
+					position: { x: 10, y: 0, z: 5 },
+					boundaryLines: [{ verts: { x: 10, y: 10, z: 10, w: 0 } }],
+					linkSection: 0,
+				},
+				{
+					position: { x: 20, y: 0, z: 5 },
+					boundaryLines: [{ verts: { x: 20, y: 0, z: 20, w: 10 } }],
+					linkSection: 2,
+				},
+			],
+		});
+		// s2 — rightmost (outside Selection). Its left edge (20, 0)–(20, 10)
+		// is shared with s1.
+		const s2 = makeSection({
+			id: 0xC,
+			corners: [
+				{ x: 20, y: 0 }, { x: 30, y: 0 }, { x: 30, y: 10 }, { x: 20, y: 10 },
+			],
+			portals: [{
+				position: { x: 20, y: 0, z: 5 },
+				boundaryLines: [{ verts: { x: 20, y: 10, z: 20, w: 0 } }],
+				linkSection: 1,
+			}],
+		});
+		return makeModel([s0, s1, s2]);
+	}
+
+	it('with a single-section Selection, matches translateSectionWithLinks byte-for-byte', () => {
+		// Regression: cascade-on single-section translate must produce the
+		// exact same model as the legacy `translateSectionWithLinks` op.
+		const model = makeTrio();
+		const a = translateSelectionWithLinks(model, [1], { x: 3, z: -2 });
+		const b = translateSectionWithLinks(model, 1, { x: 3, z: -2 });
+		expect(a).toEqual(b);
+	});
+
+	it('cascades to outside neighbours but not to inside-Selection members', () => {
+		const model = makeTrio();
+		// Select s1 alone: cascade should reach s0 AND s2 (both outside).
+		const single = translateSelectionWithLinks(model, [1], { x: 5, z: 0 });
+		// s0's reverse portal (at 10, 0, 5) should track to (15, 0, 5).
+		expect(single.sections[0].portals[0].position).toEqual({ x: 15, y: 0, z: 5 });
+		// s2's reverse portal (at 20, 0, 5) should track to (25, 0, 5).
+		expect(single.sections[2].portals[0].position).toEqual({ x: 25, y: 0, z: 5 });
+	});
+
+	it('a Selection of two adjacent sections moves both inside-rigidly and cascades only to outside neighbours', () => {
+		const model = makeTrio();
+		// Select s1 and s2: s0 is the only outside neighbour.
+		const next = translateSelectionWithLinks(model, [1, 2], { x: 7, z: 0 });
+		// s0 (outside): reverse portal cascades — was (10, 0, 5), becomes (17, 0, 5).
+		expect(next.sections[0].portals[0].position).toEqual({ x: 17, y: 0, z: 5 });
+		// s0 corners that lie on the s0/s1 shared edge (10, 0) and (10, 10)
+		// follow the cascade.
+		expect(next.sections[0].corners[1]).toEqual({ x: 17, y: 0 });
+		expect(next.sections[0].corners[2]).toEqual({ x: 17, y: 10 });
+		// s1 (inside): all corners translate by (7, 0).
+		expect(next.sections[1].corners[0]).toEqual({ x: 17, y: 0 });
+		expect(next.sections[1].corners[1]).toEqual({ x: 27, y: 0 });
+		// s2 (inside): all corners translate by (7, 0) — NO double-shift
+		// from a cascade into s2 (s1's right-portal points at s2 which is
+		// inside-Selection, so cascade is skipped per `selectedSet.has(targetIdx)`).
+		expect(next.sections[2].corners[0]).toEqual({ x: 27, y: 0 });
+		expect(next.sections[2].corners[1]).toEqual({ x: 37, y: 0 });
+	});
+
+	it('cascade-off bulk leaves outside neighbours put (regression vs cascade-on)', () => {
+		// Sanity: contrast the cascade-on result with what a rigid bulk would
+		// produce. We simulate cascade-off bulk by translating each member
+		// rigidly with `translateSectionRigid` and checking outside neighbours
+		// are stale.
+		const model = makeTrio();
+		let off = model;
+		off = translateSectionRigid(off, 1, { x: 7, y: 0, z: 0 });
+		off = translateSectionRigid(off, 2, { x: 7, y: 0, z: 0 });
+		// Cascade-off: s0's reverse portal is now stale at (10, 0, 5) — it
+		// still points at the (now-moved) s1 but at the OLD world position.
+		expect(off.sections[0].portals[0].position).toEqual({ x: 10, y: 0, z: 5 });
+
+		// Cascade-on: same delta, different outcome — s0's reverse portal
+		// follows.
+		const on = translateSelectionWithLinks(model, [1, 2], { x: 7, z: 0 });
+		expect(on.sections[0].portals[0].position).toEqual({ x: 17, y: 0, z: 5 });
+	});
+
+	it('is a no-op for an empty Selection or zero offset', () => {
+		const model = makeTrio();
+		expect(translateSelectionWithLinks(model, [], { x: 5, z: 5 })).toBe(model);
+		expect(translateSelectionWithLinks(model, [0, 1], { x: 0, z: 0 })).toBe(model);
+	});
+
+	it('throws on out-of-range index in Selection', () => {
+		const model = makeTrio();
+		expect(() => translateSelectionWithLinks(model, [0, 99], { x: 1, z: 0 })).toThrow(RangeError);
+	});
+});
+
+describe('rotateSelectionWithLinksYaw', () => {
+	function makePair(): ParsedAISectionsV12 {
+		// Same as the rotateSectionWithLinksYaw fixture.
+		const portal0to1: Portal = {
+			position: { x: 10, y: 0, z: 5 },
+			boundaryLines: [{ verts: { x: 10, y: 0, z: 10, w: 10 } }],
+			linkSection: 1,
+		};
+		const portal1to0: Portal = {
+			position: { x: 10, y: 0, z: 5 },
+			boundaryLines: [{ verts: { x: 10, y: 10, z: 10, w: 0 } }],
+			linkSection: 0,
+		};
+		const s0 = makeSection({
+			id: 0xA,
+			corners: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }],
+			portals: [portal0to1],
+		});
+		const s1 = makeSection({
+			id: 0xB,
+			corners: [{ x: 10, y: 0 }, { x: 20, y: 0 }, { x: 20, y: 10 }, { x: 10, y: 10 }],
+			portals: [portal1to0],
+		});
+		return makeModel([s0, s1]);
+	}
+
+	it('orbits every selected section around the supplied pivot', () => {
+		const model = makePair();
+		// Pivot at the s0/s1 shared edge midpoint (10, 5). Rotate π/2.
+		const next = rotateSelectionWithLinksYaw(model, [0, 1], { x: 10, z: 5 }, Math.PI / 2);
+		// s0 corner (0, 0): offset (-10, -5) → π/2 → (5, -10) → world (15, -5).
+		expect(next.sections[0].corners[0].x).toBeCloseTo(15, 6);
+		expect(next.sections[0].corners[0].y).toBeCloseTo(-5, 6);
+		// s1 corner (20, 0): offset (10, -5) → π/2 → (5, 10) → world (15, 15).
+		expect(next.sections[1].corners[1].x).toBeCloseTo(15, 6);
+		expect(next.sections[1].corners[1].y).toBeCloseTo(15, 6);
+	});
+
+	it('cascades to outside neighbours but not to inside-Selection members', () => {
+		// Build a 3-section row, select the middle one, rotate, verify only
+		// outside neighbours' reverse portals cascade.
+		const s0 = makeSection({
+			id: 0xA,
+			corners: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }],
+			portals: [{
+				position: { x: 10, y: 0, z: 5 },
+				boundaryLines: [{ verts: { x: 10, y: 0, z: 10, w: 10 } }],
+				linkSection: 1,
+			}],
+		});
+		const s1 = makeSection({
+			id: 0xB,
+			corners: [{ x: 10, y: 0 }, { x: 20, y: 0 }, { x: 20, y: 10 }, { x: 10, y: 10 }],
+			portals: [{
+				position: { x: 10, y: 0, z: 5 },
+				boundaryLines: [{ verts: { x: 10, y: 10, z: 10, w: 0 } }],
+				linkSection: 0,
+			}],
+		});
+		const model = makeModel([s0, s1]);
+		// Select s1 alone; rotate around its centroid (15, 5).
+		const next = rotateSelectionWithLinksYaw(model, [1], { x: 15, z: 5 }, Math.PI);
+		// s0 (outside): reverse portal at (10, 0, 5). Pivot (15, 5), π:
+		// offset (-5, 0) → (5, 0) → world (20, 5).
+		expect(next.sections[0].portals[0].position.x).toBeCloseTo(20, 6);
+		expect(next.sections[0].portals[0].position.z).toBeCloseTo(5, 6);
+	});
+
+	it('is a no-op for theta === 0 or an empty Selection', () => {
+		const model = makePair();
+		expect(rotateSelectionWithLinksYaw(model, [0, 1], { x: 0, z: 0 }, 0)).toBe(model);
+		expect(rotateSelectionWithLinksYaw(model, [], { x: 0, z: 0 }, 0.5)).toBe(model);
+	});
+
+	it('throws on out-of-range Selection index', () => {
+		const model = makePair();
+		expect(() => rotateSelectionWithLinksYaw(model, [99], { x: 0, z: 0 }, 0.5)).toThrow(RangeError);
 	});
 });

--- a/src/lib/core/aiSectionsOps.ts
+++ b/src/lib/core/aiSectionsOps.ts
@@ -1491,3 +1491,487 @@ export function rotateSectionAroundCentroidYaw(
 	const sections = model.sections.map((s, i) => (i === srcIdx ? next : s));
 	return { ...model, sections };
 }
+
+// =============================================================================
+// Bulk-transform: cascade-on variants (held-modifier opt-in path)
+// =============================================================================
+//
+// The **Cascade** modifier path of the **Bulk transform** gizmo (CONTEXT.md /
+// "Cascade", ADR-0009, issue #75). When the user holds the modifier (Shift)
+// at gesture start the gizmo routes through these ops instead of the rigid /
+// no-cascade ones — the same one-hop cascade `translateSectionWithLinks`
+// pioneered, generalised to rotate, single-corner, and single-portal-anchor
+// drags. The mental model is one sentence from the ADR: "the gizmo moves
+// what you selected; modifier extends to connected geometry."
+//
+// One-hop semantics are inherited from `translateSectionWithLinks`. We do not
+// chase the cascade through a neighbour's *other* portals because that doesn't
+// terminate cleanly on cyclic neighbour graphs — same trade-off documented on
+// the translate op (a two-hop drift is the user's call to fix).
+
+/**
+ * Rotate one AI section around its own centroid by `theta` radians of yaw,
+ * cascading the rotation into every neighbour the section shares a portal
+ * with — the rotate-axis sibling of {@link translateSectionWithLinks}.
+ *
+ * The source section rotates as a rigid body (corners + portal positions +
+ * portal boundary lines + no-go lines all spin together) around the
+ * pre-rotate centroid. For each `srcIdx` portal `P` pointing at neighbour
+ * `N`:
+ *
+ *   - Find `N`'s reverse portal (matched by `linkSection === srcIdx` AND a
+ *     pre-rotate `position` that approximates `P`'s pre-rotate `position`).
+ *     Rotate its `position` and every `boundaryLine.verts` endpoint around
+ *     the SAME centroid — keeping the portal pair at one shared world XZ
+ *     coordinate post-rotation (Y is unchanged by yaw).
+ *   - Rotate `N`'s corners that coincide with `P`'s pre-rotate boundary
+ *     endpoints around the centroid. `N`'s other corners stay put, so `N`
+ *     "stretches" along its other edges — same shape the translate cascade
+ *     uses, just with rotation as the per-point transform.
+ *
+ * Returns the original `model` reference when `theta === 0` so byte-for-byte
+ * BND2 writeback is preserved on a no-op gesture.
+ *
+ * Why the existing translate algorithm doesn't extend trivially: the
+ * translate cascade shifts every cascade-partner by the SAME `(dx, dz)`
+ * vector, so the order of operations doesn't matter. Rotation isn't a
+ * translation — every point's new position depends on its OWN offset from
+ * the pivot — so we have to identify the cascade partners (reverse portals,
+ * shared corners) on the *pre-rotate* geometry, then apply the rotation
+ * point-by-point with the same `(cx, cz, theta)` to each. We use the source
+ * section's centroid as the pivot rather than the section-pair centroid
+ * because the gizmo's pivot for a cardinality-1 **Selection** IS the source
+ * section's centroid (CONTEXT.md / "Pivot"). Neighbours' OTHER edges (those
+ * not shared with the source) accept the cascade-driven stretch on their
+ * shared corners and stay rigid otherwise.
+ *
+ * Cross-references via `sectionResetPairs` are not touched — they reference
+ * sections by index, not by world position, so a rotate doesn't break them.
+ *
+ * @throws RangeError if `srcIdx` is out of range.
+ */
+export function rotateSectionWithLinksYaw(
+	model: ParsedAISectionsV12,
+	srcIdx: number,
+	theta: number,
+): ParsedAISectionsV12 {
+	if (srcIdx < 0 || srcIdx >= model.sections.length) {
+		throw new RangeError(`srcIdx ${srcIdx} out of range [0, ${model.sections.length})`);
+	}
+	if (theta === 0) return model;
+
+	const src = model.sections[srcIdx];
+	if (src.corners.length === 0) return model;
+
+	// Pivot = source section centroid (cardinality-1 default per CONTEXT.md /
+	// "Pivot"). AISection.Vector2 stores world XZ in `(x, y)`, so the
+	// centroid's `(cx, cz)` lives in `(centre.x, centre.y)`.
+	const c = centroid(src.corners);
+	const cx = c.x;
+	const cz = c.y;
+	const cosT = Math.cos(theta);
+	const sinT = Math.sin(theta);
+
+	// Yaw around world +Y: with thumb along +Y, +X rotates towards +Z. Mirrors
+	// the rigid yaw op exactly so combined gestures compose deterministically.
+	const rotXZ = (x: number, z: number): { x: number; z: number } => {
+		const ox = x - cx;
+		const oz = z - cz;
+		return {
+			x: ox * cosT - oz * sinT + cx,
+			z: ox * sinT + oz * cosT + cz,
+		};
+	};
+
+	const srcRotated: AISection = {
+		...src,
+		corners: src.corners.map((corner) => {
+			const r = rotXZ(corner.x, corner.y);
+			return { x: r.x, y: r.z };
+		}),
+		portals: src.portals.map((p) => {
+			const rPos = rotXZ(p.position.x, p.position.z);
+			return {
+				...p,
+				position: { x: rPos.x, y: p.position.y, z: rPos.z },
+				boundaryLines: p.boundaryLines.map((bl) => {
+					const rStart = rotXZ(bl.verts.x, bl.verts.y);
+					const rEnd = rotXZ(bl.verts.z, bl.verts.w);
+					return { verts: { x: rStart.x, y: rStart.z, z: rEnd.x, w: rEnd.z } };
+				}),
+			};
+		}),
+		noGoLines: src.noGoLines.map((bl) => {
+			const rStart = rotXZ(bl.verts.x, bl.verts.y);
+			const rEnd = rotXZ(bl.verts.z, bl.verts.w);
+			return { verts: { x: rStart.x, y: rStart.z, z: rEnd.x, w: rEnd.z } };
+		}),
+	};
+
+	// Neighbour fix-ups — one per source portal pointing at a distinct
+	// neighbour. Multiple portals can point at the same neighbour (rare A↔B
+	// dual-edge connection): in that case each portal's fix-up applies on
+	// top of the running state via the same map-keyed accumulator the
+	// translate cascade uses.
+	const updates = new Map<number, AISection>();
+	updates.set(srcIdx, srcRotated);
+
+	for (const oldPortal of src.portals) {
+		const targetIdx = oldPortal.linkSection;
+		if (targetIdx === srcIdx) continue;
+		if (targetIdx < 0 || targetIdx >= model.sections.length) continue;
+
+		const current = updates.get(targetIdx) ?? model.sections[targetIdx];
+		const fixed = applyRotateLinkFixUp(current, srcIdx, oldPortal, rotXZ);
+		if (fixed !== current) updates.set(targetIdx, fixed);
+	}
+
+	const sections = model.sections.map((s, i) => updates.get(i) ?? s);
+	return { ...model, sections };
+}
+
+/**
+ * Per-neighbour rotate cascade: rotate the matching reverse portal and any
+ * corners on the shared edge around the same pivot the source spun about.
+ * Mirrors {@link applyLinkFixUp}'s shape — match the reverse portal by
+ * `linkSection` AND coincident pre-rotate `position`, then apply `rotXZ`
+ * point-by-point to that portal's position, its boundary-line endpoints,
+ * and the neighbour corners coincident with the source portal's pre-rotate
+ * boundary-line endpoints.
+ */
+function applyRotateLinkFixUp(
+	target: AISection,
+	srcIdx: number,
+	oldSrcPortal: Portal,
+	rotXZ: (x: number, z: number) => { x: number; z: number },
+): AISection {
+	const matchIdx = target.portals.findIndex(
+		(p) => p.linkSection === srcIdx && v3Approx(p.position, oldSrcPortal.position),
+	);
+
+	let portals = target.portals;
+	if (matchIdx >= 0) {
+		const old = target.portals[matchIdx];
+		const rPos = rotXZ(old.position.x, old.position.z);
+		const updated: Portal = {
+			...old,
+			position: { x: rPos.x, y: old.position.y, z: rPos.z },
+			boundaryLines: old.boundaryLines.map((bl) => {
+				const rStart = rotXZ(bl.verts.x, bl.verts.y);
+				const rEnd = rotXZ(bl.verts.z, bl.verts.w);
+				return { verts: { x: rStart.x, y: rStart.z, z: rEnd.x, w: rEnd.z } };
+			}),
+		};
+		portals = target.portals.slice();
+		portals[matchIdx] = updated;
+	}
+
+	// Identify shared corners by matching the source portal's pre-rotate
+	// boundary-line endpoints — same lookup the translate cascade uses.
+	const sharedPoints: Vector2[] = [];
+	for (const bl of oldSrcPortal.boundaryLines) {
+		sharedPoints.push({ x: bl.verts.x, y: bl.verts.y });
+		sharedPoints.push({ x: bl.verts.z, y: bl.verts.w });
+	}
+
+	let corners = target.corners;
+	if (sharedPoints.length > 0) {
+		let cornersChanged = false;
+		const next = target.corners.map((c) => {
+			if (sharedPoints.some((p) => v2Approx(c, p))) {
+				cornersChanged = true;
+				const r = rotXZ(c.x, c.y);
+				return { x: r.x, y: r.z };
+			}
+			return c;
+		});
+		if (cornersChanged) corners = next;
+	}
+
+	if (portals === target.portals && corners === target.corners) return target;
+	return { ...target, portals, corners };
+}
+
+/**
+ * Cascade-on translate of a single portal anchor by `(dx, dy, dz)`. The
+ * source portal at `(sectionIdx, portalIdx)` moves to its new position, and
+ * the **mirror portal** on the linked section (matched by `linkSection ===
+ * sectionIdx` AND a pre-translate `position` coincident with the source
+ * portal's pre-translate `position`) moves by the same delta so the
+ * connection stays geometrically coherent.
+ *
+ * Unlike {@link translateSectionWithLinks}, this op does NOT touch corners
+ * or boundary-line endpoints on either section. The portal anchor is a
+ * 3D point at an edge midpoint by convention (the duplicate-through-edge
+ * op's choice); dragging it slides the anchor along the connection without
+ * deforming either polygon. The user can drag corners separately to
+ * re-align the shared edge if they want.
+ *
+ * Returns the original `model` reference when `(dx, dy, dz) === (0, 0, 0)`
+ * so byte-for-byte BND2 writeback is preserved on a no-op gesture.
+ *
+ * @throws RangeError if `sectionIdx` or `portalIdx` is out of range.
+ */
+export function translatePortalAnchorWithMirror(
+	model: ParsedAISectionsV12,
+	sectionIdx: number,
+	portalIdx: number,
+	offset: { x: number; y: number; z: number },
+): ParsedAISectionsV12 {
+	if (sectionIdx < 0 || sectionIdx >= model.sections.length) {
+		throw new RangeError(`sectionIdx ${sectionIdx} out of range [0, ${model.sections.length})`);
+	}
+	const src = model.sections[sectionIdx];
+	if (portalIdx < 0 || portalIdx >= src.portals.length) {
+		throw new RangeError(`portalIdx ${portalIdx} out of range [0, ${src.portals.length})`);
+	}
+	const dx = offset.x;
+	const dy = offset.y;
+	const dz = offset.z;
+	if (dx === 0 && dy === 0 && dz === 0) return model;
+
+	const oldPortal = src.portals[portalIdx];
+	const oldPosition = { ...oldPortal.position };
+	const movedPortal: Portal = {
+		...oldPortal,
+		position: { x: oldPortal.position.x + dx, y: oldPortal.position.y + dy, z: oldPortal.position.z + dz },
+	};
+	const updatedSrc: AISection = {
+		...src,
+		portals: src.portals.map((p, i) => (i === portalIdx ? movedPortal : p)),
+	};
+
+	const updates = new Map<number, AISection>();
+	updates.set(sectionIdx, updatedSrc);
+
+	// Mirror lookup: the linked section's portal pointing back at us whose
+	// pre-translate position approximates ours. Same matching strategy as
+	// `applyLinkFixUp` so a neighbour with multiple portals back to the
+	// source resolves to the right one.
+	const linkIdx = oldPortal.linkSection;
+	if (linkIdx !== sectionIdx && linkIdx >= 0 && linkIdx < model.sections.length) {
+		const neighbour = model.sections[linkIdx];
+		const mirrorIdx = neighbour.portals.findIndex(
+			(p) => p.linkSection === sectionIdx && v3Approx(p.position, oldPosition),
+		);
+		if (mirrorIdx >= 0) {
+			const oldMirror = neighbour.portals[mirrorIdx];
+			const movedMirror: Portal = {
+				...oldMirror,
+				position: {
+					x: oldMirror.position.x + dx,
+					y: oldMirror.position.y + dy,
+					z: oldMirror.position.z + dz,
+				},
+			};
+			const updatedNeighbour: AISection = {
+				...neighbour,
+				portals: neighbour.portals.map((p, i) => (i === mirrorIdx ? movedMirror : p)),
+			};
+			updates.set(linkIdx, updatedNeighbour);
+		}
+	}
+
+	const sections = model.sections.map((s, i) => updates.get(i) ?? s);
+	return { ...model, sections };
+}
+
+/**
+ * Cascade-on translate of a multi-section **Selection** by an XZ offset.
+ * Layered on top of {@link translateSectionWithLinks}: each selected section
+ * is translated with the one-hop cascade rule, but cascades INTO other
+ * Selection members are skipped — the inside of the Selection moves as one
+ * rigid body, and only OUTSIDE neighbours get their reverse portals + shared
+ * corners dragged along (per the issue #75 acceptance criterion "cascade
+ * applied to every Selection-boundary portal/corner").
+ *
+ * Why we can't just call `translateSectionWithLinks` per member: cascading
+ * into another Selection member would double-translate that member (once by
+ * its own gizmo translate, once by the cascade from the previous member).
+ * The inside-Selection cascade is also redundant — both members move by the
+ * same delta, so their shared boundary stays coincident either way.
+ *
+ * Algorithm:
+ *   1. Build a set of cascade-target indices = the Selection's complement,
+ *      restricted to neighbours of any Selection member.
+ *   2. For each Selection member: apply the rigid translate to the source,
+ *      then for each of its portals pointing at a target NOT in the
+ *      Selection, apply the same one-hop fix-up `applyLinkFixUp` uses
+ *      (translate the reverse portal + shared corners).
+ *   3. Selection-internal portals get their `position` and `boundaryLines`
+ *      translated as part of the rigid move on the source side; the matching
+ *      reverse portal on the OTHER Selection member is similarly translated
+ *      by its own pass, so the pair stays coherent without explicit cascade.
+ *
+ * Returns the original `model` reference when `(dx, dz) === (0, 0)` so
+ * byte-for-byte BND2 writeback is preserved on a no-op gesture.
+ *
+ * Layered on top of issue #74's bulk path — when #74 lands and the bulk
+ * Selection has its own carrier, this op consumes the same `readonly
+ * number[]` of section indices. Today's caller is issue #75's cascade-on
+ * path for single-section selections too (selectedIndices = [i]); behaviour
+ * matches `translateSectionWithLinks` exactly in that single-member case.
+ *
+ * @throws RangeError if any index in `selectedIndices` is out of range.
+ */
+export function translateSelectionWithLinks(
+	model: ParsedAISectionsV12,
+	selectedIndices: readonly number[],
+	offset: { x: number; z: number },
+): ParsedAISectionsV12 {
+	if (selectedIndices.length === 0) return model;
+	for (const idx of selectedIndices) {
+		if (idx < 0 || idx >= model.sections.length) {
+			throw new RangeError(`section index ${idx} out of range [0, ${model.sections.length})`);
+		}
+	}
+	if (offset.x === 0 && offset.z === 0) return model;
+
+	const dx = offset.x;
+	const dz = offset.z;
+	const selectedSet = new Set<number>(selectedIndices);
+
+	// Per-section update accumulator (same shape as the single-section op).
+	const updates = new Map<number, AISection>();
+
+	// Pass 1 — rigid-translate every selected section. This is the "inside
+	// the Selection moves as one block" pass; outside cascade lands in pass 2.
+	for (const idx of selectedSet) {
+		const src = model.sections[idx];
+		const srcTranslated: AISection = {
+			...src,
+			corners: src.corners.map((c) => ({ x: c.x + dx, y: c.y + dz })),
+			portals: src.portals.map((p) => ({
+				...p,
+				position: { x: p.position.x + dx, y: p.position.y, z: p.position.z + dz },
+				boundaryLines: p.boundaryLines.map((bl) => ({
+					verts: { x: bl.verts.x + dx, y: bl.verts.y + dz, z: bl.verts.z + dx, w: bl.verts.w + dz },
+				})),
+			})),
+			noGoLines: src.noGoLines.map((bl) => ({
+				verts: { x: bl.verts.x + dx, y: bl.verts.y + dz, z: bl.verts.z + dx, w: bl.verts.w + dz },
+			})),
+		};
+		updates.set(idx, srcTranslated);
+	}
+
+	// Pass 2 — cascade into outside neighbours. We walk every Selection
+	// member's ORIGINAL portals (not the post-translate ones — `oldSrcPortal`
+	// in `applyLinkFixUp` references pre-translate positions for the lookup
+	// of coincident reverse portals + shared corners).
+	for (const idx of selectedSet) {
+		const src = model.sections[idx];
+		for (const oldPortal of src.portals) {
+			const targetIdx = oldPortal.linkSection;
+			if (targetIdx === idx) continue;
+			if (targetIdx < 0 || targetIdx >= model.sections.length) continue;
+			// Skip cascades INTO another Selection member — that member's
+			// rigid translate from pass 1 already covers the shared edge.
+			if (selectedSet.has(targetIdx)) continue;
+
+			const current = updates.get(targetIdx) ?? model.sections[targetIdx];
+			const fixed = applyLinkFixUp(current, idx, oldPortal, dx, dz);
+			if (fixed !== current) updates.set(targetIdx, fixed);
+		}
+	}
+
+	const sections = model.sections.map((s, i) => updates.get(i) ?? s);
+	return { ...model, sections };
+}
+
+/**
+ * Cascade-on yaw rotate of a multi-section **Selection** by `theta` radians
+ * around `pivot` (the Selection's median XZ, per CONTEXT.md / "Pivot"). The
+ * yaw-axis sibling of {@link translateSelectionWithLinks}: every selected
+ * section rotates as a rigid body around the shared pivot, and for any
+ * portal on a Selection member pointing OUTSIDE the Selection, the reverse
+ * portal + shared corners on the outside neighbour rotate around the same
+ * pivot. Selection-internal portals are covered by the rigid-pass on both
+ * member sides — they move together so their shared edge stays coincident.
+ *
+ * Returns the original `model` reference when `theta === 0` so byte-for-byte
+ * BND2 writeback is preserved on a no-op gesture.
+ *
+ * @throws RangeError if any index in `selectedIndices` is out of range.
+ */
+export function rotateSelectionWithLinksYaw(
+	model: ParsedAISectionsV12,
+	selectedIndices: readonly number[],
+	pivot: { x: number; z: number },
+	theta: number,
+): ParsedAISectionsV12 {
+	if (selectedIndices.length === 0) return model;
+	for (const idx of selectedIndices) {
+		if (idx < 0 || idx >= model.sections.length) {
+			throw new RangeError(`section index ${idx} out of range [0, ${model.sections.length})`);
+		}
+	}
+	if (theta === 0) return model;
+
+	const cx = pivot.x;
+	const cz = pivot.z;
+	const cosT = Math.cos(theta);
+	const sinT = Math.sin(theta);
+	const rotXZ = (x: number, z: number): { x: number; z: number } => {
+		const ox = x - cx;
+		const oz = z - cz;
+		return {
+			x: ox * cosT - oz * sinT + cx,
+			z: ox * sinT + oz * cosT + cz,
+		};
+	};
+
+	const selectedSet = new Set<number>(selectedIndices);
+	const updates = new Map<number, AISection>();
+
+	// Pass 1 — rigid yaw rotate of every Selection member around the
+	// shared pivot. All members spin lockstep so their relative geometry
+	// is preserved.
+	for (const idx of selectedSet) {
+		const src = model.sections[idx];
+		updates.set(idx, {
+			...src,
+			corners: src.corners.map((c) => {
+				const r = rotXZ(c.x, c.y);
+				return { x: r.x, y: r.z };
+			}),
+			portals: src.portals.map((p) => {
+				const rPos = rotXZ(p.position.x, p.position.z);
+				return {
+					...p,
+					position: { x: rPos.x, y: p.position.y, z: rPos.z },
+					boundaryLines: p.boundaryLines.map((bl) => {
+						const rStart = rotXZ(bl.verts.x, bl.verts.y);
+						const rEnd = rotXZ(bl.verts.z, bl.verts.w);
+						return { verts: { x: rStart.x, y: rStart.z, z: rEnd.x, w: rEnd.z } };
+					}),
+				};
+			}),
+			noGoLines: src.noGoLines.map((bl) => {
+				const rStart = rotXZ(bl.verts.x, bl.verts.y);
+				const rEnd = rotXZ(bl.verts.z, bl.verts.w);
+				return { verts: { x: rStart.x, y: rStart.z, z: rEnd.x, w: rEnd.z } };
+			}),
+		});
+	}
+
+	// Pass 2 — cascade into outside neighbours via per-member portals
+	// pointing OUTSIDE the Selection. Same shape as the single-section
+	// rotate cascade, just iterated over the Selection.
+	for (const idx of selectedSet) {
+		const src = model.sections[idx];
+		for (const oldPortal of src.portals) {
+			const targetIdx = oldPortal.linkSection;
+			if (targetIdx === idx) continue;
+			if (targetIdx < 0 || targetIdx >= model.sections.length) continue;
+			if (selectedSet.has(targetIdx)) continue;
+
+			const current = updates.get(targetIdx) ?? model.sections[targetIdx];
+			const fixed = applyRotateLinkFixUp(current, idx, oldPortal, rotXZ);
+			if (fixed !== current) updates.set(targetIdx, fixed);
+		}
+	}
+
+	const sections = model.sections.map((s, i) => updates.get(i) ?? s);
+	return { ...model, sections };
+}


### PR DESCRIPTION
## Summary

- Adds a held-Shift opt-in to the **Cascade** behaviour for the bulk-transform gizmo gesture (per ADR-0009 + CONTEXT.md / "Cascade"). When Shift is held at gesture start, the gizmo routes through cascade-on op variants that drag outside-neighbour reverse-portal anchors and shared corners along with the selection. Default stays cascade-off (the ADR-0009 inversion of the legacy auto-cascade behaviour).
- New cascade-on ops in `aiSectionsOps.ts` — `rotateSectionWithLinksYaw` (yaw-axis sibling of the existing `translateSectionWithLinks`), `translatePortalAnchorWithMirror` (single-portal-anchor cascade for issue #73's sub-entity gestures), and `translateSelectionWithLinks` / `rotateSelectionWithLinksYaw` (bulk variants that layer cascade on top of #74's Selection path — Selection-internal portals are skipped so inside members move as one rigid body and only outside neighbours cascade).
- Visual feedback: translucent magenta halo around the gizmo + top-centre "Cascade ON · outside neighbours follow" status hint while a Shift-held gesture is active.
- Modifier state is captured ONCE at pointer-down on `BulkTransformDelta.cascade` and pinned for the gesture's lifetime — pressing/releasing Shift mid-drag does NOT flip the mode (consistent gesture semantics; matches Blender/Maya).
- One **Workspace**-undo entry per gesture preserved across the modifier state — even though cascade-on ops mutate more sections per call, the gizmo's commit still funnels through a single `onChange` → `setResource`.

Closes #75.

## Judgment calls

- **Modifier choice**: Shift. Already used elsewhere only on click events (range-select); no conflict during drag gestures. Documented inline at `BulkTransformGizmo.beginTranslate` / `.beginRotate`.
- **Capture-at-start vs continuous**: capture-at-start. Pressing/releasing Shift mid-drag does NOT switch modes. The alternative (continuous read) was rejected because it makes the gizmo modal mid-gesture and produces split-mode renderings (half the geometry cascaded, half not) if the user fidgets on the modifier. Documented on `BulkTransformDelta.cascade` and the dragStart ref.
- **Cascade-on rotate algorithm**: the existing translate cascade can't be extended trivially — translate shifts every cascade-partner by the same `(dx, dz)` vector, but rotation depends on each point's offset from the pivot. We identify cascade partners (reverse portals + shared corners) on the *pre-rotate* geometry, then apply the same `rotXZ(x, z)` point-by-point. Source-section centroid is the pivot for the single-section op (cardinality-1 default per CONTEXT.md / "Pivot"); the bulk variant takes an explicit `pivot` argument so the caller can use the Selection's median.
- **Cascade-on bulk layering**: `translateSelectionWithLinks` skips cascades INTO other Selection members (`selectedSet.has(targetIdx)` guard). The inside-Selection rigid translate already covers shared edges on both members; cascading into a member would double-translate. This layers cleanly on top of #74 — same input shape (`readonly number[]` of section indices), works whether or not #74 has merged.

## Test plan

- [x] `bun x vitest run src/lib/core/aiSectionsOps.test.ts` — 167 tests pass (+23 new for the four cascade ops, including a regression check that `translateSelectionWithLinks([i])` matches `translateSectionWithLinks(i)` byte-for-byte)
- [x] `bun x vitest run src/context/__tests__/WorkspaceContext.bulkTransform.test.ts` — 8 tests pass (+3 new pinning ONE undo entry per cascade-on gesture; one round-trip test verifying neighbour cascades undo deep-equal to pre-edit state)
- [x] `bun x vitest run src/hooks/__tests__/useBulkTransformDrag.cascade.test.ts` — 6 tests pass (pins `BulkTransformDelta.cascade` shape and `isIdentityDelta` ignoring the modifier flag)
- [x] `bun x tsc --noEmit` — clean
- [x] `bun run test:run` — 1151 passing (+31 vs. baseline 1120). 15 failing, of which 14 are the documented baseline `ENOENT` failures for V4/V6 fixtures missing from the worktree under `example/older builds/`; the 1 additional is a transient timeout on `aiSectionsGltf.test.ts` (passes when run alone — `bun x vitest run src/lib/core/gltf/aiSectionsGltf.test.ts` → 9 passed).

## Anticipated rebase conflicts

- **#73** (sub-entity gizmo): I added `translatePortalAnchorWithMirror` so the sub-entity drag plumbing has a cascade-on op to call when Shift is held. The wiring in the overlay's sub-entity drag handlers (lives in `src/components/aisections/` / `CornerHandles`) is #73's territory — expect a small merge in `AISectionsOverlay.tsx` where #73 routes corner / portal drags through the unified gizmo + my cascade branch.
- **#74** (multi-entity bulk): I added `translateSelectionWithLinks` and `rotateSelectionWithLinksYaw` that take a `readonly number[]` of section indices. When #74's Selection-driven bulk lands, the cascade-on commit path in `AISectionsOverlay.handleGizmoCommit` will need to thread the bulk's indices into these ops instead of `[selectedSectionIndex]`. Mechanical.
- Both should be straight-forward rebases — the cascade slice deliberately doesn't touch the sub-entity drag plumbing or the bulk Selection shape; it only adds cascade-on op variants and the modifier capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)