### PR TITLE
feat: AI sub-entity gizmo for corners / portals / line endpoints (#73)

### DIFF
--- a/src/components/aisections/shared/SectionDetail.tsx
+++ b/src/components/aisections/shared/SectionDetail.tsx
@@ -103,15 +103,17 @@ export function SectionDetail<TSection, TRoot>({
 	onPickPortal,
 	onPickBoundaryLine,
 	onPickNoGoLine,
+	onPickBoundaryLineEndpoint,
+	onPickNoGoLineEndpoint,
 }: {
 	section: TSection;
 	root: TRoot;
 	accessor: SectionDetailAccessor<TSection, TRoot>;
 	/** Inspector-selected marker, used to highlight the picked sub-entity
-	 *  (portal / boundary line / no-go line). Pass `null` for bulk-only
-	 *  rendering — bulk members get the full structural geometry but no
-	 *  selected-sub-entity highlights, so the user knows which one is the
-	 *  inspector pick. */
+	 *  (portal / boundary line / no-go line / corner / endpoint). Pass `null`
+	 *  for bulk-only rendering — bulk members get the full structural
+	 *  geometry but no selected-sub-entity highlights, so the user knows
+	 *  which one is the inspector pick. */
 	marker: AISectionMarker;
 	/** Y of the section's resolved ground. Used to lift no-go lines onto
 	 *  the section's ground plane. Portal anchors and portal boundary lines
@@ -121,6 +123,12 @@ export function SectionDetail<TSection, TRoot>({
 	onPickPortal?: (portalIndex: number) => void;
 	onPickBoundaryLine?: (portalIndex: number, lineIndex: number) => void;
 	onPickNoGoLine?: (lineIndex: number) => void;
+	/** Issue #73 — endpoint pickers for the bulk-transform gizmo. `endIndex`
+	 *  is 0 (verts.x/y, the start) or 1 (verts.z/w, the end). The handlers
+	 *  are optional so the V4/V6 read-only overlay can render without
+	 *  wiring them; the V12 overlay supplies both for sub-entity editing. */
+	onPickBoundaryLineEndpoint?: (portalIndex: number, lineIndex: number, endIndex: number) => void;
+	onPickNoGoLineEndpoint?: (lineIndex: number, endIndex: number) => void;
 }) {
 	const portals = useMemo(() => accessor.portals(section), [section, accessor]);
 	const noGoLines = useMemo(() => accessor.noGoLines(section), [section, accessor]);
@@ -154,9 +162,20 @@ export function SectionDetail<TSection, TRoot>({
 					const start: [number, number, number] = [bl.verts.x, portal.position.y + 0.5, bl.verts.y];
 					const end: [number, number, number] = [bl.verts.z, portal.position.y + 0.5, bl.verts.w];
 					const isSel = marker?.kind === 'boundaryLine' && marker.portalIndex === pi && marker.lineIndex === li;
+					const isStartSel =
+						marker?.kind === 'boundaryLineEndpoint'
+						&& marker.portalIndex === pi
+						&& marker.lineIndex === li
+						&& marker.endIndex === 0;
+					const isEndSel =
+						marker?.kind === 'boundaryLineEndpoint'
+						&& marker.portalIndex === pi
+						&& marker.lineIndex === li
+						&& marker.endIndex === 1;
+					const isWholeLineHighlighted = isSel || isStartSel || isEndSel;
 					return (
 						<group key={`bl-${pi}-${li}`}>
-							<Line points={[start, end]} color={isSel ? '#ffaa33' : '#cc3333'} lineWidth={isSel ? 3 : 2} />
+							<Line points={[start, end]} color={isWholeLineHighlighted ? '#ffaa33' : '#cc3333'} lineWidth={isWholeLineHighlighted ? 3 : 2} />
 							<mesh
 								position={[(start[0] + end[0]) / 2, (start[1] + end[1]) / 2, (start[2] + end[2]) / 2]}
 								onClick={onPickBoundaryLine ? (e) => { e.stopPropagation(); onPickBoundaryLine(pi, li); } : undefined}
@@ -164,16 +183,35 @@ export function SectionDetail<TSection, TRoot>({
 								<sphereGeometry args={[2, 6, 4]} />
 								<meshBasicMaterial transparent opacity={0} />
 							</mesh>
+							{/* Endpoint pickers — small spheres at each end of the
+							    line that can be selected for the sub-entity gizmo
+							    (issue #73). The start/end spheres always render
+							    when the whole line is selected (mirrors the
+							    pre-#73 "show endpoints when line is selected"
+							    affordance) and they also act as pick targets so
+							    the user can drill from line → endpoint. */}
+							{(isWholeLineHighlighted || onPickBoundaryLineEndpoint) && (
+								<>
+									<EndpointPicker
+										position={start}
+										color={isStartSel ? '#ffffff' : '#ff4444'}
+										emissive={isStartSel ? '#666633' : '#441111'}
+										onClick={onPickBoundaryLineEndpoint
+											? () => onPickBoundaryLineEndpoint(pi, li, 0)
+											: undefined}
+									/>
+									<EndpointPicker
+										position={end}
+										color={isEndSel ? '#ffffff' : '#4444ff'}
+										emissive={isEndSel ? '#666633' : '#111144'}
+										onClick={onPickBoundaryLineEndpoint
+											? () => onPickBoundaryLineEndpoint(pi, li, 1)
+											: undefined}
+									/>
+								</>
+							)}
 							{isSel && (
 								<>
-									<mesh position={start}>
-										<sphereGeometry args={[1.5, 8, 6]} />
-										<meshStandardMaterial color="#ff4444" emissive="#441111" emissiveIntensity={0.5} />
-									</mesh>
-									<mesh position={end}>
-										<sphereGeometry args={[1.5, 8, 6]} />
-										<meshStandardMaterial color="#4444ff" emissive="#111144" emissiveIntensity={0.5} />
-									</mesh>
 									<Html position={start} center distanceFactor={120} style={{ pointerEvents: 'none' }}>
 										<div style={{ background: 'rgba(0,0,0,0.8)', color: '#ff6666', padding: '1px 4px', borderRadius: 3, fontSize: 9, fontFamily: 'monospace' }}>
 											X={bl.verts.x.toFixed(1)} Y={bl.verts.y.toFixed(1)}
@@ -196,9 +234,14 @@ export function SectionDetail<TSection, TRoot>({
 				const start: [number, number, number] = [bl.verts.x, lineY, bl.verts.y];
 				const end: [number, number, number] = [bl.verts.z, lineY, bl.verts.w];
 				const isSel = marker?.kind === 'noGoLine' && marker.lineIndex === li;
+				const isStartSel =
+					marker?.kind === 'noGoLineEndpoint' && marker.lineIndex === li && marker.endIndex === 0;
+				const isEndSel =
+					marker?.kind === 'noGoLineEndpoint' && marker.lineIndex === li && marker.endIndex === 1;
+				const isWholeLineHighlighted = isSel || isStartSel || isEndSel;
 				return (
 					<group key={`ng-${li}`}>
-						<Line points={[start, end]} color={isSel ? '#ffaa33' : '#cc8833'} lineWidth={isSel ? 3 : 2} />
+						<Line points={[start, end]} color={isWholeLineHighlighted ? '#ffaa33' : '#cc8833'} lineWidth={isWholeLineHighlighted ? 3 : 2} />
 						<mesh
 							position={[(start[0] + end[0]) / 2, lineY, (start[2] + end[2]) / 2]}
 							onClick={onPickNoGoLine ? (e) => { e.stopPropagation(); onPickNoGoLine(li); } : undefined}
@@ -206,6 +249,26 @@ export function SectionDetail<TSection, TRoot>({
 							<sphereGeometry args={[2, 6, 4]} />
 							<meshBasicMaterial transparent opacity={0} />
 						</mesh>
+						{(isWholeLineHighlighted || onPickNoGoLineEndpoint) && (
+							<>
+								<EndpointPicker
+									position={start}
+									color={isStartSel ? '#ffffff' : '#ff8844'}
+									emissive={isStartSel ? '#666633' : '#442211'}
+									onClick={onPickNoGoLineEndpoint
+										? () => onPickNoGoLineEndpoint(li, 0)
+										: undefined}
+								/>
+								<EndpointPicker
+									position={end}
+									color={isEndSel ? '#ffffff' : '#4488ff'}
+									emissive={isEndSel ? '#666633' : '#112244'}
+									onClick={onPickNoGoLineEndpoint
+										? () => onPickNoGoLineEndpoint(li, 1)
+										: undefined}
+								/>
+							</>
+						)}
 					</group>
 				);
 			})}
@@ -222,5 +285,51 @@ export function SectionDetail<TSection, TRoot>({
 				);
 			})}
 		</>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// EndpointPicker — small clickable sphere at a line endpoint.
+//
+// Issue #73 adds endpoint-level selection so the bulk-transform gizmo can
+// anchor at one end of a boundary or no-go line. The visual sphere doubles
+// as a pick target via a slightly larger invisible hit volume — the same
+// pattern CornerPickers uses. When no `onClick` is supplied (legacy V4/V6
+// overlay, or bulk-only render), the sphere renders as a passive marker.
+// ---------------------------------------------------------------------------
+function EndpointPicker({
+	position,
+	color,
+	emissive,
+	onClick,
+}: {
+	position: [number, number, number];
+	color: string;
+	emissive: string;
+	onClick?: () => void;
+}) {
+	return (
+		<group position={position}>
+			<mesh>
+				<sphereGeometry args={[1.5, 8, 6]} />
+				<meshStandardMaterial color={color} emissive={emissive} emissiveIntensity={0.5} />
+			</mesh>
+			{onClick && (
+				<mesh
+					onClick={(e) => { e.stopPropagation(); onClick(); }}
+					onPointerOver={(e) => {
+						e.stopPropagation();
+						document.body.style.cursor = 'pointer';
+					}}
+					onPointerOut={(e) => {
+						e.stopPropagation();
+						document.body.style.cursor = 'auto';
+					}}
+				>
+					<sphereGeometry args={[2.4, 6, 4]} />
+					<meshBasicMaterial transparent opacity={0} />
+				</mesh>
+			)}
+		</group>
 	);
 }

--- a/src/components/aisections/shared/selection.ts
+++ b/src/components/aisections/shared/selection.ts
@@ -1,17 +1,25 @@
 // AI Sections selection codecs — shared between the V12 editable overlay and
 // the V4/V6 read-only overlay so the marker shape stays in lock-step across
-// both. The two overlays own the same four selection kinds (section / portal
-// / boundaryLine / noGoLine); they differ only in the schema path prefix
-// (V12 paths are top-level under `sections`, V4/V6 paths nest under a
-// `legacy` wrapper field).
+// both. The two overlays own the same seven selection kinds (section / portal
+// / boundaryLine / noGoLine / corner / boundaryLineEndpoint /
+// noGoLineEndpoint); they differ only in the schema path prefix (V12 paths
+// are top-level under `sections`, V4/V6 paths nest under a `legacy` wrapper
+// field).
 //
 // Selection shape uses the unified `{ kind, indices }` form from
 // `@/components/schema-editor/viewports/selection`. Indices encode the
 // nesting tuple:
-//   - { kind: 'section',      indices: [sectionIdx] }
-//   - { kind: 'portal',       indices: [sectionIdx, portalIdx] }
-//   - { kind: 'boundaryLine', indices: [sectionIdx, portalIdx, lineIdx] }
-//   - { kind: 'noGoLine',     indices: [sectionIdx, lineIdx] }
+//   - { kind: 'section',              indices: [sectionIdx] }
+//   - { kind: 'portal',               indices: [sectionIdx, portalIdx] }
+//   - { kind: 'boundaryLine',         indices: [sectionIdx, portalIdx, lineIdx] }
+//   - { kind: 'noGoLine',             indices: [sectionIdx, lineIdx] }
+//   - { kind: 'corner',               indices: [sectionIdx, cornerIdx] }
+//   - { kind: 'boundaryLineEndpoint', indices: [sectionIdx, portalIdx, lineIdx, endIdx] }
+//   - { kind: 'noGoLineEndpoint',     indices: [sectionIdx, lineIdx, endIdx] }
+//
+// The corner / endpoint kinds (issue #73) target the bulk-transform gizmo at
+// a single sub-entity. `endIdx ∈ {0, 1}` picks the start (verts.x/y) or end
+// (verts.z/w) endpoint of a packed-Vector4 line segment.
 //
 // Sub-paths inside a primitive (e.g. a portal's `position.x`) collapse to
 // the nearest selectable kind — the inspector can drill deeper while the 3D
@@ -37,6 +45,12 @@ export type AISectionMarker =
 	| { kind: 'portal'; sectionIndex: number; portalIndex: number }
 	| { kind: 'boundaryLine'; sectionIndex: number; portalIndex: number; lineIndex: number }
 	| { kind: 'noGoLine'; sectionIndex: number; lineIndex: number }
+	// Sub-entity markers (issue #73) — single corners + single line endpoints
+	// addressable for the bulk-transform gizmo. `endIndex ∈ {0, 1}` picks the
+	// start (verts.x/y) or end (verts.z/w) of a packed-Vector4 segment.
+	| { kind: 'corner'; sectionIndex: number; cornerIndex: number }
+	| { kind: 'boundaryLineEndpoint'; sectionIndex: number; portalIndex: number; lineIndex: number; endIndex: number }
+	| { kind: 'noGoLineEndpoint'; sectionIndex: number; lineIndex: number; endIndex: number }
 	| null;
 
 // ---------------------------------------------------------------------------
@@ -62,6 +76,23 @@ export function selectionToMarker(sel: Selection | null): AISectionMarker {
 			};
 		case 'noGoLine':
 			return { kind: 'noGoLine', sectionIndex: sel.indices[0], lineIndex: sel.indices[1] };
+		case 'corner':
+			return { kind: 'corner', sectionIndex: sel.indices[0], cornerIndex: sel.indices[1] };
+		case 'boundaryLineEndpoint':
+			return {
+				kind: 'boundaryLineEndpoint',
+				sectionIndex: sel.indices[0],
+				portalIndex: sel.indices[1],
+				lineIndex: sel.indices[2],
+				endIndex: sel.indices[3],
+			};
+		case 'noGoLineEndpoint':
+			return {
+				kind: 'noGoLineEndpoint',
+				sectionIndex: sel.indices[0],
+				lineIndex: sel.indices[1],
+				endIndex: sel.indices[2],
+			};
 	}
 	return null;
 }
@@ -78,6 +109,18 @@ export function markerToSelection(m: AISectionMarker): Selection | null {
 			return { kind: 'boundaryLine', indices: [m.sectionIndex, m.portalIndex, m.lineIndex] };
 		case 'noGoLine':
 			return { kind: 'noGoLine', indices: [m.sectionIndex, m.lineIndex] };
+		case 'corner':
+			return { kind: 'corner', indices: [m.sectionIndex, m.cornerIndex] };
+		case 'boundaryLineEndpoint':
+			return {
+				kind: 'boundaryLineEndpoint',
+				indices: [m.sectionIndex, m.portalIndex, m.lineIndex, m.endIndex],
+			};
+		case 'noGoLineEndpoint':
+			return {
+				kind: 'noGoLineEndpoint',
+				indices: [m.sectionIndex, m.lineIndex, m.endIndex],
+			};
 	}
 }
 
@@ -87,7 +130,16 @@ export function markerToSelection(m: AISectionMarker): Selection | null {
 //   - ['sections', i]
 //   - ['sections', i, 'portals', p]
 //   - ['sections', i, 'portals', p, 'boundaryLines', l]
+//   - ['sections', i, 'portals', p, 'boundaryLines', l, 'endpoints', e]  (issue #73)
 //   - ['sections', i, 'noGoLines', l]
+//   - ['sections', i, 'noGoLines', l, 'endpoints', e]                    (issue #73)
+//   - ['sections', i, 'corners', c]                                      (issue #73)
+//
+// `endpoints/e` is a synthetic path segment (e ∈ {0, 1}) — the on-disk schema
+// stores the line as a single Vector4 with `verts.x/y` the start and
+// `verts.z/w` the end, so there's no array to index into. The path encoding
+// is editor-only: the bulk-transform gizmo needs to anchor at one endpoint,
+// so we treat each line as having two addressable sub-points.
 // ---------------------------------------------------------------------------
 
 export const aiSectionsV12SelectionCodec: SelectionCodec = defineSelectionCodec({
@@ -102,13 +154,38 @@ export const aiSectionsV12SelectionCodec: SelectionCodec = defineSelectionCodec(
 			const portalIndex = path[3];
 			if (path.length === 4) return { kind: 'portal', indices: [sectionIndex, portalIndex] };
 			if (path[4] === 'boundaryLines' && typeof path[5] === 'number') {
-				return { kind: 'boundaryLine', indices: [sectionIndex, portalIndex, path[5]] };
+				const lineIndex = path[5];
+				if (
+					path.length >= 8
+					&& path[6] === 'endpoints'
+					&& typeof path[7] === 'number'
+				) {
+					return {
+						kind: 'boundaryLineEndpoint',
+						indices: [sectionIndex, portalIndex, lineIndex, path[7]],
+					};
+				}
+				return { kind: 'boundaryLine', indices: [sectionIndex, portalIndex, lineIndex] };
 			}
 			// Sub-path within a portal collapses to portal selection.
 			return { kind: 'portal', indices: [sectionIndex, portalIndex] };
 		}
 		if (list === 'noGoLines' && typeof path[3] === 'number') {
-			return { kind: 'noGoLine', indices: [sectionIndex, path[3]] };
+			const lineIndex = path[3];
+			if (
+				path.length >= 6
+				&& path[4] === 'endpoints'
+				&& typeof path[5] === 'number'
+			) {
+				return {
+					kind: 'noGoLineEndpoint',
+					indices: [sectionIndex, lineIndex, path[5]],
+				};
+			}
+			return { kind: 'noGoLine', indices: [sectionIndex, lineIndex] };
+		}
+		if (list === 'corners' && typeof path[3] === 'number') {
+			return { kind: 'corner', indices: [sectionIndex, path[3]] };
 		}
 		// Anything else under a section collapses to the section itself.
 		return { kind: 'section', indices: [sectionIndex] };
@@ -123,6 +200,21 @@ export const aiSectionsV12SelectionCodec: SelectionCodec = defineSelectionCodec(
 				return ['sections', sel.indices[0], 'portals', sel.indices[1], 'boundaryLines', sel.indices[2]];
 			case 'noGoLine':
 				return ['sections', sel.indices[0], 'noGoLines', sel.indices[1]];
+			case 'corner':
+				return ['sections', sel.indices[0], 'corners', sel.indices[1]];
+			case 'boundaryLineEndpoint':
+				return [
+					'sections', sel.indices[0],
+					'portals', sel.indices[1],
+					'boundaryLines', sel.indices[2],
+					'endpoints', sel.indices[3],
+				];
+			case 'noGoLineEndpoint':
+				return [
+					'sections', sel.indices[0],
+					'noGoLines', sel.indices[1],
+					'endpoints', sel.indices[2],
+				];
 		}
 		return [];
 	},
@@ -135,7 +227,15 @@ export const aiSectionsV12SelectionCodec: SelectionCodec = defineSelectionCodec(
 //   - ['legacy', 'sections', i]
 //   - ['legacy', 'sections', i, 'portals', p]
 //   - ['legacy', 'sections', i, 'portals', p, 'boundaryLines', l]
+//   - ['legacy', 'sections', i, 'portals', p, 'boundaryLines', l, 'endpoints', e]
 //   - ['legacy', 'sections', i, 'noGoLines', l]
+//   - ['legacy', 'sections', i, 'noGoLines', l, 'endpoints', e]
+//   - ['legacy', 'sections', i, 'corners', c]
+//
+// See the V12 codec above for the `endpoints/e` (e ∈ {0, 1}) synthetic-path
+// rationale. The legacy overlay doesn't yet wire these sub-entity selections
+// to the bulk gizmo (issue #73 ships V12 first), but parsing them keeps the
+// codec siblings in lock-step.
 // ---------------------------------------------------------------------------
 
 export const aiSectionsLegacySelectionCodec: SelectionCodec = defineSelectionCodec({
@@ -151,12 +251,37 @@ export const aiSectionsLegacySelectionCodec: SelectionCodec = defineSelectionCod
 			const portalIndex = path[4];
 			if (path.length === 5) return { kind: 'portal', indices: [sectionIndex, portalIndex] };
 			if (path[5] === 'boundaryLines' && typeof path[6] === 'number') {
-				return { kind: 'boundaryLine', indices: [sectionIndex, portalIndex, path[6]] };
+				const lineIndex = path[6];
+				if (
+					path.length >= 9
+					&& path[7] === 'endpoints'
+					&& typeof path[8] === 'number'
+				) {
+					return {
+						kind: 'boundaryLineEndpoint',
+						indices: [sectionIndex, portalIndex, lineIndex, path[8]],
+					};
+				}
+				return { kind: 'boundaryLine', indices: [sectionIndex, portalIndex, lineIndex] };
 			}
 			return { kind: 'portal', indices: [sectionIndex, portalIndex] };
 		}
 		if (list === 'noGoLines' && typeof path[4] === 'number') {
-			return { kind: 'noGoLine', indices: [sectionIndex, path[4]] };
+			const lineIndex = path[4];
+			if (
+				path.length >= 7
+				&& path[5] === 'endpoints'
+				&& typeof path[6] === 'number'
+			) {
+				return {
+					kind: 'noGoLineEndpoint',
+					indices: [sectionIndex, lineIndex, path[6]],
+				};
+			}
+			return { kind: 'noGoLine', indices: [sectionIndex, lineIndex] };
+		}
+		if (list === 'corners' && typeof path[4] === 'number') {
+			return { kind: 'corner', indices: [sectionIndex, path[4]] };
 		}
 		return { kind: 'section', indices: [sectionIndex] };
 	},
@@ -174,6 +299,21 @@ export const aiSectionsLegacySelectionCodec: SelectionCodec = defineSelectionCod
 				];
 			case 'noGoLine':
 				return ['legacy', 'sections', sel.indices[0], 'noGoLines', sel.indices[1]];
+			case 'corner':
+				return ['legacy', 'sections', sel.indices[0], 'corners', sel.indices[1]];
+			case 'boundaryLineEndpoint':
+				return [
+					'legacy', 'sections', sel.indices[0],
+					'portals', sel.indices[1],
+					'boundaryLines', sel.indices[2],
+					'endpoints', sel.indices[3],
+				];
+			case 'noGoLineEndpoint':
+				return [
+					'legacy', 'sections', sel.indices[0],
+					'noGoLines', sel.indices[1],
+					'endpoints', sel.indices[2],
+				];
 		}
 		return [];
 	},

--- a/src/components/schema-editor/viewports/AISectionsOverlay.tsx
+++ b/src/components/schema-editor/viewports/AISectionsOverlay.tsx
@@ -37,21 +37,26 @@ import {
 	duplicateSectionThroughEdge,
 	rotateSectionAroundCentroidYaw,
 	rotateSectionWithLinksYaw,
-	snapCornerOffset,
-	translateCornerWithShared,
+	translateBoundaryLineEndpointRigid,
+	translateCornerRigid,
+	translateNoGoLineEndpointRigid,
+	translatePortalAnchorRigid,
 	translateSectionRigid,
 	translateSectionWithLinks,
 } from '@/lib/core/aiSectionsOps';
 import { resolveSectionYs } from '@/lib/core/aiSectionY';
 import { BulkTransformGizmo } from '@/components/common/three/BulkTransformGizmo';
-import { TRANSFORM_AXES_XZ_PACKED } from '@/lib/core/transformAxes';
+import {
+	TRANSFORM_AXES_FULL_3D,
+	TRANSFORM_AXES_XZ_PACKED,
+	type TransformAxes,
+} from '@/lib/core/transformAxes';
 import {
 	type BulkTransformDelta,
 	isIdentityDelta,
 } from '@/hooks/useBulkTransformDrag';
 import { CameraBridge, type CameraBridgeData } from '@/components/common/three/CameraBridge';
 import { MarqueeSelector } from '@/components/common/three/MarqueeSelector';
-import { CornerHandles, type CornerDragOffset } from '@/components/aisections/CornerHandles';
 import {
 	aiSectionsV12SelectionCodec,
 	BatchedSections,
@@ -189,14 +194,24 @@ function makeV12Accessor(sectionYs: ArrayLike<number>): SectionDetailAccessor<AI
 
 // While a drag is in flight we keep the live delta in local state so the
 // underlying model isn't touched until release — one gesture commits as
-// one Workspace-undo entry (CONTEXT.md / "Bulk transform"). Two distinct
-// drag flavours can be active (the bulk-transform gizmo translates/rotates
-// the whole section; the corner handles deform the polygon — the latter
-// migrates to the unified gizmo in issue #73), so we model the active
-// drag as a discriminated union with mutual exclusion.
-type ActiveDrag =
-	| { kind: 'section'; delta: BulkTransformDelta }
-	| { kind: 'corner'; cornerIdx: number; offset: CornerDragOffset };
+// one Workspace-undo entry (CONTEXT.md / "Bulk transform"). The drag is
+// keyed by the gizmo target — whole section, single corner, single portal
+// anchor, single boundary-line endpoint, single no-go-line endpoint. All
+// flow through the same `BulkTransformGizmo` per ADR-0010; the target
+// kind decides which no-cascade op runs on commit. Per ADR-0009 none of
+// these cascade — coincident corners, mirror portals, and the other end
+// of a line stay put.
+type DragTarget =
+	| { kind: 'section'; sectionIdx: number }
+	| { kind: 'corner'; sectionIdx: number; cornerIdx: number }
+	| { kind: 'portalAnchor'; sectionIdx: number; portalIdx: number }
+	| { kind: 'boundaryLineEndpoint'; sectionIdx: number; portalIdx: number; lineIdx: number; endIdx: number }
+	| { kind: 'noGoLineEndpoint'; sectionIdx: number; lineIdx: number; endIdx: number };
+
+type ActiveDrag = {
+	target: DragTarget;
+	delta: BulkTransformDelta;
+};
 
 type Props = {
 	data: ParsedAISectionsV12;
@@ -237,21 +252,59 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 	const marker = useMemo(() => aiSectionPathMarker(selectedPath), [selectedPath]);
 	const selectedSectionIndex = marker ? marker.sectionIndex : null;
 
-	// Snap radius scales with the scene — for a typical AI bundle (~200 units
-	// radius) this lands at ~4 units which feels right when sections are
-	// 10–30 units across. Recomputed when the data changes.
-	const snapRadius = useMemo(() => {
-		if (data.sections.length === 0) return 0.5;
-		const box = new THREE.Box3();
-		for (const sec of data.sections) {
-			for (const c of sec.corners) box.expandByPoint(new THREE.Vector3(c.x, 0, c.y));
+	// Identify the gizmo's target from the marker. Sub-entity selections
+	// (corner / portal anchor / line endpoint) anchor the gizmo at the
+	// sub-entity's world position and translate ONLY that sub-entity on
+	// commit — no shared-corner cascade, no mirror-anchor sync (per
+	// ADR-0009; that's the modifier-on path in issue #75). When no marker
+	// is set, the gizmo isn't shown.
+	const gizmoTarget = useMemo<DragTarget | null>(() => {
+		if (!marker) return null;
+		switch (marker.kind) {
+			case 'section':
+				return { kind: 'section', sectionIdx: marker.sectionIndex };
+			case 'corner':
+				return {
+					kind: 'corner',
+					sectionIdx: marker.sectionIndex,
+					cornerIdx: marker.cornerIndex,
+				};
+			case 'portal':
+				return {
+					kind: 'portalAnchor',
+					sectionIdx: marker.sectionIndex,
+					portalIdx: marker.portalIndex,
+				};
+			case 'boundaryLineEndpoint':
+				return {
+					kind: 'boundaryLineEndpoint',
+					sectionIdx: marker.sectionIndex,
+					portalIdx: marker.portalIndex,
+					lineIdx: marker.lineIndex,
+					endIdx: marker.endIndex,
+				};
+			case 'noGoLineEndpoint':
+				return {
+					kind: 'noGoLineEndpoint',
+					sectionIdx: marker.sectionIndex,
+					lineIdx: marker.lineIndex,
+					endIdx: marker.endIndex,
+				};
+			// `boundaryLine` / `noGoLine` (a whole-line selection) is intentionally
+			// excluded — there's no rigid-body sub-op for a whole line yet (issue
+			// #73 ships per-endpoint translates; whole-line goes through inspector
+			// numeric fields or by selecting an endpoint).
+			default:
+				return null;
 		}
-		const sphere = new THREE.Sphere();
-		box.getBoundingSphere(sphere);
-		return Math.max(sphere.radius * 0.02, 0.5);
-	}, [data]);
+	}, [marker]);
 
-	// `S` toggles snap mode.
+	// Snap is intentionally not applied to any bulk-transform path (CONTEXT.md
+	// / ADR-0009): cascade-off makes snap incoherent (snapping the source to
+	// a neighbour edge while leaving the neighbour's reverse-portal stale
+	// would surprise the user). State + toggle remain so the keyboard-shortcut
+	// muscle memory survives, but the value isn't consulted anywhere in the
+	// commit path. Issue #75 reconsiders snap once cascade is opt-in.
 	useToggleHotkey('s', setSnapEnabled);
 
 	// Per-section ground Y (issue #27). Derived once per data change from
@@ -279,47 +332,21 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 
 	// While a drag is in flight, run the relevant op on the live delta to
 	// derive a preview model. Used for the selection overlay on the source
-	// section so the user sees the gesture in real time. Section-drag picks
-	// between no-cascade ops (the ADR-0009 default) and cascade-on ops
+	// section so the user sees the gesture in real time. Section-scope drags
+	// pick between no-cascade ops (the ADR-0009 default) and cascade-on ops
 	// (`translateSectionWithLinks` / `rotateSectionWithLinksYaw`) based on
 	// `delta.cascade` — captured at gesture start from Shift, per issue #75.
-	// Corner-drag still cascades into shared corners (issue #73 migrates that
-	// gesture to the unified gizmo).
+	// Sub-entity drags (corner, portal anchor, line endpoint) are always
+	// no-cascade in this slice; extending the cascade modifier to sub-
+	// entities is tracked as a follow-up.
 	const previewModel: ParsedAISectionsV12 | null = useMemo(() => {
-		if (selectedSectionIndex == null || !selSection || !drag) return null;
+		if (!drag || isIdentityDelta(drag.delta)) return null;
 		try {
-			if (drag.kind === 'section') {
-				if (isIdentityDelta(drag.delta)) return null;
-				if (drag.delta.cascade) {
-					// Cascade-on path: translateSectionWithLinks for translate
-					// (the legacy auto-cascade behaviour preserved as the
-					// modifier-on implementation per ADR-0009), then a yaw
-					// rotate that ALSO cascades around the same pivot. We
-					// compute the rotate pivot from the source centroid AFTER
-					// translate so combined gestures compose like Blender.
-					let next = translateSectionWithLinks(data, selectedSectionIndex, {
-						x: drag.delta.translate.x,
-						z: drag.delta.translate.z,
-					});
-					if (drag.delta.rotate.y !== 0) {
-						next = rotateSectionWithLinksYaw(next, selectedSectionIndex, drag.delta.rotate.y);
-					}
-					return next;
-				}
-				const translated = translateSectionRigid(data, selectedSectionIndex, drag.delta.translate);
-				// Apply yaw rotation around the *post-translate* centroid so
-				// translate + rotate compose as a single rigid body — same
-				// shape Blender's gizmo uses for combined gestures.
-				return drag.delta.rotate.y === 0
-					? translated
-					: rotateSectionAroundCentroidYaw(translated, selectedSectionIndex, drag.delta.rotate.y);
-			}
-			if (drag.offset.x === 0 && drag.offset.z === 0) return null;
-			return translateCornerWithShared(data, selectedSectionIndex, drag.cornerIdx, drag.offset);
+			return applyDragToModel(data, drag);
 		} catch {
 			return null;
 		}
-	}, [data, selectedSectionIndex, selSection, drag]);
+	}, [data, drag]);
 
 	const previewSection: AISection | null = useMemo(() => {
 		if (!selSection) return null;
@@ -348,16 +375,103 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 		return out;
 	}, [previewModel, selectedSectionIndex, data]);
 
+	// The gizmo anchors at a different point depending on the selection kind.
+	// `previewSection` is the live source section under any in-flight drag,
+	// so the anchor tracks the gesture frame-for-frame. Returns null when
+	// there is no selectable target or its data isn't resolvable.
 	const gizmoPosition = useMemo<[number, number, number] | null>(() => {
-		if (!previewSection || previewSection.corners.length === 0) return null;
-		let sx = 0, sz = 0;
-		for (const c of previewSection.corners) { sx += c.x; sz += c.y; }
-		const n = previewSection.corners.length;
-		return [sx / n, selectedSectionY + 1.5, sz / n];
-	}, [previewSection, selectedSectionY]);
+		if (!gizmoTarget) return null;
+		// All sub-entity targets live in the same source section — read it
+		// off `previewSection` (which already accounts for the in-flight drag)
+		// when available, otherwise fall back to the unmodified data.
+		const liveSection = previewSection
+			?? data.sections[gizmoTarget.sectionIdx]
+			?? null;
+		if (!liveSection) return null;
+		switch (gizmoTarget.kind) {
+			case 'section': {
+				if (liveSection.corners.length === 0) return null;
+				let sx = 0, sz = 0;
+				for (const c of liveSection.corners) { sx += c.x; sz += c.y; }
+				const n = liveSection.corners.length;
+				return [sx / n, selectedSectionY + 1.5, sz / n];
+			}
+			case 'corner': {
+				const c = liveSection.corners[gizmoTarget.cornerIdx];
+				if (!c) return null;
+				// Corner is a Vector2 on XZ; lift the gizmo just above the
+				// section's resolved ground Y so it floats clear of the fill mesh.
+				return [c.x, selectedSectionY + 1.5, c.y];
+			}
+			case 'portalAnchor': {
+				const p = liveSection.portals[gizmoTarget.portalIdx];
+				if (!p) return null;
+				// Portal anchor is full Vector3 — anchor the gizmo at the
+				// stored Y verbatim (the inspector edits portal.position.y).
+				return [p.position.x, p.position.y, p.position.z];
+			}
+			case 'boundaryLineEndpoint': {
+				const p = liveSection.portals[gizmoTarget.portalIdx];
+				if (!p) return null;
+				const line = p.boundaryLines[gizmoTarget.lineIdx];
+				if (!line) return null;
+				// Y comes from the parent portal's anchor (matches
+				// SectionDetail's boundary-line rendering convention).
+				const v = line.verts;
+				const x = gizmoTarget.endIdx === 0 ? v.x : v.z;
+				const z = gizmoTarget.endIdx === 0 ? v.y : v.w;
+				return [x, p.position.y, z];
+			}
+			case 'noGoLineEndpoint': {
+				const line = liveSection.noGoLines[gizmoTarget.lineIdx];
+				if (!line) return null;
+				// No-go lines have no anchor Y; sit on the section's
+				// resolved baseY (matches SectionDetail's noGo rendering).
+				const v = line.verts;
+				const x = gizmoTarget.endIdx === 0 ? v.x : v.z;
+				const z = gizmoTarget.endIdx === 0 ? v.y : v.w;
+				return [x, selectedSectionY + 0.5, z];
+			}
+		}
+	}, [gizmoTarget, previewSection, data, selectedSectionY]);
+
+	// The gizmo's axis profile depends on what's being moved:
+	//   - section / corner / line endpoint: XZ-packed (ADR-0011 — no Y component)
+	//   - portal anchor: full 3D (Vector3, free Y)
+	// Single-point sub-entities (corner, endpoint) also auto-disable rotate
+	// rings — rotating a single point around itself is a no-op, so we hide
+	// the affordance rather than let the user grab it. We achieve this by
+	// AND-ing a "no rotation" mask into the axes for those targets.
+	const gizmoAxes = useMemo<TransformAxes>(() => {
+		if (!gizmoTarget) return TRANSFORM_AXES_FULL_3D;
+		switch (gizmoTarget.kind) {
+			case 'section':
+				return TRANSFORM_AXES_XZ_PACKED;
+			case 'corner':
+				// Vector2 corners — translate.y is rendered but discarded on
+				// commit (see handleGizmoCommit). Rotate disabled (single point).
+				return {
+					translate: { x: true, y: false, z: true },
+					rotate: { x: false, y: false, z: false },
+				};
+			case 'portalAnchor':
+				// Full Vector3, no rotation (single point has no orientation).
+				return {
+					translate: { x: true, y: true, z: true },
+					rotate: { x: false, y: false, z: false },
+				};
+			case 'boundaryLineEndpoint':
+			case 'noGoLineEndpoint':
+				// XZ-only packed Vector4 — translate.y discarded on commit.
+				// Rotate disabled (single point).
+				return {
+					translate: { x: true, y: false, z: true },
+					rotate: { x: false, y: false, z: false },
+				};
+		}
+	}, [gizmoTarget]);
 
 	const gizmoPixelSize = 90;
-	const cornerHandlePixelSize = 12;
 
 	const detailAccessor = useMemo(() => makeV12Accessor(sectionYs), [sectionYs]);
 
@@ -444,55 +558,68 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 		onSelect(aiSectionMarkerPath({ kind: 'noGoLine', sectionIndex: selectedSectionIndex, lineIndex }));
 	}, [onSelect, selectedSectionIndex]);
 
-	// Drag handlers — the bulk-transform gizmo translates and yaw-rotates the
-	// section as one rigid body (no cascade per ADR-0009); corner handles
-	// deform the polygon (issue #73 migrates that gesture to the unified
-	// gizmo too). Both go through their respective ops on commit and emit
-	// the new root via onChange. Without onChange these are no-ops.
-	//
-	// Snap-to-edge is intentionally not applied to the bulk-transform path:
-	// snapping a section translation to neighbour edges only made sense in
-	// the cascade-on world (the cascade re-wired neighbours so the snap
-	// looked clean). Without cascade, snap would lock the section onto a
-	// neighbour edge while leaving the neighbour's reverse-portal stale —
-	// confusing UX. The corner-drag still gets snap until #73 retires it.
-	const handleGizmoTransform = useCallback((delta: BulkTransformDelta) => {
+	// Sub-entity pickers — emit the deeper marker shape so the bulk-transform
+	// gizmo anchors at the corner / endpoint. Endpoints are addressed by the
+	// (lineIdx, endIdx) pair; endIdx ∈ {0, 1} picks verts.(x,y) vs verts.(z,w).
+	const handlePickCorner = useCallback((cornerIndex: number) => {
 		if (selectedSectionIndex == null) return;
-		setDrag({ kind: 'section', delta });
-	}, [selectedSectionIndex]);
+		onSelect(aiSectionMarkerPath({
+			kind: 'corner',
+			sectionIndex: selectedSectionIndex,
+			cornerIndex,
+		}));
+	}, [onSelect, selectedSectionIndex]);
+
+	const handlePickBoundaryLineEndpoint = useCallback(
+		(portalIndex: number, lineIndex: number, endIndex: number) => {
+			if (selectedSectionIndex == null) return;
+			onSelect(aiSectionMarkerPath({
+				kind: 'boundaryLineEndpoint',
+				sectionIndex: selectedSectionIndex,
+				portalIndex,
+				lineIndex,
+				endIndex,
+			}));
+		},
+		[onSelect, selectedSectionIndex],
+	);
+
+	const handlePickNoGoLineEndpoint = useCallback(
+		(lineIndex: number, endIndex: number) => {
+			if (selectedSectionIndex == null) return;
+			onSelect(aiSectionMarkerPath({
+				kind: 'noGoLineEndpoint',
+				sectionIndex: selectedSectionIndex,
+				lineIndex,
+				endIndex,
+			}));
+		},
+		[onSelect, selectedSectionIndex],
+	);
+
+	// Drag handlers — the bulk-transform gizmo owns every direct-manipulation
+	// gesture in the WorldViewport per ADR-0010 (one unified affordance,
+	// dispatched on the Selection kind). For section-scope selections the
+	// gizmo translates and yaw-rotates as a rigid body (PR #84). For sub-
+	// entity selections (corner / portal anchor / line endpoint, this slice)
+	// it translates only the named sub-entity — no shared-corner cascade,
+	// no mirror-portal sync (per ADR-0009; that's #75). On commit, the
+	// matching no-cascade op runs and emits the new root via onChange.
+	// Without onChange these are no-ops.
+	const handleGizmoTransform = useCallback((delta: BulkTransformDelta) => {
+		if (!gizmoTarget) return;
+		setDrag({ target: gizmoTarget, delta });
+	}, [gizmoTarget]);
 
 	const handleGizmoCommit = useCallback((delta: BulkTransformDelta) => {
 		setDrag(null);
-		if (selectedSectionIndex == null || !onChange) return;
+		if (!gizmoTarget || !onChange) return;
 		if (isIdentityDelta(delta)) return;
-		let next = data;
-		if (delta.cascade) {
-			// Cascade-on path (Shift held at gesture start per issue #75 +
-			// ADR-0009). Same op composition as the preview branch above —
-			// translate-with-links, then rotate-with-links — so commit and
-			// preview agree frame-for-frame. The yaw cascade pivots on the
-			// post-translate source centroid implicitly (the rotate-with-
-			// links op recomputes it from the section's current corners).
-			if (delta.translate.x !== 0 || delta.translate.z !== 0) {
-				next = translateSectionWithLinks(next, selectedSectionIndex, {
-					x: delta.translate.x,
-					z: delta.translate.z,
-				});
-			}
-			if (delta.rotate.y !== 0) {
-				next = rotateSectionWithLinksYaw(next, selectedSectionIndex, delta.rotate.y);
-			}
-		} else {
-			// Cascade-off path (the ADR-0009 default). Compose translate then
-			// yaw rotate in the same order as the preview (around the
-			// post-translate centroid) so commit and preview agree frame-for-
-			// frame.
-			if (delta.translate.x !== 0 || delta.translate.y !== 0 || delta.translate.z !== 0) {
-				next = translateSectionRigid(next, selectedSectionIndex, delta.translate);
-			}
-			if (delta.rotate.y !== 0) {
-				next = rotateSectionAroundCentroidYaw(next, selectedSectionIndex, delta.rotate.y);
-			}
+		let next: ParsedAISectionsV12;
+		try {
+			next = applyDragToModel(data, { target: gizmoTarget, delta });
+		} catch {
+			return;
 		}
 		if (next === data) return;
 		// Single onChange call ⇒ single setResourceAt ⇒ single
@@ -503,30 +630,9 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 		// ops mutate more sections per gesture, they still produce ONE
 		// resulting model committed via ONE onChange call.
 		onChange(next);
-	}, [data, selectedSectionIndex, onChange]);
+	}, [data, gizmoTarget, onChange]);
 
 	const handleGizmoCancel = useCallback(() => setDrag(null), []);
-
-	const handleCornerDrag = useCallback((cornerIdx: number, offset: CornerDragOffset) => {
-		const finalOffset =
-			snapEnabled && selectedSectionIndex != null
-				? snapCornerOffset(data, selectedSectionIndex, cornerIdx, offset, snapRadius)
-				: offset;
-		setDrag({ kind: 'corner', cornerIdx, offset: finalOffset });
-	}, [snapEnabled, selectedSectionIndex, data, snapRadius]);
-
-	const handleCornerCommit = useCallback((cornerIdx: number, offset: CornerDragOffset) => {
-		setDrag(null);
-		if (selectedSectionIndex == null || !onChange) return;
-		if (offset.x === 0 && offset.z === 0) return;
-		const finalOffset = snapEnabled
-			? snapCornerOffset(data, selectedSectionIndex, cornerIdx, offset, snapRadius)
-			: offset;
-		if (finalOffset.x === 0 && finalOffset.z === 0) return;
-		onChange(translateCornerWithShared(data, selectedSectionIndex, cornerIdx, finalOffset));
-	}, [data, selectedSectionIndex, snapEnabled, snapRadius, onChange]);
-
-	const handleCornerCancel = useCallback(() => setDrag(null), []);
 
 	// Reset transient edge / drag UI when the selected section changes.
 	useResetOnChange(selectedSectionIndex, () => {
@@ -670,6 +776,8 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 						onPickPortal={handlePickPortal}
 						onPickBoundaryLine={handlePickBoundaryLine}
 						onPickNoGoLine={handlePickNoGoLine}
+						onPickBoundaryLineEndpoint={handlePickBoundaryLineEndpoint}
+						onPickNoGoLineEndpoint={handlePickNoGoLineEndpoint}
 					/>
 				</>
 			)}
@@ -701,25 +809,28 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 				);
 			})}
 
-			{gizmoPosition && drag?.kind !== 'corner' && (
-				<BulkTransformGizmo
-					position={gizmoPosition}
-					pixelSize={gizmoPixelSize}
-					axes={TRANSFORM_AXES_XZ_PACKED}
-					onTransform={handleGizmoTransform}
-					onCommit={handleGizmoCommit}
-					onCancel={handleGizmoCancel}
+			{/* Corner picker spheres — click-to-select; the gizmo handles
+			    the drag once a corner is selected (per ADR-0010 / issue #73).
+			    Always shown when a section is the active inspector pick so a
+			    user can drill into any corner. The currently-picked corner is
+			    rendered in the bright "active" colour. */}
+			{previewSection && previewCorners && selectedSectionIndex != null && (
+				<CornerPickers
+					corners={previewCorners}
+					baseY={selectedSectionY}
+					selectedCornerIdx={marker?.kind === 'corner' ? marker.cornerIndex : null}
+					onPick={handlePickCorner}
 				/>
 			)}
 
-			{previewCorners && drag?.kind !== 'section' && (
-				<CornerHandles
-					corners={previewCorners}
-					pixelSize={cornerHandlePixelSize}
-					baseY={selectedSectionY}
-					onDrag={handleCornerDrag}
-					onCommit={handleCornerCommit}
-					onCancel={handleCornerCancel}
+			{gizmoPosition && (
+				<BulkTransformGizmo
+					position={gizmoPosition}
+					pixelSize={gizmoPixelSize}
+					axes={gizmoAxes}
+					onTransform={handleGizmoTransform}
+					onCommit={handleGizmoCommit}
+					onCancel={handleGizmoCancel}
 				/>
 			)}
 
@@ -869,6 +980,148 @@ function HtmlSiblings({
 	// drops our marquee / snap / context menu — see ADR-0007 / issue #24.
 	useWorldViewportHtmlSlot(isActive ? node : null);
 	return null;
+}
+
+// ---------------------------------------------------------------------------
+// applyDragToModel — single dispatcher from a gizmo gesture's (target, delta)
+// to the no-cascade op that mutates the model.
+//
+// Used twice in the overlay:
+//   - inside `previewModel` (live drag-frame derivation; no setResource)
+//   - inside `handleGizmoCommit` (one-shot on release; setResource pushes
+//     exactly one HistoryCommit — the one-undo-entry-per-gesture contract)
+//
+// Keeping the dispatch in one helper means preview and commit cannot drift —
+// what the user sees during the drag is bit-for-bit what lands in the model
+// on release. The corner / endpoint paths discard `delta.translate.y` because
+// the underlying storage (Vector2 corners, packed-Vector4 line segments) has
+// no Y component (ADR-0011). Section-scope drags also apply yaw rotation
+// after translate, around the *post-translate* centroid, so combined gestures
+// compose as a single rigid body (the same shape Blender's gizmo uses).
+// ---------------------------------------------------------------------------
+function applyDragToModel(
+	model: ParsedAISectionsV12,
+	drag: ActiveDrag,
+): ParsedAISectionsV12 {
+	const { target, delta } = drag;
+	switch (target.kind) {
+		case 'section': {
+			let next = model;
+			if (delta.cascade) {
+				// Cascade-on (Shift at gesture start, per issue #75 + ADR-0009):
+				// translate-with-links cascades neighbour reverse-portal anchors
+				// + shared corners; rotate-with-links does the same around the
+				// post-translate source centroid. translate.y is dropped because
+				// the cascade-on ops are XZ-only (the legacy auto-cascade path
+				// never moved on Y).
+				if (delta.translate.x !== 0 || delta.translate.z !== 0) {
+					next = translateSectionWithLinks(next, target.sectionIdx, {
+						x: delta.translate.x,
+						z: delta.translate.z,
+					});
+				}
+				if (delta.rotate.y !== 0) {
+					next = rotateSectionWithLinksYaw(next, target.sectionIdx, delta.rotate.y);
+				}
+				return next;
+			}
+			if (delta.translate.x !== 0 || delta.translate.y !== 0 || delta.translate.z !== 0) {
+				next = translateSectionRigid(next, target.sectionIdx, delta.translate);
+			}
+			if (delta.rotate.y !== 0) {
+				next = rotateSectionAroundCentroidYaw(next, target.sectionIdx, delta.rotate.y);
+			}
+			return next;
+		}
+		case 'corner':
+			// XZ-only — drop translate.y.
+			return translateCornerRigid(model, target.sectionIdx, target.cornerIdx, {
+				x: delta.translate.x,
+				z: delta.translate.z,
+			});
+		case 'portalAnchor':
+			// Vector3 anchor — full XYZ.
+			return translatePortalAnchorRigid(model, target.sectionIdx, target.portalIdx, delta.translate);
+		case 'boundaryLineEndpoint':
+			return translateBoundaryLineEndpointRigid(
+				model,
+				target.sectionIdx,
+				target.portalIdx,
+				target.lineIdx,
+				target.endIdx,
+				{ x: delta.translate.x, z: delta.translate.z },
+			);
+		case 'noGoLineEndpoint':
+			return translateNoGoLineEndpointRigid(
+				model,
+				target.sectionIdx,
+				target.lineIdx,
+				target.endIdx,
+				{ x: delta.translate.x, z: delta.translate.z },
+			);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CornerPickers — small click-to-select spheres at each corner of the
+// inspector-picked section.
+//
+// Pre-issue-73 the overlay rendered `CornerHandles` here, which combined
+// pick + drag. Per ADR-0010 the gizmo now owns the drag, so these are
+// click-only pickers: tap a sphere and the inspector deepens its selection
+// to `['sections', i, 'corners', c]`, which makes the gizmo anchor at the
+// corner (translate only that corner on the next drag).
+// ---------------------------------------------------------------------------
+const CORNER_PICKER_RADIUS = 0.8;
+const CORNER_PICKER_HIT = 1.6;
+
+function CornerPickers({
+	corners,
+	baseY,
+	selectedCornerIdx,
+	onPick,
+}: {
+	corners: readonly Corner[];
+	baseY: number;
+	selectedCornerIdx: number | null;
+	onPick: (cornerIdx: number) => void;
+}) {
+	const [hover, setHover] = useState<number | null>(null);
+	return (
+		<>
+			{corners.map((c, i) => {
+				const isSelected = selectedCornerIdx === i;
+				const isHover = hover === i;
+				const color = isSelected ? '#ffffff' : isHover ? '#ffd470' : '#ff8833';
+				return (
+					<group key={`corner-pick-${i}`} position={[c.x, baseY + 0.8, c.z]}>
+						<mesh>
+							<sphereGeometry args={[CORNER_PICKER_RADIUS, 12, 8]} />
+							<meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.25} />
+						</mesh>
+						{/* Invisible larger hit volume — keeps picking forgiving
+						    on small spheres at far camera distances. */}
+						<mesh
+							onClick={(e) => { e.stopPropagation(); onPick(i); }}
+							onPointerOver={(e) => {
+								e.stopPropagation();
+								setHover(i);
+								document.body.style.cursor = 'pointer';
+							}}
+							onPointerOut={(e) => {
+								e.stopPropagation();
+								setHover((h) => (h === i ? null : h));
+								document.body.style.cursor = 'auto';
+							}}
+						>
+							<sphereGeometry args={[CORNER_PICKER_HIT, 8, 6]} />
+							<meshBasicMaterial transparent opacity={0} />
+						</mesh>
+					</group>
+				);
+			})}
+		</>
+	);
 }
 
 export default AISectionsOverlay;

--- a/src/components/schema-editor/viewports/__tests__/AISectionsOverlay.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/AISectionsOverlay.test.ts
@@ -55,13 +55,49 @@ describe('AISectionsOverlay', () => {
 		expect(aiSectionPathMarker(['sections', 1, 'portals', 0, 'position', 'x']))
 			.toEqual({ kind: 'portal', sectionIndex: 1, portalIndex: 0 });
 
-		// Drilling into a section's `corners` array should keep the section highlighted.
+		// Drilling into a corner's `x`/`y` field (post-#73) collapses to the
+		// corner sub-entity selection — the bulk-transform gizmo anchors there.
+		// Before #73 this collapsed to the parent section because no corner-
+		// level Selection kind existed.
 		expect(aiSectionPathMarker(['sections', 1, 'corners', 2, 'x']))
-			.toEqual({ kind: 'section', sectionIndex: 1 });
+			.toEqual({ kind: 'corner', sectionIndex: 1, cornerIndex: 2 });
 
 		// Drilling into a boundary-line's verts should keep the boundary line highlighted.
 		expect(aiSectionPathMarker(['sections', 1, 'portals', 0, 'boundaryLines', 0, 'verts', 'x']))
 			.toEqual({ kind: 'boundaryLine', sectionIndex: 1, portalIndex: 0, lineIndex: 0 });
+	});
+
+	it('addresses sub-entities for the bulk-transform gizmo (corner / endpoint, issue #73)', () => {
+		// Corner: path → marker round-trip.
+		expect(aiSectionPathMarker(['sections', 123, 'corners', 2]))
+			.toEqual({ kind: 'corner', sectionIndex: 123, cornerIndex: 2 });
+		expect(aiSectionMarkerPath({ kind: 'corner', sectionIndex: 123, cornerIndex: 2 }))
+			.toEqual(['sections', 123, 'corners', 2]);
+
+		// Boundary-line endpoint: path → marker round-trip.
+		expect(aiSectionPathMarker(
+			['sections', 7, 'portals', 0, 'boundaryLines', 1, 'endpoints', 1],
+		)).toEqual({
+			kind: 'boundaryLineEndpoint',
+			sectionIndex: 7,
+			portalIndex: 0,
+			lineIndex: 1,
+			endIndex: 1,
+		});
+		expect(aiSectionMarkerPath({
+			kind: 'boundaryLineEndpoint',
+			sectionIndex: 7,
+			portalIndex: 0,
+			lineIndex: 1,
+			endIndex: 1,
+		})).toEqual(['sections', 7, 'portals', 0, 'boundaryLines', 1, 'endpoints', 1]);
+
+		// No-go-line endpoint: path → marker round-trip.
+		expect(aiSectionPathMarker(['sections', 7, 'noGoLines', 3, 'endpoints', 0]))
+			.toEqual({ kind: 'noGoLineEndpoint', sectionIndex: 7, lineIndex: 3, endIndex: 0 });
+		expect(aiSectionMarkerPath({
+			kind: 'noGoLineEndpoint', sectionIndex: 7, lineIndex: 3, endIndex: 0,
+		})).toEqual(['sections', 7, 'noGoLines', 3, 'endpoints', 0]);
 	});
 
 	it('returns null for paths outside the AI sections resource', () => {
@@ -83,6 +119,16 @@ describe('AISectionsOverlay', () => {
 			.toEqual({ kind: 'noGoLine', indices: [42, 7] });
 		expect(aiSectionSelectionCodec.selectionToPath({ kind: 'portal', indices: [42, 3] }))
 			.toEqual(['sections', 42, 'portals', 3]);
+
+		// Sub-entity Selection kinds added in #73.
+		expect(aiSectionSelectionCodec.pathToSelection(['sections', 42, 'corners', 3]))
+			.toEqual({ kind: 'corner', indices: [42, 3] });
+		expect(aiSectionSelectionCodec.pathToSelection(
+			['sections', 42, 'portals', 3, 'boundaryLines', 1, 'endpoints', 0],
+		)).toEqual({ kind: 'boundaryLineEndpoint', indices: [42, 3, 1, 0] });
+		expect(aiSectionSelectionCodec.pathToSelection(
+			['sections', 42, 'noGoLines', 7, 'endpoints', 1],
+		)).toEqual({ kind: 'noGoLineEndpoint', indices: [42, 7, 1] });
 	});
 
 	// The menu rides the WorldViewport's HTML slot, whose wrapper sets

--- a/src/lib/core/aiSectionsOps.test.ts
+++ b/src/lib/core/aiSectionsOps.test.ts
@@ -15,9 +15,13 @@ import {
 	snapLegacyCornerOffset,
 	snapLegacySectionOffset,
 	snapSectionOffset,
+	translateBoundaryLineEndpointRigid,
+	translateCornerRigid,
 	translateCornerWithShared,
 	translateLegacyCornerWithShared,
 	translateLegacySectionWithLinks,
+	translateNoGoLineEndpointRigid,
+	translatePortalAnchorRigid,
 	translatePortalAnchorWithMirror,
 	translateSectionRigid,
 	translateSectionWithLinks,
@@ -2699,5 +2703,302 @@ describe('rotateSelectionWithLinksYaw', () => {
 	it('throws on out-of-range Selection index', () => {
 		const model = makePair();
 		expect(() => rotateSelectionWithLinksYaw(model, [99], { x: 0, z: 0 }, 0.5)).toThrow(RangeError);
+	});
+});
+
+// =============================================================================
+// Bulk-transform sub-entity ops (issue #73) — no-cascade translate of one
+// corner, portal anchor, or line endpoint. The cascade-on path stays in
+// `translateCornerWithShared` for the modifier-on slice (#75).
+// =============================================================================
+
+describe('translateCornerRigid', () => {
+	function makeNeighbourPair(): ParsedAISectionsV12 {
+		// Two adjacent unit squares sharing the edge at x=10.
+		// Section 0: corners (0,0)→(10,0)→(10,10)→(0,10), corner #1 = (10, 0).
+		// Section 1: corners (10,0)→(20,0)→(20,10)→(10,10), corner #0 = (10, 0)
+		// — that's the SHARED corner with section 0's corner #1.
+		const s0 = makeSection({
+			id: 0xA,
+			corners: [
+				{ x: 0, y: 0 },
+				{ x: 10, y: 0 },
+				{ x: 10, y: 10 },
+				{ x: 0, y: 10 },
+			],
+			portals: [{
+				position: { x: 10, y: 0, z: 5 },
+				boundaryLines: [{ verts: { x: 10, y: 0, z: 10, w: 10 } }],
+				linkSection: 1,
+			}],
+		});
+		const s1 = makeSection({
+			id: 0xB,
+			corners: [
+				{ x: 10, y: 0 },
+				{ x: 20, y: 0 },
+				{ x: 20, y: 10 },
+				{ x: 10, y: 10 },
+			],
+		});
+		return makeModel([s0, s1]);
+	}
+
+	it('moves only the named corner; coincident neighbour corners stay put (no cascade)', () => {
+		const model = makeNeighbourPair();
+		// Move section 0's corner #1 (at (10, 0)) by (+1, +2). Section 1's
+		// corner #0 also lives at (10, 0) (shared corner) but must stay put
+		// because the no-cascade op is "tear off" by design (ADR-0009).
+		const next = translateCornerRigid(model, 0, 1, { x: 1, z: 2 });
+		expect(next.sections[0].corners[1]).toEqual({ x: 11, y: 2 });
+		// Other corners on section 0 are untouched.
+		expect(next.sections[0].corners[0]).toEqual({ x: 0, y: 0 });
+		expect(next.sections[0].corners[2]).toEqual({ x: 10, y: 10 });
+		expect(next.sections[0].corners[3]).toEqual({ x: 0, y: 10 });
+		// Neighbour section 1 is bit-for-bit unchanged (===-identical).
+		expect(next.sections[1]).toBe(model.sections[1]);
+	});
+
+	it('does not touch the section\'s portal anchors or boundary lines', () => {
+		const model = makeNeighbourPair();
+		const next = translateCornerRigid(model, 0, 1, { x: 1, z: 2 });
+		expect(next.sections[0].portals[0].position).toEqual({ x: 10, y: 0, z: 5 });
+		expect(next.sections[0].portals[0].boundaryLines[0].verts).toEqual({
+			x: 10, y: 0, z: 10, w: 10,
+		});
+	});
+
+	it('returns the original model reference for a (0, 0) offset (no-op — byte-for-byte safe)', () => {
+		const model = makeNeighbourPair();
+		const next = translateCornerRigid(model, 0, 1, { x: 0, z: 0 });
+		expect(next).toBe(model);
+	});
+
+	it('throws on out-of-range srcIdx or cornerIdx', () => {
+		const model = makeNeighbourPair();
+		expect(() => translateCornerRigid(model, 5, 0, { x: 1, z: 0 })).toThrow(RangeError);
+		expect(() => translateCornerRigid(model, -1, 0, { x: 1, z: 0 })).toThrow(RangeError);
+		expect(() => translateCornerRigid(model, 0, 4, { x: 1, z: 0 })).toThrow(RangeError);
+		expect(() => translateCornerRigid(model, 0, -1, { x: 1, z: 0 })).toThrow(RangeError);
+	});
+
+	it('does not mutate the input', () => {
+		const model = makeNeighbourPair();
+		const before = JSON.stringify(model);
+		translateCornerRigid(model, 0, 1, { x: 5, z: 7 });
+		expect(JSON.stringify(model)).toEqual(before);
+	});
+
+	it('undo round-trip: applying the inverse offset restores the original corner', () => {
+		const model = makeNeighbourPair();
+		const forward = translateCornerRigid(model, 0, 1, { x: 3, z: 5 });
+		const back = translateCornerRigid(forward, 0, 1, { x: -3, z: -5 });
+		// Deep-equal on the corner — we don't get ===-identity back because the
+		// section is rebuilt; but every Vector2 lands exactly where it started.
+		expect(back.sections[0].corners).toEqual(model.sections[0].corners);
+	});
+});
+
+describe('translatePortalAnchorRigid', () => {
+	function makeLinkedPair(): ParsedAISectionsV12 {
+		// Two sections that share a portal anchor at the same world position
+		// (typical state after duplicateSectionThroughEdge). The reverse
+		// portal on section 1 has linkSection = 0 and matching position.
+		const portal0to1: Portal = {
+			position: { x: 10, y: 5, z: 5 },
+			boundaryLines: [{ verts: { x: 10, y: 0, z: 10, w: 10 } }],
+			linkSection: 1,
+		};
+		const portal1to0: Portal = {
+			position: { x: 10, y: 5, z: 5 },
+			boundaryLines: [{ verts: { x: 10, y: 10, z: 10, w: 0 } }],
+			linkSection: 0,
+		};
+		const s0 = makeSection({ id: 0xA, portals: [portal0to1] });
+		const s1 = makeSection({ id: 0xB, portals: [portal1to0] });
+		return makeModel([s0, s1]);
+	}
+
+	it('moves only the named portal anchor; the mirror anchor stays put (stale by design — ADR-0009)', () => {
+		const model = makeLinkedPair();
+		const next = translatePortalAnchorRigid(model, 0, 0, { x: 3, y: 2, z: -4 });
+		// Source portal anchor moved by full XYZ delta.
+		expect(next.sections[0].portals[0].position).toEqual({ x: 13, y: 7, z: 1 });
+		// Mirror portal on the neighbour stays at the old position — this is
+		// the "stale mirror" state ADR-0009 accepts as the v1 default.
+		expect(next.sections[1].portals[0].position).toEqual({ x: 10, y: 5, z: 5 });
+		// Neighbour section is ===-identical.
+		expect(next.sections[1]).toBe(model.sections[1]);
+	});
+
+	it('does not touch the portal\'s boundary lines or the source section\'s corners', () => {
+		const model = makeLinkedPair();
+		const next = translatePortalAnchorRigid(model, 0, 0, { x: 3, y: 2, z: -4 });
+		// Boundary lines unchanged — only `position` shifted.
+		expect(next.sections[0].portals[0].boundaryLines[0].verts).toEqual({
+			x: 10, y: 0, z: 10, w: 10,
+		});
+		expect(next.sections[0].corners).toEqual(model.sections[0].corners);
+	});
+
+	it('returns the original model reference for an identity offset (no-op)', () => {
+		const model = makeLinkedPair();
+		expect(translatePortalAnchorRigid(model, 0, 0, { x: 0, y: 0, z: 0 })).toBe(model);
+	});
+
+	it('throws on out-of-range srcIdx or portalIdx', () => {
+		const model = makeLinkedPair();
+		expect(() => translatePortalAnchorRigid(model, 5, 0, { x: 1, y: 0, z: 0 })).toThrow(RangeError);
+		expect(() => translatePortalAnchorRigid(model, -1, 0, { x: 1, y: 0, z: 0 })).toThrow(RangeError);
+		expect(() => translatePortalAnchorRigid(model, 0, 5, { x: 1, y: 0, z: 0 })).toThrow(RangeError);
+		expect(() => translatePortalAnchorRigid(model, 0, -1, { x: 1, y: 0, z: 0 })).toThrow(RangeError);
+	});
+
+	it('does not mutate the input', () => {
+		const model = makeLinkedPair();
+		const before = JSON.stringify(model);
+		translatePortalAnchorRigid(model, 0, 0, { x: 7, y: 3, z: 2 });
+		expect(JSON.stringify(model)).toEqual(before);
+	});
+
+	it('undo round-trip: inverse offset restores the original anchor', () => {
+		const model = makeLinkedPair();
+		const forward = translatePortalAnchorRigid(model, 0, 0, { x: 3, y: 2, z: -4 });
+		const back = translatePortalAnchorRigid(forward, 0, 0, { x: -3, y: -2, z: 4 });
+		expect(back.sections[0].portals[0].position).toEqual(
+			model.sections[0].portals[0].position,
+		);
+	});
+});
+
+describe('translateBoundaryLineEndpointRigid', () => {
+	function makeWithBoundary(): ParsedAISectionsV12 {
+		const portal: Portal = {
+			position: { x: 5, y: 3, z: 5 },
+			boundaryLines: [{ verts: { x: 0, y: 0, z: 10, w: 0 } }], // start (0,0), end (10,0)
+			linkSection: 0,
+		};
+		const sec = makeSection({ id: 0xA, portals: [portal] });
+		return makeModel([sec]);
+	}
+
+	it('moves only the start endpoint (endIdx=0); end stays put', () => {
+		const model = makeWithBoundary();
+		const next = translateBoundaryLineEndpointRigid(model, 0, 0, 0, 0, { x: 1, z: 2 });
+		// Start (verts.x, verts.y) moved by (+1, +2); end (verts.z, verts.w) unchanged.
+		expect(next.sections[0].portals[0].boundaryLines[0].verts).toEqual({
+			x: 1, y: 2, z: 10, w: 0,
+		});
+	});
+
+	it('moves only the end endpoint (endIdx=1); start stays put', () => {
+		const model = makeWithBoundary();
+		const next = translateBoundaryLineEndpointRigid(model, 0, 0, 0, 1, { x: 3, z: -1 });
+		expect(next.sections[0].portals[0].boundaryLines[0].verts).toEqual({
+			x: 0, y: 0, z: 13, w: -1,
+		});
+	});
+
+	it('does not touch the portal anchor or section corners', () => {
+		const model = makeWithBoundary();
+		const next = translateBoundaryLineEndpointRigid(model, 0, 0, 0, 0, { x: 1, z: 2 });
+		expect(next.sections[0].portals[0].position).toEqual(
+			model.sections[0].portals[0].position,
+		);
+		expect(next.sections[0].corners).toEqual(model.sections[0].corners);
+	});
+
+	it('returns the original model reference for a (0, 0) offset (no-op)', () => {
+		const model = makeWithBoundary();
+		expect(translateBoundaryLineEndpointRigid(model, 0, 0, 0, 0, { x: 0, z: 0 })).toBe(model);
+	});
+
+	it('throws on out-of-range indices or endIdx not in {0, 1}', () => {
+		const model = makeWithBoundary();
+		expect(() => translateBoundaryLineEndpointRigid(model, 5, 0, 0, 0, { x: 1, z: 0 })).toThrow(RangeError);
+		expect(() => translateBoundaryLineEndpointRigid(model, 0, 5, 0, 0, { x: 1, z: 0 })).toThrow(RangeError);
+		expect(() => translateBoundaryLineEndpointRigid(model, 0, 0, 5, 0, { x: 1, z: 0 })).toThrow(RangeError);
+		expect(() => translateBoundaryLineEndpointRigid(model, 0, 0, 0, 2, { x: 1, z: 0 })).toThrow(RangeError);
+		expect(() => translateBoundaryLineEndpointRigid(model, 0, 0, 0, -1, { x: 1, z: 0 })).toThrow(RangeError);
+	});
+
+	it('does not mutate the input', () => {
+		const model = makeWithBoundary();
+		const before = JSON.stringify(model);
+		translateBoundaryLineEndpointRigid(model, 0, 0, 0, 0, { x: 5, z: 7 });
+		expect(JSON.stringify(model)).toEqual(before);
+	});
+
+	it('undo round-trip: inverse offset restores the original endpoint', () => {
+		const model = makeWithBoundary();
+		const forward = translateBoundaryLineEndpointRigid(model, 0, 0, 0, 1, { x: 3, z: -4 });
+		const back = translateBoundaryLineEndpointRigid(forward, 0, 0, 0, 1, { x: -3, z: 4 });
+		expect(back.sections[0].portals[0].boundaryLines[0].verts).toEqual(
+			model.sections[0].portals[0].boundaryLines[0].verts,
+		);
+	});
+});
+
+describe('translateNoGoLineEndpointRigid', () => {
+	function makeWithNoGo(): ParsedAISectionsV12 {
+		const sec = makeSection({ id: 0xA });
+		sec.noGoLines = [{ verts: { x: 0, y: 0, z: 5, w: 5 } }];
+		return makeModel([sec]);
+	}
+
+	it('moves only the start endpoint (endIdx=0); end stays put', () => {
+		const model = makeWithNoGo();
+		const next = translateNoGoLineEndpointRigid(model, 0, 0, 0, { x: 2, z: 3 });
+		expect(next.sections[0].noGoLines[0].verts).toEqual({ x: 2, y: 3, z: 5, w: 5 });
+	});
+
+	it('moves only the end endpoint (endIdx=1); start stays put', () => {
+		const model = makeWithNoGo();
+		const next = translateNoGoLineEndpointRigid(model, 0, 0, 1, { x: -1, z: -2 });
+		expect(next.sections[0].noGoLines[0].verts).toEqual({ x: 0, y: 0, z: 4, w: 3 });
+	});
+
+	it('does not touch corners or portals', () => {
+		const portal: Portal = {
+			position: { x: 1, y: 0, z: 1 },
+			boundaryLines: [{ verts: { x: 1, y: 1, z: 2, w: 2 } }],
+			linkSection: 0,
+		};
+		const sec = makeSection({ id: 0xA, portals: [portal] });
+		sec.noGoLines = [{ verts: { x: 0, y: 0, z: 5, w: 5 } }];
+		const model = makeModel([sec]);
+		const next = translateNoGoLineEndpointRigid(model, 0, 0, 0, { x: 2, z: 3 });
+		expect(next.sections[0].corners).toEqual(model.sections[0].corners);
+		expect(next.sections[0].portals).toEqual(model.sections[0].portals);
+	});
+
+	it('returns the original model reference for a (0, 0) offset (no-op)', () => {
+		const model = makeWithNoGo();
+		expect(translateNoGoLineEndpointRigid(model, 0, 0, 0, { x: 0, z: 0 })).toBe(model);
+	});
+
+	it('throws on out-of-range indices or endIdx not in {0, 1}', () => {
+		const model = makeWithNoGo();
+		expect(() => translateNoGoLineEndpointRigid(model, 5, 0, 0, { x: 1, z: 0 })).toThrow(RangeError);
+		expect(() => translateNoGoLineEndpointRigid(model, -1, 0, 0, { x: 1, z: 0 })).toThrow(RangeError);
+		expect(() => translateNoGoLineEndpointRigid(model, 0, 5, 0, { x: 1, z: 0 })).toThrow(RangeError);
+		expect(() => translateNoGoLineEndpointRigid(model, 0, 0, 2, { x: 1, z: 0 })).toThrow(RangeError);
+		expect(() => translateNoGoLineEndpointRigid(model, 0, 0, -1, { x: 1, z: 0 })).toThrow(RangeError);
+	});
+
+	it('does not mutate the input', () => {
+		const model = makeWithNoGo();
+		const before = JSON.stringify(model);
+		translateNoGoLineEndpointRigid(model, 0, 0, 0, { x: 5, z: 7 });
+		expect(JSON.stringify(model)).toEqual(before);
+	});
+
+	it('undo round-trip: inverse offset restores the original endpoint', () => {
+		const model = makeWithNoGo();
+		const forward = translateNoGoLineEndpointRigid(model, 0, 0, 0, { x: 4, z: -2 });
+		const back = translateNoGoLineEndpointRigid(forward, 0, 0, 0, { x: -4, z: 2 });
+		expect(back.sections[0].noGoLines[0].verts).toEqual(
+			model.sections[0].noGoLines[0].verts,
+		);
 	});
 });

--- a/src/lib/core/aiSectionsOps.ts
+++ b/src/lib/core/aiSectionsOps.ts
@@ -1399,6 +1399,221 @@ export function translateSectionRigid(
 	return { ...model, sections };
 }
 
+// =============================================================================
+// Bulk-transform: no-cascade sub-entity translates (issue #73)
+// =============================================================================
+//
+// Single-sub-entity siblings of `translateSectionRigid` for the unified gizmo
+// when the **Selection** is a sub-path (one corner, one portal anchor, one
+// boundary-line endpoint, one no-go-line endpoint). Default-off cascade per
+// ADR-0009 — these ops touch ONLY the named sub-entity. The shared-corner
+// cascade (`translateCornerWithShared`) stays in this module as the
+// modifier-on path for issue #75.
+
+/**
+ * Translate one polygon corner by an XZ offset — no cascade.
+ *
+ * Only `model.sections[srcIdx].corners[cornerIdx]` moves. Coincident corners
+ * on neighbour sections, boundary-line endpoints elsewhere in the model that
+ * happen to share the dragged point, and the section's own portal anchors
+ * all stay put — the source corner is "torn off" any shared join it
+ * participates in. The cascade-on path that drags coincident corners +
+ * boundary-line endpoints together is `translateCornerWithShared`, retained
+ * for the modifier-on slice (#75).
+ *
+ * Y is intentionally absent from the offset — corners are `Vector2` (XZ-only;
+ * see ADR-0011), so a Y translate would have nowhere to land. The gizmo's
+ * Y arrow is still rendered (the XZ-packed axes profile leaves translate.y
+ * on) but the wire-up in `AISectionsOverlay` discards a sub-entity gizmo's
+ * Y delta for corners. See ADR-0011 / CONTEXT.md / "Pivot".
+ *
+ * Returns the original `model` reference when `(dx, dz) === (0, 0)` so
+ * byte-for-byte BND2 writeback is preserved on a no-op gesture.
+ *
+ * @throws RangeError if `srcIdx` or `cornerIdx` is out of range.
+ */
+export function translateCornerRigid(
+	model: ParsedAISectionsV12,
+	srcIdx: number,
+	cornerIdx: number,
+	offset: { x: number; z: number },
+): ParsedAISectionsV12 {
+	if (srcIdx < 0 || srcIdx >= model.sections.length) {
+		throw new RangeError(`srcIdx ${srcIdx} out of range [0, ${model.sections.length})`);
+	}
+	const src = model.sections[srcIdx];
+	if (cornerIdx < 0 || cornerIdx >= src.corners.length) {
+		throw new RangeError(`cornerIdx ${cornerIdx} out of range [0, ${src.corners.length})`);
+	}
+	const dx = offset.x;
+	const dz = offset.z;
+	if (dx === 0 && dz === 0) return model;
+
+	const next: AISection = {
+		...src,
+		corners: src.corners.map((c, i) => (i === cornerIdx ? { x: c.x + dx, y: c.y + dz } : c)),
+	};
+	const sections = model.sections.map((s, i) => (i === srcIdx ? next : s));
+	return { ...model, sections };
+}
+
+/**
+ * Translate one portal anchor by a 3D offset — no cascade.
+ *
+ * Only `model.sections[srcIdx].portals[portalIdx].position` moves. The
+ * portal's boundary lines, the section's corners, and the linked section's
+ * reverse portal all stay put — the anchor is "torn off" its mirror twin,
+ * leaving the stale-mirror state ADR-0009 accepts as a v1 trade-off.
+ * Portal anchor is a `Vector3`, so full 3D motion is permitted.
+ *
+ * Returns the original `model` reference when the offset is identity so
+ * byte-for-byte BND2 writeback is preserved on a no-op gesture.
+ *
+ * @throws RangeError if `srcIdx` or `portalIdx` is out of range.
+ */
+export function translatePortalAnchorRigid(
+	model: ParsedAISectionsV12,
+	srcIdx: number,
+	portalIdx: number,
+	offset: { x: number; y: number; z: number },
+): ParsedAISectionsV12 {
+	if (srcIdx < 0 || srcIdx >= model.sections.length) {
+		throw new RangeError(`srcIdx ${srcIdx} out of range [0, ${model.sections.length})`);
+	}
+	const src = model.sections[srcIdx];
+	if (portalIdx < 0 || portalIdx >= src.portals.length) {
+		throw new RangeError(`portalIdx ${portalIdx} out of range [0, ${src.portals.length})`);
+	}
+	const dx = offset.x;
+	const dy = offset.y;
+	const dz = offset.z;
+	if (dx === 0 && dy === 0 && dz === 0) return model;
+
+	const srcPortal = src.portals[portalIdx];
+	const updatedPortal: Portal = {
+		...srcPortal,
+		position: {
+			x: srcPortal.position.x + dx,
+			y: srcPortal.position.y + dy,
+			z: srcPortal.position.z + dz,
+		},
+	};
+	const next: AISection = {
+		...src,
+		portals: src.portals.map((p, i) => (i === portalIdx ? updatedPortal : p)),
+	};
+	const sections = model.sections.map((s, i) => (i === srcIdx ? next : s));
+	return { ...model, sections };
+}
+
+/**
+ * Translate one endpoint of one portal-boundary-line by an XZ offset — no
+ * cascade.
+ *
+ * The boundary line's `verts` is a packed `Vector4`: `(x, y)` is the start
+ * XZ pair, `(z, w)` is the end XZ pair. `endIdx === 0` moves the start;
+ * `endIdx === 1` moves the end. The other endpoint stays put — the line
+ * deforms (stretches or rotates around the fixed endpoint) rather than
+ * translating wholesale. Neither the portal's anchor nor any section corners
+ * follow along.
+ *
+ * Returns the original `model` reference when `(dx, dz) === (0, 0)` so
+ * byte-for-byte BND2 writeback is preserved on a no-op gesture.
+ *
+ * @throws RangeError if any index is out of range, or if `endIdx` is not 0 or 1.
+ */
+export function translateBoundaryLineEndpointRigid(
+	model: ParsedAISectionsV12,
+	srcIdx: number,
+	portalIdx: number,
+	lineIdx: number,
+	endIdx: number,
+	offset: { x: number; z: number },
+): ParsedAISectionsV12 {
+	if (srcIdx < 0 || srcIdx >= model.sections.length) {
+		throw new RangeError(`srcIdx ${srcIdx} out of range [0, ${model.sections.length})`);
+	}
+	const src = model.sections[srcIdx];
+	if (portalIdx < 0 || portalIdx >= src.portals.length) {
+		throw new RangeError(`portalIdx ${portalIdx} out of range [0, ${src.portals.length})`);
+	}
+	const srcPortal = src.portals[portalIdx];
+	if (lineIdx < 0 || lineIdx >= srcPortal.boundaryLines.length) {
+		throw new RangeError(`lineIdx ${lineIdx} out of range [0, ${srcPortal.boundaryLines.length})`);
+	}
+	if (endIdx !== 0 && endIdx !== 1) {
+		throw new RangeError(`endIdx ${endIdx} must be 0 (start) or 1 (end)`);
+	}
+	const dx = offset.x;
+	const dz = offset.z;
+	if (dx === 0 && dz === 0) return model;
+
+	const srcLine = srcPortal.boundaryLines[lineIdx];
+	const v = srcLine.verts;
+	const updatedLine: BoundaryLine = {
+		verts: endIdx === 0
+			? { x: v.x + dx, y: v.y + dz, z: v.z, w: v.w }
+			: { x: v.x, y: v.y, z: v.z + dx, w: v.w + dz },
+	};
+	const updatedPortal: Portal = {
+		...srcPortal,
+		boundaryLines: srcPortal.boundaryLines.map((bl, i) => (i === lineIdx ? updatedLine : bl)),
+	};
+	const next: AISection = {
+		...src,
+		portals: src.portals.map((p, i) => (i === portalIdx ? updatedPortal : p)),
+	};
+	const sections = model.sections.map((s, i) => (i === srcIdx ? next : s));
+	return { ...model, sections };
+}
+
+/**
+ * Translate one endpoint of one no-go-line by an XZ offset — no cascade.
+ *
+ * Same shape as {@link translateBoundaryLineEndpointRigid} but operates on
+ * `section.noGoLines[lineIdx]` instead of `portal.boundaryLines[lineIdx]`.
+ *
+ * Returns the original `model` reference when `(dx, dz) === (0, 0)` so
+ * byte-for-byte BND2 writeback is preserved on a no-op gesture.
+ *
+ * @throws RangeError if any index is out of range, or if `endIdx` is not 0 or 1.
+ */
+export function translateNoGoLineEndpointRigid(
+	model: ParsedAISectionsV12,
+	srcIdx: number,
+	lineIdx: number,
+	endIdx: number,
+	offset: { x: number; z: number },
+): ParsedAISectionsV12 {
+	if (srcIdx < 0 || srcIdx >= model.sections.length) {
+		throw new RangeError(`srcIdx ${srcIdx} out of range [0, ${model.sections.length})`);
+	}
+	const src = model.sections[srcIdx];
+	if (lineIdx < 0 || lineIdx >= src.noGoLines.length) {
+		throw new RangeError(`lineIdx ${lineIdx} out of range [0, ${src.noGoLines.length})`);
+	}
+	if (endIdx !== 0 && endIdx !== 1) {
+		throw new RangeError(`endIdx ${endIdx} must be 0 (start) or 1 (end)`);
+	}
+	const dx = offset.x;
+	const dz = offset.z;
+	if (dx === 0 && dz === 0) return model;
+
+	const srcLine = src.noGoLines[lineIdx];
+	const v = srcLine.verts;
+	const updatedLine: BoundaryLine = {
+		verts: endIdx === 0
+			? { x: v.x + dx, y: v.y + dz, z: v.z, w: v.w }
+			: { x: v.x, y: v.y, z: v.z + dx, w: v.w + dz },
+	};
+	const next: AISection = {
+		...src,
+		noGoLines: src.noGoLines.map((bl, i) => (i === lineIdx ? updatedLine : bl)),
+	};
+	const sections = model.sections.map((s, i) => (i === srcIdx ? next : s));
+	return { ...model, sections };
+}
+
 /**
  * Rotate one AI section as a rigid body around its own centroid by `theta`
  * radians of yaw (rotation about world +Y). No cascade into neighbours.


### PR DESCRIPTION
## Summary
- Extends the unified `BulkTransformGizmo` (PR #84) to anchor at any AI section sub-entity when the Selection is a sub-path — single corner, single portal anchor, single boundary-line endpoint, single no-go-line endpoint. Replaces the legacy per-corner `CornerHandles` drag in `AISectionsOverlay` with click-to-select + gizmo-drag, matching the "one gizmo on screen at any time" rule from ADR-0010.
- Adds four new pure no-cascade ops in `aiSectionsOps.ts`: `translateCornerRigid`, `translatePortalAnchorRigid`, `translateBoundaryLineEndpointRigid`, `translateNoGoLineEndpointRigid`. All return the input reference on a no-op gesture (byte-for-byte BND2 writeback safe). The cascade-on `translateCornerWithShared` stays in the codebase for the modifier-on slice (#75).
- Per ADR-0011: corner and line-endpoint gizmos render with XZ-only translate (`translate.y` disabled — Vector2 / packed-Vector4 storage has no Y). Portal anchor gizmos render with full XYZ translate (Vector3). Rotate rings auto-disable for every single-point sub-entity (a single point has no orientation to change); they stay enabled for section-scope selections (PR #84 behaviour preserved).
- Selection codec (V12 + V4/V6 in lock-step) gains three new kinds — `corner`, `boundaryLineEndpoint`, `noGoLineEndpoint` — with synthetic `['sections', i, 'corners', c]` and `[..., 'boundaryLines', l, 'endpoints', e]` path encodings.
- One gesture = one Workspace-undo entry: the overlay's commit-on-release dispatches on the gizmo target (section / corner / portal / endpoint), runs the matching no-cascade op once, and emits via `onChange` exactly once.

Closes #73.

## Test plan
- [x] `bun x vitest run src/lib/core/aiSectionsOps.test.ts` — 170 tests pass (+26 new). New tests cover translate + identity (no-op) + immutability + undo round-trip for each new sub-entity op, plus the "coincident neighbour corners stay put" / "mirror anchor stays stale" invariants from ADR-0009.
- [x] `bun x vitest run src/components/schema-editor/viewports/__tests__/AISectionsOverlay.test.ts` — 6 tests pass (+1 new sub-entity codec test). The "collapses sub-paths" test updated: `['sections', 1, 'corners', 2, 'x']` now resolves to the new `corner` Selection kind (was collapsing to the parent section pre-#73).
- [x] `bun x vitest run src/context/__tests__/WorkspaceContext.bulkTransform.test.ts` — 5 tests pass (no changes; section-scope commit path unchanged).
- [x] `bun test:run` (full suite) — 1147 passing, 14 failing. All 14 failures are the pre-existing baseline `ENOENT` errors for legacy fixtures missing from the worktree under `example/older builds/`; none introduced by this PR.
- [x] `bun x tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)