### PR TITLE
fix(aisections-overlay): hoist sectionYs above bulkPivotLive to avoid TDZ crash

### DIFF
--- a/src/components/schema-editor/viewports/AISectionsOverlay.tsx
+++ b/src/components/schema-editor/viewports/AISectionsOverlay.tsx
@@ -320,6 +320,17 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 
 	const isBulkActive = bulkEntityCount >= 2;
 
+	// Per-section ground Y (issue #27). Derived once per data change from
+	// portal Ys plus a BFS through the section graph for portal-less sections.
+	// Memoised here so the renderer doesn't re-walk all 8.7k V12 sections on
+	// every frame — the hot path is `previewModel`-driven re-renders during a
+	// drag, which never change `data.sections`.
+	// Declared ahead of `bulkPivotLive` because that useMemo references
+	// `sectionYs` in both its callback and its deps array — keeping the
+	// declaration below would TDZ-throw on mount during any render where
+	// `bulkPivotLive` is reached.
+	const sectionYs = useMemo(() => resolveSectionYs(data), [data]);
+
 	// Bulk Pivot — median of every selected entity position, computed
 	// against the live data (NOT the preview model). Snapshotted at gesture
 	// start in `bulkPivotRef` so it doesn't drift mid-rotate (re-deriving
@@ -390,13 +401,6 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 	// muscle memory survives, but the value isn't consulted anywhere in the
 	// commit path. Issue #75 reconsiders snap once cascade is opt-in.
 	useToggleHotkey('s', setSnapEnabled);
-
-	// Per-section ground Y (issue #27). Derived once per data change from
-	// portal Ys plus a BFS through the section graph for portal-less sections.
-	// Memoised here so the renderer doesn't re-walk all 8.7k V12 sections on
-	// every frame — the hot path is `previewModel`-driven re-renders during a
-	// drag, which never change `data.sections`.
-	const sectionYs = useMemo(() => resolveSectionYs(data), [data]);
 
 	const scene = useMemo(
 		() => buildBatchedSections(data.sections, v12Accessor, sectionYs),


### PR DESCRIPTION
## Summary

Fixes a runtime crash on the `/workspace` route when an `AISectionsOverlay` mounts inside the `WorldViewport`.

```
ReferenceError: Cannot access 'sectionYs' before initialization
    at AISectionsOverlay (.../AISectionsOverlay.tsx:284:9)
```

## Root cause

`bulkPivotLive` is computed via `useMemo` early in the component body and references `sectionYs` both inside its callback **and** inside its dependency array:

```ts
const bulkPivotLive = useMemo(() => {
  if (!isBulkActive) return null;
  const yResolver = (idx: number) => (idx < sectionYs.length ? sectionYs[idx] : 0);
  return bulkSelectionPivot(data, bulkRefs, yResolver);
}, [isBulkActive, bulkRefs, data, sectionYs]);  // ← sectionYs not yet declared
```

`sectionYs` was declared further down via `const sectionYs = useMemo(() => resolveSectionYs(data), [data])`. The deps array is evaluated synchronously every render — it hits the `const` binding in its TDZ and throws unconditionally. The callback body was never reached, but the deps array doesn't care.

## Fix

Hoist the `sectionYs` declaration (and its short context comment) to a position immediately above the `bulkPivotRef`/`bulkPivotLive` block. No cascading moves needed — `sectionYs` only depends on the `data` prop, which is available from the function signature. Hook order is preserved (the `useMemo` simply runs earlier in the unconditional sequence).

A short note was added in the relocated comment block explaining *why* the position matters, so a future refactor doesn't move it back down.

## Verification

- Re-read the modified region: `sectionYs` is now declared before every reference.
- Spot-checked the other `useMemo`s in the file (`gizmoTarget`, `previewModel`, `previewSection`, `gizmoPosition`) — none reference identifiers declared further down.
- Build/test verification skipped during agent run (sandbox without node_modules) — please run `npm run build && npm run test:run` locally.

## Test plan

- [ ] `npm install && npm run build` succeeds
- [ ] `npm run test:run` passes
- [ ] Open `/workspace` in the browser — the AI sections overlay mounts without the ReferenceError
- [ ] Toggle bulk selection (multi-select 2+ AI sections) — `bulkPivotLive` recomputes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)