### PR TITLE
chore(dead-code): remove 120 unused exports/types (round 2, replaces stale #90)

### DIFF
--- a/src/components/schema-editor/extensions/aiSectionsExtensions.tsx
+++ b/src/components/schema-editor/extensions/aiSectionsExtensions.tsx
@@ -28,7 +28,7 @@ import { EdgesList } from '@/components/aisections/EdgesList';
 // ---------------------------------------------------------------------------
 
 // WholeResource: legacy overview tab that operates on the full root.
-export const AISectionsOverviewExtension: React.FC<WholeResourceExtensionProps> = ({
+const AISectionsOverviewExtension: React.FC<WholeResourceExtensionProps> = ({
 	data,
 	setData,
 }) => (
@@ -50,7 +50,7 @@ export const AISectionsOverviewExtension: React.FC<WholeResourceExtensionProps> 
 // WholeResource: list tab needs the full sections array; selectChild is
 // relative to the extension's path (which is the root for a property-group
 // tab) so `['sections', i]` lands on the right section.
-export const AISectionsListExtension: React.FC<WholeResourceExtensionProps> = ({
+const AISectionsListExtension: React.FC<WholeResourceExtensionProps> = ({
 	data,
 	setData,
 	selectChild,
@@ -89,7 +89,7 @@ export const AISectionsListExtension: React.FC<WholeResourceExtensionProps> = ({
 // ---------------------------------------------------------------------------
 
 // WholeResource: legacy reset-pairs tab operates on the full root.
-export const AISectionsResetPairsExtension: React.FC<WholeResourceExtensionProps> = ({
+const AISectionsResetPairsExtension: React.FC<WholeResourceExtensionProps> = ({
 	data,
 	setData,
 }) => (
@@ -115,7 +115,7 @@ export const AISectionsResetPairsExtension: React.FC<WholeResourceExtensionProps
 //
 // WholeResource: the EdgesList resolves duplicate-edge targets across
 // other sections, so the full `ParsedAISectionsV12` model is required.
-export const AISectionEdgesExtension: React.FC<
+const AISectionEdgesExtension: React.FC<
 	WholeResourceExtensionProps<AISection | undefined>
 > = ({ path, value, data }) => {
 	if (path.length < 2 || path[0] !== 'sections' || typeof path[1] !== 'number') {

--- a/src/components/schema-editor/extensions/challengeListExtensions.tsx
+++ b/src/components/schema-editor/extensions/challengeListExtensions.tsx
@@ -124,7 +124,7 @@ function computeStats(data: ParsedChallengeList): OverviewStats {
 // WholeResource: this is a root-level overview that aggregates stats across
 // every challenge in the resource — the narrow per-node view doesn't reach
 // siblings.
-export const ChallengeOverviewExtension: React.FC<WholeResourceExtensionProps> = ({ data }) => {
+const ChallengeOverviewExtension: React.FC<WholeResourceExtensionProps> = ({ data }) => {
 	const typed = data as ParsedChallengeList;
 	const stats = useMemo(() => computeStats(typed), [typed]);
 	return <ChallengeOverview data={typed} stats={stats} />;
@@ -179,8 +179,8 @@ function makeActionExtension(
 	return Component;
 }
 
-export const ChallengeAction1Extension = makeActionExtension({ actionIndex: 0 });
-export const ChallengeAction2Extension = makeActionExtension({ actionIndex: 1 });
+const ChallengeAction1Extension = makeActionExtension({ actionIndex: 0 });
+const ChallengeAction2Extension = makeActionExtension({ actionIndex: 1 });
 
 // ---------------------------------------------------------------------------
 // Registry bundle — hand this map to SchemaEditorProvider.

--- a/src/components/schema-editor/extensions/collisionTagExtension.tsx
+++ b/src/components/schema-editor/extensions/collisionTagExtension.tsx
@@ -203,7 +203,7 @@ export function FlagCheckbox({ label, value, onChange, disabled }: FlagCheckboxP
 // Main extension — decoded inspector for a single polygon's collisionTag
 // ---------------------------------------------------------------------------
 
-export const CollisionTagExtension: React.FC<SchemaExtensionProps<number>> = ({
+const CollisionTagExtension: React.FC<SchemaExtensionProps<number>> = ({
 	value,
 	setValue,
 }) => {

--- a/src/components/schema-editor/extensions/renderableExtensions.tsx
+++ b/src/components/schema-editor/extensions/renderableExtensions.tsx
@@ -356,7 +356,7 @@ function NotDecodedHint() {
 // Narrow: reads `path` to look up its renderable in the decoded-renderable
 // React context, which is separate from the schema editor's `data`. No
 // cross-tree access needed.
-export const RenderableCardExtension: React.FC<SchemaExtensionProps> = ({ path }) => {
+const RenderableCardExtension: React.FC<SchemaExtensionProps> = ({ path }) => {
 	const ctx = useRenderableDecoded();
 	const wi = path[0] === 'renderables' && typeof path[1] === 'number' ? (path[1] as number) : null;
 	if (wi == null) {
@@ -390,7 +390,7 @@ export const RenderableCardExtension: React.FC<SchemaExtensionProps> = ({ path }
 
 // Single-mesh view — like the full card but scoped to one mesh row. Narrow
 // for the same reason as RenderableCardExtension above.
-export const RenderableMeshCardExtension: React.FC<SchemaExtensionProps> = ({ path }) => {
+const RenderableMeshCardExtension: React.FC<SchemaExtensionProps> = ({ path }) => {
 	const ctx = useRenderableDecoded();
 	const wi = path[0] === 'renderables' && typeof path[1] === 'number' ? (path[1] as number) : null;
 	const mi = path[2] === 'meshes' && typeof path[3] === 'number' ? (path[3] as number) : null;

--- a/src/components/schema-editor/extensions/streetDataExtensions.tsx
+++ b/src/components/schema-editor/extensions/streetDataExtensions.tsx
@@ -23,7 +23,7 @@ import { ChallengesTab } from '@/components/streetdata/ChallengesTab';
 // Adapters — every one is WholeResource (legacy whole-tree tabs).
 // ---------------------------------------------------------------------------
 
-export const StreetDataOverviewExtension: React.FC<WholeResourceExtensionProps> = ({
+const StreetDataOverviewExtension: React.FC<WholeResourceExtensionProps> = ({
 	data,
 	setData,
 }) => (
@@ -33,28 +33,28 @@ export const StreetDataOverviewExtension: React.FC<WholeResourceExtensionProps> 
 	/>
 );
 
-export const StreetsExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
+const StreetsExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<StreetsTab
 		data={data as ParsedStreetData}
 		onChange={setData as (next: ParsedStreetData) => void}
 	/>
 );
 
-export const JunctionsExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
+const JunctionsExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<JunctionsTab
 		data={data as ParsedStreetData}
 		onChange={setData as (next: ParsedStreetData) => void}
 	/>
 );
 
-export const RoadsExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
+const RoadsExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<RoadsTab
 		data={data as ParsedStreetData}
 		onChange={setData as (next: ParsedStreetData) => void}
 	/>
 );
 
-export const ChallengesExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
+const ChallengesExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<ChallengesTab
 		data={data as ParsedStreetData}
 		onChange={setData as (next: ParsedStreetData) => void}

--- a/src/components/schema-editor/extensions/trafficDataExtensions.tsx
+++ b/src/components/schema-editor/extensions/trafficDataExtensions.tsx
@@ -89,14 +89,14 @@ function useTabSelectionBridge() {
 // past one path.
 // ---------------------------------------------------------------------------
 
-export const FlowTypesExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
+const FlowTypesExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<FlowTypesTab
 		data={data as ParsedTrafficDataRetail}
 		onChange={setData as (next: ParsedTrafficDataRetail) => void}
 	/>
 );
 
-export const PaintColoursExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
+const PaintColoursExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<PaintColoursTab
 		data={data as ParsedTrafficDataRetail}
 		onChange={setData as (next: ParsedTrafficDataRetail) => void}
@@ -107,7 +107,7 @@ export const PaintColoursExtension: React.FC<WholeResourceExtensionProps> = ({ d
 // clicking a hull in the summary jumps to that hull node. `selectChild`
 // from the root resolves to the absolute path because the extension's
 // `path` is `[]` (it's a root-level property group).
-export const OverviewExtension: React.FC<WholeResourceExtensionProps> = ({
+const OverviewExtension: React.FC<WholeResourceExtensionProps> = ({
 	data,
 	setData,
 	selectChild,
@@ -119,14 +119,14 @@ export const OverviewExtension: React.FC<WholeResourceExtensionProps> = ({
 	/>
 );
 
-export const KillZonesExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
+const KillZonesExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<KillZonesTab
 		data={data as ParsedTrafficDataRetail}
 		onChange={setData as (next: ParsedTrafficDataRetail) => void}
 	/>
 );
 
-export const VehiclesExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
+const VehiclesExtension: React.FC<WholeResourceExtensionProps> = ({ data, setData }) => (
 	<VehiclesTab
 		data={data as ParsedTrafficDataRetail}
 		onChange={setData as (next: ParsedTrafficDataRetail) => void}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -32,4 +32,4 @@ function Badge({ className, variant, ...props }: BadgeProps) {
   )
 }
 
-export { Badge, badgeVariants }
+export { Badge }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -44,18 +44,6 @@ const CardTitle = React.forwardRef<
 ))
 CardTitle.displayName = "CardTitle"
 
-const CardDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
-  <p
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-CardDescription.displayName = "CardDescription"
-
 const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
@@ -64,16 +52,4 @@ const CardContent = React.forwardRef<
 ))
 CardContent.displayName = "CardContent"
 
-const CardFooter = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
-    {...props}
-  />
-))
-CardFooter.displayName = "CardFooter"
-
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export { Card, CardHeader, CardTitle, CardContent }

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,10 +1,8 @@
 import * as React from "react"
-import { type DialogProps } from "@radix-ui/react-dialog"
 import { Command as CommandPrimitive } from "cmdk"
 import { Search } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -20,20 +18,6 @@ const Command = React.forwardRef<
   />
 ))
 Command.displayName = CommandPrimitive.displayName
-
-type CommandDialogProps = DialogProps;
-
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
-  return (
-    <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
-          {children}
-        </Command>
-      </DialogContent>
-    </Dialog>
-  )
-}
 
 const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
@@ -80,34 +64,6 @@ const CommandEmpty = React.forwardRef<
 
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName
 
-const CommandGroup = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Group>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive.Group
-    ref={ref}
-    className={cn(
-      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
-      className
-    )}
-    {...props}
-  />
-))
-
-CommandGroup.displayName = CommandPrimitive.Group.displayName
-
-const CommandSeparator = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 h-px bg-border", className)}
-    {...props}
-  />
-))
-CommandSeparator.displayName = CommandPrimitive.Separator.displayName
-
 const CommandItem = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
@@ -124,30 +80,10 @@ const CommandItem = React.forwardRef<
 
 CommandItem.displayName = CommandPrimitive.Item.displayName
 
-const CommandShortcut = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLSpanElement>) => {
-  return (
-    <span
-      className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground",
-        className
-      )}
-      {...props}
-    />
-  )
-}
-CommandShortcut.displayName = "CommandShortcut"
-
 export {
   Command,
-  CommandDialog,
   CommandInput,
   CommandList,
   CommandEmpty,
-  CommandGroup,
   CommandItem,
-  CommandShortcut,
-  CommandSeparator,
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -6,11 +6,7 @@ import { cn } from "@/lib/utils"
 
 const Dialog = DialogPrimitive.Root
 
-const DialogTrigger = DialogPrimitive.Trigger
-
 const DialogPortal = DialogPrimitive.Portal
-
-const DialogClose = DialogPrimitive.Close
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -108,10 +104,6 @@ DialogDescription.displayName = DialogPrimitive.Description.displayName
 
 export {
   Dialog,
-  DialogPortal,
-  DialogOverlay,
-  DialogClose,
-  DialogTrigger,
   DialogContent,
   DialogHeader,
   DialogFooter,

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -6,8 +6,6 @@ import { cn } from "@/lib/utils"
 
 const Select = SelectPrimitive.Root
 
-const SelectGroup = SelectPrimitive.Group
-
 const SelectValue = SelectPrimitive.Value
 
 const SelectTrigger = React.forwardRef<
@@ -97,18 +95,6 @@ const SelectContent = React.forwardRef<
 ))
 SelectContent.displayName = SelectPrimitive.Content.displayName
 
-const SelectLabel = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Label
-    ref={ref}
-    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
-    {...props}
-  />
-))
-SelectLabel.displayName = SelectPrimitive.Label.displayName
-
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
@@ -132,27 +118,10 @@ const SelectItem = React.forwardRef<
 ))
 SelectItem.displayName = SelectPrimitive.Item.displayName
 
-const SelectSeparator = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
-    {...props}
-  />
-))
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName
-
 export {
   Select,
-  SelectGroup,
   SelectValue,
   SelectTrigger,
   SelectContent,
-  SelectLabel,
   SelectItem,
-  SelectSeparator,
-  SelectScrollUpButton,
-  SelectScrollDownButton,
 }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from "next-themes"
-import { Toaster as Sonner, toast } from "sonner"
+import { Toaster as Sonner } from "sonner"
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
@@ -26,4 +26,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
   )
 }
 
-export { Toaster, toast }
+export { Toaster }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -36,21 +36,6 @@ const TableBody = React.forwardRef<
 ))
 TableBody.displayName = "TableBody"
 
-const TableFooter = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <tfoot
-    ref={ref}
-    className={cn(
-      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-      className
-    )}
-    {...props}
-  />
-))
-TableFooter.displayName = "TableFooter"
-
 const TableRow = React.forwardRef<
   HTMLTableRowElement,
   React.HTMLAttributes<HTMLTableRowElement>
@@ -93,25 +78,11 @@ const TableCell = React.forwardRef<
 ))
 TableCell.displayName = "TableCell"
 
-const TableCaption = React.forwardRef<
-  HTMLTableCaptionElement,
-  React.HTMLAttributes<HTMLTableCaptionElement>
->(({ className, ...props }, ref) => (
-  <caption
-    ref={ref}
-    className={cn("mt-4 text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-TableCaption.displayName = "TableCaption"
-
 export {
   Table,
   TableHeader,
   TableBody,
-  TableFooter,
   TableHead,
   TableRow,
   TableCell,
-  TableCaption,
 }

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -123,5 +123,4 @@ export {
   ToastTitle,
   ToastDescription,
   ToastClose,
-  ToastAction,
 }

--- a/src/lib/core/aiSections.ts
+++ b/src/lib/core/aiSections.ts
@@ -172,7 +172,6 @@ export {
 	LegacyAISectionFlagV4,
 	LegacyAISectionFlagV6,
 	LegacyEDistrict,
-	LEGACY_AI_SECTION_VERSIONS,
 } from './aiSectionsLegacy';
 
 // =============================================================================

--- a/src/lib/core/aiSectionsLegacy.ts
+++ b/src/lib/core/aiSectionsLegacy.ts
@@ -28,10 +28,10 @@ import { BinReader, BinWriter } from './binTools';
 // =============================================================================
 
 /** Versions this module knows how to parse and write. */
-export const LEGACY_AI_SECTION_VERSIONS = [4, 6] as const;
+const LEGACY_AI_SECTION_VERSIONS = [4, 6] as const;
 export type LegacyAISectionsVersion = typeof LEGACY_AI_SECTION_VERSIONS[number];
 
-export const CORNERS_PER_LEGACY_SECTION = 4;
+const CORNERS_PER_LEGACY_SECTION = 4;
 
 const LEGACY_HEADER_SIZE = 0x10;
 const PORTAL_SIZE = 0x20;

--- a/src/lib/core/bundle/bundle1.ts
+++ b/src/lib/core/bundle/bundle1.ts
@@ -45,8 +45,7 @@ import { resourceCtxFromBundle } from '../registry/handler';
 // Magic / version constants
 // ============================================================================
 
-export const BND1_MAGIC = 'bndl';
-export const BND1_MAGIC_BYTES = new Uint8Array([0x62, 0x6E, 0x64, 0x6C]);
+const BND1_MAGIC_BYTES = new Uint8Array([0x62, 0x6E, 0x64, 0x6C]);
 
 const SUPPORTED_BND1_VERSIONS = [5] as const;
 export type Bnd1Version = typeof SUPPORTED_BND1_VERSIONS[number];
@@ -190,20 +189,6 @@ export function isBundle1Magic(buffer: ArrayBuffer): boolean {
       && dv.getUint8(1) === 0x6E
       && dv.getUint8(2) === 0x64
       && dv.getUint8(3) === 0x6C;
-}
-
-export function detectBundle1LittleEndian(buffer: ArrayBuffer): boolean {
-  // BND1 platform field is 4 bytes deep into the header — peek at version (BE)
-  // first as a coarse sanity check, then decide LE vs BE from the platform
-  // byte (PC=1=>LE, X360/PS3=>BE).
-  if (buffer.byteLength < 0x10) return true;
-  const dv = new DataView(buffer);
-  // muPlatform sits at different file offsets per platform — the easiest
-  // robust read is the version field (always at +0x04). BND1 v5 in BE is
-  // 0x00000005 in BE = 5; in LE it would be 0x05000000 = 83886080. Use
-  // the version byte to disambiguate.
-  if (dv.getUint32(0x04, false) >= 3 && dv.getUint32(0x04, false) <= 5) return false;
-  return true;
 }
 
 // ============================================================================
@@ -839,14 +824,6 @@ export function writeBundle1Fresh(
   return outBytes.buffer;
 }
 
-/**
- * Helper used by tests: decompresses a chunk if it's zlib-compressed.
- * Wraps decompressData so callers don't need to import the resource manager.
- */
-export function decompressChunkIfNeeded(bytes: Uint8Array): Uint8Array {
-  return isCompressed(bytes) ? decompressData(bytes) : bytes;
-}
-
 // ============================================================================
 // Cross-container conversion helpers
 // ============================================================================
@@ -1256,5 +1233,3 @@ export function reencodeResourceChunksForTarget(
   return overrides;
 }
 
-// Re-export the alignment helpers since some BND1 callers may want them.
-export { extractAlignment };

--- a/src/lib/core/bundle/bundleEntry.ts
+++ b/src/lib/core/bundle/bundleEntry.ts
@@ -3,7 +3,6 @@
 import {
   object,
   arrayOf,
-  string,
   u8,
   u16,
   u32,
@@ -18,7 +17,7 @@ import { bigIntToU64, u64, u64ToBigInt } from '../u64';
 // Resource Entry Schema (80 bytes)
 // ============================================================================
 
-export const ResourceEntrySchema = object({
+const ResourceEntrySchema = object({
   resourceId: u64,       // 8 bytes
   importHash: u64,       // 8 bytes
   uncompressedSizeAndAlignment: arrayOf(u32, 3), // 12 bytes
@@ -35,7 +34,7 @@ export const ResourceEntrySchema = object({
 // Import Entry Schema (16 bytes)
 // ============================================================================
 
-export const ImportEntrySchema = object({
+const ImportEntrySchema = object({
   resourceId: u64,       // 8 bytes
   offset: u32,                 // 4 bytes
   padding: u32                 // 4 bytes - padding
@@ -50,34 +49,6 @@ export type ResourceEntry = Parsed<typeof ResourceEntrySchema>;
 
 // ImportEntry with bigint conversion for resourceId
 export type ImportEntry = Parsed<typeof ImportEntrySchema>;
-
-// ============================================================================
-// Bundle Writing Schemas
-// ============================================================================
-
-// Entry block schema for writing (matches the bundleWriter EntryBlock interface)
-export const EntryBlockWriteSchema = object({
-  compressed: u8,  // Convert boolean to byte
-  compressedSize: u32,
-  uncompressedSize: u32,
-  uncompressedAlignment: u32
-  // Note: data is handled separately as it can be large and variable
-});
-
-// Bundle entry schema for writing (matches bundleWriter BundleEntry interface)
-export const BundleEntryWriteSchema = object({
-  id: object({ low: u32, high: u32 }),
-  references: object({ low: u32, high: u32 }),
-  // entryBlocks handled separately
-  dependenciesListOffset: u32,
-  type: u32,
-  dependencyCount: u32
-});
-
-// Resource string table schema
-export const ResourceStringTableSchema = object({
-  content: string  // Null-terminated string
-});
 
 // ============================================================================
 // Entry Creation and Conversion Functions
@@ -96,53 +67,6 @@ export function createEmptyResourceEntry(): ResourceEntry {
     flags: 0,
     streamIndex: 0
   };
-}
-
-// Convert bigint to schema format for writing
-export function bundleEntryToSchema(entry: {
-  id: bigint;
-  references: bigint;
-  dependenciesListOffset: number;
-  type: number;
-  dependencyCount: number;
-}): Parsed<typeof BundleEntryWriteSchema> {
-  return {
-    id: { low: Number(entry.id & 0xFFFFFFFFn), high: Number((entry.id >> 32n) & 0xFFFFFFFFn) },
-    references: { low: Number(entry.references & 0xFFFFFFFFn), high: Number((entry.references >> 32n) & 0xFFFFFFFFn) },
-    dependenciesListOffset: entry.dependenciesListOffset,
-    type: entry.type,
-    dependencyCount: entry.dependencyCount
-  };
-}
-
-// Convert resource entry to schema format
-export function resourceEntryToSchema(entry: ResourceEntry): Parsed<typeof ResourceEntrySchema> {
-  return {
-    resourceId: entry.resourceId,
-    importHash: entry.importHash,
-    uncompressedSizeAndAlignment: entry.uncompressedSizeAndAlignment.slice(0, 3) as [number, number, number],
-    sizeAndAlignmentOnDisk: entry.sizeAndAlignmentOnDisk.slice(0, 3) as [number, number, number],
-    diskOffsets: entry.diskOffsets.slice(0, 3) as [number, number, number],
-    importOffset: entry.importOffset,
-    resourceTypeId: entry.resourceTypeId,
-    importCount: entry.importCount,
-    flags: entry.flags,
-    streamIndex: entry.streamIndex
-  };
-}
-
-// ============================================================================
-// Schema Factories for Fixed-Length Collections
-// ============================================================================
-
-// Fixed-length resource entries array
-export function makeResourceEntriesSchema(count: number) {
-  return arrayOf(ResourceEntrySchema, count);
-}
-
-// Fixed-length import entries array
-export function makeImportEntriesSchema(count: number) {
-  return arrayOf(ImportEntrySchema, count);
 }
 
 // ============================================================================

--- a/src/lib/core/bundle/bundleHeader.ts
+++ b/src/lib/core/bundle/bundleHeader.ts
@@ -35,7 +35,7 @@ export function detectBundleLittleEndian(buffer: ArrayBuffer): boolean {
 }
 
 // Bundle header schema including magic prefix for convenience
-export const BundleHeaderSchema = object({
+const BundleHeaderSchema = object({
   magic: chars(4),         // 4 bytes, typically "bnd2"
   version: u32,
   platform: u32,
@@ -81,7 +81,7 @@ export function parseHeader(
 /**
  * Validates bundle header
  */
-export function validateBundleHeader(header: BundleHeader): ValidationError[] {
+function validateBundleHeader(header: BundleHeader): ValidationError[] {
   const errors: ValidationError[] = [];
 
   if (header.magic !== 'bnd2') {

--- a/src/lib/core/bundle/debugData.ts
+++ b/src/lib/core/bundle/debugData.ts
@@ -91,13 +91,6 @@ export function parseDebugDataFromBuffer(buffer: ArrayBuffer, header: BundleHead
 // ============================================================================
 
 /**
- * Finds a debug resource by name
- */
-export function findDebugResourceByName(debugResources: DebugResource[], name: string): DebugResource | undefined {
-  return debugResources.find(r => r.name === name);
-}
-
-/**
  * Normalize a resource id to the form RST entries store: lowercase hex
  * without `0x` prefix and without leading zeros. Accepts inputs in any of:
  *   - "0x0000000000334801" (formatResourceId output, uppercase, 16 chars)

--- a/src/lib/core/bundle/index.ts
+++ b/src/lib/core/bundle/index.ts
@@ -45,7 +45,6 @@ import { extractResourceSize, extractAlignment, packSizeAndAlignment, isCompress
 import { parseChallengeList, type ParsedChallengeList } from '../challengeList';
 import { parseStreetData, type ParsedStreetData } from '../streetData';
 import { registry, getHandlerByTypeId, resourceCtxFromBundle } from '../registry';
-import { parseBundleResourcesViaRegistry } from '../registry/bundleOps';
 import { u64ToBigInt } from '../u64';
 
 // ============================================================================
@@ -704,35 +703,6 @@ export type ParsedResources = {
   challengeList?: ParsedChallengeList;
   streetData?: ParsedStreetData;
 };
-
-/**
- * Parses all known resource types from a bundle and returns the legacy
- * ParsedResources shape. Internally delegates to the registry-driven
- * parseBundleResourcesViaRegistry — this function exists only as a thin
- * compatibility shim for callers that still expect the named fields. Step 6
- * of the CLI refactor migrates BundleContext to the generic map form and
- * removes this shim.
- */
-export function parseBundleResources(
-  buffer: ArrayBuffer,
-  bundle: ParsedBundle
-): ParsedResources {
-  const map = parseBundleResourcesViaRegistry(buffer, bundle);
-  const out: ParsedResources = {};
-  const vehicleList = map.get('vehicleList') as ParsedVehicleList | undefined;
-  if (vehicleList) out.vehicleList = vehicleList;
-  const playerCarColours = map.get('playerCarColours') as PlayerCarColours | undefined;
-  if (playerCarColours) out.playerCarColours = playerCarColours;
-  const iceTakeDictionary = map.get('iceTakeDictionary') as ParsedIceTakeDictionary | undefined;
-  if (iceTakeDictionary) out.iceTakeDictionary = iceTakeDictionary;
-  const triggerData = map.get('triggerData') as ParsedTriggerData | undefined;
-  if (triggerData) out.triggerData = triggerData;
-  const challengeList = map.get('challengeList') as ParsedChallengeList | undefined;
-  if (challengeList) out.challengeList = challengeList;
-  const streetData = map.get('streetData') as ParsedStreetData | undefined;
-  if (streetData) out.streetData = streetData;
-  return out;
-}
 
 // ============================================================================
 // Import helpers are re-exported from bundleEntry.ts at the top of this file:

--- a/src/lib/core/dxbc/index.ts
+++ b/src/lib/core/dxbc/index.ts
@@ -43,6 +43,4 @@ export function translateDxbc(bytes: Uint8Array): TranslatedShader {
 	return { parsed, decoded, source, unsupported, programLabel, summary };
 }
 
-export { parseDxbc, isDxbc, decodeShex, emitGlsl };
 export type { ParsedDxbc } from './parser';
-export type { DecodedShader, DxbcInstruction } from './ops';

--- a/src/lib/core/dxbc/ops.ts
+++ b/src/lib/core/dxbc/ops.ts
@@ -18,7 +18,7 @@
 // Opcode → (name, arity). Arity is the number of operands; `dcl_*` opcodes
 // are handled as a special case because they embed their operand count in
 // the instruction-length field.
-export const OP_TABLE: Record<number, { name: string; arity: number; kind?: 'alu' | 'cmp' | 'tex' | 'flow' | 'decl' | 'mov' }> = {
+const OP_TABLE: Record<number, { name: string; arity: number; kind?: 'alu' | 'cmp' | 'tex' | 'flow' | 'decl' | 'mov' }> = {
 	0x00: { name: 'add',   arity: 3, kind: 'alu' },
 	0x01: { name: 'and',   arity: 3, kind: 'alu' },
 	0x02: { name: 'break', arity: 0, kind: 'flow' },
@@ -111,7 +111,7 @@ export const OP_TABLE: Record<number, { name: string; arity: number; kind?: 'alu
 
 /** Operand file — which bank / namespace the operand lives in. SM5 has many;
  *  only the ones our fixture actually produces need full support. */
-export type DxbcOperandType =
+type DxbcOperandType =
 	| 'temp'           // r0..rN
 	| 'input'          // v0..vN
 	| 'output'         // o0..oN
@@ -127,7 +127,7 @@ export type DxbcOperandType =
 	| 'null'
 	| 'unknown';
 
-export type DxbcOperandIndex =
+type DxbcOperandIndex =
 	/** Literal index, e.g. r4 → { kind:'immediate', value:4 } */
 	| { kind: 'immediate'; value: number }
 	/** Relative addressing (r[r0.x+3]) → { kind:'relative', base, offset } */
@@ -162,7 +162,7 @@ export type DxbcOperand = {
 
 /** Result of decoding one `dcl_*` opcode into declaration metadata. Kept
  *  compact; the emitter only needs a subset of this. */
-export type DxbcDecl =
+type DxbcDecl =
 	| { kind: 'resource'; register: number; dim: number; returnType: number }
 	| { kind: 'sampler'; register: number; mode: number }
 	| { kind: 'constantBuffer'; register: number; size: number; accessPattern: number }

--- a/src/lib/core/dxbc/parser.ts
+++ b/src/lib/core/dxbc/parser.ts
@@ -20,12 +20,12 @@
 // Types
 // ---------------------------------------------------------------------------
 
-export type DxbcProgramType = 'pixel' | 'vertex' | 'geometry' | 'hull' | 'domain' | 'compute';
+type DxbcProgramType = 'pixel' | 'vertex' | 'geometry' | 'hull' | 'domain' | 'compute';
 
-export type DxbcChunkKind = 'RDEF' | 'ISGN' | 'OSGN' | 'SHEX' | 'SHDR' | 'STAT' | 'PCSG' | 'SFI0' | 'ICFE' | string;
+type DxbcChunkKind = 'RDEF' | 'ISGN' | 'OSGN' | 'SHEX' | 'SHDR' | 'STAT' | 'PCSG' | 'SFI0' | 'ICFE' | string;
 
 /** A single chunk record as it lives in the DXBC file. */
-export type DxbcChunk = {
+type DxbcChunk = {
 	kind: DxbcChunkKind;
 	/** Absolute offset of the chunk tag in the DXBC buffer. */
 	offset: number;
@@ -34,7 +34,7 @@ export type DxbcChunk = {
 };
 
 /** A single input or output signature element (ISGN/OSGN). */
-export type DxbcSignatureElement = {
+type DxbcSignatureElement = {
 	/** Semantic name, e.g. "POSITION", "TEXCOORD". */
 	semanticName: string;
 	/** Semantic index, e.g. 0 for TEXCOORD0. */
@@ -52,7 +52,7 @@ export type DxbcSignatureElement = {
 };
 
 /** A constant-buffer variable (RDEF). */
-export type DxbcCbVariable = {
+type DxbcCbVariable = {
 	name: string;
 	/** Offset into the containing cbuffer, in bytes. */
 	startOffset: number;
@@ -62,7 +62,7 @@ export type DxbcCbVariable = {
 	type: DxbcTypeDesc;
 };
 
-export type DxbcTypeDesc = {
+type DxbcTypeDesc = {
 	/** SHADER_VARIABLE_CLASS: 0=scalar, 1=vector, 2=matrix_rows, 3=matrix_columns,
 	 *  4=object, 5=struct, 6=interface, 7=interface_pointer. */
 	class: number;
@@ -73,7 +73,7 @@ export type DxbcTypeDesc = {
 	elements: number;
 };
 
-export type DxbcConstantBuffer = {
+type DxbcConstantBuffer = {
 	name: string;
 	/** Size in bytes. */
 	size: number;
@@ -82,7 +82,7 @@ export type DxbcConstantBuffer = {
 	variables: DxbcCbVariable[];
 };
 
-export type DxbcResourceBinding = {
+type DxbcResourceBinding = {
 	name: string;
 	/** D3D_SHADER_INPUT_TYPE: 0=cbuffer, 1=tbuffer, 2=texture, 3=sampler,
 	 *  4=uav_rwtyped, 5=structured, 6=uav_rwstructured, ... */
@@ -98,7 +98,7 @@ export type DxbcResourceBinding = {
 	flags: number;
 };
 
-export type DxbcReflection = {
+type DxbcReflection = {
 	constantBuffers: DxbcConstantBuffer[];
 	resourceBindings: DxbcResourceBinding[];
 };
@@ -392,16 +392,3 @@ function parseRdef(bytes: Uint8Array, chunk: DxbcChunk): DxbcReflection {
 	return { constantBuffers, resourceBindings };
 }
 
-// ---------------------------------------------------------------------------
-// Small helpers used by the instruction decoder
-// ---------------------------------------------------------------------------
-
-export function programVersionLabel(p: ParsedDxbc): string {
-	const stage = p.programType === 'vertex' ? 'vs'
-		: p.programType === 'pixel' ? 'ps'
-		: p.programType === 'geometry' ? 'gs'
-		: p.programType === 'hull' ? 'hs'
-		: p.programType === 'domain' ? 'ds'
-		: 'cs';
-	return `${stage}_${p.programMajor}_${p.programMinor}`;
-}

--- a/src/lib/core/gltf/index.ts
+++ b/src/lib/core/gltf/index.ts
@@ -2,35 +2,6 @@
 // See docs/worldlogic-gltf-roundtrip.md for the overall design.
 
 export {
-	addStreetDataSubtree,
-	buildStreetDataDocument,
-	exportStreetDataToGltf,
-	exportStreetDataToGltfJson,
-	importStreetDataFromDocument,
-	importStreetDataFromGltf,
-	readStreetDataFromDocument,
-} from './streetDataGltf';
-
-export {
-	addTrafficDataSubtree,
-	buildTrafficDataDocument,
-	exportTrafficDataToGltf,
-	exportTrafficDataToGltfJson,
-	importTrafficDataFromGltf,
-	readTrafficDataFromDocument,
-} from './trafficDataGltf';
-
-export {
-	addAISectionsSubtree,
-	buildAISectionsDocument,
-	exportAISectionsToGltf,
-	exportAISectionsToGltfJson,
-	importAISectionsFromGltf,
-	readAISectionsFromDocument,
-} from './aiSectionsGltf';
-
-export {
-	addTriggerDataSubtree,
 	buildTriggerDataDocument,
 	exportTriggerDataToGltf,
 	exportTriggerDataToGltfJson,

--- a/src/lib/core/polygonSoupList.ts
+++ b/src/lib/core/polygonSoupList.ts
@@ -37,12 +37,12 @@ import { BinReader } from './binTools';
 // Constants
 // =============================================================================
 
-export const POLYGON_SOUP_LIST_HEADER_SIZE = 0x30;
-export const POLYGON_SOUP_STRUCT_SIZE = 0x20;
-export const POLYGON_SOUP_POLY_SIZE = 0x0C;
-export const POLYGON_SOUP_VERTEX_SIZE = 0x06;
-export const AABB4_ROW_SIZE = 0x70;
-export const SOUPS_PER_AABB4_ROW = 4;
+const POLYGON_SOUP_LIST_HEADER_SIZE = 0x30;
+const POLYGON_SOUP_STRUCT_SIZE = 0x20;
+const POLYGON_SOUP_POLY_SIZE = 0x0C;
+const POLYGON_SOUP_VERTEX_SIZE = 0x06;
+const AABB4_ROW_SIZE = 0x70;
+const SOUPS_PER_AABB4_ROW = 4;
 
 // =============================================================================
 // Types
@@ -447,7 +447,7 @@ function align4(pos: number): number {
  * a soup is missing its offset entirely. Mutations that only reorder or
  * remove soups (pop, swap) leave the layout valid and skip normalization.
  */
-export function hasLayoutConflict(model: ParsedPolygonSoupList): boolean {
+function hasLayoutConflict(model: ParsedPolygonSoupList): boolean {
 	if (model.soups.length === 0) return false;
 	const seen = new Set<number>();
 	for (const s of model.soups) {

--- a/src/lib/core/registry/bundleOps.ts
+++ b/src/lib/core/registry/bundleOps.ts
@@ -6,7 +6,7 @@
 
 import type { ParsedBundle } from '../types';
 import { extractResourceRaw } from './extract';
-import { registry, getHandlerByTypeId } from './index';
+import { registry } from './index';
 import { resourceCtxFromBundle } from './handler';
 
 /**
@@ -82,11 +82,3 @@ export function parseAllBundleResourcesViaRegistry(
 	return out;
 }
 
-/**
- * Convenience lookup used by the UI during Step 6. Returns the raw handler
- * so callers can also reach describe() / caps / name.
- */
-export function findHandlerForResource(bundle: ParsedBundle, typeId: number) {
-	if (!bundle.resources.some((r) => r.resourceTypeId === typeId)) return undefined;
-	return getHandlerByTypeId(typeId);
-}

--- a/src/lib/core/registry/index.ts
+++ b/src/lib/core/registry/index.ts
@@ -126,7 +126,6 @@ export {
 	type ResourceCategory,
 	type StressScenario,
 	type HandlerPlatform,
-	HANDLER_PLATFORM,
 	resourceCtxFromBundle,
 } from './handler';
 export { extractResourceRaw } from './extract';

--- a/src/lib/core/resourceManager.ts
+++ b/src/lib/core/resourceManager.ts
@@ -269,28 +269,6 @@ export function isNestedBundle(data: Uint8Array): boolean {
   return true;
 }
 
-/**
- * Extracts data from nested bundle sections
- */
-export function extractFromNestedBundle(
-  buffer: ArrayBuffer,
-  nestedData: Uint8Array,
-  targetResourceTypeId: number
-): Uint8Array | null {
-  if (!isNestedBundle(nestedData)) {
-    return null;
-  }
-
-  try {
-    // This would need to import parseBundle, but to avoid circular deps,
-    // we'll handle this in the specific parsers
-    return null;
-  } catch (error) {
-    console.warn('Failed to parse nested bundle:', error);
-    return null;
-  }
-}
-
 // ============================================================================
 // Resource Validation
 // ============================================================================
@@ -345,20 +323,6 @@ export function validateResourceEntry(resource: ResourceEntry, bufferSize: numbe
 // ============================================================================
 
 /**
- * Finds a resource by type ID
- */
-export function findResourceByType(resources: ResourceEntry[], typeId: number): ResourceEntry | undefined {
-  return resources.find(r => r.resourceTypeId === typeId);
-}
-
-/**
- * Finds all resources of a specific type
- */
-export function findResourcesByType(resources: ResourceEntry[], typeId: number): ResourceEntry[] {
-  return resources.filter(r => r.resourceTypeId === typeId);
-}
-
-/**
  * Gets the memory type name for a platform
  */
 export function getMemoryTypeName(platform: number, memoryIndex: number): string {
@@ -369,13 +333,6 @@ export function getMemoryTypeName(platform: number, memoryIndex: number): string
   }[platform];
   
   return types?.[memoryIndex] || `Unknown Memory Type ${memoryIndex}`;
-}
-
-/**
- * Formats a resource ID as a hex string
- */
-export function formatResourceId(resourceId: bigint): string {
-  return `0x${resourceId.toString(16).toUpperCase().padStart(16, '0')}`;
 }
 
 /**

--- a/src/lib/core/trafficData.ts
+++ b/src/lib/core/trafficData.ts
@@ -702,17 +702,6 @@ const V22_HEADER_SIZE = 0x30;
 // Vec4 is missing in v22; everything else lines up.
 const V22_PVS_HEADER_SIZE = 0x30;
 
-// Read-only structural parser for the v22 prototype TrafficData payload.
-// Exported alongside the main `parseTrafficDataData` dispatcher so callers
-// who already know they have a v22 payload can skip the version probe and
-// pin the result type to `ParsedTrafficDataV22` directly.
-export function parseTrafficDataV22(
-  data: Uint8Array,
-  littleEndian = false,
-): ParsedTrafficDataV22 {
-  return parseTrafficDataV22Internal(data, littleEndian);
-}
-
 // Internal implementation. Returns a `ParsedTrafficDataV22` carrying the
 // header + Pvs + hull pointer table that decoded cleanly, plus raw bytes
 // for the hull contents and four trailing regions we don't yet interpret.

--- a/src/lib/core/triggerData.ts
+++ b/src/lib/core/triggerData.ts
@@ -12,20 +12,20 @@ import { BinReader, BinWriter } from './binTools';
 // typed-binary Schemas (for header and basic structs)
 // =============================================================================
 
-export const Vector3Schema = object({
+const Vector3Schema = object({
   x: f32,
   y: f32,
   z: f32
 });
 
-export const Vector4Schema = object({
+const Vector4Schema = object({
   x: f32,
   y: f32,
   z: f32,
   w: f32
 });
 
-export const BoxRegionSchema = object({
+const BoxRegionSchema = object({
   position: Vector3Schema,
   rotation: Vector3Schema,
   dimensions: Vector3Schema,
@@ -701,19 +701,6 @@ export function writeTriggerDataData(td: ParsedTriggerData, littleEndian: boolea
 
 	return w.bytes;
 }
-
-// =============================================================================
-// High-level wrapper with progress (optional)
-// =============================================================================
-
-export function writeTriggerData(td: ParsedTriggerData, options: { littleEndian?: boolean } = {}, progress?: ProgressCallback): Uint8Array {
-	progress?.({ type: 'write', stage: 'write', progress: 0.0, message: 'Serializing TriggerData' });
-	const out = writeTriggerDataData(td, options.littleEndian !== false);
-	progress?.({ type: 'write', stage: 'write', progress: 1.0, message: 'Done' });
-	return out;
-}
-
-
 
 // =============================================================================
 // High-level parsing wrapper (mirrors vehicle list style)

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -23,12 +23,6 @@ export const BUNDLE_FLAGS = {
   HAS_DEBUG_DATA: 0x8,
 } as const;
 
-export const MEMORY_TYPES = {
-  [PLATFORMS.PC]: ['Main Memory', 'Disposable', 'Dummy'],
-  [PLATFORMS.XBOX360]: ['Main Memory', 'Physical', 'Dummy'],
-  [PLATFORMS.PS3]: ['Main Memory', 'Graphics System', 'Graphics Local'],
-} as const;
-
 // ============================================================================
 // Resource Type Constants
 // ============================================================================


### PR DESCRIPTION
## What this is

Same content as **#90**, rebased onto current `main`.

## Why a new PR

#90 was opened with `base: chore/dead-code-cleanup` (stacked on #89). When #89 squash-merged into `main` as `fe3617e`, the cleanup branch's history was effectively orphaned. #90 was then merged into the now-orphaned cleanup branch — GitHub marks it MERGED, but the 32 commits never reached `main`. This PR delivers them properly.

## Summary

32 commits, 32 files, 55 insertions(+), 477 deletions(−). No code logic changes — only:
- `export` keywords removed from symbols used only inside their own module (~61)
- truly unused definitions deleted (~59)

| Batch | Area | Files | Symbols |
|---|---|---:|---:|
| R2-1 | `src/lib/core/dxbc/*` | 3 | 20 |
| R2-2 | `src/lib/core/gltf/index.ts` (barrel re-exports) | 1 | 20 |
| R2-3 | `src/components/schema-editor/extensions/*` | 6 | 20 |
| R2-4 | `src/lib/core/bundle/*` + `src/lib/core/registry/*` | 7 | 20 |
| R2-5 | `src/components/ui/*` (shadcn survivors) | 8 | 20 |
| R2-6 | `src/lib/core/*.ts` (top-level) | 7 | 20 |
| **Total** | | **32** | **120** |

Full per-batch findings, methodology, and notable patterns: see [#90](https://github.com/derneuere/paradise-bundle-steward/pull/90).

## Test plan

- [ ] `npm install`
- [ ] `npm run build` succeeds
- [ ] `npm run test:run` passes
- [ ] `npm run lint` shows no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)