### PR TITLE
fix(trafficdata): clear all 6 rules-of-hooks violations

### DIFF
--- a/src/components/trafficdata/LaneRungsTab.tsx
+++ b/src/components/trafficdata/LaneRungsTab.tsx
@@ -50,18 +50,18 @@ export const LaneRungsTab: React.FC<Props> = ({ data, hullIndex, onChange, scrol
 	const [search, setSearch] = useState('');
 	const parentRef = useRef<HTMLDivElement>(null);
 	const hull = data.hulls[hullIndex];
-	if (!hull) return null;
 
-	const rungToSection = useMemo(() => buildRungToSectionMap(hull), [hull]);
+	const rungToSection = useMemo(() => hull ? buildRungToSectionMap(hull) : new Int32Array(), [hull]);
 
 	const filtered = useMemo(() => {
+		if (!hull) return [];
 		let list = hull.rungs.map((r, i) => ({ r, i }));
 		if (search) {
 			const q = search.toLowerCase();
 			list = list.filter(({ i }) => i.toString().includes(q));
 		}
 		return list;
-	}, [hull.rungs, search]);
+	}, [hull?.rungs, search]);
 
 	const rowVirtualizer = useVirtualizer({
 		count: filtered.length,
@@ -69,6 +69,8 @@ export const LaneRungsTab: React.FC<Props> = ({ data, hullIndex, onChange, scrol
 		estimateSize: () => 44,
 		overscan: 12,
 	});
+
+	if (!hull) return null;
 
 	scrollToIndexRef.current = (originalIndex: number) => {
 		const filteredIdx = filtered.findIndex(({ i }) => i === originalIndex);

--- a/src/components/trafficdata/SectionsTab.tsx
+++ b/src/components/trafficdata/SectionsTab.tsx
@@ -19,16 +19,16 @@ export const SectionsTab: React.FC<Props> = ({ data, hullIndex, onChange, select
 	const [search, setSearch] = useState('');
 	const parentRef = useRef<HTMLDivElement>(null);
 	const hull = data.hulls[hullIndex];
-	if (!hull) return null;
 
 	const filtered = useMemo(() => {
+		if (!hull) return [];
 		let list = hull.sections.map((s, i) => ({ s, i }));
 		if (search) {
 			const q = search.toLowerCase();
 			list = list.filter(({ i }) => i.toString().includes(q));
 		}
 		return list;
-	}, [hull.sections, search]);
+	}, [hull, search]);
 
 	const rowVirtualizer = useVirtualizer({
 		count: filtered.length,
@@ -36,6 +36,8 @@ export const SectionsTab: React.FC<Props> = ({ data, hullIndex, onChange, select
 		estimateSize: () => 44,
 		overscan: 12,
 	});
+
+	if (!hull) return null;
 
 	scrollToIndexRef.current = (originalIndex: number) => {
 		const filteredIdx = filtered.findIndex(({ i }) => i === originalIndex);

--- a/src/components/trafficdata/TrafficDataViewport.tsx
+++ b/src/components/trafficdata/TrafficDataViewport.tsx
@@ -342,9 +342,9 @@ export function AllLaneConnections({ hulls, activeHullIndex }: { hulls: TrafficH
 
 export function SectionHighlight({ hull, sectionIndex }: { hull: TrafficHull; sectionIndex: number }) {
 	const sec = hull.sections[sectionIndex];
-	if (!sec) return null;
 
 	const geo = useMemo(() => {
+		if (!sec) return null;
 		const count = sec.muNumRungs;
 		const positions = new Float32Array(count * 2 * 3);
 		for (let r = 0; r < count; r++) {
@@ -360,6 +360,8 @@ export function SectionHighlight({ hull, sectionIndex }: { hull: TrafficHull; se
 		g.computeBoundingSphere();
 		return g;
 	}, [hull, sec, sectionIndex]);
+
+	if (!sec || !geo) return null;
 
 	return (
 		<lineSegments geometry={geo}>


### PR DESCRIPTION
## Summary

Fixes all 6 React rules-of-hooks violations flagged by react-doctor / oxlint, all of them in `src/components/trafficdata/`. Three opus 4.7 agents worked in parallel — one per file — since multiple violations in the same file always shared one underlying bug.

| File | Violations | Root cause | Fix |
|---|---:|---|---|
| `TrafficDataViewport.tsx` | 1 (L347 useMemo) | `if (!sec) return null;` at L345 inside `SectionHighlight` | Pull null-check into the memo callback; re-check `sec`/`geo` after the hook before the JSX return. |
| `SectionsTab.tsx` | 2 (L24 useMemo, L33 useVirtualizer) | `if (!hull) return null;` at L22 above 2 hooks | Move null-check below both hooks. `useMemo` short-circuits on falsy hull → empty result. `useVirtualizer` naturally safe (count: 0). Deps updated to `[hull, search]`. |
| `LaneRungsTab.tsx` | 3 (L55, L57 useMemo + L66 useVirtualizer) | `if (!hull) return null;` at L53 above 3 hooks | Move null-check below all 3 hooks. First `useMemo` returns `new Int32Array()` (matching `buildRungToSectionMap` return type) when hull is falsy; second uses `if (!hull) return [];` and optional-chained deps. |

## Why these are real bugs (not just lint warnings)

When a hook's call site sits below a conditional `return`, the hook only runs in some renders. React tracks hook calls by ORDER per render, so any later mount/unmount/state-change that flips the condition can re-bind the wrong state to the wrong slot, throwing off the hook table. Symptoms range from stale state to the same family of `Cannot access 'X' before initialization` / "Rendered more hooks than during the previous render" crashes that #91 fixed for `AISectionsOverlay`.

In all 3 cases the fix preserves behavior: when the precondition is unmet the component still returns `null`, just *after* hooks have run with safe fallback inputs.

## Diff stats

- 3 files changed, 12 insertions(+), 6 deletions(−)
- 3 commits (one per file)

## Test plan

- [ ] `npm install`
- [ ] `npm run build` — no TS errors
- [ ] `npm run test:run` — passes
- [ ] `npm run lint` — rules-of-hooks count drops from 6 to 0
- [ ] Open the trafficdata viewport / sections tab / lane rungs tab in the app and verify they render and respond to interactions normally
- [ ] Specifically: trigger the path where `hull`/`sec` is undefined (e.g. before any selection) — the components should render `null` without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)