### PR TITLE
feat: cross-Bundle bulk transform (per-Bundle dirty + one undo) (#80)

### DIFF
--- a/src/components/schema-editor/viewports/AISectionsOverlay.tsx
+++ b/src/components/schema-editor/viewports/AISectionsOverlay.tsx
@@ -82,6 +82,7 @@ import {
 	type SectionDetailAccessor,
 } from '@/components/aisections/shared';
 import { useAISectionsBulk } from '@/components/workspace/AISectionsBulkProvider';
+import { useCrossBundleBulkController } from '@/components/workspace/useCrossBundleBulkController';
 import {
 	useBatchedSelection,
 	selectionKey,
@@ -251,6 +252,16 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 
 	const cameraBridge = useRef<CameraBridgeData | null>(null);
 	const aiBulk = useAISectionsBulk();
+	// Cross-Bundle bulk controller — owns the workspace-wide view of every
+	// (bundleId, index) bulk + the per-Bundle dispatch on commit (issue
+	// #80). When the bulk lives in a single Bundle this is essentially
+	// dormant (slices has at most one entry, isCrossBundle === false) and
+	// the overlay falls through to the legacy single-Bundle commit path.
+	// When the bulk spans 2+ Bundles, the gizmo anchors at the cross-
+	// Bundle Pivot, the commit goes through `controller.commitDelta` (one
+	// multi-Bundle HistoryCommit), and the marquee dispatch walks every
+	// loaded + visible AI sections instance instead of just this overlay's.
+	const crossBundle = useCrossBundleBulkController();
 	// Resolve "this overlay's bulk" via the workspace bulk's per-instance
 	// lookup. When `bundleId`/`index` are missing (legacy single-resource
 	// page route) we synthesise an empty handle so the rest of the overlay
@@ -318,7 +329,16 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 		return seen.size;
 	}, [bulkRefs]);
 
-	const isBulkActive = bulkEntityCount >= 2;
+	const isBulkActive = bulkEntityCount >= 2 || crossBundle.isCrossBundle;
+	// True when the bulk extends BEYOND this overlay's own (bundleId,
+	// index) — at least one other Bundle has its own non-empty bulk
+	// participating in the same gesture. The gizmo's pivot / refs / commit
+	// path branches on this: cross-Bundle gestures route through
+	// `setResourcesMulti` (one multi-Bundle HistoryCommit per gesture),
+	// single-Bundle ones stay on the legacy `onChange` → `setResourceAt`
+	// path (one single-Bundle HistoryCommit). Both produce exactly ONE
+	// Workspace-undo entry per gesture (CONTEXT.md / "Bulk transform").
+	const useCrossBundlePath = crossBundle.isCrossBundle;
 
 	// Per-section ground Y (issue #27). Derived once per data change from
 	// portal Ys plus a BFS through the section graph for portal-less sections.
@@ -339,9 +359,15 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 	const bulkPivotRef = useRef<{ x: number; y: number; z: number } | null>(null);
 	const bulkPivotMedian = useMemo<{ x: number; y: number; z: number } | null>(() => {
 		if (!isBulkActive) return null;
+		// Cross-Bundle bulks anchor at the median across every slice's
+		// spatial samples — the cross-Bundle Pivot the controller exposes
+		// (issue #80 / CONTEXT.md / "Pivot"). The single-Bundle pivot
+		// stays scoped to this overlay's own data so legacy single-Bundle
+		// gestures don't pick up phantom samples from cross-Bundle code.
+		if (useCrossBundlePath) return crossBundle.pivot;
 		const yResolver = (idx: number) => (idx < sectionYs.length ? sectionYs[idx] : 0);
 		return bulkSelectionPivot(data, bulkRefs, yResolver);
-	}, [isBulkActive, bulkRefs, data, sectionYs]);
+	}, [isBulkActive, useCrossBundlePath, crossBundle.pivot, bulkRefs, data, sectionYs]);
 
 	// **Pivot drag-reposition** (issue #76 / CONTEXT.md / "Pivot"). The user
 	// can grab the dedicated pivot handle on the gizmo and drop it anywhere
@@ -790,8 +816,38 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 		setDrag(null);
 		const snapshotPivot = bulkPivotRef.current;
 		bulkPivotRef.current = null;
-		if (!gizmoTarget || !onChange) return;
+		if (!gizmoTarget) return;
 		if (isIdentityDelta(delta)) return;
+		// Cross-Bundle bulk gesture (issue #80): route through the
+		// workspace-level controller so every affected Bundle is
+		// independently dirtied and one multi-Bundle HistoryCommit covers
+		// the whole gesture. The active overlay's own bundle is included
+		// as one slice among many — its single-Bundle `onChange` path is
+		// intentionally skipped here to avoid double-writing this slice
+		// (once via the per-Bundle dispatch, again via `onChange` →
+		// `setResourceAt`).
+		if (
+			gizmoTarget.kind === 'bulk' &&
+			useCrossBundlePath &&
+			snapshotPivot
+		) {
+			const written = crossBundle.commitDelta(
+				{ x: snapshotPivot.x, z: snapshotPivot.z },
+				{
+					translate: delta.translate,
+					rotateY: delta.rotate.y,
+				},
+			);
+			// `written === 0` means every slice resolved to a no-op (the
+			// model-reference identity guard in `buildCrossBundleWrites`).
+			// No history entry to push; the gesture is a true no-op.
+			void written;
+			return;
+		}
+		// Single-Bundle path — unchanged from the pre-issue-#80 shape
+		// (one setResourceAt → one HistoryCommit, regression-guarded by
+		// the existing #74 tests).
+		if (!onChange) return;
 		// For bulk commits, use the snapshotted pivot from the gesture's
 		// first frame — NOT a freshly-computed median (which would have
 		// moved with the preview).
@@ -814,7 +870,7 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 		// ops mutate more sections per gesture, they still produce ONE
 		// resulting model committed via ONE onChange call.
 		onChange(next);
-	}, [data, gizmoTarget, onChange]);
+	}, [data, gizmoTarget, onChange, useCrossBundlePath, crossBundle]);
 
 	const handleGizmoCancel = useCallback(() => {
 		setDrag(null);
@@ -892,32 +948,24 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 		setEdgeMenu(null);
 	}, [data, edgeMenu, onChange, onSelect]);
 
-	// Marquee wiring: pick AI sections whose corner-centroid is inside the
-	// dragged rectangle and union/subtract their schema paths into the
-	// workspace bulk. Sections store XY corners on the Y=0 ground plane
-	// (height is implicit), so the centroid we project is (avgX, 0, avgY).
-	// Routes through `sectionBulk.onApplyPaths` — the workspace-side bulk —
-	// so the right-sidebar BulkPanelStack, the tree's amber rows, and the
-	// persistent yellow-outline-with-portals overlay rendering all light up
-	// in one dispatch.
+	// Marquee wiring (issue #80 cross-Bundle): the marquee delegates to
+	// the workspace-level dispatcher so a rectangle spanning N Bundles
+	// hits every loaded + visible AI sections instance, not just this
+	// overlay's. Each Bundle's bulk is dispatched independently via
+	// `onBulkApplyPaths(bundleId, index, hits, mode)` — invisible
+	// Bundles / resource-types / instances are filtered out by the
+	// controller's per-instance visibility check, so a hidden Bundle's
+	// sections are never picked up even if they sit inside the marquee
+	// rectangle (acceptance criterion: "Invisible Bundles are not part
+	// of the Selection"). Routes through the same WORKSPACE
+	// `onBulkApplyPaths` the single-Bundle path used so the right-sidebar
+	// BulkPanelStack, the tree's amber rows, and the persistent yellow
+	// outline overlay rendering all light up in one dispatch per Bundle.
 	const handleMarquee = useCallback(
 		(frustum: THREE.Frustum, mode: 'add' | 'remove') => {
-			if (!sectionBulk) return;
-			const hits: NodePath[] = [];
-			const pt = new THREE.Vector3();
-			for (let i = 0; i < data.sections.length; i++) {
-				const corners = data.sections[i].corners;
-				if (corners.length === 0) continue;
-				let sx = 0, sy = 0;
-				for (const c of corners) { sx += c.x; sy += c.y; }
-				const n = corners.length;
-				pt.set(sx / n, 0, sy / n);
-				if (frustum.containsPoint(pt)) hits.push(['sections', i]);
-			}
-			if (hits.length === 0) return;
-			sectionBulk.onApplyPaths(hits, mode);
+			crossBundle.marqueeDispatch(frustum, mode);
 		},
-		[data, sectionBulk],
+		[crossBundle],
 	);
 
 	return (
@@ -1051,7 +1099,14 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 				/>
 			)}
 
-			{gizmoPosition && (
+			{/* Gizmo gates on `isActive` so cross-Bundle gestures show
+			    exactly one gizmo on screen (per ADR-0010): the overlay
+			    matching the current selection renders it, every other
+			    overlay's gizmoPosition is suppressed. When no selection
+			    is in any AI Sections instance, no gizmo renders — the
+			    user clicks any section first to anchor the affordance,
+			    even for a cross-Bundle marquee. */}
+			{isActive && gizmoPosition && (
 				<BulkTransformGizmo
 					position={gizmoPosition}
 					pixelSize={gizmoPixelSize}

--- a/src/components/workspace/crossBundleBulk.ts
+++ b/src/components/workspace/crossBundleBulk.ts
@@ -1,0 +1,289 @@
+// Pure helpers for the cross-Bundle bulk transform path (issue #80).
+//
+// A bulk Selection that spans multiple Bundles (e.g. a marquee dragged
+// across two adjacent track-unit Bundles) produces one rigid gizmo gesture
+// that translates / rotates every selected entity around a single shared
+// pivot, applied per-Bundle. Each affected Bundle dirties independently
+// (CONTEXT.md / "Workspace", "Bundle addressing") and the entire gesture
+// commits as ONE Workspace-undo entry — a `{ kind: 'multi', entries }`
+// HistoryCommit (ADR-0006 + the multi-Bundle extension in
+// `WorkspaceContext.types.ts`).
+//
+// Design decision (a) vs (b) from the issue brief: we picked **(b) —
+// group refs by Bundle in the dispatch layer**. The AISectionEntityRef
+// shape stays single-Bundle (no `bundleId` field on every variant), the
+// existing single-Bundle ops (`bulkTranslateEntities`,
+// `bulkRotateEntitiesYaw`, `bulkSelectionPivot`) keep working unchanged,
+// and the cross-Bundle plumbing collects N per-Bundle ref lists, calls
+// the existing op once per Bundle, then dispatches every result as ONE
+// `setResourcesMulti` to the workspace. That call pushes one multi-Bundle
+// HistoryCommit so undo reverts the whole gesture atomically.
+//
+// What this module owns:
+//   - Walking the workspace bulks + filtering by visibility to produce
+//     a per-Bundle `(bundleId, index, refs)` triple list.
+//   - Computing the cross-Bundle pivot — the per-axis median of every
+//     spatial point every ref addresses, across every affected Bundle.
+//   - Building the `setResourcesMulti` write list from a delta: one
+//     write per (bundleId, index) with the new model produced by running
+//     the existing bulk ops against that Bundle's per-Bundle refs.
+
+import {
+	bulkRotateEntitiesYaw,
+	bulkSelectionPivot,
+	bulkTranslateEntities,
+	type AISectionEntityRef,
+} from '@/lib/core/aiSectionsOps';
+import type { ParsedAISectionsV12 } from '@/lib/core/aiSections';
+import { resolveSectionYs } from '@/lib/core/aiSectionY';
+import type { BundleId, VisibilityNode } from '@/context/WorkspaceContext.types';
+import { parseSectionPathKey } from './aiSectionsBulk';
+
+// ---------------------------------------------------------------------------
+// Per-Bundle bulk slice
+// ---------------------------------------------------------------------------
+
+/**
+ * One Bundle's slice of a cross-Bundle bulk Selection — the (bundleId,
+ * index) addressing plus the flat per-Bundle `AISectionEntityRef[]` the
+ * existing single-Bundle bulk ops consume. The cross-Bundle dispatch
+ * iterates these and runs the same op per slice.
+ */
+export type CrossBundleBulkSlice = {
+	bundleId: BundleId;
+	index: number;
+	model: ParsedAISectionsV12;
+	refs: readonly AISectionEntityRef[];
+};
+
+// ---------------------------------------------------------------------------
+// Build slices from the workspace bulk summaries
+// ---------------------------------------------------------------------------
+
+/** Input shape from `WorkspaceAISectionsBulkValue.summaries` — we only
+ *  need the (bundleId, index, pathKeys) triple here. */
+export type WorkspaceBulkSummaryInput = {
+	bundleId: BundleId;
+	index: number;
+	pathKeys: ReadonlySet<string>;
+};
+
+/** Input shape for resolving a parsed AI Sections model by (bundleId,
+ *  index). The composition feeds this via `getResources('aiSections')`. */
+export type ResolveModel = (
+	bundleId: BundleId,
+	index: number,
+) => ParsedAISectionsV12 | null;
+
+/**
+ * Translate the workspace's per-(bundleId, index) bulk path-key Sets into
+ * the per-Bundle slice list the cross-Bundle dispatch operates on.
+ * Visibility-filtering is applied to the OUTER bundle key — an invisible
+ * (loaded-but-toggled-off) Bundle / resource / instance is dropped from
+ * the slice list so its sections never participate in the bulk, even if
+ * their path-keys still live in the workspace bulk store (the user can
+ * curate a bulk in one Bundle then toggle it off; the gizmo must ignore
+ * those entities). The acceptance criterion "invisible Bundles are not
+ * affected by the transform" hinges on this filter.
+ *
+ * Only V12 sections are emitted today; legacy V4/V6 bulks (variant
+ * `legacy`) are silently skipped because the legacy overlay is read-only
+ * and `bulkTranslateEntities` / `bulkRotateEntitiesYaw` only accept
+ * V12-shaped roots. Adding a legacy editable path is a separate issue.
+ */
+export function buildCrossBundleSlices(
+	summaries: readonly WorkspaceBulkSummaryInput[],
+	resolveModel: ResolveModel,
+	isVisible: (node: VisibilityNode) => boolean,
+): CrossBundleBulkSlice[] {
+	const out: CrossBundleBulkSlice[] = [];
+	for (const summary of summaries) {
+		if (summary.pathKeys.size === 0) continue;
+		// Visibility is checked at the instance scope — same convention
+		// `filterOverlaysByVisibility` uses in WorldViewportComposition.
+		// An invisible Bundle / resource type cascades hidden to its
+		// instances, so this single check is enough.
+		const visible = isVisible({
+			bundleId: summary.bundleId,
+			resourceKey: 'aiSections',
+			index: summary.index,
+		});
+		if (!visible) continue;
+		const model = resolveModel(summary.bundleId, summary.index);
+		if (!model) continue;
+		const refs: AISectionEntityRef[] = [];
+		for (const key of summary.pathKeys) {
+			const addr = parseSectionPathKey(key);
+			if (!addr) continue;
+			if (addr.variant !== 'v12') continue;
+			if (addr.sectionIndex < 0 || addr.sectionIndex >= model.sections.length) continue;
+			refs.push({ kind: 'section', sectionIdx: addr.sectionIndex });
+		}
+		if (refs.length === 0) continue;
+		out.push({
+			bundleId: summary.bundleId,
+			index: summary.index,
+			model,
+			refs,
+		});
+	}
+	return out;
+}
+
+// ---------------------------------------------------------------------------
+// Cross-Bundle pivot
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the cross-Bundle bulk Pivot — the per-axis median of every
+ * spatial point every selected entity addresses, across every slice.
+ *
+ * Implementation note: we re-derive the per-slice section Ys here because
+ * the existing `bulkSelectionPivot` takes a `sectionY` resolver scoped to
+ * a single model. For the cross-Bundle case we walk each slice with its
+ * own Y-resolver, concatenate the spatial samples, and take the per-axis
+ * median across the union. Same median (not centroid) convention as the
+ * single-Bundle pivot — CONTEXT.md / "Pivot".
+ *
+ * Returns `null` when there are no slices, or when every slice's refs
+ * point at out-of-range entities (defensive — shouldn't happen if
+ * buildCrossBundleSlices filtered range).
+ */
+export function crossBundleBulkPivot(
+	slices: readonly CrossBundleBulkSlice[],
+): { x: number; y: number; z: number } | null {
+	const xs: number[] = [];
+	const ys: number[] = [];
+	const zs: number[] = [];
+	for (const slice of slices) {
+		const sectionYs = resolveSectionYs(slice.model);
+		const yResolver = (idx: number) => (idx < sectionYs.length ? sectionYs[idx] : 0);
+		// `bulkSelectionPivot` returns the *median per axis* of the slice's
+		// samples — but we need the union median across all slices, so we
+		// re-walk the refs here (a partial duplicate of bulkSelectionPivot,
+		// kept here so the helper stays self-contained — extracting a
+		// "samples-only" helper from the aiSectionsOps module is a
+		// separate, lower-stakes refactor).
+		for (const ref of slice.refs) {
+			const sec = slice.model.sections[ref.sectionIdx];
+			if (!sec) continue;
+			const y = yResolver(ref.sectionIdx);
+			if (ref.kind === 'section') {
+				for (const c of sec.corners) {
+					xs.push(c.x); ys.push(y); zs.push(c.y);
+				}
+				for (const p of sec.portals) {
+					xs.push(p.position.x); ys.push(p.position.y); zs.push(p.position.z);
+				}
+				continue;
+			}
+			if (ref.kind === 'portal') {
+				const p = sec.portals[ref.portalIdx];
+				if (!p) continue;
+				xs.push(p.position.x); ys.push(p.position.y); zs.push(p.position.z);
+				continue;
+			}
+			if (ref.kind === 'boundaryLineEndpoint') {
+				const p = sec.portals[ref.portalIdx];
+				const bl = p?.boundaryLines[ref.lineIdx];
+				if (!bl) continue;
+				if (ref.end === 0) { xs.push(bl.verts.x); ys.push(y); zs.push(bl.verts.y); }
+				else { xs.push(bl.verts.z); ys.push(y); zs.push(bl.verts.w); }
+				continue;
+			}
+			if (ref.kind === 'noGoLineEndpoint') {
+				const bl = sec.noGoLines[ref.lineIdx];
+				if (!bl) continue;
+				if (ref.end === 0) { xs.push(bl.verts.x); ys.push(y); zs.push(bl.verts.y); }
+				else { xs.push(bl.verts.z); ys.push(y); zs.push(bl.verts.w); }
+				continue;
+			}
+		}
+	}
+	if (xs.length === 0) return null;
+	return { x: median(xs), y: median(ys), z: median(zs) };
+}
+
+function median(values: number[]): number {
+	const sorted = values.slice().sort((a, b) => a - b);
+	const n = sorted.length;
+	if (n === 0) return 0;
+	const mid = n >> 1;
+	return n % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+// ---------------------------------------------------------------------------
+// Per-Bundle dispatch
+// ---------------------------------------------------------------------------
+
+/**
+ * Cross-Bundle bulk-transform delta — the same shape `BulkTransformDelta`
+ * carries, but flattened to the fields the cross-Bundle dispatch actually
+ * uses (translate XYZ + yaw rotate around the shared pivot). Pulled into
+ * a local type so this module doesn't depend on the React-side delta type.
+ */
+export type CrossBundleDelta = {
+	translate: { x: number; y: number; z: number };
+	rotateY: number;
+};
+
+/**
+ * Apply a single delta to every Bundle slice, producing one
+ * `setResourcesMulti` write per affected Bundle/instance pair. The
+ * compose order mirrors the single-Bundle bulk path (translate, then yaw
+ * rotate around the post-translate pivot) so the cross-Bundle preview and
+ * commit agree frame-for-frame with what the user sees during the drag.
+ *
+ * Returns an empty array if every slice's op resolved to the identity
+ * (no-op gesture) — the caller short-circuits on empty to keep the
+ * history stack clean on a cancelled gesture.
+ */
+export function buildCrossBundleWrites(
+	slices: readonly CrossBundleBulkSlice[],
+	pivot: { x: number; z: number },
+	delta: CrossBundleDelta,
+): {
+	bundleId: BundleId;
+	resourceKey: string;
+	index: number;
+	value: unknown;
+}[] {
+	const writes: {
+		bundleId: BundleId;
+		resourceKey: string;
+		index: number;
+		value: unknown;
+	}[] = [];
+	for (const slice of slices) {
+		let next: ParsedAISectionsV12 = slice.model;
+		if (delta.translate.x !== 0 || delta.translate.y !== 0 || delta.translate.z !== 0) {
+			next = bulkTranslateEntities(next, slice.refs, delta.translate);
+		}
+		if (delta.rotateY !== 0) {
+			next = bulkRotateEntitiesYaw(
+				next,
+				slice.refs,
+				{
+					x: pivot.x + delta.translate.x,
+					z: pivot.z + delta.translate.z,
+				},
+				delta.rotateY,
+			);
+		}
+		// Skip slices whose op returned the same model reference — the
+		// op short-circuits to `===` on no-op deltas, so this filters out
+		// any slice that didn't actually change. Avoids dirtying a Bundle
+		// for a zero-op transform.
+		if (next === slice.model) continue;
+		writes.push({
+			bundleId: slice.bundleId,
+			resourceKey: 'aiSections',
+			index: slice.index,
+			value: next,
+		});
+	}
+	return writes;
+}
+
+// Re-export so tests can construct a slice via the same helper API.
+export { bulkSelectionPivot };

--- a/src/components/workspace/useCrossBundleBulkController.ts
+++ b/src/components/workspace/useCrossBundleBulkController.ts
@@ -1,0 +1,181 @@
+// useCrossBundleBulkController — workspace-level coordination for the
+// cross-Bundle bulk transform path (issue #80).
+//
+// The active AISections overlay owns the gizmo (per ADR-0010: exactly one
+// gizmo on screen). This hook reads the WORKSPACE-wide AI sections bulk
+// summaries (every (bundleId, index) with a non-empty bulk Set), filters
+// them by visibility, and exposes:
+//
+//   - `slices` — per-Bundle `(bundleId, index, model, refs)` triples for
+//     every loaded + visible AI sections instance whose bulk is non-empty.
+//     The overlay uses this list to:
+//       * compute the cross-Bundle Pivot (median of every spatial point
+//         across every slice — `crossBundleBulkPivot`)
+//       * iterate slices when committing a delta — one model write per
+//         slice, all funneled through `setResourcesMulti` as one
+//         multi-Bundle HistoryCommit (ADR-0006 + the multi-Bundle
+//         extension in WorkspaceContext.types.ts)
+//
+//   - `commitDelta(pivot, delta)` — convenience: builds the
+//     `setResourcesMulti` write list via `buildCrossBundleWrites` and
+//     dispatches in one call. The whole gesture becomes ONE Workspace-undo
+//     entry that reverts every affected Bundle atomically.
+//
+//   - `marqueeDispatch(hits)` — when the user drags a marquee that spans
+//     multiple Bundles, the overlay walks ITS OWN sections for hits but
+//     needs to dispatch hits in OTHER bundles too. This hook walks every
+//     loaded + visible AI sections instance, runs the same containsPoint
+//     test, and dispatches per-Bundle via `onBulkApplyPaths`. Single
+//     visibility check: invisible Bundles are excluded.
+//
+// Invisible Bundles are filtered at the outer (bundleId, index) scope —
+// any cascade up the visibility tree (Bundle off, resource off, instance
+// off) drops the slice from `slices` and the dispatch from
+// `marqueeDispatch`. This is what makes the issue's
+// "invisible-Bundle isolation" acceptance criterion hold.
+
+import { useCallback, useMemo } from 'react';
+import * as THREE from 'three';
+import { useWorkspace } from '@/context/WorkspaceContext';
+import {
+	useWorkspaceAISectionsBulk,
+} from './AISectionsBulkProvider';
+import {
+	buildCrossBundleSlices,
+	buildCrossBundleWrites,
+	crossBundleBulkPivot,
+	type CrossBundleBulkSlice,
+	type CrossBundleDelta,
+} from './crossBundleBulk';
+import type { ParsedAISectionsV12 } from '@/lib/core/aiSections';
+import type { NodePath } from '@/lib/schema/walk';
+
+export type CrossBundleBulkController = {
+	/** Per-Bundle slices for every loaded + visible AI sections instance
+	 *  with a non-empty bulk. Empty when no cross-Bundle bulk exists —
+	 *  caller falls back to the single-Bundle path. */
+	slices: readonly CrossBundleBulkSlice[];
+
+	/** True when the bulk spans 2+ distinct Bundles (cardinality measured
+	 *  at the Bundle level, not the entity level). Drives the overlay's
+	 *  decision of "should the gizmo treat this as cross-Bundle?" */
+	isCrossBundle: boolean;
+
+	/** Cross-Bundle Pivot (median of every spatial point across every
+	 *  slice). `null` when `slices` is empty. Computed lazily off the
+	 *  slice list — the overlay snapshots this at gesture start to avoid
+	 *  drift mid-rotate. */
+	pivot: { x: number; y: number; z: number } | null;
+
+	/** Apply a single delta to every slice and dispatch as ONE workspace
+	 *  multi-write — one HistoryCommit covers the whole gesture (issue
+	 *  #80). The `pivot` here is the XZ slice of the gesture-start
+	 *  snapshot (see CONTEXT.md / "Pivot": rotation is around the
+	 *  fixed-from-gesture-start pivot). Returns the number of Bundles
+	 *  that actually received a write — zero means the delta was no-op
+	 *  across the board, no history entry pushed. */
+	commitDelta: (
+		pivot: { x: number; z: number },
+		delta: CrossBundleDelta,
+	) => number;
+
+	/** Dispatch a marquee's frustum across every loaded + visible AI
+	 *  sections instance. Walks each Bundle's sections, runs the same
+	 *  XZ-centroid containsPoint test the single-Bundle marquee uses,
+	 *  and dispatches per-Bundle via `onBulkApplyPaths`. Mode follows
+	 *  the user's alt-on-pointerup decision (`'add' | 'remove'`). */
+	marqueeDispatch: (
+		frustum: THREE.Frustum,
+		mode: 'add' | 'remove',
+	) => void;
+};
+
+const AI_KEY = 'aiSections';
+
+export function useCrossBundleBulkController(): CrossBundleBulkController {
+	const { bundles, isVisible, setResourcesMulti } = useWorkspace();
+	const workspaceBulk = useWorkspaceAISectionsBulk();
+
+	// Resolve a parsed AI sections model by (bundleId, index). Pulled out
+	// into a closed-over helper so both the slice builder and the marquee
+	// dispatcher share one lookup path.
+	const resolveModel = useCallback(
+		(bundleId: string, index: number): ParsedAISectionsV12 | null => {
+			const b = bundles.find((x) => x.id === bundleId);
+			if (!b) return null;
+			const list = b.parsedResourcesAll.get(AI_KEY);
+			const model = list?.[index];
+			if (!model || typeof model !== 'object') return null;
+			// V12 is the only editable shape; legacy V4/V6 has a `legacy`
+			// wrapper and isn't yet wired through the bulk ops (the legacy
+			// overlay is read-only).
+			if ('legacy' in (model as object)) return null;
+			return model as ParsedAISectionsV12;
+		},
+		[bundles],
+	);
+
+	const slices = useMemo<readonly CrossBundleBulkSlice[]>(() => {
+		const summaries = workspaceBulk?.summaries ?? [];
+		return buildCrossBundleSlices(summaries, resolveModel, isVisible);
+	}, [workspaceBulk?.summaries, resolveModel, isVisible]);
+
+	const isCrossBundle = useMemo(() => {
+		const distinctBundles = new Set<string>();
+		for (const slice of slices) distinctBundles.add(slice.bundleId);
+		return distinctBundles.size >= 2;
+	}, [slices]);
+
+	const pivot = useMemo(() => crossBundleBulkPivot(slices), [slices]);
+
+	const commitDelta = useCallback(
+		(
+			snapshotPivot: { x: number; z: number },
+			delta: CrossBundleDelta,
+		): number => {
+			const writes = buildCrossBundleWrites(slices, snapshotPivot, delta);
+			if (writes.length === 0) return 0;
+			setResourcesMulti(writes);
+			return writes.length;
+		},
+		[slices, setResourcesMulti],
+	);
+
+	const marqueeDispatch = useCallback(
+		(frustum: THREE.Frustum, mode: 'add' | 'remove') => {
+			if (!workspaceBulk) return;
+			// Iterate every loaded Bundle's aiSections instances. The
+			// visibility check drops invisible (bundle / resource-type /
+			// instance) entries — same gate the slice builder uses, so
+			// "marquee can't pick up hidden Bundle's sections" is one-and-
+			// the-same with "hidden Bundle is not in the bulk".
+			for (const bundle of bundles) {
+				const list = bundle.parsedResourcesAll.get(AI_KEY);
+				if (!list || list.length === 0) continue;
+				for (let index = 0; index < list.length; index++) {
+					const model = list[index];
+					if (!model || typeof model !== 'object') continue;
+					if ('legacy' in (model as object)) continue;
+					if (!isVisible({ bundleId: bundle.id, resourceKey: AI_KEY, index })) continue;
+					const v12 = model as ParsedAISectionsV12;
+					const hits: NodePath[] = [];
+					const pt = new THREE.Vector3();
+					for (let i = 0; i < v12.sections.length; i++) {
+						const corners = v12.sections[i].corners;
+						if (corners.length === 0) continue;
+						let sx = 0, sy = 0;
+						for (const c of corners) { sx += c.x; sy += c.y; }
+						const n = corners.length;
+						pt.set(sx / n, 0, sy / n);
+						if (frustum.containsPoint(pt)) hits.push(['sections', i]);
+					}
+					if (hits.length === 0) continue;
+					workspaceBulk.onBulkApplyPaths(bundle.id, index, hits, mode);
+				}
+			}
+		},
+		[bundles, isVisible, workspaceBulk],
+	);
+
+	return { slices, isCrossBundle, pivot, commitDelta, marqueeDispatch };
+}

--- a/src/context/WorkspaceContext.helpers.ts
+++ b/src/context/WorkspaceContext.helpers.ts
@@ -325,6 +325,13 @@ export function removeBundleById(
  * Used by both close (after user confirms) and replace (the new bytes shadow
  * the old ones at the same id, so prior commits no longer apply cleanly).
  *
+ * For multi-Bundle commits (issue #80): drop the whole commit if any entry
+ * referenced the closed Bundle. The conservative choice — surgically
+ * removing only that Bundle's entries would leave a half-applied cross-
+ * Bundle undo step that no longer round-trips. Resurrecting a closed
+ * Bundle silently via a partial undo is far worse than losing the commit;
+ * the user can re-load the Bundle if they need the undo path back.
+ *
  * Stack identity is preserved when no entries match, so a no-op prune
  * doesn't churn React state.
  */
@@ -332,8 +339,14 @@ export function dropHistoryForBundle(
 	history: HistoryStack<HistoryCommit>,
 	bundleId: BundleId,
 ): HistoryStack<HistoryCommit> {
-	const past = history.past.filter((c) => c.bundleId !== bundleId);
-	const future = history.future.filter((c) => c.bundleId !== bundleId);
+	const commitReferencesBundle = (c: HistoryCommit): boolean => {
+		if (c.kind === 'multi' && c.entries) {
+			return c.entries.some((e) => e.bundleId === bundleId);
+		}
+		return c.bundleId === bundleId;
+	};
+	const past = history.past.filter((c) => !commitReferencesBundle(c));
+	const future = history.future.filter((c) => !commitReferencesBundle(c));
 	if (past.length === history.past.length && future.length === history.future.length) {
 		return history;
 	}

--- a/src/context/WorkspaceContext.tsx
+++ b/src/context/WorkspaceContext.tsx
@@ -54,6 +54,7 @@ import type {
 	BundleId,
 	EditableBundle,
 	HistoryCommit,
+	HistoryCommitEntry,
 	VisibilityNode,
 	WorkspaceContextValue,
 	WorkspaceProviderProps,
@@ -252,6 +253,101 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
 		[setResourceAt],
 	);
 
+	// Multi-Bundle write — one HistoryCommit of kind 'multi' covers N
+	// per-(bundleId, resourceKey, index) writes. Each affected Bundle is
+	// dirtied independently (separate dirtyMulti entries + isModified flag),
+	// but the workspace-wide history stack grows by exactly one entry. Drives
+	// the cross-Bundle bulk transform (issue #80 / CONTEXT.md "Bulk transform"
+	// cross-Bundle paragraph): a marquee that spans two Bundles + drag of the
+	// gizmo produces one atomic undo step. Writes to unloaded Bundle ids are
+	// dropped — keeps the caller from having to filter against the live
+	// bundles list across an async boundary.
+	const setResourcesMulti = useCallback(
+		(
+			writes: readonly {
+				bundleId: BundleId;
+				resourceKey: string;
+				index: number;
+				value: unknown;
+			}[],
+		) => {
+			if (writes.length === 0) return;
+			// Snapshot prior values via the live bundles list so we can build
+			// the HistoryCommitEntry shape with the correct `previous`. Writes
+			// targeting unloaded Bundles are filtered here so the resulting
+			// history entry never references a stale Bundle id.
+			const liveBundles = bundlesRef.current;
+			const entries: HistoryCommitEntry[] = [];
+			for (const w of writes) {
+				const b = liveBundles.find((x) => x.id === w.bundleId);
+				if (!b) continue;
+				const previous = b.parsedResourcesAll.get(w.resourceKey)?.[w.index] ?? null;
+				entries.push({
+					bundleId: w.bundleId,
+					resourceKey: w.resourceKey,
+					index: w.index,
+					previous,
+					next: w.value,
+				});
+			}
+			if (entries.length === 0) return;
+			// Two writes targeting the same `(bundleId, resourceKey, index)` in
+			// one dispatch is malformed — the second would clobber the first's
+			// `next` snapshot reading. We accept callers will rarely hit this
+			// (group-by-bundle in the dispatch layer already collapses per-
+			// bundle refs into a single value) so we don't defend against it
+			// here; the test suite asserts the documented single-write-per-triple
+			// invariant.
+			//
+			// Multi commit shape uses the same flat field layout as a
+			// single-Bundle commit (preserves backwards compatibility on the
+			// top-level fields) with `kind: 'multi'` + `entries` as the
+			// discriminator. The flat top-level fields are placeholder zeros
+			// — readers branch on `kind === 'multi'` before touching them.
+			const first = entries[0];
+			const multiCommit: HistoryCommit = {
+				bundleId: first.bundleId,
+				resourceKey: first.resourceKey,
+				index: first.index,
+				previous: null,
+				next: null,
+				kind: 'multi',
+				entries,
+			};
+			setHistory((prev) => recordCommit<HistoryCommit>(prev, multiCommit));
+			// Group entries by bundleId so each affected Bundle's record is
+			// rebuilt once (cumulative writes across keys/indexes inside one
+			// Bundle apply as one chained reduce — avoids stacking three Bundle
+			// records when three writes hit the same Bundle).
+			const byBundle = new Map<BundleId, HistoryCommitEntry[]>();
+			for (const e of entries) {
+				const list = byBundle.get(e.bundleId) ?? [];
+				list.push(e);
+				byBundle.set(e.bundleId, list);
+			}
+			// Apply every write in a single setBundles pass so React batches
+			// the resulting render — avoids a flash where some Bundles have
+			// updated and others haven't between consecutive setState calls.
+			setBundles((prev) =>
+				prev.map((b) => {
+					const writesForBundle = byBundle.get(b.id);
+					if (!writesForBundle) return b;
+					let nextBundle = b;
+					for (const e of writesForBundle) {
+						nextBundle = applyResourceWriteToBundle(
+							nextBundle,
+							e.resourceKey,
+							e.index,
+							e.next,
+						);
+					}
+					return nextBundle;
+				}),
+			);
+		},
+		[],
+	);
+
 	// Selection --------------------------------------------------------------
 
 	const select = useCallback((next: WorkspaceSelection) => {
@@ -285,11 +381,67 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
 	}, []);
 
 	// Undo / redo ------------------------------------------------------------
+	//
+	// Both directions handle two HistoryCommit shapes:
+	//   - Single-Bundle (legacy): { bundleId, resourceKey, index, previous,
+	//     next } — kind omitted. The original pre-issue-#80 shape.
+	//   - Multi-Bundle (issue #80): { kind: 'multi', entries: [...] } — N
+	//     per-Bundle snapshots reverted/replayed atomically.
+	//
+	// In both cases we always read the *live* current value from the bundles
+	// map (not from the stack) when building the future/past head — matches
+	// the original single-Bundle approach and keeps non-tracked replaces
+	// (load, save) from desyncing.
 
 	const undo = useCallback(() => {
 		setHistory((prev) => {
 			const top = prev.past[prev.past.length - 1];
 			if (!top) return prev;
+			if (top.kind === 'multi' && top.entries) {
+				// Build `actualCurrent` by reading every live entry's current
+				// value, then revert every entry to its `previous` snapshot in
+				// one setBundles pass — atomic across N Bundles.
+				const topEntries = top.entries;
+				const liveEntries: HistoryCommitEntry[] = topEntries.map((e) => {
+					const live = bundles.find((b) => b.id === e.bundleId);
+					return {
+						bundleId: e.bundleId,
+						resourceKey: e.resourceKey,
+						index: e.index,
+						previous: e.previous,
+						next: live?.parsedResourcesAll.get(e.resourceKey)?.[e.index] ?? null,
+					};
+				});
+				const actualCurrent: HistoryCommit = {
+					bundleId: top.bundleId,
+					resourceKey: top.resourceKey,
+					index: top.index,
+					previous: null,
+					next: null,
+					kind: 'multi',
+					entries: liveEntries,
+				};
+				const out = recordUndo<HistoryCommit>(prev, actualCurrent);
+				if (!out) return prev;
+				const byBundle = new Map<BundleId, HistoryCommitEntry[]>();
+				for (const e of topEntries) {
+					const list = byBundle.get(e.bundleId) ?? [];
+					list.push(e);
+					byBundle.set(e.bundleId, list);
+				}
+				setBundles((prevBundles) =>
+					prevBundles.map((b) => {
+						const writes = byBundle.get(b.id);
+						if (!writes) return b;
+						let nb = b;
+						for (const e of writes) {
+							nb = applyResourceWriteToBundle(nb, e.resourceKey, e.index, e.previous);
+						}
+						return nb;
+					}),
+				);
+				return out.stack;
+			}
 			// Read the current value from the live bundles array — same
 			// reasoning as in BundleContext: the source of truth is the model
 			// store, not the history stack, so non-tracked replaces (load,
@@ -313,6 +465,48 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
 		setHistory((prev) => {
 			const head = prev.future[0];
 			if (!head) return prev;
+			if (head.kind === 'multi' && head.entries) {
+				const headEntries = head.entries;
+				const liveEntries: HistoryCommitEntry[] = headEntries.map((e) => {
+					const live = bundles.find((b) => b.id === e.bundleId);
+					return {
+						bundleId: e.bundleId,
+						resourceKey: e.resourceKey,
+						index: e.index,
+						previous: live?.parsedResourcesAll.get(e.resourceKey)?.[e.index] ?? null,
+						next: e.next,
+					};
+				});
+				const actualCurrent: HistoryCommit = {
+					bundleId: head.bundleId,
+					resourceKey: head.resourceKey,
+					index: head.index,
+					previous: null,
+					next: null,
+					kind: 'multi',
+					entries: liveEntries,
+				};
+				const out = recordRedo<HistoryCommit>(prev, actualCurrent);
+				if (!out) return prev;
+				const byBundle = new Map<BundleId, HistoryCommitEntry[]>();
+				for (const e of headEntries) {
+					const list = byBundle.get(e.bundleId) ?? [];
+					list.push(e);
+					byBundle.set(e.bundleId, list);
+				}
+				setBundles((prevBundles) =>
+					prevBundles.map((b) => {
+						const writes = byBundle.get(b.id);
+						if (!writes) return b;
+						let nb = b;
+						for (const e of writes) {
+							nb = applyResourceWriteToBundle(nb, e.resourceKey, e.index, e.next);
+						}
+						return nb;
+					}),
+				);
+				return out.stack;
+			}
 			const live = bundles.find((b) => b.id === head.bundleId);
 			const actualCurrent: HistoryCommit = {
 				bundleId: head.bundleId,
@@ -574,6 +768,7 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
 			getResources,
 			setResource,
 			setResourceAt,
+			setResourcesMulti,
 			selection,
 			select,
 			isVisible,
@@ -602,6 +797,7 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
 			getResources,
 			setResource,
 			setResourceAt,
+			setResourcesMulti,
 			selection,
 			select,
 			isVisible,

--- a/src/context/WorkspaceContext.types.ts
+++ b/src/context/WorkspaceContext.types.ts
@@ -199,19 +199,55 @@ export type VisibilityNode =
 // ---------------------------------------------------------------------------
 
 /**
- * One entry in the Workspace's global history stack. Records the (Bundle,
+ * One leaf in the Workspace's global history stack. Records the (Bundle,
  * resource, instance) that was edited and the before/after snapshots needed
  * to step in either direction.
  *
- * The single global stack replaces the pre-Workspace per-`(handlerKey, index)`
- * stacks — see ADR-0006 for the rationale.
+ * Used directly as a `HistoryCommit` for single-Bundle edits, and as the
+ * payload shape inside a `HistoryCommit`'s `entries` list when the commit
+ * spans multiple Bundles — the two share the same per-(Bundle, resource,
+ * index) snapshot shape so undo/redo handling can iterate uniformly.
  */
-export type HistoryCommit = {
+export type HistoryCommitEntry = {
 	bundleId: BundleId;
 	resourceKey: string;
 	index: number;
 	previous: unknown | null;
 	next: unknown | null;
+};
+
+/**
+ * One entry in the Workspace's global history stack. The pre-issue-#80
+ * shape (a flat `HistoryCommitEntry` — bundleId / resourceKey / index /
+ * previous / next at the top level) is preserved verbatim and is what
+ * every single-Bundle edit pushes today. Issue #80 adds two OPTIONAL
+ * fields for cross-Bundle bulk gestures:
+ *
+ *   - `kind?: 'multi'` — discriminator. Absent or undefined means
+ *     "this is a single-Bundle commit, read the top-level
+ *     bundleId/resourceKey/index/previous/next as usual."
+ *   - `entries?: readonly HistoryCommitEntry[]` — present iff
+ *     `kind === 'multi'`. Each entry describes one (Bundle, resource,
+ *     instance) snapshot in the multi-Bundle commit; undo/redo replay
+ *     them all atomically.
+ *
+ * Keeping the original fields at the top level (instead of splitting into
+ * a discriminated union) means existing tests / helpers that read
+ * `commit.bundleId` keep compiling and behaving correctly for
+ * single-Bundle commits. Multi-Bundle commits leave those fields as
+ * placeholders — readers MUST branch on `kind === 'multi'` before
+ * interpreting the data.
+ *
+ * The single global stack replaces the pre-Workspace per-`(handlerKey,
+ * index)` stacks — see ADR-0006 for the rationale. The multi-Bundle
+ * extension is the only way the same physical "one gesture = one undo
+ * step" contract can cover a cross-Bundle bulk transform: a single
+ * setResourcesMulti call pushes one HistoryCommit whose entries span
+ * every affected Bundle.
+ */
+export type HistoryCommit = HistoryCommitEntry & {
+	kind?: 'multi';
+	entries?: readonly HistoryCommitEntry[];
 };
 
 // ---------------------------------------------------------------------------
@@ -286,6 +322,28 @@ export type WorkspaceContextValue = {
 		key: string,
 		index: number,
 		value: T,
+	) => void;
+
+	/**
+	 * Replace N `(bundleId, resourceKey, index, value)` writes as ONE
+	 * Workspace-undo entry. Every affected Bundle is independently dirtied
+	 * (each gets its own `dirtyMulti` entry + `isModified = true`), but the
+	 * global history stack grows by exactly one commit — a `{ kind: 'multi',
+	 * entries }` HistoryCommit whose entries are the per-Bundle before/after
+	 * snapshots. Undoing reverts every entry atomically (issue #80 / cross-
+	 * Bundle bulk transform). Writes targeting Bundle ids that aren't loaded
+	 * are silently skipped — the caller is responsible for filtering against
+	 * the current visibility before dispatching.
+	 *
+	 * If `writes` is empty, this is a no-op (no history entry pushed).
+	 */
+	setResourcesMulti: (
+		writes: readonly {
+			bundleId: BundleId;
+			resourceKey: string;
+			index: number;
+			value: unknown;
+		}[],
 	) => void;
 
 	// -------------------------------------------------------------------------

--- a/src/context/__tests__/WorkspaceContext.crossBundleBulk.test.ts
+++ b/src/context/__tests__/WorkspaceContext.crossBundleBulk.test.ts
@@ -1,0 +1,565 @@
+// Integration test: cross-Bundle bulk transform (issue #80).
+//
+// The contract a cross-Bundle bulk gesture must satisfy:
+//   1. One marquee that lassos sections across N Bundles produces N
+//      per-Bundle bulks (the workspace bulk store + the controller's
+//      per-Bundle slices).
+//   2. The gizmo anchors at the median pivot of EVERY selected entity
+//      across EVERY Bundle.
+//   3. Committing a delta (translate / rotate) applies it to every
+//      affected Bundle — each Bundle dirties independently for its own
+//      save, with no spill into Bundles whose sections weren't in the bulk.
+//   4. The whole gesture commits as exactly ONE Workspace-undo entry — a
+//      `{ kind: 'multi', entries }` HistoryCommit (ADR-0006 + the multi-
+//      Bundle extension in WorkspaceContext.types.ts). Undoing reverts
+//      every affected Bundle atomically.
+//   5. Invisible (loaded-but-toggled-off) Bundles are filtered out of
+//      the marquee dispatch AND the commit dispatch — a hidden Bundle's
+//      sections are never picked up by the cross-Bundle path, even if
+//      their centroids sit inside the marquee rectangle.
+//
+// Same vitest-node shape as `WorkspaceContext.bulkTransform.test.ts`: a
+// tiny state shim mirroring the live provider's wiring (bundles list +
+// global history stack + a `setResourcesMulti` that records one multi
+// commit + applies N per-Bundle writes). No DOM, no React mount.
+
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { makeEditableBundle } from '../WorkspaceContext.bundle';
+import {
+	applyResourceWriteToBundle,
+	isVisibleIn,
+	visibilityKey,
+} from '../WorkspaceContext.helpers';
+import {
+	emptyHistory,
+	recordCommit,
+	recordUndo,
+	type HistoryStack,
+} from '@/lib/history';
+import {
+	buildCrossBundleSlices,
+	buildCrossBundleWrites,
+	crossBundleBulkPivot,
+} from '@/components/workspace/crossBundleBulk';
+import type {
+	EditableBundle,
+	HistoryCommit,
+	HistoryCommitEntry,
+	VisibilityNode,
+} from '../WorkspaceContext.types';
+import type { ParsedAISectionsV12 } from '@/lib/core/aiSections';
+
+const FIXTURE = path.resolve(__dirname, '../../../example/AI.DAT');
+
+function loadFixture(): ArrayBuffer {
+	const raw = fs.readFileSync(FIXTURE);
+	const bytes = new Uint8Array(raw.byteLength);
+	bytes.set(raw);
+	return bytes.buffer;
+}
+
+// Tiny state shim mirroring the live provider's shape — bundles list,
+// global history stack, visibility map.
+type State = {
+	bundles: EditableBundle[];
+	history: HistoryStack<HistoryCommit>;
+	visibility: Map<string, boolean>;
+};
+
+function getAI(state: State, bundleId: string): ParsedAISectionsV12 {
+	const b = state.bundles.find((x) => x.id === bundleId);
+	if (!b) throw new Error(`bundle not found: ${bundleId}`);
+	const ai = b.parsedResources.get('aiSections') as ParsedAISectionsV12 | undefined;
+	if (!ai) throw new Error('aiSections not loaded');
+	return ai;
+}
+
+// `setResourcesMulti` mirrors the provider's multi-Bundle write — applies
+// N per-(bundleId, resourceKey, index) writes AND pushes ONE multi
+// HistoryCommit. The flat top-level fields use the first entry's
+// addressing as a placeholder (matches the live provider's commit shape;
+// readers branch on `kind === 'multi'` before touching them).
+function setResourcesMulti(
+	state: State,
+	writes: readonly { bundleId: string; resourceKey: string; index: number; value: unknown }[],
+): State {
+	if (writes.length === 0) return state;
+	const entries: HistoryCommitEntry[] = [];
+	for (const w of writes) {
+		const b = state.bundles.find((x) => x.id === w.bundleId);
+		if (!b) continue;
+		const previous = b.parsedResourcesAll.get(w.resourceKey)?.[w.index] ?? null;
+		entries.push({
+			bundleId: w.bundleId,
+			resourceKey: w.resourceKey,
+			index: w.index,
+			previous,
+			next: w.value,
+		});
+	}
+	if (entries.length === 0) return state;
+	const first = entries[0];
+	const commit: HistoryCommit = {
+		bundleId: first.bundleId,
+		resourceKey: first.resourceKey,
+		index: first.index,
+		previous: null,
+		next: null,
+		kind: 'multi',
+		entries,
+	};
+	const nextHistory = recordCommit<HistoryCommit>(state.history, commit);
+	const byBundle = new Map<string, HistoryCommitEntry[]>();
+	for (const e of entries) {
+		const list = byBundle.get(e.bundleId) ?? [];
+		list.push(e);
+		byBundle.set(e.bundleId, list);
+	}
+	const nextBundles = state.bundles.map((b) => {
+		const ws = byBundle.get(b.id);
+		if (!ws) return b;
+		let nb = b;
+		for (const e of ws) {
+			nb = applyResourceWriteToBundle(nb, e.resourceKey, e.index, e.next);
+		}
+		return nb;
+	});
+	return { ...state, bundles: nextBundles, history: nextHistory };
+}
+
+function undo(state: State): State {
+	const top = state.history.past[state.history.past.length - 1];
+	if (!top) return state;
+	if (top.kind === 'multi' && top.entries) {
+		const liveEntries: HistoryCommitEntry[] = top.entries.map((e) => {
+			const live = state.bundles.find((b) => b.id === e.bundleId);
+			return {
+				bundleId: e.bundleId,
+				resourceKey: e.resourceKey,
+				index: e.index,
+				previous: e.previous,
+				next: live?.parsedResourcesAll.get(e.resourceKey)?.[e.index] ?? null,
+			};
+		});
+		const actualCurrent: HistoryCommit = {
+			bundleId: top.bundleId,
+			resourceKey: top.resourceKey,
+			index: top.index,
+			previous: null,
+			next: null,
+			kind: 'multi',
+			entries: liveEntries,
+		};
+		const out = recordUndo(state.history, actualCurrent);
+		if (!out) return state;
+		const byBundle = new Map<string, HistoryCommitEntry[]>();
+		for (const e of top.entries) {
+			const list = byBundle.get(e.bundleId) ?? [];
+			list.push(e);
+			byBundle.set(e.bundleId, list);
+		}
+		const nextBundles = state.bundles.map((b) => {
+			const ws = byBundle.get(b.id);
+			if (!ws) return b;
+			let nb = b;
+			for (const e of ws) {
+				nb = applyResourceWriteToBundle(nb, e.resourceKey, e.index, e.previous);
+			}
+			return nb;
+		});
+		return { ...state, bundles: nextBundles, history: out.stack };
+	}
+	const live = state.bundles.find((b) => b.id === top.bundleId);
+	const actualCurrent: HistoryCommit = {
+		bundleId: top.bundleId,
+		resourceKey: top.resourceKey,
+		index: top.index,
+		previous: top.previous,
+		next: live?.parsedResourcesAll.get(top.resourceKey)?.[top.index] ?? null,
+	};
+	const out = recordUndo(state.history, actualCurrent);
+	if (!out) return state;
+	const nextBundles = state.bundles.map((b) =>
+		b.id === top.bundleId
+			? applyResourceWriteToBundle(b, top.resourceKey, top.index, top.previous)
+			: b,
+	);
+	return { ...state, bundles: nextBundles, history: out.stack };
+}
+
+function isVisibleHelper(state: State, node: VisibilityNode): boolean {
+	return isVisibleIn(state.visibility, node);
+}
+
+function makeMultiBundleState(): State {
+	// Two Bundles loaded from the same fixture under different ids —
+	// suffices for the cross-Bundle bulk path's invariants since the data
+	// shape is identical and the per-Bundle dispatch only keys on
+	// (bundleId, resourceKey, index). In production each Bundle would
+	// have distinct sections; here we just need two physical Bundles
+	// with addressable AI sections instances.
+	const bundleA = makeEditableBundle(loadFixture(), 'A.DAT');
+	const bundleB = makeEditableBundle(loadFixture(), 'B.DAT');
+	return {
+		bundles: [bundleA, bundleB],
+		history: emptyHistory<HistoryCommit>(),
+		visibility: new Map(),
+	};
+}
+
+// Resolver helper used by `buildCrossBundleSlices` — pulls the parsed
+// AI Sections model out of the given Bundle's resource map. Returns null
+// for non-V12 / missing instances exactly as the live resolver does.
+function resolveModel(state: State, bundleId: string, index: number): ParsedAISectionsV12 | null {
+	const b = state.bundles.find((x) => x.id === bundleId);
+	if (!b) return null;
+	const list = b.parsedResourcesAll.get('aiSections');
+	const model = list?.[index];
+	if (!model || typeof model !== 'object') return null;
+	if ('legacy' in (model as object)) return null;
+	return model as ParsedAISectionsV12;
+}
+
+// =============================================================================
+// Helpers (path) → workspace bulk summaries
+// =============================================================================
+
+function summariesFor(
+	bulksByBundle: Record<string, readonly number[]>,
+): { bundleId: string; index: number; pathKeys: ReadonlySet<string> }[] {
+	const out: { bundleId: string; index: number; pathKeys: ReadonlySet<string> }[] = [];
+	for (const bundleId of Object.keys(bulksByBundle)) {
+		const sectionIdxs = bulksByBundle[bundleId];
+		const pathKeys = new Set<string>();
+		for (const sIdx of sectionIdxs) pathKeys.add(`sections/${sIdx}`);
+		out.push({ bundleId, index: 0, pathKeys });
+	}
+	return out;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Cross-Bundle bulk transform (issue #80)', () => {
+	it('builds per-Bundle slices for two Bundles with non-empty bulks', () => {
+		// Acceptance: the cross-Bundle dispatch sees one slice per Bundle
+		// (B-id + index + the (`AISectionEntityRef[]`, model) pair the
+		// existing single-Bundle bulk ops consume).
+		const state = makeMultiBundleState();
+		const summaries = summariesFor({
+			'A.DAT': [0, 1, 2],
+			'B.DAT': [5, 6],
+		});
+		const slices = buildCrossBundleSlices(
+			summaries,
+			(bId, i) => resolveModel(state, bId, i),
+			(node) => isVisibleHelper(state, node),
+		);
+		expect(slices.length).toBe(2);
+		const sliceA = slices.find((s) => s.bundleId === 'A.DAT')!;
+		const sliceB = slices.find((s) => s.bundleId === 'B.DAT')!;
+		expect(sliceA.refs.map((r) => r.kind === 'section' ? r.sectionIdx : -1)).toEqual([0, 1, 2]);
+		expect(sliceB.refs.map((r) => r.kind === 'section' ? r.sectionIdx : -1)).toEqual([5, 6]);
+	});
+
+	it('cross-Bundle Pivot is the median of every selected entity across every Bundle', () => {
+		// The Pivot is what the gizmo anchors at — must be in display
+		// coordinates and reflect the union of every spatial sample,
+		// regardless of which Bundle the entity lives in.
+		const state = makeMultiBundleState();
+		const slices = buildCrossBundleSlices(
+			summariesFor({ 'A.DAT': [0, 1], 'B.DAT': [10, 11] }),
+			(bId, i) => resolveModel(state, bId, i),
+			(node) => isVisibleHelper(state, node),
+		);
+		const pivot = crossBundleBulkPivot(slices);
+		expect(pivot).not.toBeNull();
+		expect(Number.isFinite(pivot!.x)).toBe(true);
+		expect(Number.isFinite(pivot!.y)).toBe(true);
+		expect(Number.isFinite(pivot!.z)).toBe(true);
+	});
+
+	it('one cross-Bundle bulk-translate gesture pushes EXACTLY one HistoryCommit (kind: multi)', () => {
+		const state = makeMultiBundleState();
+		const slices = buildCrossBundleSlices(
+			summariesFor({ 'A.DAT': [0, 1], 'B.DAT': [10, 11] }),
+			(bId, i) => resolveModel(state, bId, i),
+			(node) => isVisibleHelper(state, node),
+		);
+		const pivot = crossBundleBulkPivot(slices)!;
+		const writes = buildCrossBundleWrites(
+			slices,
+			{ x: pivot.x, z: pivot.z },
+			{ translate: { x: 12, y: 0, z: -7 }, rotateY: 0 },
+		);
+		// One write per affected Bundle/instance.
+		expect(writes.length).toBe(2);
+		const after = setResourcesMulti(state, writes);
+		// The undo stack grew by EXACTLY one — even though two Bundles
+		// were mutated, the gesture lands as one multi commit (CONTEXT.md
+		// "Bulk transform" cross-Bundle paragraph + ADR-0006).
+		expect(after.history.past.length).toBe(1);
+		const top = after.history.past[0];
+		expect(top.kind).toBe('multi');
+		expect(top.entries?.length).toBe(2);
+	});
+
+	it('each affected Bundle is independently dirtied; outside-marquee Bundles stay clean', () => {
+		// Acceptance: "Translating / rotating the bulk dirties every
+		// affected Bundle for its own save." Each Bundle keeps its own
+		// dirty bookkeeping (CONTEXT.md / "Workspace" — "Each Bundle in
+		// the Workspace retains its own file identity and its own dirty
+		// state").
+		const state = makeMultiBundleState();
+		// Add a third Bundle whose AI sections are NOT in the bulk —
+		// it must remain clean.
+		const bundleC = makeEditableBundle(loadFixture(), 'C.DAT');
+		const stateWithC = { ...state, bundles: [...state.bundles, bundleC] };
+
+		const slices = buildCrossBundleSlices(
+			summariesFor({ 'A.DAT': [0, 1], 'B.DAT': [10] }),
+			(bId, i) => resolveModel(stateWithC, bId, i),
+			(node) => isVisibleHelper(stateWithC, node),
+		);
+		const pivot = crossBundleBulkPivot(slices)!;
+		const writes = buildCrossBundleWrites(
+			slices,
+			{ x: pivot.x, z: pivot.z },
+			{ translate: { x: 5, y: 0, z: -3 }, rotateY: 0 },
+		);
+		const after = setResourcesMulti(stateWithC, writes);
+
+		const aAfter = after.bundles.find((b) => b.id === 'A.DAT')!;
+		const bAfter = after.bundles.find((b) => b.id === 'B.DAT')!;
+		const cAfter = after.bundles.find((b) => b.id === 'C.DAT')!;
+		expect(aAfter.isModified).toBe(true);
+		expect(bAfter.isModified).toBe(true);
+		expect(cAfter.isModified).toBe(false);
+		// And dirtyMulti entries point at the right (resourceKey, index)
+		// in each affected Bundle.
+		expect(aAfter.dirtyMulti.has('aiSections:0')).toBe(true);
+		expect(bAfter.dirtyMulti.has('aiSections:0')).toBe(true);
+		expect(cAfter.dirtyMulti.size).toBe(0);
+	});
+
+	it('single undo reverts every affected Bundle in one step', () => {
+		// Acceptance: "Undo reverts the change in every affected Bundle
+		// in one step." Each Bundle's pre-gesture state is restored
+		// atomically — partial undo (one Bundle restored, another still
+		// edited) would be a regression.
+		const state = makeMultiBundleState();
+		const beforeA = getAI(state, 'A.DAT').sections[0].corners.map((c) => ({ ...c }));
+		const beforeB = getAI(state, 'B.DAT').sections[10].corners.map((c) => ({ ...c }));
+
+		const slices = buildCrossBundleSlices(
+			summariesFor({ 'A.DAT': [0], 'B.DAT': [10] }),
+			(bId, i) => resolveModel(state, bId, i),
+			(node) => isVisibleHelper(state, node),
+		);
+		const pivot = crossBundleBulkPivot(slices)!;
+		const writes = buildCrossBundleWrites(
+			slices,
+			{ x: pivot.x, z: pivot.z },
+			{ translate: { x: 7, y: 0, z: -4 }, rotateY: 0 },
+		);
+		const after = setResourcesMulti(state, writes);
+
+		// Confirm the translate took effect in BOTH Bundles.
+		expect(getAI(after, 'A.DAT').sections[0].corners[0].x).toBeCloseTo(beforeA[0].x + 7, 6);
+		expect(getAI(after, 'B.DAT').sections[10].corners[0].x).toBeCloseTo(beforeB[0].x + 7, 6);
+
+		// One undo reverts BOTH Bundles atomically. The history stack
+		// drops from 1 to 0 in a single step — no intermediate state
+		// where only one Bundle has been reverted.
+		const afterUndo = undo(after);
+		expect(afterUndo.history.past.length).toBe(0);
+		expect(getAI(afterUndo, 'A.DAT').sections[0].corners).toEqual(beforeA);
+		expect(getAI(afterUndo, 'B.DAT').sections[10].corners).toEqual(beforeB);
+	});
+
+	it('cross-Bundle bulk-rotate around the shared pivot rotates every entity in every Bundle', () => {
+		// Same shape as the translate test but exercising yaw rotate.
+		// Every selected entity orbits the SHARED cross-Bundle pivot —
+		// not each Bundle's own per-slice centre. CONTEXT.md / "Bulk
+		// transform": "Cross-Bundle Selections apply the same delta
+		// per-Bundle."
+		const state = makeMultiBundleState();
+		const slices = buildCrossBundleSlices(
+			summariesFor({ 'A.DAT': [0, 1], 'B.DAT': [10, 11] }),
+			(bId, i) => resolveModel(state, bId, i),
+			(node) => isVisibleHelper(state, node),
+		);
+		const pivot = crossBundleBulkPivot(slices)!;
+		const writes = buildCrossBundleWrites(
+			slices,
+			{ x: pivot.x, z: pivot.z },
+			{ translate: { x: 0, y: 0, z: 0 }, rotateY: 0.3 },
+		);
+		const after = setResourcesMulti(state, writes);
+		expect(after.history.past.length).toBe(1);
+		expect(after.history.past[0].kind).toBe('multi');
+		// Sections inside the bulk moved; sections outside the bulk
+		// (e.g. A.DAT's section 5) did not.
+		const aAfter = getAI(after, 'A.DAT');
+		const aBefore = getAI(state, 'A.DAT');
+		expect(aAfter.sections[5].corners).toEqual(aBefore.sections[5].corners);
+	});
+
+	it('combined translate + yaw rotate still produces one cross-Bundle HistoryCommit', () => {
+		// The dispatcher composes translate then yaw rotate against the
+		// post-translate pivot inside `buildCrossBundleWrites`. The
+		// resulting write list dispatches ONCE through `setResourcesMulti`,
+		// producing one multi commit.
+		const state = makeMultiBundleState();
+		const slices = buildCrossBundleSlices(
+			summariesFor({ 'A.DAT': [0, 1], 'B.DAT': [10, 11] }),
+			(bId, i) => resolveModel(state, bId, i),
+			(node) => isVisibleHelper(state, node),
+		);
+		const pivot = crossBundleBulkPivot(slices)!;
+		const writes = buildCrossBundleWrites(
+			slices,
+			{ x: pivot.x, z: pivot.z },
+			{ translate: { x: 5, y: 0, z: -2 }, rotateY: 0.2 },
+		);
+		const after = setResourcesMulti(state, writes);
+		expect(after.history.past.length).toBe(1);
+	});
+
+	it('no-op cross-Bundle gesture (zero delta) produces no writes and no history entry', () => {
+		// The byte-for-byte BND2 writeback safety guard from the
+		// single-Bundle path extends to the cross-Bundle one: a zero-
+		// delta gesture must not dirty any Bundle.
+		const state = makeMultiBundleState();
+		const slices = buildCrossBundleSlices(
+			summariesFor({ 'A.DAT': [0, 1], 'B.DAT': [10, 11] }),
+			(bId, i) => resolveModel(state, bId, i),
+			(node) => isVisibleHelper(state, node),
+		);
+		const pivot = crossBundleBulkPivot(slices)!;
+		const writes = buildCrossBundleWrites(
+			slices,
+			{ x: pivot.x, z: pivot.z },
+			{ translate: { x: 0, y: 0, z: 0 }, rotateY: 0 },
+		);
+		// Every slice's op returned `model` unchanged → no writes emitted.
+		expect(writes.length).toBe(0);
+		const after = setResourcesMulti(state, writes);
+		expect(after.history.past.length).toBe(0);
+		// No bundle dirtied.
+		for (const b of after.bundles) expect(b.isModified).toBe(false);
+	});
+
+	it('invisible Bundle is excluded from the bulk dispatch even if its bulk Set is non-empty', () => {
+		// Acceptance: "Invisible Bundles are not affected by the transform,
+		// even if loaded." The Bundle/-resource/-instance visibility
+		// cascade gates participation in the cross-Bundle path — at the
+		// slice-build step, hidden Bundles drop out entirely.
+		const state = makeMultiBundleState();
+		// Toggle Bundle B's whole-Bundle visibility off (cascades to its
+		// aiSections instance via `isVisibleIn`).
+		state.visibility.set(visibilityKey({ bundleId: 'B.DAT' }), false);
+
+		const slices = buildCrossBundleSlices(
+			summariesFor({ 'A.DAT': [0, 1], 'B.DAT': [10, 11] }),
+			(bId, i) => resolveModel(state, bId, i),
+			(node) => isVisibleHelper(state, node),
+		);
+		// B.DAT was hidden; its slice was dropped. Only A.DAT survives.
+		expect(slices.length).toBe(1);
+		expect(slices[0].bundleId).toBe('A.DAT');
+
+		// Build the write list — only A.DAT's instance gets a write,
+		// even though both Bundles had bulks.
+		const pivot = crossBundleBulkPivot(slices)!;
+		const writes = buildCrossBundleWrites(
+			slices,
+			{ x: pivot.x, z: pivot.z },
+			{ translate: { x: 5, y: 0, z: -3 }, rotateY: 0 },
+		);
+		expect(writes.length).toBe(1);
+		expect(writes[0].bundleId).toBe('A.DAT');
+
+		const after = setResourcesMulti(state, writes);
+		// B's model is byte-equal to its pre-gesture state — its data
+		// is untouched. The history entry is still a `kind: 'multi'`
+		// commit because we always dispatch through `setResourcesMulti`
+		// for cross-Bundle gestures; that single-entry multi commit is
+		// indistinguishable from a single-Bundle write at the data layer
+		// and undo reverts it correctly.
+		const bBefore = getAI(state, 'B.DAT');
+		const bAfter = getAI(after, 'B.DAT');
+		expect(bAfter).toBe(bBefore);
+		expect(after.bundles.find((b) => b.id === 'B.DAT')!.isModified).toBe(false);
+	});
+
+	it('hidden instance inside a visible Bundle is also filtered out (cascade)', () => {
+		// The visibility cascade is per CONTEXT.md / "Visibility" — hiding
+		// the (bundleId, resourceKey, index) triple alone (without hiding
+		// the whole Bundle) still drops the slice. Tests the
+		// instance-scope branch of `isVisibleIn`.
+		const state = makeMultiBundleState();
+		state.visibility.set(
+			visibilityKey({ bundleId: 'B.DAT', resourceKey: 'aiSections', index: 0 }),
+			false,
+		);
+
+		const slices = buildCrossBundleSlices(
+			summariesFor({ 'A.DAT': [0], 'B.DAT': [10] }),
+			(bId, i) => resolveModel(state, bId, i),
+			(node) => isVisibleHelper(state, node),
+		);
+		expect(slices.map((s) => s.bundleId)).toEqual(['A.DAT']);
+	});
+});
+
+// =============================================================================
+// Regression: the single-Bundle path is byte-for-byte unchanged
+// =============================================================================
+//
+// The whole point of choosing option (b) — group refs by Bundle in the
+// dispatch layer instead of (a) extending the ref shape — is that the
+// existing single-Bundle bulk ops keep working unchanged. This block
+// pins that contract: a single-slice bulk (1 Bundle) routed through
+// `buildCrossBundleWrites` produces a model that matches what the
+// single-Bundle `bulkTranslateEntities` would produce directly.
+
+import { bulkTranslateEntities } from '@/lib/core/aiSectionsOps';
+
+describe('Cross-Bundle dispatch — single-Bundle slice agrees with single-Bundle op', () => {
+	it('single-slice translate matches `bulkTranslateEntities` byte-for-byte', () => {
+		const state = makeMultiBundleState();
+		const slices = buildCrossBundleSlices(
+			summariesFor({ 'A.DAT': [0, 1, 2] }),
+			(bId, i) => resolveModel(state, bId, i),
+			(node) => isVisibleHelper(state, node),
+		);
+		expect(slices.length).toBe(1);
+		const pivot = crossBundleBulkPivot(slices)!;
+		const writes = buildCrossBundleWrites(
+			slices,
+			{ x: pivot.x, z: pivot.z },
+			{ translate: { x: 5, y: 0, z: -3 }, rotateY: 0 },
+		);
+		expect(writes.length).toBe(1);
+		const dispatchResult = writes[0].value as ParsedAISectionsV12;
+		const directResult = bulkTranslateEntities(
+			getAI(state, 'A.DAT'),
+			[
+				{ kind: 'section', sectionIdx: 0 },
+				{ kind: 'section', sectionIdx: 1 },
+				{ kind: 'section', sectionIdx: 2 },
+			],
+			{ x: 5, y: 0, z: -3 },
+		);
+		// Compare the changed sections — section 5 (not in bulk) stays
+		// === between both since the op short-circuits per-section.
+		expect(dispatchResult.sections[0].corners).toEqual(directResult.sections[0].corners);
+		expect(dispatchResult.sections[1].corners).toEqual(directResult.sections[1].corners);
+		expect(dispatchResult.sections[2].corners).toEqual(directResult.sections[2].corners);
+	});
+});


### PR DESCRIPTION
Closes #80.

## Summary

- A marquee that spans 2+ loaded Bundles now produces one bulk Selection whose entries reference their owning Bundle. The gizmo anchors at the median pivot across every selected entity in every Bundle.
- Translate / rotate applies the same delta per-Bundle; each affected Bundle dirties independently for its own save (CONTEXT.md / Workspace).
- The whole gesture commits as exactly one Workspace-undo entry — a `{ kind: ''multi'', entries }` `HistoryCommit` whose entries are the per-Bundle before/after snapshots. Undo reverts every affected Bundle atomically (ADR-0006).
- Invisible (loaded-but-toggled-off) Bundles are filtered out of both the marquee dispatch and the commit dispatch — a hidden Bundle''s sections are never picked up by the cross-Bundle path even if they sit inside the marquee rectangle.

## Design notes

- **Approach (b) from the issue brief** — group refs by Bundle in the dispatch layer instead of extending `AISectionEntityRef` with `bundleId`. The existing single-Bundle bulk ops keep working byte-for-byte; `WorkspaceContext.bulkTransform.test.ts` still passes unchanged.
- **`HistoryCommit` extension** — added optional `kind?: ''multi''` + `entries?: readonly HistoryCommitEntry[]` to the flat `HistoryCommit` shape. Single-Bundle commits are byte-identical to pre-#80; `dropHistoryForBundle` / helpers tests still pass. The flat top-level fields stay as placeholders on multi commits; readers branch on `kind === ''multi''` first.
- **`setResourcesMulti(writes)`** on the `WorkspaceContext` — applies N writes as one multi commit. Reused by both the new `useCrossBundleBulkController` and (potentially) future cross-Bundle resource families.
- **`crossBundleBulk.ts`** — pure helpers: `buildCrossBundleSlices`, `crossBundleBulkPivot`, `buildCrossBundleWrites`. Visibility-gated at slice build so the invisible-Bundle isolation contract is enforced upstream of any model touching.

## Test plan

- [x] Cross-Bundle bulk translate (2 Bundles): per-Bundle dirty + one multi history entry.
- [x] Cross-Bundle bulk rotate around shared pivot: same.
- [x] Combined translate + yaw: still exactly one multi history entry.
- [x] Single undo reverts every affected Bundle atomically.
- [x] No-op gesture (zero delta) produces no writes and no history entry.
- [x] Invisible Bundle is excluded from the bulk dispatch even when its bulk Set is non-empty.
- [x] Hidden instance inside a visible Bundle is also filtered out (cascade).
- [x] Single-slice dispatch agrees byte-for-byte with the direct single-Bundle op (regression guard for option (b)).
- [x] Pre-existing `WorkspaceContext.bulkTransform.test.ts` (#74) still passes — single-Bundle path unchanged.
- [x] Baseline 14 ENOENT failures unchanged; 11 new tests pass (1221/1235 vs 1210/1224 pre-PR).

## Anticipated rebase conflicts

Likely mechanical conflicts with the five parallel PRs (#76 / #77 / #79 / #81 / #82) — every one of them touches `BulkTransformGizmo.tsx` / `AISectionsOverlay.tsx` / `useBulkTransformDrag.ts`. This PR''s overlay edits are localised to:
- the `useCrossBundleBulkController` import + hook call
- the `bulkPivotLive` `useMemo` (cross-Bundle branch)
- the `handleGizmoCommit` (cross-Bundle commit short-circuit)
- the `handleMarquee` (delegated to controller)
- one `isActive` gate on `<BulkTransformGizmo>` rendering

Out of scope: trigger boxes (#77 / #79), numeric panel (#81), pivot drag (#76). The cross-Bundle plumbing is resource-family agnostic at the workspace layer (`setResourcesMulti`, multi `HistoryCommit`) so those resource families plug in cleanly once their bulk ops land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)