### PR TITLE
feat: integrate zone, traffic-yaw, street-ref, lane-rung resources with Bulk transform (#79)

### DIFF
--- a/src/components/schema-editor/viewports/StreetDataOverlay.tsx
+++ b/src/components/schema-editor/viewports/StreetDataOverlay.tsx
@@ -24,6 +24,17 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { Grid, Html } from '@react-three/drei';
 import * as THREE from 'three';
 import type { ParsedStreetData } from '@/lib/core/streetData';
+import {
+	STREET_REF_POSITION_AXES,
+	bulkTranslateRoadRefs,
+	streetDataSelectionPivot,
+	type StreetDataEntityRef,
+} from '@/lib/core/streetDataOps';
+import { BulkTransformGizmo } from '@/components/common/three/BulkTransformGizmo';
+import {
+	type BulkTransformDelta,
+	isIdentityDelta,
+} from '@/hooks/useBulkTransformDrag';
 import type { NodePath } from '@/lib/schema/walk';
 import type { WorldOverlayComponent } from './WorldViewport.types';
 import {
@@ -295,9 +306,7 @@ export const StreetDataOverlay: WorldOverlayComponent<ParsedStreetData> = ({
 	data,
 	selectedPath,
 	onSelect,
-	// onChange — accepted to satisfy the WorldOverlayProps contract; unused
-	// today because StreetData has no in-scene drag handles. Future drag work
-	// will call it with the next root.
+	onChange,
 }: Props) => {
 	const [hovered, setHovered] = useState<Selection | null>(null);
 	const { center, radius } = useMemo(() => computeBounds(data), [data]);
@@ -311,6 +320,52 @@ export const StreetDataOverlay: WorldOverlayComponent<ParsedStreetData> = ({
 		(sel: Selection) => onSelect(streetSelectionCodec.selectionToPath(sel)),
 		[onSelect],
 	);
+
+	// =========================================================================
+	// Bulk-transform gizmo (issue #79)
+	//
+	// Single-road selection only in this slice — the gizmo's translate arrows
+	// move `Road.mReferencePosition` (Vector3, full 3D). Rotation is disabled
+	// for a single point (orbit around itself is a no-op); multi-road bulks
+	// will re-enable yaw rings via the workspace bulk Set in a later slice.
+	// =========================================================================
+	const bulkRefs = useMemo<readonly StreetDataEntityRef[]>(() => {
+		if (primary?.kind !== 'road') return [];
+		const idx = primary.indices[0];
+		if (idx < 0 || idx >= data.roads.length) return [];
+		return [{ kind: 'road', roadIdx: idx }];
+	}, [primary, data.roads.length]);
+
+	const bulkPivotLive = useMemo(
+		() => (bulkRefs.length > 0 ? streetDataSelectionPivot(data, bulkRefs) : null),
+		[data, bulkRefs],
+	);
+	const [dragDelta, setDragDelta] = useState<BulkTransformDelta | null>(null);
+
+	const gizmoPosition = useMemo<[number, number, number] | null>(() => {
+		if (!bulkPivotLive) return null;
+		const dx = dragDelta?.translate.x ?? 0;
+		const dy = dragDelta?.translate.y ?? 0;
+		const dz = dragDelta?.translate.z ?? 0;
+		return [bulkPivotLive.x + dx, bulkPivotLive.y + dy, bulkPivotLive.z + dz];
+	}, [bulkPivotLive, dragDelta]);
+
+	const handleGizmoTransform = useCallback((delta: BulkTransformDelta) => {
+		setDragDelta(delta);
+	}, []);
+
+	const handleGizmoCommit = useCallback((delta: BulkTransformDelta) => {
+		setDragDelta(null);
+		if (!onChange) return;
+		if (bulkRefs.length === 0) return;
+		if (isIdentityDelta(delta)) return;
+		const next = bulkTranslateRoadRefs(data, bulkRefs, delta.translate);
+		if (next !== data) onChange(next);
+	}, [data, onChange, bulkRefs]);
+
+	const handleGizmoCancel = useCallback(() => {
+		setDragDelta(null);
+	}, []);
 
 	return (
 		<>
@@ -328,6 +383,15 @@ export const StreetDataOverlay: WorldOverlayComponent<ParsedStreetData> = ({
 			<StreetInstances data={data} primary={primary} hovered={hovered} onPick={handlePick} onHover={setHovered} />
 			<JunctionInstances data={data} primary={primary} hovered={hovered} onPick={handlePick} onHover={setHovered} />
 			<SelectedLabel data={data} primary={primary} hovered={hovered} />
+			{onChange && gizmoPosition && (
+				<BulkTransformGizmo
+					position={gizmoPosition}
+					axes={STREET_REF_POSITION_AXES}
+					onTransform={handleGizmoTransform}
+					onCommit={handleGizmoCommit}
+					onCancel={handleGizmoCancel}
+				/>
+			)}
 		</>
 	);
 };

--- a/src/components/schema-editor/viewports/TrafficDataOverlay.tsx
+++ b/src/components/schema-editor/viewports/TrafficDataOverlay.tsx
@@ -27,6 +27,19 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 import type { ParsedTrafficDataRetail } from '@/lib/core/trafficData';
 import {
+	TRAFFIC_LANE_RUNG_AXES,
+	TRAFFIC_YAW_PACKED_AXES,
+	bulkRotateTrafficEntitiesYaw,
+	bulkTranslateTrafficEntities,
+	trafficDataSelectionPivot,
+	type TrafficDataEntityRef,
+} from '@/lib/core/trafficDataOps';
+import { BulkTransformGizmo } from '@/components/common/three/BulkTransformGizmo';
+import {
+	type BulkTransformDelta,
+	isIdentityDelta,
+} from '@/hooks/useBulkTransformDrag';
+import {
 	AllJunctionInstances,
 	AllLaneConnections,
 	AllLightTriggerInstances,
@@ -183,7 +196,7 @@ type Props = {
 };
 
 export const TrafficDataOverlay: WorldOverlayComponent<ParsedTrafficDataRetail> = ({
-	data, selectedPath, onSelect, isActive = true,
+	data, selectedPath, onSelect, onChange, isActive = true,
 }: Props) => {
 	const hulls = data.hulls;
 
@@ -246,6 +259,98 @@ export const TrafficDataOverlay: WorldOverlayComponent<ParsedTrafficDataRetail> 
 		selected && !isPvsCellSelection(selected) && selected.sub?.type === 'section'
 			? selected.sub.index
 			: -1;
+
+	// =========================================================================
+	// Bulk-transform gizmo (issue #79)
+	//
+	// Maps the schema-Selection (junction / lightTrigger / rung) to a single
+	// `TrafficDataEntityRef`, anchors the gizmo at the entity's pivot, and on
+	// commit applies the bulk op (rigid translate + yaw rotate). The yaw rotate
+	// of a yaw-packed box composes BOTH the position orbit AND the .w slot —
+	// the gesture's yaw delta is added to the box's stored yaw (rigid-body
+	// composition per issue #79). Lane rungs orbit both endpoints around the
+	// pivot so the rung remains a single segment.
+	// =========================================================================
+	const bulkRefs = useMemo<readonly TrafficDataEntityRef[]>(() => {
+		if (!selected || isPvsCellSelection(selected)) return [];
+		if (!selected.sub) return [];
+		const hullIdx = selected.hullIndex;
+		switch (selected.sub.type) {
+			case 'junction':
+				return [{ kind: 'junction', hullIdx, junctionIdx: selected.sub.index }];
+			case 'lightTrigger':
+				return [{ kind: 'lightTrigger', hullIdx, triggerIdx: selected.sub.index }];
+			case 'rung':
+				return [{ kind: 'laneRung', hullIdx, rungIdx: selected.sub.index }];
+			default:
+				// Section / staticVehicle picks fall through — sections are
+				// region-only (no transform target yet), static vehicles are
+				// Matrix44 and live in issue #78.
+				return [];
+		}
+	}, [selected]);
+
+	// Snapshot the pivot at gesture start so it doesn't drift mid-rotate — see
+	// the AISectionsOverlay comment for the rationale.
+	const bulkPivotRef = useRef<{ x: number; y: number; z: number } | null>(null);
+	const bulkPivotLive = useMemo(
+		() => (bulkRefs.length > 0 ? trafficDataSelectionPivot(data, bulkRefs) : null),
+		[data, bulkRefs],
+	);
+	const [dragDelta, setDragDelta] = useState<BulkTransformDelta | null>(null);
+
+	const gizmoAxes = useMemo(() => {
+		if (bulkRefs.length === 0) return TRAFFIC_YAW_PACKED_AXES;
+		// Lane rung vs yaw-packed share the same axis profile today, but we
+		// dispatch through the canonical constant for each so a future
+		// differentiation lands without re-wiring.
+		return bulkRefs[0].kind === 'laneRung'
+			? TRAFFIC_LANE_RUNG_AXES
+			: TRAFFIC_YAW_PACKED_AXES;
+	}, [bulkRefs]);
+
+	const gizmoPosition = useMemo<[number, number, number] | null>(() => {
+		const pivot = bulkPivotRef.current ?? bulkPivotLive;
+		if (!pivot) return null;
+		const dx = dragDelta?.translate.x ?? 0;
+		const dy = dragDelta?.translate.y ?? 0;
+		const dz = dragDelta?.translate.z ?? 0;
+		return [pivot.x + dx, pivot.y + dy, pivot.z + dz];
+	}, [bulkPivotLive, dragDelta]);
+
+	const handleGizmoTransform = useCallback((delta: BulkTransformDelta) => {
+		if (!bulkPivotRef.current && bulkPivotLive) {
+			bulkPivotRef.current = bulkPivotLive;
+		}
+		setDragDelta(delta);
+	}, [bulkPivotLive]);
+
+	const handleGizmoCommit = useCallback((delta: BulkTransformDelta) => {
+		setDragDelta(null);
+		const pivot = bulkPivotRef.current;
+		bulkPivotRef.current = null;
+		if (!onChange) return;
+		if (bulkRefs.length === 0) return;
+		if (isIdentityDelta(delta)) return;
+		let next = data;
+		if (delta.translate.x !== 0 || delta.translate.y !== 0 || delta.translate.z !== 0) {
+			next = bulkTranslateTrafficEntities(next, bulkRefs, delta.translate);
+		}
+		if (delta.rotate.y !== 0 && pivot) {
+			next = bulkRotateTrafficEntitiesYaw(
+				next,
+				bulkRefs,
+				{ x: pivot.x + delta.translate.x, z: pivot.z + delta.translate.z },
+				delta.rotate.y,
+			);
+		}
+		if (next !== data) onChange(next);
+	}, [data, onChange, bulkRefs]);
+
+	const handleGizmoCancel = useCallback(() => {
+		setDragDelta(null);
+		bulkPivotRef.current = null;
+	}, []);
 
 	// HTML siblings — registered into the chrome's slot.
 	const htmlNode = useMemo(
@@ -346,6 +451,16 @@ export const TrafficDataOverlay: WorldOverlayComponent<ParsedTrafficDataRetail> 
 			)}
 
 			<SelectionLabel hulls={hulls} selected={selected} />
+
+			{onChange && gizmoPosition && (
+				<BulkTransformGizmo
+					position={gizmoPosition}
+					axes={gizmoAxes}
+					onTransform={handleGizmoTransform}
+					onCommit={handleGizmoCommit}
+					onCancel={handleGizmoCancel}
+				/>
+			)}
 
 			<CameraBridge bridge={cameraBridge} />
 		</>

--- a/src/components/schema-editor/viewports/ZoneListOverlay.tsx
+++ b/src/components/schema-editor/viewports/ZoneListOverlay.tsx
@@ -16,7 +16,7 @@
 // vertex colors for one zone at a time so a hover hop only touches the
 // vertices that actually changed state.
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { Html, Line } from '@react-three/drei';
 import * as THREE from 'three';
 import {
@@ -24,6 +24,19 @@ import {
 	type Zone,
 	NEIGHBOUR_FLAGS,
 } from '@/lib/core/zoneList';
+import {
+	ZONE_POINT_AXES,
+	bulkRotateZoneEntitiesYaw,
+	bulkTranslateZoneEntities,
+	translateZoneRigid,
+	zoneListSelectionPivot,
+	type ZoneListEntityRef,
+} from '@/lib/core/zoneListOps';
+import { BulkTransformGizmo } from '@/components/common/three/BulkTransformGizmo';
+import {
+	type BulkTransformDelta,
+	isIdentityDelta,
+} from '@/hooks/useBulkTransformDrag';
 import type { NodePath } from '@/lib/schema/walk';
 import type { WorldOverlayComponent } from './WorldViewport.types';
 import {
@@ -247,10 +260,13 @@ type Props = {
 	/** When true (default), draw lines from each selected zone to its safe +
 	 *  unsafe neighbours so the streaming graph is visible at a glance. */
 	showNeighbourGraph?: boolean;
+	/** Present when the parent route can apply edits — the Bulk-transform
+	 *  gizmo emits the next root through this callback on commit. */
+	onChange?: (next: ParsedZoneList) => void;
 };
 
 export const ZoneListOverlay: WorldOverlayComponent<ParsedZoneList> = ({
-	data, selectedPath, onSelect, showNeighbourGraph = true,
+	data, selectedPath, onSelect, showNeighbourGraph = true, onChange,
 }: Props) => {
 	const scene = useMemo(() => buildBatchedZones(data.zones), [data.zones]);
 	const [hovered, setHovered] = useState<Selection | null>(null);
@@ -305,6 +321,86 @@ export const ZoneListOverlay: WorldOverlayComponent<ParsedZoneList> = ({
 		return pts;
 	}, [selectedZone]);
 
+	// =========================================================================
+	// Bulk-transform gizmo (issue #79)
+	//
+	// Single-zone selection only in this slice — multi-zone bulk-select would
+	// flow through the workspace bulk Set (mirrors AISections' pattern). The
+	// gizmo anchors at the selected zone's median XZ; on commit we drop the
+	// delta.y because zone points are `Vec2Padded` (XZ-only, ADR-0011).
+	// =========================================================================
+	const bulkRefs = useMemo<readonly ZoneListEntityRef[]>(
+		() => (selectedZone ? [{ kind: 'zone', zoneIdx: selectedZoneIndex }] : []),
+		[selectedZone, selectedZoneIndex],
+	);
+	// Snapshot the pivot at gesture start so it doesn't drift mid-rotate — see
+	// the AISectionsOverlay comment for the rationale (re-deriving the median
+	// against moving positions every frame produces a spiral instead of a
+	// rigid rotate).
+	const bulkPivotRef = useRef<{ x: number; y: number; z: number } | null>(null);
+	const bulkPivotLive = useMemo(
+		() => (bulkRefs.length > 0 ? zoneListSelectionPivot(data, bulkRefs) : null),
+		[data, bulkRefs],
+	);
+	const [dragDelta, setDragDelta] = useState<BulkTransformDelta | null>(null);
+
+	const gizmoPosition = useMemo<[number, number, number] | null>(() => {
+		const pivot = bulkPivotRef.current ?? bulkPivotLive;
+		if (!pivot) return null;
+		const dx = dragDelta?.translate.x ?? 0;
+		const dz = dragDelta?.translate.z ?? 0;
+		// Lift slightly above the fill mesh so the gizmo is grabbable.
+		return [pivot.x + dx, pivot.y + 1.5, pivot.z + dz];
+	}, [bulkPivotLive, dragDelta]);
+
+	const handleGizmoTransform = useCallback((delta: BulkTransformDelta) => {
+		if (!bulkPivotRef.current && bulkPivotLive) {
+			bulkPivotRef.current = bulkPivotLive;
+		}
+		setDragDelta(delta);
+	}, [bulkPivotLive]);
+
+	const handleGizmoCommit = useCallback((delta: BulkTransformDelta) => {
+		setDragDelta(null);
+		const pivot = bulkPivotRef.current;
+		bulkPivotRef.current = null;
+		if (!onChange) return;
+		if (bulkRefs.length === 0) return;
+		if (isIdentityDelta(delta)) return;
+		let next = data;
+		// Translate first, then yaw rotate around the post-translate pivot —
+		// mirrors the AI sections gizmo's compose order so preview and commit
+		// agree frame-for-frame. translate.y is discarded for the zone points
+		// (XZ-packed per ADR-0011) — the gizmo's Y arrow still renders but
+		// the model has no slot to receive it.
+		if (delta.translate.x !== 0 || delta.translate.z !== 0) {
+			// Whole-zone refs only in this slice — use the bulk op so the same
+			// code path is hot when multi-zone bulk-select lands later.
+			next = bulkTranslateZoneEntities(next, bulkRefs, {
+				x: delta.translate.x,
+				z: delta.translate.z,
+			});
+		}
+		if (delta.rotate.y !== 0 && pivot) {
+			next = bulkRotateZoneEntitiesYaw(
+				next,
+				bulkRefs,
+				{ x: pivot.x + delta.translate.x, z: pivot.z + delta.translate.z },
+				delta.rotate.y,
+			);
+		}
+		if (next !== data) onChange(next);
+	}, [data, onChange, bulkRefs]);
+
+	const handleGizmoCancel = useCallback(() => {
+		setDragDelta(null);
+		bulkPivotRef.current = null;
+	}, []);
+
+	// Suppress unused warning — single-zone translate helper available for
+	// future per-point selections; the bulk op covers today's whole-zone path.
+	void translateZoneRigid;
+
 	return (
 		<>
 			<mesh
@@ -319,6 +415,15 @@ export const ZoneListOverlay: WorldOverlayComponent<ParsedZoneList> = ({
 			{selectedZone && <ZoneLabel zone={selectedZone} index={selectedZoneIndex} color={SELECTED_COLOR} />}
 			{showNeighbourGraph && selectedZoneIndex >= 0 && (
 				<NeighbourGraph data={data} zoneIndex={selectedZoneIndex} centroids={scene.centroids} />
+			)}
+			{onChange && gizmoPosition && (
+				<BulkTransformGizmo
+					position={gizmoPosition}
+					axes={ZONE_POINT_AXES}
+					onTransform={handleGizmoTransform}
+					onCommit={handleGizmoCommit}
+					onCancel={handleGizmoCancel}
+				/>
 			)}
 		</>
 	);

--- a/src/lib/core/__tests__/transformAxesXzPackedFamilies.test.ts
+++ b/src/lib/core/__tests__/transformAxesXzPackedFamilies.test.ts
@@ -1,0 +1,111 @@
+// Cross-resource auto-disable integration tests (issue #79).
+//
+// Verifies the ADR-0011 invariant for the four resource families wired in
+// by this slice: zone-list points, traffic yaw-packed boxes, traffic lane
+// rungs, and street-data reference positions. Any Selection containing any
+// XZ-packed contributor (zone, traffic yaw box, lane rung) must AND down
+// the rotate.x and rotate.z rings via `intersectTransformAxes`. A
+// pure-3D contributor (street ref) on its own leaves all rings enabled,
+// but mixing it with an XZ-packed sibling still grays out pitch/roll.
+
+import { describe, it, expect } from 'vitest';
+import {
+	bulkAISectionsAxes,
+	type AISectionEntityRef,
+} from '../aiSectionsOps';
+import {
+	bulkStreetDataAxes,
+	type StreetDataEntityRef,
+} from '../streetDataOps';
+import {
+	bulkTrafficDataAxes,
+	type TrafficDataEntityRef,
+} from '../trafficDataOps';
+import {
+	bulkZoneListAxes,
+	type ZoneListEntityRef,
+} from '../zoneListOps';
+import {
+	intersectTransformAxes,
+	TRANSFORM_AXES_FULL_3D,
+} from '../transformAxes';
+
+describe('auto-disable rule — XZ-packed contributor in Selection forces yaw-only', () => {
+	it('zone point alone: yaw-only', () => {
+		const refs: ZoneListEntityRef[] = [{ kind: 'zone', zoneIdx: 0 }];
+		const axes = bulkZoneListAxes(refs);
+		expect(axes?.rotate.x).toBe(false);
+		expect(axes?.rotate.y).toBe(true);
+		expect(axes?.rotate.z).toBe(false);
+	});
+
+	it('traffic yaw box alone: yaw-only', () => {
+		const refs: TrafficDataEntityRef[] = [
+			{ kind: 'junction', hullIdx: 0, junctionIdx: 0 },
+		];
+		const axes = bulkTrafficDataAxes(refs);
+		expect(axes?.rotate.x).toBe(false);
+		expect(axes?.rotate.y).toBe(true);
+		expect(axes?.rotate.z).toBe(false);
+	});
+
+	it('traffic lane rung alone: yaw-only', () => {
+		const refs: TrafficDataEntityRef[] = [
+			{ kind: 'laneRung', hullIdx: 0, rungIdx: 0 },
+		];
+		const axes = bulkTrafficDataAxes(refs);
+		expect(axes?.rotate.x).toBe(false);
+		expect(axes?.rotate.y).toBe(true);
+		expect(axes?.rotate.z).toBe(false);
+	});
+
+	it('street ref alone: full 3-axis rotate (pure 3D, no veto)', () => {
+		const refs: StreetDataEntityRef[] = [{ kind: 'road', roadIdx: 0 }];
+		const axes = bulkStreetDataAxes(refs);
+		expect(axes?.rotate.x).toBe(true);
+		expect(axes?.rotate.y).toBe(true);
+		expect(axes?.rotate.z).toBe(true);
+	});
+
+	it('mixed: street ref + zone point → yaw-only (zone vetoes pitch/roll)', () => {
+		const streetAxes = bulkStreetDataAxes([{ kind: 'road', roadIdx: 0 }]);
+		const zoneAxes = bulkZoneListAxes([{ kind: 'zone', zoneIdx: 0 }]);
+		expect(streetAxes).not.toBeNull();
+		expect(zoneAxes).not.toBeNull();
+		const intersected = intersectTransformAxes([streetAxes!, zoneAxes!]);
+		expect(intersected.rotate.x).toBe(false);
+		expect(intersected.rotate.y).toBe(true);
+		expect(intersected.rotate.z).toBe(false);
+	});
+
+	it('mixed: trigger box (full 3D placeholder) + zone point → yaw-only', () => {
+		// Until trigger boxes (issue #77) land we use TRANSFORM_AXES_FULL_3D
+		// as the trigger-box stand-in. Once #77 merges this test stands as
+		// the auto-disable regression for the cross-resource case.
+		const zoneAxes = bulkZoneListAxes([{ kind: 'zone', zoneIdx: 0 }]);
+		const intersected = intersectTransformAxes([TRANSFORM_AXES_FULL_3D, zoneAxes!]);
+		expect(intersected.rotate.x).toBe(false);
+		expect(intersected.rotate.y).toBe(true);
+		expect(intersected.rotate.z).toBe(false);
+	});
+
+	it('mixed: traffic yaw box + zone point + AI section + lane rung → yaw-only', () => {
+		const aiRefs: AISectionEntityRef[] = [{ kind: 'section', sectionIdx: 0 }];
+		const zoneRefs: ZoneListEntityRef[] = [{ kind: 'zone', zoneIdx: 0 }];
+		const trafficRefs: TrafficDataEntityRef[] = [
+			{ kind: 'junction', hullIdx: 0, junctionIdx: 0 },
+			{ kind: 'laneRung', hullIdx: 0, rungIdx: 0 },
+		];
+		const aiAxes = bulkAISectionsAxes(aiRefs)!;
+		const zoneAxes = bulkZoneListAxes(zoneRefs)!;
+		const trafficAxes = bulkTrafficDataAxes(trafficRefs)!;
+		const intersected = intersectTransformAxes([aiAxes, zoneAxes, trafficAxes]);
+		expect(intersected.rotate.x).toBe(false);
+		expect(intersected.rotate.y).toBe(true);
+		expect(intersected.rotate.z).toBe(false);
+		// Translate stays 3-axis (all members allow it).
+		expect(intersected.translate.x).toBe(true);
+		expect(intersected.translate.y).toBe(true);
+		expect(intersected.translate.z).toBe(true);
+	});
+});

--- a/src/lib/core/streetDataOps/bulk.test.ts
+++ b/src/lib/core/streetDataOps/bulk.test.ts
@@ -1,0 +1,165 @@
+// Unit tests for streetDataOps — single-entity translate, bulk translate,
+// bulk yaw rotate, axes intersection contribution.
+
+import { describe, it, expect } from 'vitest';
+import type { ParsedStreetData, Road } from '../streetData';
+import {
+	STREET_REF_POSITION_AXES,
+	STREET_REF_POSITION_BULK_AXES,
+	bulkRotateRoadRefsYaw,
+	bulkStreetDataAxes,
+	bulkTranslateRoadRefs,
+	streetDataSelectionPivot,
+	translateRoadRefPositionRigid,
+	type StreetDataEntityRef,
+} from '.';
+
+function makeRoad(opts: { id: bigint; pos: { x: number; y: number; z: number } }): Road {
+	return {
+		mReferencePosition: opts.pos,
+		mpaSpans: 0,
+		mId: opts.id,
+		miRoadLimitId0: 0n,
+		miRoadLimitId1: 0n,
+		macDebugName: '',
+		mChallenge: 0,
+		miSpanCount: 0,
+		unknown: 1,
+		padding: [0, 0, 0, 0],
+	};
+}
+
+function makeModel(roads: Road[]): ParsedStreetData {
+	return {
+		miVersion: 0,
+		mpaStreets: 0,
+		mpaJunctions: 0,
+		mpaRoads: 0,
+		mpaChallengeParScores: 0,
+		streets: [],
+		junctions: [],
+		roads,
+		challengeParScores: [],
+	};
+}
+
+describe('translateRoadRefPositionRigid', () => {
+	it('shifts mReferencePosition by (dx, dy, dz)', () => {
+		const model = makeModel([makeRoad({ id: 0n, pos: { x: 1, y: 2, z: 3 } })]);
+		const next = translateRoadRefPositionRigid(model, 0, { x: 4, y: 5, z: 6 });
+		expect(next.roads[0].mReferencePosition).toEqual({ x: 5, y: 7, z: 9 });
+		// Other fields on the road untouched.
+		expect(next.roads[0].mId).toBe(0n);
+	});
+
+	it('returns the original model on identity offset', () => {
+		const model = makeModel([makeRoad({ id: 0n, pos: { x: 1, y: 2, z: 3 } })]);
+		expect(
+			translateRoadRefPositionRigid(model, 0, { x: 0, y: 0, z: 0 }),
+		).toBe(model);
+	});
+
+	it('throws RangeError for out-of-range index', () => {
+		const model = makeModel([makeRoad({ id: 0n, pos: { x: 0, y: 0, z: 0 } })]);
+		expect(() => translateRoadRefPositionRigid(model, 9, { x: 1, y: 0, z: 0 })).toThrow(
+			RangeError,
+		);
+	});
+});
+
+describe('bulkTranslateRoadRefs', () => {
+	function makeTrio(): ParsedStreetData {
+		return makeModel([
+			makeRoad({ id: 1n, pos: { x: 0, y: 0, z: 0 } }),
+			makeRoad({ id: 2n, pos: { x: 100, y: 0, z: 0 } }),
+			makeRoad({ id: 3n, pos: { x: 200, y: 0, z: 0 } }),
+		]);
+	}
+
+	it('translates every selected road by the same delta', () => {
+		const model = makeTrio();
+		const refs: StreetDataEntityRef[] = [
+			{ kind: 'road', roadIdx: 0 },
+			{ kind: 'road', roadIdx: 2 },
+		];
+		const next = bulkTranslateRoadRefs(model, refs, { x: 10, y: 20, z: 30 });
+		expect(next.roads[0].mReferencePosition).toEqual({ x: 10, y: 20, z: 30 });
+		expect(next.roads[2].mReferencePosition).toEqual({ x: 210, y: 20, z: 30 });
+		expect(next.roads[1]).toBe(model.roads[1]); // unselected untouched
+	});
+
+	it('returns the original model on identity offset', () => {
+		const model = makeTrio();
+		expect(
+			bulkTranslateRoadRefs(model, [{ kind: 'road', roadIdx: 0 }], { x: 0, y: 0, z: 0 }),
+		).toBe(model);
+	});
+
+	it('returns the original model on empty refs', () => {
+		const model = makeTrio();
+		expect(bulkTranslateRoadRefs(model, [], { x: 1, y: 0, z: 0 })).toBe(model);
+	});
+});
+
+describe('bulkRotateRoadRefsYaw', () => {
+	it('orbits a road around the pivot by theta on the XZ plane', () => {
+		const model = makeModel([makeRoad({ id: 1n, pos: { x: 10, y: 7, z: 0 } })]);
+		const next = bulkRotateRoadRefsYaw(
+			model,
+			[{ kind: 'road', roadIdx: 0 }],
+			{ x: 0, z: 0 },
+			Math.PI / 2,
+		);
+		const p = next.roads[0].mReferencePosition;
+		expect(p.x).toBeCloseTo(0, 5);
+		expect(p.y).toBe(7); // Y untouched
+		expect(p.z).toBeCloseTo(10, 5);
+	});
+
+	it('returns the original model on theta === 0', () => {
+		const model = makeModel([makeRoad({ id: 1n, pos: { x: 1, y: 1, z: 1 } })]);
+		expect(
+			bulkRotateRoadRefsYaw(model, [{ kind: 'road', roadIdx: 0 }], { x: 0, z: 0 }, 0),
+		).toBe(model);
+	});
+});
+
+describe('streetDataSelectionPivot', () => {
+	it('returns the median XYZ across roads', () => {
+		const model = makeModel([
+			makeRoad({ id: 1n, pos: { x: 0, y: 0, z: 0 } }),
+			makeRoad({ id: 2n, pos: { x: 100, y: 50, z: 50 } }),
+			makeRoad({ id: 3n, pos: { x: 200, y: 100, z: 100 } }),
+		]);
+		const pivot = streetDataSelectionPivot(model, [
+			{ kind: 'road', roadIdx: 0 },
+			{ kind: 'road', roadIdx: 1 },
+			{ kind: 'road', roadIdx: 2 },
+		]);
+		expect(pivot).toEqual({ x: 100, y: 50, z: 50 });
+	});
+
+	it('returns null for empty refs', () => {
+		expect(streetDataSelectionPivot(makeModel([]), [])).toBeNull();
+	});
+});
+
+describe('bulkStreetDataAxes', () => {
+	it('reports all 3 axes for translate AND rotate so it does not veto pitch / roll', () => {
+		const axes = bulkStreetDataAxes([{ kind: 'road', roadIdx: 0 }]);
+		expect(axes).toEqual(STREET_REF_POSITION_BULK_AXES);
+		expect(axes?.rotate.x).toBe(true);
+		expect(axes?.rotate.y).toBe(true);
+		expect(axes?.rotate.z).toBe(true);
+	});
+
+	it('returns null for empty refs', () => {
+		expect(bulkStreetDataAxes([])).toBeNull();
+	});
+
+	it('single-entity STREET_REF_POSITION_AXES disables rotation rings (single point)', () => {
+		expect(STREET_REF_POSITION_AXES.rotate.x).toBe(false);
+		expect(STREET_REF_POSITION_AXES.rotate.y).toBe(false);
+		expect(STREET_REF_POSITION_AXES.rotate.z).toBe(false);
+	});
+});

--- a/src/lib/core/streetDataOps/bulk.ts
+++ b/src/lib/core/streetDataOps/bulk.ts
@@ -1,0 +1,176 @@
+// Bulk-transform ops for the street-data resource family.
+//
+// Today the only spatial datum on a Road is its `mReferencePosition`
+// (Vector3) — Streets and Junctions share a Road's anchor in the overlay
+// today (they're indexed off a parent Road), so the bulk-transform target
+// is the Road itself. If/when Street and Junction acquire their own
+// world-space positions they'll fold into this same module.
+//
+// Pure-3D resource (per ADR-0011): does NOT auto-disable any rotate axis.
+// The intersection helper will AND down pitch/roll only if the bulk also
+// contains an XZ-packed contributor (zone point, AI section corner, traffic
+// yaw box, lane rung).
+
+import type { ParsedStreetData, Road } from '../streetData';
+import type { TransformAxes } from '../transformAxes';
+import { STREET_REF_POSITION_BULK_AXES } from './transformAxes';
+
+// =============================================================================
+// Entity references
+// =============================================================================
+
+/** Discriminated reference to a single spatial datum in a ParsedStreetData. */
+export type StreetDataEntityRef =
+	/** A road's `mReferencePosition` (Vector3). */
+	| { kind: 'road'; roadIdx: number };
+
+// =============================================================================
+// Pivot
+// =============================================================================
+
+/**
+ * Median (per-component) of every spatial point the Selection addresses.
+ * Returns `null` when the refs list is empty or every ref points at an
+ * out-of-range entity.
+ */
+export function streetDataSelectionPivot(
+	model: ParsedStreetData,
+	refs: readonly StreetDataEntityRef[],
+): { x: number; y: number; z: number } | null {
+	const xs: number[] = [];
+	const ys: number[] = [];
+	const zs: number[] = [];
+	for (const ref of refs) {
+		const road = model.roads[ref.roadIdx];
+		if (!road) continue;
+		xs.push(road.mReferencePosition.x);
+		ys.push(road.mReferencePosition.y);
+		zs.push(road.mReferencePosition.z);
+	}
+	if (xs.length === 0) return null;
+	return { x: median(xs), y: median(ys), z: median(zs) };
+}
+
+function median(values: number[]): number {
+	const sorted = values.slice().sort((a, b) => a - b);
+	const n = sorted.length;
+	if (n === 0) return 0;
+	const mid = n >> 1;
+	return n % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+// =============================================================================
+// Translate
+// =============================================================================
+
+/**
+ * Translate every road reference in the Selection by the same
+ * `(dx, dy, dz)` offset, treating the bulk as one rigid body. No cascade —
+ * no spatial join to maintain.
+ *
+ * Returns the original `model` reference on an identity offset OR an empty
+ * refs list so byte-for-byte BND2 writeback is preserved on a no-op
+ * gesture.
+ */
+export function bulkTranslateRoadRefs(
+	model: ParsedStreetData,
+	refs: readonly StreetDataEntityRef[],
+	offset: { x: number; y: number; z: number },
+): ParsedStreetData {
+	const dx = offset.x;
+	const dy = offset.y;
+	const dz = offset.z;
+	if (dx === 0 && dy === 0 && dz === 0) return model;
+	if (refs.length === 0) return model;
+
+	const touched = new Set<number>();
+	for (const ref of refs) touched.add(ref.roadIdx);
+
+	let anyChange = false;
+	const nextRoads = model.roads.map((road, idx) => {
+		if (!touched.has(idx)) return road;
+		anyChange = true;
+		const next: Road = {
+			...road,
+			mReferencePosition: {
+				x: road.mReferencePosition.x + dx,
+				y: road.mReferencePosition.y + dy,
+				z: road.mReferencePosition.z + dz,
+			},
+		};
+		return next;
+	});
+	if (!anyChange) return model;
+	return { ...model, roads: nextRoads };
+}
+
+// =============================================================================
+// Rotate (yaw)
+// =============================================================================
+
+/**
+ * Yaw-rotate every road reference in the Selection around `pivot` by
+ * `theta` radians. Treats the bulk as one rigid body — every selected
+ * position orbits the single shared pivot, so relative distances are
+ * preserved exactly. Y is left untouched (yaw is the only ring exposed for
+ * cross-resource bulks containing XZ-packed contributors — for pure
+ * street-ref bulks we still call this op via the gizmo's yaw ring).
+ *
+ * Returns the original `model` reference on `theta === 0` OR an empty refs
+ * list.
+ */
+export function bulkRotateRoadRefsYaw(
+	model: ParsedStreetData,
+	refs: readonly StreetDataEntityRef[],
+	pivot: { x: number; z: number },
+	theta: number,
+): ParsedStreetData {
+	if (theta === 0) return model;
+	if (refs.length === 0) return model;
+
+	const cosT = Math.cos(theta);
+	const sinT = Math.sin(theta);
+	const cx = pivot.x;
+	const cz = pivot.z;
+
+	const touched = new Set<number>();
+	for (const ref of refs) touched.add(ref.roadIdx);
+
+	let anyChange = false;
+	const nextRoads = model.roads.map((road, idx) => {
+		if (!touched.has(idx)) return road;
+		anyChange = true;
+		const ox = road.mReferencePosition.x - cx;
+		const oz = road.mReferencePosition.z - cz;
+		const rx = ox * cosT - oz * sinT + cx;
+		const rz = ox * sinT + oz * cosT + cz;
+		const next: Road = {
+			...road,
+			mReferencePosition: { x: rx, y: road.mReferencePosition.y, z: rz },
+		};
+		return next;
+	});
+	if (!anyChange) return model;
+	return { ...model, roads: nextRoads };
+}
+
+// =============================================================================
+// Axes intersection contribution
+// =============================================================================
+
+/**
+ * Effective TransformAxes for a multi-Selection of street-data entities.
+ * Street refs are pure-3D, so they don't veto any rotation axis. The bulk
+ * helper here returns the all-enabled axes set; cross-resource bulks
+ * (street + zone point, for instance) get pitch/roll AND-ed off by the
+ * XZ-packed contributor's profile.
+ *
+ * Returns `null` for an empty refs list so callers can fall back to "no
+ * gizmo".
+ */
+export function bulkStreetDataAxes(
+	refs: readonly StreetDataEntityRef[],
+): TransformAxes | null {
+	if (refs.length === 0) return null;
+	return STREET_REF_POSITION_BULK_AXES;
+}

--- a/src/lib/core/streetDataOps/index.ts
+++ b/src/lib/core/streetDataOps/index.ts
@@ -1,0 +1,18 @@
+// Barrel for `@/lib/core/streetDataOps`.
+//
+// Re-exports every public symbol from the directory's sub-modules so that
+// external callers can keep `import { ... } from '@/lib/core/streetDataOps'`
+// without caring which file the symbol lives in.
+
+export {
+	STREET_REF_POSITION_AXES,
+	STREET_REF_POSITION_BULK_AXES,
+} from './transformAxes';
+export { translateRoadRefPositionRigid } from './translateRigid';
+export {
+	bulkRotateRoadRefsYaw,
+	bulkStreetDataAxes,
+	bulkTranslateRoadRefs,
+	streetDataSelectionPivot,
+	type StreetDataEntityRef,
+} from './bulk';

--- a/src/lib/core/streetDataOps/transformAxes.ts
+++ b/src/lib/core/streetDataOps/transformAxes.ts
@@ -1,0 +1,37 @@
+// Transform-axis profile for street-data resource entities.
+//
+// `Road.mReferencePosition` is a plain Vector3 (`{ x, y, z }`) — a pure 3D
+// anchor point with no rotation field. The bulk gizmo therefore exposes
+// full 3-axis translate for it. Rotation is enabled in the *bulk* sense
+// (the position orbits the bulk pivot) but disabled for single-entity
+// Selections (a point rotating around itself is a no-op, so we hide the
+// affordance rather than let the user grab it).
+//
+// Street refs DO NOT auto-disable any rotate axis when mixed into a bulk —
+// they're genuinely 3D, so they don't veto pitch or roll. An XZ-packed
+// resource sharing the same bulk does (per ADR-0011) — the intersection in
+// `intersectTransformAxes` handles that.
+
+import type { TransformAxes } from '../transformAxes';
+
+/**
+ * Single street-data reference position: a pure 3D point. Translate is full
+ * 3-axis; rotation is disabled because rotating a point around itself is a
+ * no-op.
+ */
+export const STREET_REF_POSITION_AXES: TransformAxes = {
+	translate: { x: true, y: true, z: true },
+	rotate: { x: false, y: false, z: false },
+};
+
+/**
+ * Street ref as a *bulk* contributor — i.e. the entity is one of two-plus
+ * Selection members. Rotation is enabled (all three rings) because the
+ * position orbits a real pivot; pitch and roll stay enabled too because
+ * the data has no XZ-only constraint. The intersection helper will AND
+ * these flags with other contributors' profiles.
+ */
+export const STREET_REF_POSITION_BULK_AXES: TransformAxes = {
+	translate: { x: true, y: true, z: true },
+	rotate: { x: true, y: true, z: true },
+};

--- a/src/lib/core/streetDataOps/translateRigid.ts
+++ b/src/lib/core/streetDataOps/translateRigid.ts
@@ -1,0 +1,51 @@
+// Street-data single-entity rigid translate.
+//
+// `Road.mReferencePosition` is a plain `Vector3` — no rotation field — so the
+// gizmo exposes translate only. Bulk Selections (where the position orbits a
+// pivot) use `bulkRotateRoadRefsYaw` in `./bulk.ts`; for a single-entity
+// pick rotation has nowhere to apply (a point rotating around itself is a
+// no-op).
+//
+// No cascade — Roads have no "linked" topology to drag along; the resource's
+// only structural pointers (Streets / Junctions / Spans / Challenges) are
+// graph edges by index, not geometric joins, so a translate leaves them
+// semantically intact.
+
+import type { ParsedStreetData, Road } from '../streetData';
+
+/**
+ * Translate one road's reference position by a 3D offset. Only
+ * `model.roads[roadIdx].mReferencePosition` moves; every other field on the
+ * road, every other road, and every other top-level array stays
+ * structurally identical (===-equal).
+ *
+ * Returns the original `model` reference when `(dx, dy, dz) === (0, 0, 0)`
+ * so byte-for-byte BND2 writeback is preserved on a no-op gesture.
+ *
+ * @throws RangeError if `roadIdx` is out of range.
+ */
+export function translateRoadRefPositionRigid(
+	model: ParsedStreetData,
+	roadIdx: number,
+	offset: { x: number; y: number; z: number },
+): ParsedStreetData {
+	if (roadIdx < 0 || roadIdx >= model.roads.length) {
+		throw new RangeError(`roadIdx ${roadIdx} out of range [0, ${model.roads.length})`);
+	}
+	const dx = offset.x;
+	const dy = offset.y;
+	const dz = offset.z;
+	if (dx === 0 && dy === 0 && dz === 0) return model;
+
+	const src = model.roads[roadIdx];
+	const next: Road = {
+		...src,
+		mReferencePosition: {
+			x: src.mReferencePosition.x + dx,
+			y: src.mReferencePosition.y + dy,
+			z: src.mReferencePosition.z + dz,
+		},
+	};
+	const roads = model.roads.map((r, i) => (i === roadIdx ? next : r));
+	return { ...model, roads };
+}

--- a/src/lib/core/trafficDataOps/bulk.test.ts
+++ b/src/lib/core/trafficDataOps/bulk.test.ts
@@ -1,0 +1,450 @@
+// Unit tests for trafficDataOps — single-entity translate, bulk translate,
+// bulk yaw rotate (with rigid-body .w composition for yaw-packed boxes),
+// axes intersection contribution.
+
+import { describe, it, expect } from 'vitest';
+import type {
+	ParsedTrafficDataRetail,
+	TrafficHull,
+	TrafficJunctionLogicBox,
+	TrafficLaneRung,
+	TrafficLightCollection,
+	TrafficLightTrigger,
+	Vec4,
+} from '../trafficData';
+import {
+	TRAFFIC_YAW_PACKED_AXES,
+	bulkRotateTrafficEntitiesYaw,
+	bulkTrafficDataAxes,
+	bulkTranslateTrafficEntities,
+	trafficDataSelectionPivot,
+	translateCoronaRigid,
+	translateJunctionRigid,
+	translateLaneRungRigid,
+	translateLightInstanceRigid,
+	translateLightTriggerRigid,
+	type TrafficDataEntityRef,
+} from '.';
+
+// ---------------------------------------------------------------------------
+// Fixtures — minimal valid retail model. Most arrays are empty; we only
+// populate what each test exercises.
+// ---------------------------------------------------------------------------
+
+function vec4(x: number, y: number, z: number, w: number): Vec4 {
+	return { x, y, z, w };
+}
+
+function makeJunction(pos: Vec4): TrafficJunctionLogicBox {
+	return {
+		muID: 0,
+		mauStateTimings: new Array(16).fill(0),
+		mauStoppedLightStates: new Array(16).fill(0),
+		muNumStates: 0,
+		muNumLights: 0,
+		_pad36: [0, 0],
+		muEventJunctionID: 0,
+		miOfflineStartDataIndex: -1,
+		miOnlineStartDataIndex: -1,
+		miBikeStartDataIndex: -1,
+		maTrafficLightControllers: [],
+		_pad108: [],
+		mPosition: pos,
+	};
+}
+
+function makeLightTrigger(pos: Vec4): TrafficLightTrigger {
+	return {
+		mDimensions: vec4(1, 1, 1, 0),
+		mPosPlusYRot: pos,
+	};
+}
+
+function makeRung(a: Vec4, b: Vec4): TrafficLaneRung {
+	return { maPoints: [a, b] };
+}
+
+function makeHull(opts: {
+	junctions?: TrafficJunctionLogicBox[];
+	lightTriggers?: TrafficLightTrigger[];
+	rungs?: TrafficLaneRung[];
+} = {}): TrafficHull {
+	return {
+		muNumSections: 0,
+		muNumSectionSpans: 0,
+		muNumJunctions: opts.junctions?.length ?? 0,
+		muNumStoplines: 0,
+		muNumNeighbours: 0,
+		muNumStaticTraffic: 0,
+		muNumVehicleAssets: 0,
+		_pad07: 0,
+		muNumRungs: opts.rungs?.length ?? 0,
+		muFirstTrafficLight: 0,
+		muLastTrafficLight: 0,
+		muNumLightTriggers: opts.lightTriggers?.length ?? 0,
+		muNumLightTriggersStartData: 0,
+		sections: [],
+		rungs: opts.rungs ?? [],
+		cumulativeRungLengths: [],
+		neighbours: [],
+		sectionSpans: [],
+		staticTrafficVehicles: [],
+		sectionFlows: [],
+		junctions: opts.junctions ?? [],
+		stopLines: [],
+		lightTriggers: opts.lightTriggers ?? [],
+		lightTriggerStartData: [],
+		lightTriggerJunctionLookup: [],
+		mauVehicleAssets: [],
+	};
+}
+
+function makeLights(opts: {
+	posAndYRotations?: Vec4[];
+	coronaPositions?: Vec4[];
+} = {}): TrafficLightCollection {
+	return {
+		posAndYRotations: opts.posAndYRotations ?? [],
+		instanceIDs: [],
+		instanceTypes: [],
+		trafficLightTypes: [],
+		coronaTypes: [],
+		coronaPositions: opts.coronaPositions ?? [],
+		mauInstanceHashOffsets: [],
+		instanceHashTable: [],
+		instanceHashToIndexLookup: [],
+	};
+}
+
+function makeModel(opts: {
+	hulls?: TrafficHull[];
+	lights?: TrafficLightCollection;
+} = {}): ParsedTrafficDataRetail {
+	return {
+		kind: 'v45',
+		muDataVersion: 45,
+		muSizeInBytes: 0,
+		pvs: {
+			mGridMin: vec4(0, 0, 0, 0),
+			mCellSize: vec4(1, 1, 1, 0),
+			mRecipCellSize: vec4(1, 1, 1, 0),
+			muNumCells_X: 0,
+			muNumCells_Z: 0,
+			muNumCells: 0,
+			hullPvsSets: [],
+		},
+		hulls: opts.hulls ?? [],
+		flowTypes: [],
+		killZoneIds: [],
+		killZones: [],
+		killZoneRegions: [],
+		vehicleTypes: [],
+		vehicleTypesUpdate: [],
+		vehicleAssets: [],
+		vehicleTraits: [],
+		trafficLights: opts.lights ?? makeLights(),
+		paintColours: [],
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Single-entity translate ops
+// ---------------------------------------------------------------------------
+
+describe('translateJunctionRigid', () => {
+	it('shifts mPosition.{x,y,z} and preserves .w (yaw)', () => {
+		const model = makeModel({
+			hulls: [makeHull({ junctions: [makeJunction(vec4(10, 20, 30, 1.5))] })],
+		});
+		const next = translateJunctionRigid(model, 0, 0, { x: 1, y: 2, z: 3 });
+		expect(next.hulls[0].junctions[0].mPosition).toEqual({ x: 11, y: 22, z: 33, w: 1.5 });
+	});
+
+	it('returns the original model on identity offset', () => {
+		const model = makeModel({
+			hulls: [makeHull({ junctions: [makeJunction(vec4(0, 0, 0, 0))] })],
+		});
+		expect(translateJunctionRigid(model, 0, 0, { x: 0, y: 0, z: 0 })).toBe(model);
+	});
+});
+
+describe('translateLightTriggerRigid', () => {
+	it('shifts mPosPlusYRot.{x,y,z} and preserves .w', () => {
+		const model = makeModel({
+			hulls: [makeHull({ lightTriggers: [makeLightTrigger(vec4(0, 0, 0, 2.5))] })],
+		});
+		const next = translateLightTriggerRigid(model, 0, 0, { x: 5, y: 0, z: -5 });
+		expect(next.hulls[0].lightTriggers[0].mPosPlusYRot).toEqual({ x: 5, y: 0, z: -5, w: 2.5 });
+	});
+});
+
+describe('translateLightInstanceRigid', () => {
+	it('shifts the addressed posAndYRotations Vec4 and preserves .w', () => {
+		const model = makeModel({
+			lights: makeLights({
+				posAndYRotations: [vec4(1, 1, 1, 0.5), vec4(2, 2, 2, 1.0)],
+			}),
+		});
+		const next = translateLightInstanceRigid(model, 1, { x: 10, y: 0, z: 0 });
+		expect(next.trafficLights.posAndYRotations[1]).toEqual({ x: 12, y: 2, z: 2, w: 1.0 });
+		// Sibling untouched (===).
+		expect(next.trafficLights.posAndYRotations[0]).toBe(model.trafficLights.posAndYRotations[0]);
+	});
+});
+
+describe('translateCoronaRigid', () => {
+	it('shifts the addressed coronaPositions Vec4 and preserves .w', () => {
+		const model = makeModel({
+			lights: makeLights({ coronaPositions: [vec4(0, 0, 0, 3.14)] }),
+		});
+		const next = translateCoronaRigid(model, 0, { x: 1, y: 0, z: 0 });
+		expect(next.trafficLights.coronaPositions[0]).toEqual({ x: 1, y: 0, z: 0, w: 3.14 });
+	});
+});
+
+describe('translateLaneRungRigid', () => {
+	it('shifts both endpoints by the same delta and preserves .w on each', () => {
+		const model = makeModel({
+			hulls: [
+				makeHull({
+					rungs: [makeRung(vec4(0, 0, 0, 0.1), vec4(10, 0, 0, 0.2))],
+				}),
+			],
+		});
+		const next = translateLaneRungRigid(model, 0, 0, { x: 5, y: 1, z: 2 });
+		const rung = next.hulls[0].rungs[0];
+		expect(rung.maPoints[0]).toEqual({ x: 5, y: 1, z: 2, w: 0.1 });
+		expect(rung.maPoints[1]).toEqual({ x: 15, y: 1, z: 2, w: 0.2 });
+		// Segment length preserved (rung remains a single segment).
+		const before = Math.hypot(
+			model.hulls[0].rungs[0].maPoints[1].x - model.hulls[0].rungs[0].maPoints[0].x,
+			model.hulls[0].rungs[0].maPoints[1].z - model.hulls[0].rungs[0].maPoints[0].z,
+		);
+		const after = Math.hypot(
+			rung.maPoints[1].x - rung.maPoints[0].x,
+			rung.maPoints[1].z - rung.maPoints[0].z,
+		);
+		expect(after).toBeCloseTo(before, 6);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Bulk translate
+// ---------------------------------------------------------------------------
+
+describe('bulkTranslateTrafficEntities', () => {
+	it('translates a mixed Selection (junction + lane rung + light instance) by the same delta', () => {
+		const model = makeModel({
+			hulls: [
+				makeHull({
+					junctions: [makeJunction(vec4(0, 0, 0, 0))],
+					rungs: [makeRung(vec4(10, 0, 0, 0), vec4(20, 0, 0, 0))],
+				}),
+			],
+			lights: makeLights({
+				posAndYRotations: [vec4(100, 50, 100, 0.5)],
+			}),
+		});
+		const refs: TrafficDataEntityRef[] = [
+			{ kind: 'junction', hullIdx: 0, junctionIdx: 0 },
+			{ kind: 'laneRung', hullIdx: 0, rungIdx: 0 },
+			{ kind: 'lightInstance', instanceIdx: 0 },
+		];
+		const next = bulkTranslateTrafficEntities(model, refs, { x: 5, y: 0, z: -5 });
+
+		expect(next.hulls[0].junctions[0].mPosition).toEqual({ x: 5, y: 0, z: -5, w: 0 });
+		expect(next.hulls[0].rungs[0].maPoints[0]).toMatchObject({ x: 15, z: -5 });
+		expect(next.hulls[0].rungs[0].maPoints[1]).toMatchObject({ x: 25, z: -5 });
+		expect(next.trafficLights.posAndYRotations[0]).toEqual({ x: 105, y: 50, z: 95, w: 0.5 });
+	});
+
+	it('preserves .w on every yaw-packed box across the translate', () => {
+		const model = makeModel({
+			hulls: [makeHull({ junctions: [makeJunction(vec4(0, 0, 0, 2.7))] })],
+		});
+		const next = bulkTranslateTrafficEntities(
+			model,
+			[{ kind: 'junction', hullIdx: 0, junctionIdx: 0 }],
+			{ x: 1, y: 1, z: 1 },
+		);
+		expect(next.hulls[0].junctions[0].mPosition.w).toBe(2.7);
+	});
+
+	it('returns the original model on identity offset', () => {
+		const model = makeModel({
+			hulls: [makeHull({ junctions: [makeJunction(vec4(0, 0, 0, 0))] })],
+		});
+		expect(
+			bulkTranslateTrafficEntities(
+				model,
+				[{ kind: 'junction', hullIdx: 0, junctionIdx: 0 }],
+				{ x: 0, y: 0, z: 0 },
+			),
+		).toBe(model);
+	});
+
+	it('returns the original model on empty refs list', () => {
+		const model = makeModel({});
+		expect(bulkTranslateTrafficEntities(model, [], { x: 1, y: 0, z: 0 })).toBe(model);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Bulk yaw rotate — rigid-body composition (position orbit + .w increment)
+// ---------------------------------------------------------------------------
+
+describe('bulkRotateTrafficEntitiesYaw', () => {
+	it('yaw-packed box: position orbits AND .w increments by theta (rigid composition)', () => {
+		// Junction at (10, 0, 0) with initial yaw .w = 0.0. Rotate +π/2
+		// around origin. Expected: position → (0, 0, 10), yaw → π/2.
+		const model = makeModel({
+			hulls: [makeHull({ junctions: [makeJunction(vec4(10, 0, 0, 0))] })],
+		});
+		const next = bulkRotateTrafficEntitiesYaw(
+			model,
+			[{ kind: 'junction', hullIdx: 0, junctionIdx: 0 }],
+			{ x: 0, z: 0 },
+			Math.PI / 2,
+		);
+		const p = next.hulls[0].junctions[0].mPosition;
+		expect(p.x).toBeCloseTo(0, 5);
+		expect(p.y).toBe(0);
+		expect(p.z).toBeCloseTo(10, 5);
+		// Critical: .w accumulates the gesture's yaw delta.
+		expect(p.w).toBeCloseTo(Math.PI / 2, 6);
+	});
+
+	it('yaw-packed box: pre-existing .w sums with the gesture delta', () => {
+		const initialYaw = 1.0;
+		const delta = 0.25;
+		const model = makeModel({
+			hulls: [makeHull({ junctions: [makeJunction(vec4(0, 0, 5, initialYaw))] })],
+		});
+		const next = bulkRotateTrafficEntitiesYaw(
+			model,
+			[{ kind: 'junction', hullIdx: 0, junctionIdx: 0 }],
+			{ x: 0, z: 0 },
+			delta,
+		);
+		expect(next.hulls[0].junctions[0].mPosition.w).toBeCloseTo(initialYaw + delta, 6);
+	});
+
+	it('lane rung: both endpoints orbit the pivot AND rung remains a single segment', () => {
+		// A rung from (10, 0) to (20, 0) — segment length 10. Rotate +π/2
+		// around origin. Both endpoints should land in the +Z half-plane and
+		// the segment length is preserved.
+		const model = makeModel({
+			hulls: [
+				makeHull({
+					rungs: [makeRung(vec4(10, 0, 0, 0.7), vec4(20, 0, 0, 0.8))],
+				}),
+			],
+		});
+		const next = bulkRotateTrafficEntitiesYaw(
+			model,
+			[{ kind: 'laneRung', hullIdx: 0, rungIdx: 0 }],
+			{ x: 0, z: 0 },
+			Math.PI / 2,
+		);
+		const rung = next.hulls[0].rungs[0];
+		expect(rung.maPoints[0].x).toBeCloseTo(0, 5);
+		expect(rung.maPoints[0].z).toBeCloseTo(10, 5);
+		expect(rung.maPoints[1].x).toBeCloseTo(0, 5);
+		expect(rung.maPoints[1].z).toBeCloseTo(20, 5);
+		// .w on lane rung endpoints is opaque, preserved verbatim.
+		expect(rung.maPoints[0].w).toBe(0.7);
+		expect(rung.maPoints[1].w).toBe(0.8);
+		// Segment length preserved.
+		const segLen = Math.hypot(
+			rung.maPoints[1].x - rung.maPoints[0].x,
+			rung.maPoints[1].z - rung.maPoints[0].z,
+		);
+		expect(segLen).toBeCloseTo(10, 5);
+	});
+
+	it('preserves relative distances within the bulk after rotation', () => {
+		// Two junctions — rotate as one rigid body around a midpoint pivot.
+		const model = makeModel({
+			hulls: [
+				makeHull({
+					junctions: [
+						makeJunction(vec4(0, 0, 0, 0)),
+						makeJunction(vec4(20, 0, 0, 0)),
+					],
+				}),
+			],
+		});
+		const refs: TrafficDataEntityRef[] = [
+			{ kind: 'junction', hullIdx: 0, junctionIdx: 0 },
+			{ kind: 'junction', hullIdx: 0, junctionIdx: 1 },
+		];
+		const next = bulkRotateTrafficEntitiesYaw(model, refs, { x: 10, z: 0 }, Math.PI / 3);
+		const a = next.hulls[0].junctions[0].mPosition;
+		const b = next.hulls[0].junctions[1].mPosition;
+		const dist = Math.hypot(b.x - a.x, b.z - a.z);
+		expect(dist).toBeCloseTo(20, 4);
+	});
+
+	it('returns the original model on theta === 0', () => {
+		const model = makeModel({});
+		expect(bulkRotateTrafficEntitiesYaw(model, [], { x: 0, z: 0 }, 0)).toBe(model);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Pivot
+// ---------------------------------------------------------------------------
+
+describe('trafficDataSelectionPivot', () => {
+	it('returns the median XYZ across a mixed Selection', () => {
+		const model = makeModel({
+			hulls: [
+				makeHull({
+					junctions: [makeJunction(vec4(0, 0, 0, 0))],
+					rungs: [makeRung(vec4(10, 0, 0, 0), vec4(20, 0, 0, 0))],
+				}),
+			],
+		});
+		// Refs contribute: junction (0,0,0) + rung endpoints (10,0,0)+(20,0,0).
+		// Median of x ∈ {0,10,20} = 10; median of z = 0.
+		const pivot = trafficDataSelectionPivot(model, [
+			{ kind: 'junction', hullIdx: 0, junctionIdx: 0 },
+			{ kind: 'laneRung', hullIdx: 0, rungIdx: 0 },
+		]);
+		expect(pivot?.x).toBe(10);
+		expect(pivot?.z).toBe(0);
+	});
+
+	it('returns null on an empty refs list', () => {
+		expect(trafficDataSelectionPivot(makeModel({}), [])).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Axes
+// ---------------------------------------------------------------------------
+
+describe('bulkTrafficDataAxes', () => {
+	it('reports yaw-only for any non-empty traffic Selection', () => {
+		const axes = bulkTrafficDataAxes([
+			{ kind: 'junction', hullIdx: 0, junctionIdx: 0 },
+		]);
+		expect(axes).toEqual(TRAFFIC_YAW_PACKED_AXES);
+		expect(axes?.rotate.x).toBe(false);
+		expect(axes?.rotate.y).toBe(true);
+		expect(axes?.rotate.z).toBe(false);
+	});
+
+	it('reports yaw-only for a lane-rung Selection (rung is XZ-packed too)', () => {
+		const axes = bulkTrafficDataAxes([
+			{ kind: 'laneRung', hullIdx: 0, rungIdx: 0 },
+		]);
+		expect(axes?.rotate.x).toBe(false);
+		expect(axes?.rotate.y).toBe(true);
+		expect(axes?.rotate.z).toBe(false);
+	});
+
+	it('returns null for empty refs', () => {
+		expect(bulkTrafficDataAxes([])).toBeNull();
+	});
+});

--- a/src/lib/core/trafficDataOps/bulk.ts
+++ b/src/lib/core/trafficDataOps/bulk.ts
@@ -1,0 +1,435 @@
+// Bulk-transform ops for the traffic-data resource family — yaw-packed
+// boxes + lane rungs (issue #79).
+//
+// Cardinality ≥ 1 entry points for the unified Bulk-transform gizmo. A
+// **Selection** of any combination of traffic yaw-packed boxes and lane
+// rungs is treated as one rigid body: every member orbits the same pivot,
+// and every yaw-packed box's `.w` slot picks up the gesture's yaw delta in
+// addition to the position orbit (rigid-body composition).
+//
+// Static traffic vehicles (Matrix44, full 3D) live in their own module —
+// they're the subject of issue #78, blocked on issue #77's trigger-box
+// work. Not folded into this file because their axis profile differs (full
+// 3-axis vs yaw-only) and the rotate semantics aren't the same (a Matrix44
+// composes with the rotation matrix; a Vec4 box composes only the W slot).
+
+import type {
+	ParsedTrafficDataRetail,
+	TrafficHull,
+	TrafficJunctionLogicBox,
+	TrafficLaneRung,
+	TrafficLightCollection,
+	TrafficLightTrigger,
+	Vec4,
+} from '../trafficData';
+import type { TransformAxes } from '../transformAxes';
+import { TRAFFIC_YAW_PACKED_AXES } from './transformAxes';
+
+// =============================================================================
+// Entity references
+// =============================================================================
+
+/**
+ * Discriminated reference to a single spatial datum in a
+ * ParsedTrafficDataRetail. Static vehicles intentionally omitted — they
+ * live in their own module and have a different axis profile.
+ *
+ * Lane rungs are addressed as a single ref (NOT per-endpoint): both
+ * endpoints move together so the rung remains a single segment. Selecting
+ * one endpoint at a time would tear the lane topology — see the comment in
+ * `translateLaneRungRigid` for the rationale.
+ */
+export type TrafficDataEntityRef =
+	| { kind: 'junction'; hullIdx: number; junctionIdx: number }
+	| { kind: 'lightTrigger'; hullIdx: number; triggerIdx: number }
+	| { kind: 'lightInstance'; instanceIdx: number }
+	| { kind: 'corona'; coronaIdx: number }
+	| { kind: 'laneRung'; hullIdx: number; rungIdx: number };
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function median(values: number[]): number {
+	const sorted = values.slice().sort((a, b) => a - b);
+	const n = sorted.length;
+	if (n === 0) return 0;
+	const mid = n >> 1;
+	return n % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function resolveYawBox(
+	model: ParsedTrafficDataRetail,
+	ref: TrafficDataEntityRef,
+): Vec4 | null {
+	switch (ref.kind) {
+		case 'junction': {
+			const hull = model.hulls[ref.hullIdx];
+			return hull?.junctions[ref.junctionIdx]?.mPosition ?? null;
+		}
+		case 'lightTrigger': {
+			const hull = model.hulls[ref.hullIdx];
+			return hull?.lightTriggers[ref.triggerIdx]?.mPosPlusYRot ?? null;
+		}
+		case 'lightInstance':
+			return model.trafficLights.posAndYRotations[ref.instanceIdx] ?? null;
+		case 'corona':
+			return model.trafficLights.coronaPositions[ref.coronaIdx] ?? null;
+		case 'laneRung':
+			return null;
+	}
+}
+
+// =============================================================================
+// Pivot
+// =============================================================================
+
+/**
+ * Median (per-component) of every spatial point the Selection addresses.
+ * Each yaw-packed box contributes its `(x, y, z)` (ignoring `.w`). Each
+ * lane rung contributes BOTH endpoints (xyz × 2). Returns `null` for empty
+ * / out-of-range refs.
+ */
+export function trafficDataSelectionPivot(
+	model: ParsedTrafficDataRetail,
+	refs: readonly TrafficDataEntityRef[],
+): { x: number; y: number; z: number } | null {
+	const xs: number[] = [];
+	const ys: number[] = [];
+	const zs: number[] = [];
+	for (const ref of refs) {
+		if (ref.kind === 'laneRung') {
+			const hull = model.hulls[ref.hullIdx];
+			const rung = hull?.rungs[ref.rungIdx];
+			if (!rung) continue;
+			for (const v of rung.maPoints) {
+				xs.push(v.x);
+				ys.push(v.y);
+				zs.push(v.z);
+			}
+			continue;
+		}
+		const box = resolveYawBox(model, ref);
+		if (!box) continue;
+		xs.push(box.x);
+		ys.push(box.y);
+		zs.push(box.z);
+	}
+	if (xs.length === 0) return null;
+	return { x: median(xs), y: median(ys), z: median(zs) };
+}
+
+// =============================================================================
+// Bucketing
+// =============================================================================
+
+type HullBucket = {
+	junctionIdxs: Set<number>;
+	lightTriggerIdxs: Set<number>;
+	laneRungIdxs: Set<number>;
+};
+
+type Buckets = {
+	hulls: Map<number, HullBucket>;
+	lightInstances: Set<number>;
+	coronas: Set<number>;
+};
+
+function bucketRefs(refs: readonly TrafficDataEntityRef[]): Buckets {
+	const hulls = new Map<number, HullBucket>();
+	const lightInstances = new Set<number>();
+	const coronas = new Set<number>();
+	const getHull = (h: number): HullBucket => {
+		let b = hulls.get(h);
+		if (!b) {
+			b = {
+				junctionIdxs: new Set(),
+				lightTriggerIdxs: new Set(),
+				laneRungIdxs: new Set(),
+			};
+			hulls.set(h, b);
+		}
+		return b;
+	};
+	for (const ref of refs) {
+		switch (ref.kind) {
+			case 'junction':
+				getHull(ref.hullIdx).junctionIdxs.add(ref.junctionIdx);
+				break;
+			case 'lightTrigger':
+				getHull(ref.hullIdx).lightTriggerIdxs.add(ref.triggerIdx);
+				break;
+			case 'laneRung':
+				getHull(ref.hullIdx).laneRungIdxs.add(ref.rungIdx);
+				break;
+			case 'lightInstance':
+				lightInstances.add(ref.instanceIdx);
+				break;
+			case 'corona':
+				coronas.add(ref.coronaIdx);
+				break;
+		}
+	}
+	return { hulls, lightInstances, coronas };
+}
+
+// =============================================================================
+// Translate
+// =============================================================================
+
+/**
+ * Translate every entity in the Selection by the same `(dx, dy, dz)`
+ * offset. Yaw-packed boxes' `.w` slots are preserved verbatim; lane rung
+ * endpoints both shift by the same delta (rung stays a single segment).
+ *
+ * Returns the original `model` reference on identity offset OR an empty
+ * refs list so byte-for-byte BND2 writeback is preserved on a no-op
+ * gesture.
+ */
+export function bulkTranslateTrafficEntities(
+	model: ParsedTrafficDataRetail,
+	refs: readonly TrafficDataEntityRef[],
+	offset: { x: number; y: number; z: number },
+): ParsedTrafficDataRetail {
+	const dx = offset.x;
+	const dy = offset.y;
+	const dz = offset.z;
+	if (dx === 0 && dy === 0 && dz === 0) return model;
+	if (refs.length === 0) return model;
+
+	const buckets = bucketRefs(refs);
+
+	const shift = (v: Vec4): Vec4 => ({
+		x: v.x + dx,
+		y: v.y + dy,
+		z: v.z + dz,
+		w: v.w,
+	});
+
+	// Hull-scope updates: junctions, lightTriggers, laneRungs.
+	let hullsChanged = false;
+	const nextHulls = model.hulls.map((hull, hullIdx): TrafficHull => {
+		const bucket = buckets.hulls.get(hullIdx);
+		if (!bucket) return hull;
+		let touched = false;
+
+		const nextJunctions = bucket.junctionIdxs.size
+			? hull.junctions.map((j, i): TrafficJunctionLogicBox => {
+					if (!bucket.junctionIdxs.has(i)) return j;
+					touched = true;
+					return { ...j, mPosition: shift(j.mPosition) };
+				})
+			: hull.junctions;
+
+		const nextLightTriggers = bucket.lightTriggerIdxs.size
+			? hull.lightTriggers.map((t, i): TrafficLightTrigger => {
+					if (!bucket.lightTriggerIdxs.has(i)) return t;
+					touched = true;
+					return { ...t, mPosPlusYRot: shift(t.mPosPlusYRot) };
+				})
+			: hull.lightTriggers;
+
+		const nextRungs = bucket.laneRungIdxs.size
+			? hull.rungs.map((r, i): TrafficLaneRung => {
+					if (!bucket.laneRungIdxs.has(i)) return r;
+					touched = true;
+					return { maPoints: [shift(r.maPoints[0]), shift(r.maPoints[1])] };
+				})
+			: hull.rungs;
+
+		if (!touched) return hull;
+		hullsChanged = true;
+		return {
+			...hull,
+			junctions: nextJunctions,
+			lightTriggers: nextLightTriggers,
+			rungs: nextRungs,
+		};
+	});
+
+	// Top-level traffic-light collection: lightInstances + coronas.
+	let tlcChanged = false;
+	let nextTrafficLights: TrafficLightCollection = model.trafficLights;
+	if (buckets.lightInstances.size || buckets.coronas.size) {
+		const tlc = model.trafficLights;
+		const nextPos = buckets.lightInstances.size
+			? tlc.posAndYRotations.map((v, i) => {
+					if (!buckets.lightInstances.has(i)) return v;
+					tlcChanged = true;
+					return shift(v);
+				})
+			: tlc.posAndYRotations;
+		const nextCoronas = buckets.coronas.size
+			? tlc.coronaPositions.map((v, i) => {
+					if (!buckets.coronas.has(i)) return v;
+					tlcChanged = true;
+					return shift(v);
+				})
+			: tlc.coronaPositions;
+		if (tlcChanged) {
+			nextTrafficLights = {
+				...tlc,
+				posAndYRotations: nextPos,
+				coronaPositions: nextCoronas,
+			};
+		}
+	}
+
+	if (!hullsChanged && !tlcChanged) return model;
+	return {
+		...model,
+		...(hullsChanged ? { hulls: nextHulls } : {}),
+		...(tlcChanged ? { trafficLights: nextTrafficLights } : {}),
+	};
+}
+
+// =============================================================================
+// Rotate (yaw) — rigid-body composition
+// =============================================================================
+
+/**
+ * Yaw-rotate every entity in the Selection around `pivot` by `theta`
+ * radians. The composition rule (per issue #79):
+ *
+ *   - Yaw-packed boxes: position `(x, y, z)` orbits the pivot in the XZ
+ *     plane (Y unchanged); the W slot picks up `+ theta` (the gesture's
+ *     yaw delta is added to the box's own stored yaw). This is the rigid-
+ *     body interpretation — when you rotate a yaw-packed box around a
+ *     pivot, both its world position AND its own facing rotate together.
+ *
+ *   - Lane rungs: both endpoints' positions orbit the pivot in the XZ
+ *     plane (Y unchanged on each); the W slot on each endpoint is
+ *     preserved verbatim (lane rungs don't carry their own yaw — W is an
+ *     opaque slot here).
+ *
+ * Yaw direction follows the right-hand rule with thumb along world +Y, so
+ * positive `theta` rotates +X towards +Z — same convention as the AI
+ * sections bulk and three.js's `Object3D.rotation.y`.
+ *
+ * Returns the original `model` reference on `theta === 0` OR an empty refs
+ * list.
+ */
+export function bulkRotateTrafficEntitiesYaw(
+	model: ParsedTrafficDataRetail,
+	refs: readonly TrafficDataEntityRef[],
+	pivot: { x: number; z: number },
+	theta: number,
+): ParsedTrafficDataRetail {
+	if (theta === 0) return model;
+	if (refs.length === 0) return model;
+
+	const cosT = Math.cos(theta);
+	const sinT = Math.sin(theta);
+	const cx = pivot.x;
+	const cz = pivot.z;
+
+	const orbit = (v: Vec4, addToW: boolean): Vec4 => {
+		const ox = v.x - cx;
+		const oz = v.z - cz;
+		return {
+			x: ox * cosT - oz * sinT + cx,
+			y: v.y,
+			z: ox * sinT + oz * cosT + cz,
+			w: addToW ? v.w + theta : v.w,
+		};
+	};
+
+	const buckets = bucketRefs(refs);
+
+	let hullsChanged = false;
+	const nextHulls = model.hulls.map((hull, hullIdx): TrafficHull => {
+		const bucket = buckets.hulls.get(hullIdx);
+		if (!bucket) return hull;
+		let touched = false;
+
+		const nextJunctions = bucket.junctionIdxs.size
+			? hull.junctions.map((j, i): TrafficJunctionLogicBox => {
+					if (!bucket.junctionIdxs.has(i)) return j;
+					touched = true;
+					return { ...j, mPosition: orbit(j.mPosition, true) };
+				})
+			: hull.junctions;
+
+		const nextLightTriggers = bucket.lightTriggerIdxs.size
+			? hull.lightTriggers.map((t, i): TrafficLightTrigger => {
+					if (!bucket.lightTriggerIdxs.has(i)) return t;
+					touched = true;
+					return { ...t, mPosPlusYRot: orbit(t.mPosPlusYRot, true) };
+				})
+			: hull.lightTriggers;
+
+		const nextRungs = bucket.laneRungIdxs.size
+			? hull.rungs.map((r, i): TrafficLaneRung => {
+					if (!bucket.laneRungIdxs.has(i)) return r;
+					touched = true;
+					return {
+						maPoints: [
+							orbit(r.maPoints[0], false),
+							orbit(r.maPoints[1], false),
+						],
+					};
+				})
+			: hull.rungs;
+
+		if (!touched) return hull;
+		hullsChanged = true;
+		return {
+			...hull,
+			junctions: nextJunctions,
+			lightTriggers: nextLightTriggers,
+			rungs: nextRungs,
+		};
+	});
+
+	let tlcChanged = false;
+	let nextTrafficLights: TrafficLightCollection = model.trafficLights;
+	if (buckets.lightInstances.size || buckets.coronas.size) {
+		const tlc = model.trafficLights;
+		const nextPos = buckets.lightInstances.size
+			? tlc.posAndYRotations.map((v, i) => {
+					if (!buckets.lightInstances.has(i)) return v;
+					tlcChanged = true;
+					return orbit(v, true);
+				})
+			: tlc.posAndYRotations;
+		const nextCoronas = buckets.coronas.size
+			? tlc.coronaPositions.map((v, i) => {
+					if (!buckets.coronas.has(i)) return v;
+					tlcChanged = true;
+					return orbit(v, true);
+				})
+			: tlc.coronaPositions;
+		if (tlcChanged) {
+			nextTrafficLights = {
+				...tlc,
+				posAndYRotations: nextPos,
+				coronaPositions: nextCoronas,
+			};
+		}
+	}
+
+	if (!hullsChanged && !tlcChanged) return model;
+	return {
+		...model,
+		...(hullsChanged ? { hulls: nextHulls } : {}),
+		...(tlcChanged ? { trafficLights: nextTrafficLights } : {}),
+	};
+}
+
+// =============================================================================
+// Axes intersection contribution
+// =============================================================================
+
+/**
+ * Effective TransformAxes for a multi-Selection of traffic-data entities
+ * covered by this module (junctions, lightTriggers, lightInstances,
+ * coronas, laneRungs). All are XZ-packed per ADR-0011 — yaw-only.
+ *
+ * Returns `null` for an empty refs list.
+ */
+export function bulkTrafficDataAxes(
+	refs: readonly TrafficDataEntityRef[],
+): TransformAxes | null {
+	if (refs.length === 0) return null;
+	return TRAFFIC_YAW_PACKED_AXES;
+}

--- a/src/lib/core/trafficDataOps/index.ts
+++ b/src/lib/core/trafficDataOps/index.ts
@@ -1,0 +1,28 @@
+// Barrel for `@/lib/core/trafficDataOps`.
+//
+// Re-exports every public symbol from the directory's sub-modules so that
+// external callers can keep `import { ... } from '@/lib/core/trafficDataOps'`
+// without caring which file the symbol lives in. Scope is yaw-packed boxes
+// (junction logic boxes, light triggers, traffic-light collection elements,
+// corona positions) plus lane rungs — every traffic entity whose spatial
+// data is XZ-packed per ADR-0011. Static traffic vehicles (Matrix44, full
+// 3D) live in their own module and are tracked by issue #78.
+
+export {
+	TRAFFIC_LANE_RUNG_AXES,
+	TRAFFIC_YAW_PACKED_AXES,
+} from './transformAxes';
+export {
+	translateCoronaRigid,
+	translateJunctionRigid,
+	translateLaneRungRigid,
+	translateLightInstanceRigid,
+	translateLightTriggerRigid,
+} from './translateRigid';
+export {
+	bulkRotateTrafficEntitiesYaw,
+	bulkTrafficDataAxes,
+	bulkTranslateTrafficEntities,
+	trafficDataSelectionPivot,
+	type TrafficDataEntityRef,
+} from './bulk';

--- a/src/lib/core/trafficDataOps/transformAxes.ts
+++ b/src/lib/core/trafficDataOps/transformAxes.ts
@@ -1,0 +1,40 @@
+// Transform-axis profile for traffic-data resource entities.
+//
+// Per ADR-0011, every entity covered by this module has spatial data that
+// is XZ-packed in some way:
+//
+//   - Yaw-packed Vector4 boxes (junction logic boxes, light triggers,
+//     traffic-light collection elements, corona positions) carry `(x, y, z,
+//     yaw)` and rotate around world +Y only — pitch/roll have no `.w` slot
+//     to land in, so they auto-disable.
+//   - Lane rungs hold two Vector4 endpoints whose Y is interpreted as
+//     terrain height. The rung is a horizontal segment between two world
+//     points; rotating it out of the XZ plane breaks the lane topology, so
+//     pitch/roll auto-disable. (We retain Y on translate so a user
+//     repositioning a rung between two elevation tiers can shift it
+//     vertically — the inspector numeric fields can still edit Y directly.)
+//
+// Static traffic vehicles are full-3D `Matrix44` and live in a separate
+// module (issue #78) — they DO NOT auto-disable pitch or roll.
+
+import type { TransformAxes } from '../transformAxes';
+
+/**
+ * Traffic yaw-packed Vector4 box / element: full 3-axis translate, yaw-only
+ * rotate. The `.w` field receives the yaw delta; `.x/.y/.z` orbit the bulk
+ * pivot on a yaw rotate (rigid-body composition).
+ */
+export const TRAFFIC_YAW_PACKED_AXES: TransformAxes = {
+	translate: { x: true, y: true, z: true },
+	rotate: { x: false, y: true, z: false },
+};
+
+/**
+ * Traffic lane rung: full 3-axis translate, yaw-only rotate. Same profile
+ * as the yaw-packed boxes — the two endpoints together act as a horizontal
+ * segment, and rotating them out of the XZ plane has no on-disk meaning.
+ */
+export const TRAFFIC_LANE_RUNG_AXES: TransformAxes = {
+	translate: { x: true, y: true, z: true },
+	rotate: { x: false, y: true, z: false },
+};

--- a/src/lib/core/trafficDataOps/translateRigid.ts
+++ b/src/lib/core/trafficDataOps/translateRigid.ts
@@ -1,0 +1,230 @@
+// Traffic-data rigid single-entity translate ops.
+//
+// Yaw-packed boxes (`TrafficJunctionLogicBox.mPosition`,
+// `TrafficLightTrigger.mPosPlusYRot`, `TrafficLightCollection.posAndYRotations[]`,
+// `TrafficLightCollection.coronaPositions[]`) all carry their position in
+// the XYZ slots of a `Vec4`, with the W slot reserved for the per-box yaw
+// (Y rotation). A translate gesture shifts only the position — the yaw is
+// preserved verbatim. A rotate gesture is a *bulk* concern (a point can't
+// rotate around itself) and lives in `./bulk.ts` so the position orbits a
+// shared pivot AND the W slot picks up the gesture's yaw delta.
+//
+// Lane rungs (`TrafficLaneRung.maPoints[2]`) are pairs of `Vec4` endpoints
+// that form a single horizontal segment. Translate moves both endpoints by
+// the same delta; yaw rotate (in `./bulk.ts`) orbits each endpoint around
+// the pivot. The pair is the unit of selection — there's no "select a
+// single rung endpoint" affordance, because doing so would tear the segment.
+
+import type {
+	ParsedTrafficDataRetail,
+	TrafficHull,
+	TrafficJunctionLogicBox,
+	TrafficLaneRung,
+	TrafficLightCollection,
+	TrafficLightTrigger,
+	Vec4,
+} from '../trafficData';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function replaceHull(
+	model: ParsedTrafficDataRetail,
+	hullIdx: number,
+	next: TrafficHull,
+): ParsedTrafficDataRetail {
+	const hulls = model.hulls.map((h, i) => (i === hullIdx ? next : h));
+	return { ...model, hulls };
+}
+
+function translateVec4Xyz(v: Vec4, dx: number, dy: number, dz: number): Vec4 {
+	return { x: v.x + dx, y: v.y + dy, z: v.z + dz, w: v.w };
+}
+
+// =============================================================================
+// Junction logic box — `mPosition` Vec4 with yaw in `.w`
+// =============================================================================
+
+/**
+ * Translate a single junction logic box's `mPosition` by a 3D offset.
+ * Touches only `mPosition.{x,y,z}` — the W slot (yaw) is preserved verbatim.
+ *
+ * Returns the original `model` reference when `(dx, dy, dz) === (0, 0, 0)`
+ * so byte-for-byte BND2 writeback is preserved on a no-op gesture.
+ *
+ * @throws RangeError if any index is out of range.
+ */
+export function translateJunctionRigid(
+	model: ParsedTrafficDataRetail,
+	hullIdx: number,
+	junctionIdx: number,
+	offset: { x: number; y: number; z: number },
+): ParsedTrafficDataRetail {
+	if (hullIdx < 0 || hullIdx >= model.hulls.length) {
+		throw new RangeError(`hullIdx ${hullIdx} out of range [0, ${model.hulls.length})`);
+	}
+	const hull = model.hulls[hullIdx];
+	if (junctionIdx < 0 || junctionIdx >= hull.junctions.length) {
+		throw new RangeError(`junctionIdx ${junctionIdx} out of range [0, ${hull.junctions.length})`);
+	}
+	const dx = offset.x;
+	const dy = offset.y;
+	const dz = offset.z;
+	if (dx === 0 && dy === 0 && dz === 0) return model;
+
+	const src = hull.junctions[junctionIdx];
+	const next: TrafficJunctionLogicBox = {
+		...src,
+		mPosition: translateVec4Xyz(src.mPosition, dx, dy, dz),
+	};
+	const junctions = hull.junctions.map((j, i) => (i === junctionIdx ? next : j));
+	return replaceHull(model, hullIdx, { ...hull, junctions });
+}
+
+// =============================================================================
+// Light trigger — `mPosPlusYRot` Vec4 with yaw in `.w`
+// =============================================================================
+
+/**
+ * Translate a single light trigger's `mPosPlusYRot` by a 3D offset.
+ * Touches only the XYZ slots; the W slot (yaw) is preserved verbatim.
+ *
+ * Returns the original `model` reference on identity offset.
+ *
+ * @throws RangeError if any index is out of range.
+ */
+export function translateLightTriggerRigid(
+	model: ParsedTrafficDataRetail,
+	hullIdx: number,
+	triggerIdx: number,
+	offset: { x: number; y: number; z: number },
+): ParsedTrafficDataRetail {
+	if (hullIdx < 0 || hullIdx >= model.hulls.length) {
+		throw new RangeError(`hullIdx ${hullIdx} out of range [0, ${model.hulls.length})`);
+	}
+	const hull = model.hulls[hullIdx];
+	if (triggerIdx < 0 || triggerIdx >= hull.lightTriggers.length) {
+		throw new RangeError(`triggerIdx ${triggerIdx} out of range [0, ${hull.lightTriggers.length})`);
+	}
+	const dx = offset.x;
+	const dy = offset.y;
+	const dz = offset.z;
+	if (dx === 0 && dy === 0 && dz === 0) return model;
+
+	const src = hull.lightTriggers[triggerIdx];
+	const next: TrafficLightTrigger = {
+		...src,
+		mPosPlusYRot: translateVec4Xyz(src.mPosPlusYRot, dx, dy, dz),
+	};
+	const lightTriggers = hull.lightTriggers.map((t, i) => (i === triggerIdx ? next : t));
+	return replaceHull(model, hullIdx, { ...hull, lightTriggers });
+}
+
+// =============================================================================
+// Traffic-light collection — top-level (not under hulls)
+// =============================================================================
+
+/**
+ * Translate one `posAndYRotations[i]` (per-light position + yaw) by a 3D
+ * offset. The W slot (yaw) is preserved verbatim.
+ */
+export function translateLightInstanceRigid(
+	model: ParsedTrafficDataRetail,
+	instanceIdx: number,
+	offset: { x: number; y: number; z: number },
+): ParsedTrafficDataRetail {
+	const tlc = model.trafficLights;
+	if (instanceIdx < 0 || instanceIdx >= tlc.posAndYRotations.length) {
+		throw new RangeError(
+			`instanceIdx ${instanceIdx} out of range [0, ${tlc.posAndYRotations.length})`,
+		);
+	}
+	const dx = offset.x;
+	const dy = offset.y;
+	const dz = offset.z;
+	if (dx === 0 && dy === 0 && dz === 0) return model;
+
+	const next: TrafficLightCollection = {
+		...tlc,
+		posAndYRotations: tlc.posAndYRotations.map((v, i) =>
+			i === instanceIdx ? translateVec4Xyz(v, dx, dy, dz) : v,
+		),
+	};
+	return { ...model, trafficLights: next };
+}
+
+/**
+ * Translate one `coronaPositions[i]` Vec4 by a 3D offset. The W slot is
+ * preserved verbatim — it carries a corona-specific authored value (yaw or
+ * scale, depending on light type) that the gizmo doesn't reinterpret.
+ */
+export function translateCoronaRigid(
+	model: ParsedTrafficDataRetail,
+	coronaIdx: number,
+	offset: { x: number; y: number; z: number },
+): ParsedTrafficDataRetail {
+	const tlc = model.trafficLights;
+	if (coronaIdx < 0 || coronaIdx >= tlc.coronaPositions.length) {
+		throw new RangeError(
+			`coronaIdx ${coronaIdx} out of range [0, ${tlc.coronaPositions.length})`,
+		);
+	}
+	const dx = offset.x;
+	const dy = offset.y;
+	const dz = offset.z;
+	if (dx === 0 && dy === 0 && dz === 0) return model;
+
+	const next: TrafficLightCollection = {
+		...tlc,
+		coronaPositions: tlc.coronaPositions.map((v, i) =>
+			i === coronaIdx ? translateVec4Xyz(v, dx, dy, dz) : v,
+		),
+	};
+	return { ...model, trafficLights: next };
+}
+
+// =============================================================================
+// Lane rung — pair of Vec4 endpoints, moved as a single segment
+// =============================================================================
+
+/**
+ * Translate a single lane rung as a rigid segment. Both endpoints move by
+ * the same `(dx, dy, dz)`; the W slot on each is preserved verbatim.
+ *
+ * The rung is the unit of selection (per the rung-integrity rule in issue
+ * #79's spec) — there's no "select one rung endpoint" affordance, because
+ * tearing a rung's endpoints apart breaks the lane segment it represents.
+ *
+ * Returns the original `model` reference on identity offset.
+ *
+ * @throws RangeError if any index is out of range.
+ */
+export function translateLaneRungRigid(
+	model: ParsedTrafficDataRetail,
+	hullIdx: number,
+	rungIdx: number,
+	offset: { x: number; y: number; z: number },
+): ParsedTrafficDataRetail {
+	if (hullIdx < 0 || hullIdx >= model.hulls.length) {
+		throw new RangeError(`hullIdx ${hullIdx} out of range [0, ${model.hulls.length})`);
+	}
+	const hull = model.hulls[hullIdx];
+	if (rungIdx < 0 || rungIdx >= hull.rungs.length) {
+		throw new RangeError(`rungIdx ${rungIdx} out of range [0, ${hull.rungs.length})`);
+	}
+	const dx = offset.x;
+	const dy = offset.y;
+	const dz = offset.z;
+	if (dx === 0 && dy === 0 && dz === 0) return model;
+
+	const src = hull.rungs[rungIdx];
+	const next: TrafficLaneRung = {
+		maPoints: [
+			translateVec4Xyz(src.maPoints[0], dx, dy, dz),
+			translateVec4Xyz(src.maPoints[1], dx, dy, dz),
+		],
+	};
+	const rungs = hull.rungs.map((r, i) => (i === rungIdx ? next : r));
+	return replaceHull(model, hullIdx, { ...hull, rungs });
+}

--- a/src/lib/core/zoneListOps/bulk.test.ts
+++ b/src/lib/core/zoneListOps/bulk.test.ts
@@ -1,0 +1,289 @@
+// Unit tests for zoneListOps — single-entity translate, bulk translate,
+// bulk yaw rotate, axes intersection contribution.
+
+import { describe, it, expect } from 'vitest';
+import type { ParsedZoneList, Zone } from '../zoneList';
+import {
+	ZONE_POINT_AXES,
+	bulkRotateZoneEntitiesYaw,
+	bulkTranslateZoneEntities,
+	bulkZoneListAxes,
+	translateZonePointRigid,
+	translateZoneRigid,
+	zoneListSelectionPivot,
+	type ZoneListEntityRef,
+} from '.';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makePoint(x: number, y: number) {
+	// Vec2Padded with deliberately non-zero pad slots so we can pin
+	// "padding survives a translate / rotate" in assertions.
+	return { x, y, _padA: 0.5, _padB: -0.25 };
+}
+
+function makeZone(opts: { id: bigint; points: { x: number; y: number }[] }): Zone {
+	return {
+		muZoneId: opts.id,
+		miZoneType: 0,
+		miNumPoints: opts.points.length,
+		muFlags: 0,
+		points: opts.points.map((p) => makePoint(p.x, p.y)),
+		safeNeighbours: [],
+		unsafeNeighbours: [],
+		_pad0C: 0,
+		_pad24: [0, 0, 0],
+		_trailingNeighbourPad: new Uint8Array(0),
+	};
+}
+
+function makeModel(zones: Zone[]): ParsedZoneList {
+	return { zones };
+}
+
+const PADS = { _padA: 0.5, _padB: -0.25 };
+
+// ---------------------------------------------------------------------------
+// Single-entity translate
+// ---------------------------------------------------------------------------
+
+describe('translateZonePointRigid', () => {
+	it('shifts the addressed point by (dx, dz) and preserves padding', () => {
+		const model = makeModel([
+			makeZone({
+				id: 0xA00n,
+				points: [
+					{ x: 0, y: 0 },
+					{ x: 10, y: 0 },
+					{ x: 10, y: 10 },
+					{ x: 0, y: 10 },
+				],
+			}),
+		]);
+		const next = translateZonePointRigid(model, 0, 1, { x: 3, z: -2 });
+		const moved = next.zones[0].points[1];
+		expect(moved.x).toBe(13);
+		expect(moved.y).toBe(-2);
+		expect(moved._padA).toBe(0.5);
+		expect(moved._padB).toBe(-0.25);
+		// Other points are referentially identical.
+		expect(next.zones[0].points[0]).toBe(model.zones[0].points[0]);
+		expect(next.zones[0].points[2]).toBe(model.zones[0].points[2]);
+		expect(next.zones[0].points[3]).toBe(model.zones[0].points[3]);
+	});
+
+	it('returns the original model on a (0, 0) offset', () => {
+		const model = makeModel([makeZone({ id: 0n, points: [{ x: 0, y: 0 }] })]);
+		expect(translateZonePointRigid(model, 0, 0, { x: 0, z: 0 })).toBe(model);
+	});
+
+	it('throws RangeError for out-of-range indices', () => {
+		const model = makeModel([makeZone({ id: 0n, points: [{ x: 0, y: 0 }] })]);
+		expect(() => translateZonePointRigid(model, 5, 0, { x: 1, z: 0 })).toThrow(RangeError);
+		expect(() => translateZonePointRigid(model, 0, 5, { x: 1, z: 0 })).toThrow(RangeError);
+	});
+});
+
+describe('translateZoneRigid', () => {
+	it('shifts every point of the addressed zone by the same offset', () => {
+		const model = makeModel([
+			makeZone({
+				id: 1n,
+				points: [
+					{ x: 0, y: 0 },
+					{ x: 10, y: 0 },
+					{ x: 10, y: 10 },
+					{ x: 0, y: 10 },
+				],
+			}),
+		]);
+		const next = translateZoneRigid(model, 0, { x: 5, z: 5 });
+		expect(next.zones[0].points.map((p) => [p.x, p.y])).toEqual([
+			[5, 5], [15, 5], [15, 15], [5, 15],
+		]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Bulk translate
+// ---------------------------------------------------------------------------
+
+describe('bulkTranslateZoneEntities', () => {
+	function makeTrio(): ParsedZoneList {
+		return makeModel([
+			makeZone({ id: 1n, points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }] }),
+			makeZone({ id: 2n, points: [{ x: 20, y: 0 }, { x: 30, y: 0 }, { x: 30, y: 10 }, { x: 20, y: 10 }] }),
+			makeZone({ id: 3n, points: [{ x: 40, y: 0 }, { x: 50, y: 0 }, { x: 50, y: 10 }, { x: 40, y: 10 }] }),
+		]);
+	}
+
+	it('translates whole-zone refs by the same delta as a rigid body', () => {
+		const model = makeTrio();
+		const refs: ZoneListEntityRef[] = [
+			{ kind: 'zone', zoneIdx: 0 },
+			{ kind: 'zone', zoneIdx: 2 },
+		];
+		const next = bulkTranslateZoneEntities(model, refs, { x: 1, z: 2 });
+		// Selected zones shifted.
+		expect(next.zones[0].points[0]).toMatchObject({ x: 1, y: 2 });
+		expect(next.zones[2].points[0]).toMatchObject({ x: 41, y: 2 });
+		// Unselected zone untouched (===).
+		expect(next.zones[1]).toBe(model.zones[1]);
+	});
+
+	it('translates point-scope refs without touching siblings on the same zone', () => {
+		const model = makeTrio();
+		const refs: ZoneListEntityRef[] = [
+			{ kind: 'zonePoint', zoneIdx: 0, pointIdx: 0 },
+			{ kind: 'zonePoint', zoneIdx: 0, pointIdx: 2 },
+		];
+		const next = bulkTranslateZoneEntities(model, refs, { x: 5, z: -5 });
+		expect(next.zones[0].points[0]).toMatchObject({ x: 5, y: -5 });
+		expect(next.zones[0].points[2]).toMatchObject({ x: 15, y: 5 });
+		// Siblings untouched (===).
+		expect(next.zones[0].points[1]).toBe(model.zones[0].points[1]);
+		expect(next.zones[0].points[3]).toBe(model.zones[0].points[3]);
+		// Sibling zones untouched (===).
+		expect(next.zones[1]).toBe(model.zones[1]);
+		expect(next.zones[2]).toBe(model.zones[2]);
+	});
+
+	it('returns the original model on an identity offset', () => {
+		const model = makeTrio();
+		expect(
+			bulkTranslateZoneEntities(model, [{ kind: 'zone', zoneIdx: 0 }], { x: 0, z: 0 }),
+		).toBe(model);
+	});
+
+	it('returns the original model on an empty refs list', () => {
+		const model = makeTrio();
+		expect(bulkTranslateZoneEntities(model, [], { x: 1, z: 1 })).toBe(model);
+	});
+
+	it('preserves padding (_padA, _padB) verbatim across the translate', () => {
+		const model = makeTrio();
+		const next = bulkTranslateZoneEntities(
+			model,
+			[{ kind: 'zonePoint', zoneIdx: 0, pointIdx: 0 }],
+			{ x: 7, z: 7 },
+		);
+		expect(next.zones[0].points[0]._padA).toBe(PADS._padA);
+		expect(next.zones[0].points[0]._padB).toBe(PADS._padB);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Bulk yaw rotate
+// ---------------------------------------------------------------------------
+
+describe('bulkRotateZoneEntitiesYaw', () => {
+	it('rotates a point 90° around the world origin', () => {
+		// A single point at (10, 0) → (0, 10) after +π/2 yaw around origin.
+		const model = makeModel([
+			makeZone({ id: 1n, points: [{ x: 10, y: 0 }] }),
+		]);
+		const next = bulkRotateZoneEntitiesYaw(
+			model,
+			[{ kind: 'zone', zoneIdx: 0 }],
+			{ x: 0, z: 0 },
+			Math.PI / 2,
+		);
+		const r = next.zones[0].points[0];
+		expect(r.x).toBeCloseTo(0, 5);
+		expect(r.y).toBeCloseTo(10, 5);
+	});
+
+	it('preserves relative distances within the bulk after rotation', () => {
+		// Two zones — rotate as one rigid body around (5, 5). The distance
+		// between the two centres must equal the pre-rotation distance.
+		const model = makeModel([
+			makeZone({ id: 1n, points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }] }),
+			makeZone({ id: 2n, points: [{ x: 20, y: 0 }, { x: 30, y: 0 }, { x: 30, y: 10 }, { x: 20, y: 10 }] }),
+		]);
+		const refs: ZoneListEntityRef[] = [
+			{ kind: 'zone', zoneIdx: 0 },
+			{ kind: 'zone', zoneIdx: 1 },
+		];
+		const beforeC0 = avgPoint(model.zones[0].points);
+		const beforeC1 = avgPoint(model.zones[1].points);
+		const beforeDist = Math.hypot(beforeC1.x - beforeC0.x, beforeC1.z - beforeC0.z);
+		const next = bulkRotateZoneEntitiesYaw(model, refs, { x: 5, z: 5 }, Math.PI / 3);
+		const afterC0 = avgPoint(next.zones[0].points);
+		const afterC1 = avgPoint(next.zones[1].points);
+		const afterDist = Math.hypot(afterC1.x - afterC0.x, afterC1.z - afterC0.z);
+		expect(afterDist).toBeCloseTo(beforeDist, 4);
+	});
+
+	it('returns the original model on theta === 0', () => {
+		const model = makeModel([makeZone({ id: 1n, points: [{ x: 1, y: 1 }] })]);
+		expect(
+			bulkRotateZoneEntitiesYaw(
+				model,
+				[{ kind: 'zone', zoneIdx: 0 }],
+				{ x: 0, z: 0 },
+				0,
+			),
+		).toBe(model);
+	});
+
+	it('returns the original model on an empty refs list', () => {
+		const model = makeModel([makeZone({ id: 1n, points: [{ x: 1, y: 1 }] })]);
+		expect(bulkRotateZoneEntitiesYaw(model, [], { x: 0, z: 0 }, Math.PI)).toBe(model);
+	});
+});
+
+function avgPoint(points: readonly { x: number; y: number }[]) {
+	let sx = 0, sy = 0;
+	for (const p of points) { sx += p.x; sy += p.y; }
+	const n = points.length || 1;
+	return { x: sx / n, z: sy / n };
+}
+
+// ---------------------------------------------------------------------------
+// Pivot
+// ---------------------------------------------------------------------------
+
+describe('zoneListSelectionPivot', () => {
+	it('returns the median XZ of the whole zone for a single whole-zone ref', () => {
+		const model = makeModel([
+			makeZone({ id: 1n, points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }] }),
+		]);
+		const pivot = zoneListSelectionPivot(model, [{ kind: 'zone', zoneIdx: 0 }]);
+		// Median of [0, 0, 10, 10] is (0+10)/2 = 5 for both X and Z.
+		expect(pivot).toEqual({ x: 5, y: 0, z: 5 });
+	});
+
+	it('returns null on an empty / out-of-range refs list', () => {
+		const model = makeModel([]);
+		expect(zoneListSelectionPivot(model, [])).toBeNull();
+		expect(
+			zoneListSelectionPivot(
+				makeModel([makeZone({ id: 1n, points: [{ x: 0, y: 0 }] })]),
+				[{ kind: 'zone', zoneIdx: 99 }],
+			),
+		).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Axes
+// ---------------------------------------------------------------------------
+
+describe('bulkZoneListAxes', () => {
+	it('reports yaw-only for any non-empty zone-point Selection', () => {
+		const axes = bulkZoneListAxes([{ kind: 'zone', zoneIdx: 0 }]);
+		expect(axes).toEqual(ZONE_POINT_AXES);
+		expect(axes?.rotate.x).toBe(false);
+		expect(axes?.rotate.y).toBe(true);
+		expect(axes?.rotate.z).toBe(false);
+		// Translate Y still on — the gizmo renders the Y arrow and the
+		// commit-side drops the delta.y for XZ-packed entities.
+		expect(axes?.translate.y).toBe(true);
+	});
+
+	it('returns null for an empty refs list', () => {
+		expect(bulkZoneListAxes([])).toBeNull();
+	});
+});

--- a/src/lib/core/zoneListOps/bulk.ts
+++ b/src/lib/core/zoneListOps/bulk.ts
@@ -1,0 +1,236 @@
+// Bulk-transform ops for the zone-list resource family.
+//
+// Cardinality ≥ 1 entry points for the unified Bulk-transform gizmo. A
+// **Selection** of zone points (whole zones AND/or individual points across
+// any zones) is treated as one rigid body: every member orbits the same
+// pivot. No cascade — there's no "neighbour follows" topology to maintain
+// on zones (the safe/unsafe-neighbour lists are graph edges, not geometric
+// joins — moving a zone leaves them semantically intact).
+//
+// XZ-packed per ADR-0011: yaw-only rotate, full 3-axis translate (the Y
+// delta is dropped on commit because zone points are `Vec2Padded` with no
+// Y component). The transformAxes profile lives in `./transformAxes`.
+
+import type { ParsedZoneList, Zone } from '../zoneList';
+import type { TransformAxes } from '../transformAxes';
+import { ZONE_POINT_AXES } from './transformAxes';
+
+// =============================================================================
+// Entity references
+// =============================================================================
+
+/** Discriminated reference to a single spatial datum in a ParsedZoneList. */
+export type ZoneListEntityRef =
+	/** The whole zone — every point moves together. */
+	| { kind: 'zone'; zoneIdx: number }
+	/** A single point on a zone (one of four in retail). */
+	| { kind: 'zonePoint'; zoneIdx: number; pointIdx: number };
+
+// =============================================================================
+// Pivot
+// =============================================================================
+
+/**
+ * Median (per-component) of every spatial point the Selection addresses.
+ * Returns a 3D point with Y = 0 — zone points have no Y, but the gizmo's
+ * pivot is a `Vector3` so heterogeneous bulks (zone + 3D resource) can mix.
+ *
+ * Returns `null` when the refs list is empty or every ref points at an
+ * out-of-range entity.
+ */
+export function zoneListSelectionPivot(
+	model: ParsedZoneList,
+	refs: readonly ZoneListEntityRef[],
+): { x: number; y: number; z: number } | null {
+	const xs: number[] = [];
+	const zs: number[] = [];
+	for (const ref of refs) {
+		const zone = model.zones[ref.zoneIdx];
+		if (!zone) continue;
+		if (ref.kind === 'zone') {
+			for (const p of zone.points) {
+				xs.push(p.x);
+				zs.push(p.y);
+			}
+			continue;
+		}
+		const point = zone.points[ref.pointIdx];
+		if (!point) continue;
+		xs.push(point.x);
+		zs.push(point.y);
+	}
+	if (xs.length === 0) return null;
+	return { x: median(xs), y: 0, z: median(zs) };
+}
+
+function median(values: number[]): number {
+	const sorted = values.slice().sort((a, b) => a - b);
+	const n = sorted.length;
+	if (n === 0) return 0;
+	const mid = n >> 1;
+	return n % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+// =============================================================================
+// Bucketing helpers
+// =============================================================================
+
+type ZoneRefBucket = {
+	wholeZone: boolean;
+	pointIdxs: Set<number>;
+};
+
+function bucketRefs(refs: readonly ZoneListEntityRef[]): Map<number, ZoneRefBucket> {
+	const map = new Map<number, ZoneRefBucket>();
+	for (const ref of refs) {
+		let bucket = map.get(ref.zoneIdx);
+		if (!bucket) {
+			bucket = { wholeZone: false, pointIdxs: new Set() };
+			map.set(ref.zoneIdx, bucket);
+		}
+		if (ref.kind === 'zone') bucket.wholeZone = true;
+		else bucket.pointIdxs.add(ref.pointIdx);
+	}
+	return map;
+}
+
+// =============================================================================
+// Translate
+// =============================================================================
+
+/**
+ * Translate every entity in the Selection by the same `(dx, dz)` offset,
+ * treating the bulk as one rigid body. No cascade — neighbour lists keep
+ * their indices and the zone graph is otherwise untouched.
+ *
+ * Returns the original `model` reference on a (0, 0) offset OR an empty
+ * refs list so byte-for-byte BND2 writeback is preserved on a no-op
+ * gesture.
+ */
+export function bulkTranslateZoneEntities(
+	model: ParsedZoneList,
+	refs: readonly ZoneListEntityRef[],
+	offset: { x: number; z: number },
+): ParsedZoneList {
+	const dx = offset.x;
+	const dz = offset.z;
+	if (dx === 0 && dz === 0) return model;
+	if (refs.length === 0) return model;
+
+	const buckets = bucketRefs(refs);
+	let anyChange = false;
+	const nextZones = model.zones.map((zone, zoneIdx) => {
+		const bucket = buckets.get(zoneIdx);
+		if (!bucket) return zone;
+		if (bucket.wholeZone) {
+			anyChange = true;
+			return {
+				...zone,
+				points: zone.points.map((p) => ({ ...p, x: p.x + dx, y: p.y + dz })),
+			};
+		}
+		let zoneTouched = false;
+		const nextPoints = zone.points.map((p, pi) => {
+			if (!bucket.pointIdxs.has(pi)) return p;
+			zoneTouched = true;
+			return { ...p, x: p.x + dx, y: p.y + dz };
+		});
+		if (!zoneTouched) return zone;
+		anyChange = true;
+		return { ...zone, points: nextPoints } satisfies Zone;
+	});
+	if (!anyChange) return model;
+	return { ...model, zones: nextZones };
+}
+
+// =============================================================================
+// Rotate (yaw)
+// =============================================================================
+
+/**
+ * Yaw-rotate every entity in the Selection around `pivot` by `theta`
+ * radians. Treats the bulk as one rigid body — every selected coordinate
+ * orbits the single shared pivot, so relative distances within the bulk
+ * are preserved exactly.
+ *
+ * Yaw direction follows the right-hand rule with thumb along world +Y
+ * (positive `theta` rotates +X towards +Z) — same convention as
+ * `bulkRotateEntitiesYaw` for AI sections.
+ *
+ * Returns the original `model` reference on `theta === 0` OR an empty
+ * refs list.
+ */
+export function bulkRotateZoneEntitiesYaw(
+	model: ParsedZoneList,
+	refs: readonly ZoneListEntityRef[],
+	pivot: { x: number; z: number },
+	theta: number,
+): ParsedZoneList {
+	if (theta === 0) return model;
+	if (refs.length === 0) return model;
+
+	const cosT = Math.cos(theta);
+	const sinT = Math.sin(theta);
+	const cx = pivot.x;
+	const cz = pivot.z;
+
+	const rotXZ = (x: number, z: number): { x: number; z: number } => {
+		const ox = x - cx;
+		const oz = z - cz;
+		return {
+			x: ox * cosT - oz * sinT + cx,
+			z: ox * sinT + oz * cosT + cz,
+		};
+	};
+
+	const buckets = bucketRefs(refs);
+	let anyChange = false;
+	const nextZones = model.zones.map((zone, zoneIdx) => {
+		const bucket = buckets.get(zoneIdx);
+		if (!bucket) return zone;
+		if (bucket.wholeZone) {
+			anyChange = true;
+			return {
+				...zone,
+				points: zone.points.map((p) => {
+					const r = rotXZ(p.x, p.y);
+					return { ...p, x: r.x, y: r.z };
+				}),
+			};
+		}
+		let zoneTouched = false;
+		const nextPoints = zone.points.map((p, pi) => {
+			if (!bucket.pointIdxs.has(pi)) return p;
+			zoneTouched = true;
+			const r = rotXZ(p.x, p.y);
+			return { ...p, x: r.x, y: r.z };
+		});
+		if (!zoneTouched) return zone;
+		anyChange = true;
+		return { ...zone, points: nextPoints };
+	});
+	if (!anyChange) return model;
+	return { ...model, zones: nextZones };
+}
+
+// =============================================================================
+// Axes intersection contribution
+// =============================================================================
+
+/**
+ * Effective TransformAxes for a multi-Selection of zone-list entities. Every
+ * member is XZ-packed (`Vec2Padded`) per ADR-0011 — yaw-only on rotate. The
+ * function exists as a separate export so cross-resource bulks (zone +
+ * trigger box, for instance) can run their axes profile through
+ * `intersectTransformAxes` and have the zone-list contribution AND-down the
+ * pitch/roll rings.
+ *
+ * Returns `null` for an empty refs list so callers can fall back to "no
+ * gizmo".
+ */
+export function bulkZoneListAxes(
+	refs: readonly ZoneListEntityRef[],
+): TransformAxes | null {
+	if (refs.length === 0) return null;
+	return ZONE_POINT_AXES;
+}

--- a/src/lib/core/zoneListOps/index.ts
+++ b/src/lib/core/zoneListOps/index.ts
@@ -1,0 +1,19 @@
+// Barrel for `@/lib/core/zoneListOps`.
+//
+// Re-exports every public symbol from the directory's sub-modules so that
+// external callers can keep `import { ... } from '@/lib/core/zoneListOps'`
+// without caring which file the symbol lives in. Mirrors the shape of
+// `aiSectionsOps` — see that directory's `index.ts` for the rationale.
+
+export { ZONE_POINT_AXES } from './transformAxes';
+export {
+	translateZonePointRigid,
+	translateZoneRigid,
+} from './translateRigid';
+export {
+	bulkRotateZoneEntitiesYaw,
+	bulkTranslateZoneEntities,
+	bulkZoneListAxes,
+	zoneListSelectionPivot,
+	type ZoneListEntityRef,
+} from './bulk';

--- a/src/lib/core/zoneListOps/transformAxes.ts
+++ b/src/lib/core/zoneListOps/transformAxes.ts
@@ -1,0 +1,26 @@
+// Transform-axis profile for zone-list resource entities.
+//
+// Per ADR-0011, zone points are `Vec2Padded` (XZ on the ground plane, with
+// two trailing f32 pad slots preserved verbatim for byte-for-byte BND2
+// writeback). They have no Y component to receive pitch (around X) or roll
+// (around Z), so any **Selection** containing a zone point auto-disables the
+// X/Z rotate rings. Yaw stays enabled because corners orbit cleanly around a
+// world-+Y axis.
+//
+// Translate Y is intentionally still ON: the bulk gizmo always renders a Y
+// arrow for visual consistency, and dragging it on a pure-XZ entity is a
+// no-op for that entity. Mixed-Selection bulks (zone point + Vector3 ref)
+// honour the Y arrow on the 3D members; the zone-point member just discards
+// its own Y delta on commit.
+
+import type { TransformAxes } from '../transformAxes';
+
+/**
+ * Yaw-only rotate, full 3-axis translate. Same profile AI section corners
+ * and boundary lines wear today — the gizmo greys out the X and Z rotate
+ * rings whenever any zone point is in the Selection.
+ */
+export const ZONE_POINT_AXES: TransformAxes = {
+	translate: { x: true, y: true, z: true },
+	rotate: { x: false, y: true, z: false },
+};

--- a/src/lib/core/zoneListOps/translateRigid.ts
+++ b/src/lib/core/zoneListOps/translateRigid.ts
@@ -1,0 +1,87 @@
+// Zone-list rigid translate/rotate (single-entity Bulk-transform ops).
+//
+// Zone points live on the streaming PVS quad — four `Vec2Padded` entries per
+// zone, addressed by `(zoneIdx, pointIdx)`. The padded `Vec2` keeps `_padA`
+// and `_padB` as opaque f32 slots so byte-for-byte BND2 writeback survives
+// any edit (the disk format defines a 16-byte stride per point, of which
+// only the first 8 bytes are interpreted as `(x, z)` in editor-display
+// coordinates — `Vec2Padded.y` holds the world Z, matching the AI-section
+// convention).
+//
+// XZ-packed per ADR-0011: every gesture is yaw-only on the rotate axis;
+// translate.y is dropped at the call site. The transformAxes profile lives
+// in `./transformAxes`; these ops accept only the XZ delta to make the
+// no-Y contract explicit at the type level.
+
+import type { ParsedZoneList, Zone } from '../zoneList';
+
+/**
+ * Translate one zone point by an XZ offset — no cascade. Touches only the
+ * single `Vec2Padded` addressed by `(zoneIdx, pointIdx)`; the padded slots
+ * (`_padA`, `_padB`) on that point are preserved verbatim, and every other
+ * point + every other zone in the model stays structurally identical
+ * (===-equal) so React memoisation along the spine survives.
+ *
+ * Returns the original `model` reference when `(dx, dz) === (0, 0)` so
+ * byte-for-byte BND2 writeback is preserved on a no-op gesture.
+ *
+ * @throws RangeError if `zoneIdx` or `pointIdx` is out of range.
+ */
+export function translateZonePointRigid(
+	model: ParsedZoneList,
+	zoneIdx: number,
+	pointIdx: number,
+	offset: { x: number; z: number },
+): ParsedZoneList {
+	if (zoneIdx < 0 || zoneIdx >= model.zones.length) {
+		throw new RangeError(`zoneIdx ${zoneIdx} out of range [0, ${model.zones.length})`);
+	}
+	const src = model.zones[zoneIdx];
+	if (pointIdx < 0 || pointIdx >= src.points.length) {
+		throw new RangeError(`pointIdx ${pointIdx} out of range [0, ${src.points.length})`);
+	}
+	const dx = offset.x;
+	const dz = offset.z;
+	if (dx === 0 && dz === 0) return model;
+
+	const next: Zone = {
+		...src,
+		points: src.points.map((p, i) =>
+			i === pointIdx
+				? { ...p, x: p.x + dx, y: p.y + dz }
+				: p,
+		),
+	};
+	const zones = model.zones.map((z, i) => (i === zoneIdx ? next : z));
+	return { ...model, zones };
+}
+
+/**
+ * Translate every point of one zone (a "whole-zone" Selection) by the same
+ * XZ offset. Equivalent to calling {@link translateZonePointRigid} four
+ * times, but produces fewer intermediate objects on the array spine.
+ *
+ * Returns the original `model` reference when `(dx, dz) === (0, 0)`.
+ *
+ * @throws RangeError if `zoneIdx` is out of range.
+ */
+export function translateZoneRigid(
+	model: ParsedZoneList,
+	zoneIdx: number,
+	offset: { x: number; z: number },
+): ParsedZoneList {
+	if (zoneIdx < 0 || zoneIdx >= model.zones.length) {
+		throw new RangeError(`zoneIdx ${zoneIdx} out of range [0, ${model.zones.length})`);
+	}
+	const dx = offset.x;
+	const dz = offset.z;
+	if (dx === 0 && dz === 0) return model;
+
+	const src = model.zones[zoneIdx];
+	const next: Zone = {
+		...src,
+		points: src.points.map((p) => ({ ...p, x: p.x + dx, y: p.y + dz })),
+	};
+	const zones = model.zones.map((z, i) => (i === zoneIdx ? next : z));
+	return { ...model, zones };
+}


### PR DESCRIPTION
## Summary

- New resource-adapter modules mirroring `aiSectionsOps`:
  - `src/lib/core/zoneListOps/` — zone-point translate/rotate (XZ-packed, ADR-0011)
  - `src/lib/core/streetDataOps/` — Road `mReferencePosition` translate (pure 3D)
  - `src/lib/core/trafficDataOps/` — junction logic boxes, light triggers, traffic-light collection elements, corona positions, lane rungs (all XZ-packed)
- Yaw rotation of yaw-packed Vec4 traffic boxes composes as a rigid body: position orbits the pivot AND `.w` picks up the gesture's yaw delta. Lane rungs orbit both endpoints around the pivot so the rung remains a single segment.
- Auto-disable rule made exhaustive — any **Selection** containing any XZ-packed resource (AI section corner, boundary line, no-go line, zone point, traffic yaw box, lane rung) reports yaw-only via `intersectTransformAxes`. Pure-3D street refs don't veto pitch/roll, but mixed Selections (street + zone) still gray out the X/Z rings.
- Wired the `BulkTransformGizmo` into `ZoneListOverlay`, `StreetDataOverlay`, and `TrafficDataOverlay`. Commit-on-release for one Workspace-undo entry per gesture.

## Judgment calls

- **Lane rung selection is the pair, not the endpoint.** Selecting one endpoint would tear the segment; the issue spec calls this out. The `TrafficDataEntityRef` uses a single `{ kind: 'laneRung', hullIdx, rungIdx }` and both endpoints move/orbit together. Lane-rung endpoint `.w` is preserved verbatim (opaque slot per data shape).
- **Corona position counted as yaw-packed.** `TrafficLightCollection.coronaPositions[i]` is a `Vec4`; the issue spec groups it with yaw-packed boxes, so it inherits the same axis profile and `.w` composition rule. Coronas don't carry a separate yaw field anyway — `.w` is interpreted as the per-corona yaw exactly as the spec dictates.
- **Street ref's single-entity vs bulk axes.** Single-entity selection disables all rotate rings (a point can't rotate around itself); bulk axes are full 3-axis so street refs don't veto pitch/roll in mixed Selections — only the XZ-packed sibling does, via the existing intersection helper.

## Tests added

- `zoneListOps/bulk.test.ts` (17 tests) — translate/rotate semantics, padding preservation, pivot, axes.
- `streetDataOps/bulk.test.ts` (13 tests) — translate-only single & bulk, axes profile differences.
- `trafficDataOps/bulk.test.ts` (20 tests) — yaw box rigid-body composition (position + `.w`), lane rung pair integrity, pivot, axes.
- `__tests__/transformAxesXzPackedFamilies.test.ts` (7 tests) — cross-resource auto-disable: zone+street, zone+trigger placeholder, AI+zone+traffic mixed Selection.

Total **57** new tests, all passing.

## Pre-existing test failures

Baseline 14 (all ENOENT: `example/older builds/AI.dat` fixture missing) — unchanged. 1267 passing (was 1210 baseline).

## Anticipated rebase conflicts

- **#76 (Pivot drag), #77 (trigger boxes), #80 / #81 / #82** all touch `BulkTransformGizmo.tsx` or the overlay wiring. Conflicts will be mechanical:
  - `transformAxesXzPackedFamilies.test.ts` will swap in the real `bulkTriggerDataAxes` once #77 lands (the test currently uses `TRANSFORM_AXES_FULL_3D` as the trigger-box stand-in).
  - The three overlays' gizmo-block insertions are siblings to other gizmo work — easy 3-way merge if the AISections pattern is shared.

## Test plan

- [ ] Drag a zone point — yaw-only rotate, XYZ translate, no model mutation until release.
- [ ] Drag a junction box / light trigger / lane rung — rotate ring increments `.w` AND orbits position.
- [ ] Drag a Road marker — full 3-axis translate, single rotate disabled.
- [ ] Mixed Selection (street + zone point in same Workspace bulk) — yaw-only.

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)