### PR TITLE
feat: static traffic vehicle integration with Bulk transform (Matrix44 composition) (#78)

### DIFF
--- a/src/components/schema-editor/viewports/TrafficDataOverlay.tsx
+++ b/src/components/schema-editor/viewports/TrafficDataOverlay.tsx
@@ -28,8 +28,11 @@ import * as THREE from 'three';
 import type { ParsedTrafficDataRetail } from '@/lib/core/trafficData';
 import {
 	TRAFFIC_LANE_RUNG_AXES,
+	TRAFFIC_STATIC_VEHICLE_AXES,
 	TRAFFIC_YAW_PACKED_AXES,
+	bulkRotateTrafficEntitiesMatrix44,
 	bulkRotateTrafficEntitiesYaw,
+	bulkTrafficDataAxes,
 	bulkTranslateTrafficEntities,
 	trafficDataSelectionPivot,
 	type TrafficDataEntityRef,
@@ -261,34 +264,75 @@ export const TrafficDataOverlay: WorldOverlayComponent<ParsedTrafficDataRetail> 
 			: -1;
 
 	// =========================================================================
-	// Bulk-transform gizmo (issue #79)
+	// Bulk-transform gizmo (issues #78 + #79)
 	//
-	// Maps the schema-Selection (junction / lightTrigger / rung) to a single
-	// `TrafficDataEntityRef`, anchors the gizmo at the entity's pivot, and on
-	// commit applies the bulk op (rigid translate + yaw rotate). The yaw rotate
-	// of a yaw-packed box composes BOTH the position orbit AND the .w slot —
-	// the gesture's yaw delta is added to the box's stored yaw (rigid-body
-	// composition per issue #79). Lane rungs orbit both endpoints around the
-	// pivot so the rung remains a single segment.
+	// Maps the schema-Selection (junction / lightTrigger / rung / static
+	// vehicle) to a `TrafficDataEntityRef` list and folds in any
+	// marquee-selected static vehicles from the schema bulk context, then
+	// anchors the gizmo at the median pivot. On commit:
+	//
+	//   - Translate: every entity's position shifts by the same delta —
+	//     yaw-packed boxes shift the XYZ slots of their Vec4, lane rungs
+	//     shift both endpoints, static vehicles shift the translation
+	//     column of their `mTransform`.
+	//   - Rotate: composition depends on the Selection's axis profile.
+	//     A pure-static-vehicle Selection (issue #78) rotates with the
+	//     full-3D Matrix44 path — pre-multiplying each vehicle's
+	//     `mTransform` by `T(P) · R(delta) · T(-P)`. Any Selection
+	//     containing a yaw-packed sibling collapses to yaw-only (ADR-0011)
+	//     and runs the legacy yaw rotate (`bulkRotateTrafficEntitiesYaw`),
+	//     which orbits positions in XZ AND adds the yaw delta to each
+	//     box's stored `.w` (or pre-multiplies the static vehicle's matrix
+	//     by a Y-axis rotation, if a vehicle happens to be in the mix).
 	// =========================================================================
 	const bulkRefs = useMemo<readonly TrafficDataEntityRef[]>(() => {
-		if (!selected || isPvsCellSelection(selected)) return [];
-		if (!selected.sub) return [];
-		const hullIdx = selected.hullIndex;
-		switch (selected.sub.type) {
-			case 'junction':
-				return [{ kind: 'junction', hullIdx, junctionIdx: selected.sub.index }];
-			case 'lightTrigger':
-				return [{ kind: 'lightTrigger', hullIdx, triggerIdx: selected.sub.index }];
-			case 'rung':
-				return [{ kind: 'laneRung', hullIdx, rungIdx: selected.sub.index }];
-			default:
-				// Section / staticVehicle picks fall through — sections are
-				// region-only (no transform target yet), static vehicles are
-				// Matrix44 and live in issue #78.
-				return [];
+		const out: TrafficDataEntityRef[] = [];
+		const seen = new Set<string>();
+
+		const addStaticVehicle = (hullIdx: number, vehicleIdx: number) => {
+			if (hullIdx < 0 || hullIdx >= hulls.length) return;
+			const hull = hulls[hullIdx];
+			if (vehicleIdx < 0 || vehicleIdx >= hull.staticTrafficVehicles.length) return;
+			const key = `sv:${hullIdx}:${vehicleIdx}`;
+			if (seen.has(key)) return;
+			seen.add(key);
+			out.push({ kind: 'staticVehicle', hullIdx, vehicleIdx });
+		};
+
+		// Marquee-selected static vehicles. Paths look like
+		// `['hulls', h, 'staticTrafficVehicles', s]` (see the marquee
+		// handler that emits them above).
+		if (bulk?.bulkPathKeys) {
+			for (const key of bulk.bulkPathKeys) {
+				const parts = key.split('/');
+				if (parts.length !== 4 || parts[0] !== 'hulls' || parts[2] !== 'staticTrafficVehicles') continue;
+				const h = Number(parts[1]);
+				const s = Number(parts[3]);
+				if (Number.isFinite(h) && Number.isFinite(s)) addStaticVehicle(h, s);
+			}
 		}
-	}, [selected]);
+
+		// Inspector pick (single-select).
+		if (selected && !isPvsCellSelection(selected) && selected.sub) {
+			const hullIdx = selected.hullIndex;
+			switch (selected.sub.type) {
+				case 'junction':
+					out.push({ kind: 'junction', hullIdx, junctionIdx: selected.sub.index });
+					break;
+				case 'lightTrigger':
+					out.push({ kind: 'lightTrigger', hullIdx, triggerIdx: selected.sub.index });
+					break;
+				case 'rung':
+					out.push({ kind: 'laneRung', hullIdx, rungIdx: selected.sub.index });
+					break;
+				case 'staticVehicle':
+					addStaticVehicle(hullIdx, selected.sub.index);
+					break;
+				// Section picks have no transform target — pass-through.
+			}
+		}
+		return out;
+	}, [selected, bulk, hulls]);
 
 	// Snapshot the pivot at gesture start so it doesn't drift mid-rotate — see
 	// the AISectionsOverlay comment for the rationale.
@@ -301,13 +345,37 @@ export const TrafficDataOverlay: WorldOverlayComponent<ParsedTrafficDataRetail> 
 
 	const gizmoAxes = useMemo(() => {
 		if (bulkRefs.length === 0) return TRAFFIC_YAW_PACKED_AXES;
+		// Pure-static-vehicle Selection → full 3-axis (Matrix44). Anything
+		// else falls into the AND-intersection — a yaw-packed sibling
+		// vetoes pitch/roll per ADR-0011. The single-entity static-vehicle
+		// case is a one-element list of kind 'staticVehicle' so it short-
+		// circuits to the full-3D constant.
+		if (bulkRefs.every((r) => r.kind === 'staticVehicle')) {
+			return TRAFFIC_STATIC_VEHICLE_AXES;
+		}
 		// Lane rung vs yaw-packed share the same axis profile today, but we
 		// dispatch through the canonical constant for each so a future
-		// differentiation lands without re-wiring.
+		// differentiation lands without re-wiring. When a static vehicle is
+		// mixed with a yaw-only sibling, the AND-intersection in
+		// `bulkTrafficDataAxes` collapses to yaw-only.
+		const mixed = bulkTrafficDataAxes(bulkRefs);
+		if (mixed) return mixed;
 		return bulkRefs[0].kind === 'laneRung'
 			? TRAFFIC_LANE_RUNG_AXES
 			: TRAFFIC_YAW_PACKED_AXES;
 	}, [bulkRefs]);
+
+	// Selections containing a static vehicle take the full-3D Matrix44
+	// rotate path on commit, because that's the only op that knows how to
+	// pre-multiply a `mTransform`. For mixed Selections the gizmo's
+	// rotation rings will already be greyed down to yaw-only by
+	// `gizmoAxes` above, so the matrix-44 path just composes a yaw delta
+	// (`{x: 0, y: theta, z: 0}`) — same result as the legacy yaw rotate,
+	// but it covers the static-vehicle case too.
+	const usesMatrix44Rotate = useMemo(
+		() => bulkRefs.some((r) => r.kind === 'staticVehicle'),
+		[bulkRefs],
+	);
 
 	const gizmoPosition = useMemo<[number, number, number] | null>(() => {
 		const pivot = bulkPivotRef.current ?? bulkPivotLive;
@@ -336,16 +404,33 @@ export const TrafficDataOverlay: WorldOverlayComponent<ParsedTrafficDataRetail> 
 		if (delta.translate.x !== 0 || delta.translate.y !== 0 || delta.translate.z !== 0) {
 			next = bulkTranslateTrafficEntities(next, bulkRefs, delta.translate);
 		}
-		if (delta.rotate.y !== 0 && pivot) {
-			next = bulkRotateTrafficEntitiesYaw(
-				next,
-				bulkRefs,
-				{ x: pivot.x + delta.translate.x, z: pivot.z + delta.translate.z },
-				delta.rotate.y,
-			);
+		const hasRotate = delta.rotate.x !== 0 || delta.rotate.y !== 0 || delta.rotate.z !== 0;
+		if (hasRotate && pivot) {
+			// The translated pivot — bulk rotate is applied AFTER translate, so
+			// the pivot has to move with the gesture's translate delta.
+			const rotatedPivot = {
+				x: pivot.x + delta.translate.x,
+				y: pivot.y + delta.translate.y,
+				z: pivot.z + delta.translate.z,
+			};
+			if (usesMatrix44Rotate) {
+				next = bulkRotateTrafficEntitiesMatrix44(
+					next,
+					bulkRefs,
+					rotatedPivot,
+					delta.rotate,
+				);
+			} else if (delta.rotate.y !== 0) {
+				next = bulkRotateTrafficEntitiesYaw(
+					next,
+					bulkRefs,
+					{ x: rotatedPivot.x, z: rotatedPivot.z },
+					delta.rotate.y,
+				);
+			}
 		}
 		if (next !== data) onChange(next);
-	}, [data, onChange, bulkRefs]);
+	}, [data, onChange, bulkRefs, usesMatrix44Rotate]);
 
 	const handleGizmoCancel = useCallback(() => {
 		setDragDelta(null);

--- a/src/lib/core/trafficDataOps/bulk.test.ts
+++ b/src/lib/core/trafficDataOps/bulk.test.ts
@@ -1,8 +1,9 @@
 // Unit tests for trafficDataOps — single-entity translate, bulk translate,
 // bulk yaw rotate (with rigid-body .w composition for yaw-packed boxes),
-// axes intersection contribution.
+// bulk Matrix44 rotate (full 3-axis for static vehicles), axes intersection.
 
 import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
 import type {
 	ParsedTrafficDataRetail,
 	TrafficHull,
@@ -10,13 +11,17 @@ import type {
 	TrafficLaneRung,
 	TrafficLightCollection,
 	TrafficLightTrigger,
+	TrafficStaticVehicle,
 	Vec4,
 } from '../trafficData';
 import {
+	TRAFFIC_STATIC_VEHICLE_AXES,
 	TRAFFIC_YAW_PACKED_AXES,
+	bulkRotateTrafficEntitiesMatrix44,
 	bulkRotateTrafficEntitiesYaw,
 	bulkTrafficDataAxes,
 	bulkTranslateTrafficEntities,
+	trafficDataRefAxes,
 	trafficDataSelectionPivot,
 	translateCoronaRigid,
 	translateJunctionRigid,
@@ -25,6 +30,7 @@ import {
 	translateLightTriggerRigid,
 	type TrafficDataEntityRef,
 } from '.';
+import { intersectTransformAxes } from '../transformAxes';
 
 // ---------------------------------------------------------------------------
 // Fixtures — minimal valid retail model. Most arrays are empty; we only
@@ -64,10 +70,34 @@ function makeRung(a: Vec4, b: Vec4): TrafficLaneRung {
 	return { maPoints: [a, b] };
 }
 
+/** Build a `TrafficStaticVehicle` from a translation + Euler rotation,
+ *  composing via `THREE.Matrix4` so the storage layout (column-major) is
+ *  the canonical one — same shape `readMatrix` consumes. */
+function makeStaticVehicle(
+	pos: { x: number; y: number; z: number },
+	euler: { x: number; y: number; z: number } = { x: 0, y: 0, z: 0 },
+): TrafficStaticVehicle {
+	const mat = new THREE.Matrix4().compose(
+		new THREE.Vector3(pos.x, pos.y, pos.z),
+		new THREE.Quaternion().setFromEuler(new THREE.Euler(euler.x, euler.y, euler.z, 'XYZ')),
+		new THREE.Vector3(1, 1, 1),
+	);
+	const arr = mat.toArray();
+	arr[3] = 0; arr[7] = 0; arr[11] = 0; arr[15] = 0;
+	return {
+		mTransform: arr,
+		mFlowTypeID: 0,
+		mExistsAtAllChance: 0,
+		muFlags: 0,
+		_pad43: new Array(12).fill(0),
+	};
+}
+
 function makeHull(opts: {
 	junctions?: TrafficJunctionLogicBox[];
 	lightTriggers?: TrafficLightTrigger[];
 	rungs?: TrafficLaneRung[];
+	staticVehicles?: TrafficStaticVehicle[];
 } = {}): TrafficHull {
 	return {
 		muNumSections: 0,
@@ -75,7 +105,7 @@ function makeHull(opts: {
 		muNumJunctions: opts.junctions?.length ?? 0,
 		muNumStoplines: 0,
 		muNumNeighbours: 0,
-		muNumStaticTraffic: 0,
+		muNumStaticTraffic: opts.staticVehicles?.length ?? 0,
 		muNumVehicleAssets: 0,
 		_pad07: 0,
 		muNumRungs: opts.rungs?.length ?? 0,
@@ -88,7 +118,7 @@ function makeHull(opts: {
 		cumulativeRungLengths: [],
 		neighbours: [],
 		sectionSpans: [],
-		staticTrafficVehicles: [],
+		staticTrafficVehicles: opts.staticVehicles ?? [],
 		sectionFlows: [],
 		junctions: opts.junctions ?? [],
 		stopLines: [],
@@ -425,7 +455,7 @@ describe('trafficDataSelectionPivot', () => {
 // ---------------------------------------------------------------------------
 
 describe('bulkTrafficDataAxes', () => {
-	it('reports yaw-only for any non-empty traffic Selection', () => {
+	it('reports yaw-only for a yaw-packed Selection', () => {
 		const axes = bulkTrafficDataAxes([
 			{ kind: 'junction', hullIdx: 0, junctionIdx: 0 },
 		]);
@@ -444,7 +474,277 @@ describe('bulkTrafficDataAxes', () => {
 		expect(axes?.rotate.z).toBe(false);
 	});
 
+	it('reports full 3-axis rotate for a pure static-vehicle Selection (issue #78)', () => {
+		const axes = bulkTrafficDataAxes([
+			{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 },
+		]);
+		expect(axes?.rotate.x).toBe(true);
+		expect(axes?.rotate.y).toBe(true);
+		expect(axes?.rotate.z).toBe(true);
+	});
+
+	it('AND-intersects: static vehicle + yaw-packed sibling → yaw-only (ADR-0011)', () => {
+		const axes = bulkTrafficDataAxes([
+			{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 },
+			{ kind: 'junction', hullIdx: 0, junctionIdx: 0 },
+		]);
+		expect(axes?.rotate.x).toBe(false);
+		expect(axes?.rotate.y).toBe(true);
+		expect(axes?.rotate.z).toBe(false);
+	});
+
+	it('AND-intersects: static vehicle + lane rung → yaw-only', () => {
+		const axes = bulkTrafficDataAxes([
+			{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 },
+			{ kind: 'laneRung', hullIdx: 0, rungIdx: 0 },
+		]);
+		expect(axes?.rotate.x).toBe(false);
+		expect(axes?.rotate.y).toBe(true);
+		expect(axes?.rotate.z).toBe(false);
+	});
+
 	it('returns null for empty refs', () => {
 		expect(bulkTrafficDataAxes([])).toBeNull();
+	});
+
+	it('per-ref helper: trafficDataRefAxes(staticVehicle) reports full 3D', () => {
+		expect(trafficDataRefAxes({ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 })).toEqual(
+			TRAFFIC_STATIC_VEHICLE_AXES,
+		);
+	});
+
+	it('per-ref helper: trafficDataRefAxes(junction) reports yaw-only', () => {
+		expect(trafficDataRefAxes({ kind: 'junction', hullIdx: 0, junctionIdx: 0 })).toEqual(
+			TRAFFIC_YAW_PACKED_AXES,
+		);
+	});
+
+	it('cross-resource: static vehicle + simulated trigger-box (FULL_3D) → all 3 axes (issue #77 + #78)', () => {
+		// Trigger boxes are full-3D; mixing them with a static vehicle should
+		// keep the rotate rings interactive on all three axes.
+		const svAxes = bulkTrafficDataAxes([
+			{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 },
+		])!;
+		const triggerAxes = { translate: { x: true, y: true, z: true }, rotate: { x: true, y: true, z: true } };
+		const intersected = intersectTransformAxes([svAxes, triggerAxes]);
+		expect(intersected.rotate.x).toBe(true);
+		expect(intersected.rotate.y).toBe(true);
+		expect(intersected.rotate.z).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Static vehicle — single + bulk + cross-validation (issue #78)
+// ---------------------------------------------------------------------------
+
+describe('bulkTranslateTrafficEntities — static vehicles', () => {
+	it('shifts the translation column of every selected vehicle by the same delta', () => {
+		const a = makeStaticVehicle({ x: 0, y: 0, z: 0 });
+		const b = makeStaticVehicle({ x: 10, y: 0, z: 0 });
+		const model = makeModel({ hulls: [makeHull({ staticVehicles: [a, b] })] });
+		const next = bulkTranslateTrafficEntities(
+			model,
+			[
+				{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 },
+				{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 1 },
+			],
+			{ x: 1, y: 2, z: 3 },
+		);
+		const v0 = next.hulls[0].staticTrafficVehicles[0];
+		const v1 = next.hulls[0].staticTrafficVehicles[1];
+		expect(v0.mTransform[12]).toBe(1);
+		expect(v0.mTransform[13]).toBe(2);
+		expect(v0.mTransform[14]).toBe(3);
+		expect(v1.mTransform[12]).toBe(11);
+		expect(v1.mTransform[13]).toBe(2);
+		expect(v1.mTransform[14]).toBe(3);
+	});
+
+	it('mixed Selection (static vehicle + junction): every entity moves by the delta', () => {
+		const sv = makeStaticVehicle({ x: 5, y: 5, z: 5 });
+		const model = makeModel({
+			hulls: [
+				makeHull({
+					junctions: [makeJunction(vec4(0, 0, 0, 1.0))],
+					staticVehicles: [sv],
+				}),
+			],
+		});
+		const next = bulkTranslateTrafficEntities(
+			model,
+			[
+				{ kind: 'junction', hullIdx: 0, junctionIdx: 0 },
+				{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 },
+			],
+			{ x: 2, y: 0, z: -1 },
+		);
+		expect(next.hulls[0].junctions[0].mPosition).toEqual({ x: 2, y: 0, z: -1, w: 1.0 });
+		const svNext = next.hulls[0].staticTrafficVehicles[0];
+		expect(svNext.mTransform[12]).toBe(7);
+		expect(svNext.mTransform[13]).toBe(5);
+		expect(svNext.mTransform[14]).toBe(4);
+	});
+
+	it('returns the original model on identity offset', () => {
+		const sv = makeStaticVehicle({ x: 0, y: 0, z: 0 });
+		const model = makeModel({ hulls: [makeHull({ staticVehicles: [sv] })] });
+		expect(
+			bulkTranslateTrafficEntities(
+				model,
+				[{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 }],
+				{ x: 0, y: 0, z: 0 },
+			),
+		).toBe(model);
+	});
+});
+
+describe('bulkRotateTrafficEntitiesMatrix44 — static vehicles', () => {
+	it('rotates a single vehicle around its own position: position unchanged, facing rotates by delta', () => {
+		const pos = { x: 7, y: 0, z: -5 };
+		const v = makeStaticVehicle(pos);
+		const model = makeModel({ hulls: [makeHull({ staticVehicles: [v] })] });
+		const next = bulkRotateTrafficEntitiesMatrix44(
+			model,
+			[{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 }],
+			pos,
+			{ x: 0, y: Math.PI / 2, z: 0 },
+		);
+		const m = next.hulls[0].staticTrafficVehicles[0].mTransform;
+		expect(m[12]).toBeCloseTo(pos.x, 5);
+		expect(m[13]).toBeCloseTo(pos.y, 5);
+		expect(m[14]).toBeCloseTo(pos.z, 5);
+	});
+
+	it('rotates two vehicles around a common pivot: pairwise distance preserved', () => {
+		const a = makeStaticVehicle({ x: 0, y: 0, z: 0 });
+		const b = makeStaticVehicle({ x: 20, y: 0, z: 0 });
+		const model = makeModel({ hulls: [makeHull({ staticVehicles: [a, b] })] });
+		const next = bulkRotateTrafficEntitiesMatrix44(
+			model,
+			[
+				{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 },
+				{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 1 },
+			],
+			{ x: 10, y: 0, z: 0 },
+			{ x: 0, y: Math.PI / 3, z: 0 },
+		);
+		const ta = next.hulls[0].staticTrafficVehicles[0].mTransform;
+		const tb = next.hulls[0].staticTrafficVehicles[1].mTransform;
+		const dist = Math.hypot(tb[12] - ta[12], tb[13] - ta[13], tb[14] - ta[14]);
+		expect(dist).toBeCloseTo(20, 4);
+	});
+
+	it('returns the original model on identity rotation', () => {
+		const sv = makeStaticVehicle({ x: 0, y: 0, z: 0 });
+		const model = makeModel({ hulls: [makeHull({ staticVehicles: [sv] })] });
+		expect(
+			bulkRotateTrafficEntitiesMatrix44(
+				model,
+				[{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 }],
+				{ x: 0, y: 0, z: 0 },
+				{ x: 0, y: 0, z: 0 },
+			),
+		).toBe(model);
+	});
+
+	it('no-op rotate returns the SAME mTransform reference (byte-for-byte writeback)', () => {
+		// Critical invariant: byte-for-byte BND2 writeback survives a
+		// no-op rotate gesture. The reference equality on `mTransform`
+		// (not just deep-equality) is what guarantees the writer emits
+		// identical bytes — and per the contract, `===` survives because
+		// the op short-circuits on identity delta.
+		const sv = makeStaticVehicle({ x: 12, y: 3, z: -4 }, { x: 0.1, y: 0.2, z: 0 });
+		const model = makeModel({ hulls: [makeHull({ staticVehicles: [sv] })] });
+		const next = bulkRotateTrafficEntitiesMatrix44(
+			model,
+			[{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 }],
+			{ x: 0, y: 0, z: 0 },
+			{ x: 0, y: 0, z: 0 },
+		);
+		expect(next.hulls[0].staticTrafficVehicles[0].mTransform).toBe(sv.mTransform);
+	});
+});
+
+describe('bulkRotateTrafficEntitiesYaw — static vehicles take the same yaw delta', () => {
+	it('static vehicle position orbits the pivot AND its mTransform rotation portion picks up the yaw delta', () => {
+		const sv = makeStaticVehicle({ x: 10, y: 0, z: 0 });
+		const model = makeModel({ hulls: [makeHull({ staticVehicles: [sv] })] });
+		const next = bulkRotateTrafficEntitiesYaw(
+			model,
+			[{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 }],
+			{ x: 0, z: 0 },
+			Math.PI / 2,
+		);
+		const m = next.hulls[0].staticTrafficVehicles[0].mTransform;
+		// Position orbits to (0, 0, -10) — three.js right-hand convention,
+		// same as the trigger-box adapter (issue #77).
+		expect(m[12]).toBeCloseTo(0, 5);
+		expect(m[14]).toBeCloseTo(-10, 5);
+	});
+
+	it('static vehicle yaw rotate is identical to the Matrix44 path with delta.y only', () => {
+		const sv = makeStaticVehicle({ x: 25, y: 5, z: -10 }, { x: 0, y: 0.4, z: 0 });
+		const model1 = makeModel({ hulls: [makeHull({ staticVehicles: [sv] })] });
+		const model2 = makeModel({ hulls: [makeHull({ staticVehicles: [sv] })] });
+		const a = bulkRotateTrafficEntitiesYaw(
+			model1,
+			[{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 }],
+			{ x: 5, z: -5 },
+			Math.PI / 6,
+		);
+		const b = bulkRotateTrafficEntitiesMatrix44(
+			model2,
+			[{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 }],
+			{ x: 5, y: 0, z: -5 },
+			{ x: 0, y: Math.PI / 6, z: 0 },
+		);
+		const ma = a.hulls[0].staticTrafficVehicles[0].mTransform;
+		const mb = b.hulls[0].staticTrafficVehicles[0].mTransform;
+		for (let i = 0; i < 16; i++) {
+			expect(ma[i]).toBeCloseTo(mb[i], 5);
+		}
+	});
+});
+
+describe('trafficDataSelectionPivot — static vehicles contribute their translation column', () => {
+	it('median of three vehicles at x = {0, 10, 20} is x = 10', () => {
+		const model = makeModel({
+			hulls: [
+				makeHull({
+					staticVehicles: [
+						makeStaticVehicle({ x: 0, y: 0, z: 0 }),
+						makeStaticVehicle({ x: 10, y: 0, z: 0 }),
+						makeStaticVehicle({ x: 20, y: 0, z: 0 }),
+					],
+				}),
+			],
+		});
+		const pivot = trafficDataSelectionPivot(model, [
+			{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 },
+			{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 1 },
+			{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 2 },
+		]);
+		expect(pivot?.x).toBe(10);
+		expect(pivot?.y).toBe(0);
+		expect(pivot?.z).toBe(0);
+	});
+
+	it('mixed: static vehicle + junction contributes both', () => {
+		const model = makeModel({
+			hulls: [
+				makeHull({
+					junctions: [makeJunction(vec4(0, 0, 0, 0))],
+					staticVehicles: [makeStaticVehicle({ x: 10, y: 5, z: 20 })],
+				}),
+			],
+		});
+		const pivot = trafficDataSelectionPivot(model, [
+			{ kind: 'junction', hullIdx: 0, junctionIdx: 0 },
+			{ kind: 'staticVehicle', hullIdx: 0, vehicleIdx: 0 },
+		]);
+		// Two samples: medians = the per-axis mean of the two values.
+		expect(pivot?.x).toBeCloseTo(5, 6);
+		expect(pivot?.y).toBeCloseTo(2.5, 6);
+		expect(pivot?.z).toBeCloseTo(10, 6);
 	});
 });

--- a/src/lib/core/trafficDataOps/bulk.ts
+++ b/src/lib/core/trafficDataOps/bulk.ts
@@ -1,17 +1,29 @@
 // Bulk-transform ops for the traffic-data resource family — yaw-packed
-// boxes + lane rungs (issue #79).
+// boxes + lane rungs (issue #79) + static traffic vehicles (issue #78).
 //
 // Cardinality ≥ 1 entry points for the unified Bulk-transform gizmo. A
-// **Selection** of any combination of traffic yaw-packed boxes and lane
-// rungs is treated as one rigid body: every member orbits the same pivot,
-// and every yaw-packed box's `.w` slot picks up the gesture's yaw delta in
-// addition to the position orbit (rigid-body composition).
+// **Selection** of any combination of traffic-data entities is treated as
+// one rigid body: every member orbits the same pivot, and each member
+// composes the gesture rotation according to its own representation:
 //
-// Static traffic vehicles (Matrix44, full 3D) live in their own module —
-// they're the subject of issue #78, blocked on issue #77's trigger-box
-// work. Not folded into this file because their axis profile differs (full
-// 3-axis vs yaw-only) and the rotate semantics aren't the same (a Matrix44
-// composes with the rotation matrix; a Vec4 box composes only the W slot).
+//   - Yaw-packed boxes (junctions / light triggers / light instances /
+//     coronas): position orbits the pivot in XZ; the `.w` slot picks up
+//     the gesture's yaw delta. ADR-0011 yaw-only contributor — pitch/roll
+//     auto-disable for any Selection that includes one of these.
+//   - Lane rungs: both endpoints orbit the pivot in XZ. `.w` preserved
+//     verbatim (rung endpoints don't carry yaw). Yaw-only contributor.
+//   - Static vehicles (`mTransform` Matrix44): position orbits the pivot
+//     AND the matrix is pre-multiplied by the gesture's rotation matrix.
+//     Full 3D contributor — translates and rotates all three axes when
+//     the Selection is purely static-vehicle (or mixed with another full
+//     3D family like trigger boxes).
+//
+// The full-3D rotation path applies to static vehicles even when the
+// Selection contains a yaw-only sibling — but the auto-disable rule from
+// ADR-0011 (`intersectTransformAxes`) means the gizmo's pitch and roll
+// rings only render interactive when every contributor agrees. So in
+// practice a mixed Selection's rotate gesture only carries a yaw delta,
+// and that yaw delta still pre-multiplies the static vehicle's matrix.
 
 import type {
 	ParsedTrafficDataRetail,
@@ -20,9 +32,18 @@ import type {
 	TrafficLaneRung,
 	TrafficLightCollection,
 	TrafficLightTrigger,
+	TrafficStaticVehicle,
 	Vec4,
 } from '../trafficData';
-import type { TransformAxes } from '../transformAxes';
+import {
+	TRANSFORM_AXES_FULL_3D,
+	intersectTransformAxes,
+	type TransformAxes,
+} from '../transformAxes';
+import {
+	rotateStaticVehicleMatrix44,
+	translateStaticVehicleMatrix44,
+} from './staticVehicleMatrix44';
 import { TRAFFIC_YAW_PACKED_AXES } from './transformAxes';
 
 // =============================================================================
@@ -31,20 +52,25 @@ import { TRAFFIC_YAW_PACKED_AXES } from './transformAxes';
 
 /**
  * Discriminated reference to a single spatial datum in a
- * ParsedTrafficDataRetail. Static vehicles intentionally omitted — they
- * live in their own module and have a different axis profile.
+ * ParsedTrafficDataRetail.
  *
  * Lane rungs are addressed as a single ref (NOT per-endpoint): both
  * endpoints move together so the rung remains a single segment. Selecting
  * one endpoint at a time would tear the lane topology — see the comment in
  * `translateLaneRungRigid` for the rationale.
+ *
+ * Static vehicles are the only Matrix44 (full-3D) contributor — every
+ * other kind is yaw-only per ADR-0011. The axis intersection in
+ * `bulkTrafficDataAxes` collapses mixed selections back to yaw-only as
+ * soon as a yaw-packed sibling joins.
  */
 export type TrafficDataEntityRef =
 	| { kind: 'junction'; hullIdx: number; junctionIdx: number }
 	| { kind: 'lightTrigger'; hullIdx: number; triggerIdx: number }
 	| { kind: 'lightInstance'; instanceIdx: number }
 	| { kind: 'corona'; coronaIdx: number }
-	| { kind: 'laneRung'; hullIdx: number; rungIdx: number };
+	| { kind: 'laneRung'; hullIdx: number; rungIdx: number }
+	| { kind: 'staticVehicle'; hullIdx: number; vehicleIdx: number };
 
 // =============================================================================
 // Helpers
@@ -76,8 +102,24 @@ function resolveYawBox(
 		case 'corona':
 			return model.trafficLights.coronaPositions[ref.coronaIdx] ?? null;
 		case 'laneRung':
+		case 'staticVehicle':
 			return null;
 	}
+}
+
+/**
+ * Resolve a static vehicle ref to its `TrafficStaticVehicle` entry. Used
+ * by the pivot, translate, and rotate ops in this file. Returns `null`
+ * on out-of-range refs so the bulk ops can skip them silently (parity
+ * with `resolveYawBox`).
+ */
+function resolveStaticVehicle(
+	model: ParsedTrafficDataRetail,
+	ref: TrafficDataEntityRef,
+): TrafficStaticVehicle | null {
+	if (ref.kind !== 'staticVehicle') return null;
+	const hull = model.hulls[ref.hullIdx];
+	return hull?.staticTrafficVehicles[ref.vehicleIdx] ?? null;
 }
 
 // =============================================================================
@@ -87,8 +129,9 @@ function resolveYawBox(
 /**
  * Median (per-component) of every spatial point the Selection addresses.
  * Each yaw-packed box contributes its `(x, y, z)` (ignoring `.w`). Each
- * lane rung contributes BOTH endpoints (xyz × 2). Returns `null` for empty
- * / out-of-range refs.
+ * lane rung contributes BOTH endpoints (xyz × 2). Each static vehicle
+ * contributes its `mTransform` translation column `(m[12], m[13], m[14])`.
+ * Returns `null` for empty / out-of-range refs.
  */
 export function trafficDataSelectionPivot(
 	model: ParsedTrafficDataRetail,
@@ -109,6 +152,14 @@ export function trafficDataSelectionPivot(
 			}
 			continue;
 		}
+		if (ref.kind === 'staticVehicle') {
+			const sv = resolveStaticVehicle(model, ref);
+			if (!sv) continue;
+			xs.push(sv.mTransform[12] ?? 0);
+			ys.push(sv.mTransform[13] ?? 0);
+			zs.push(sv.mTransform[14] ?? 0);
+			continue;
+		}
 		const box = resolveYawBox(model, ref);
 		if (!box) continue;
 		xs.push(box.x);
@@ -127,6 +178,7 @@ type HullBucket = {
 	junctionIdxs: Set<number>;
 	lightTriggerIdxs: Set<number>;
 	laneRungIdxs: Set<number>;
+	staticVehicleIdxs: Set<number>;
 };
 
 type Buckets = {
@@ -146,6 +198,7 @@ function bucketRefs(refs: readonly TrafficDataEntityRef[]): Buckets {
 				junctionIdxs: new Set(),
 				lightTriggerIdxs: new Set(),
 				laneRungIdxs: new Set(),
+				staticVehicleIdxs: new Set(),
 			};
 			hulls.set(h, b);
 		}
@@ -161,6 +214,9 @@ function bucketRefs(refs: readonly TrafficDataEntityRef[]): Buckets {
 				break;
 			case 'laneRung':
 				getHull(ref.hullIdx).laneRungIdxs.add(ref.rungIdx);
+				break;
+			case 'staticVehicle':
+				getHull(ref.hullIdx).staticVehicleIdxs.add(ref.vehicleIdx);
 				break;
 			case 'lightInstance':
 				lightInstances.add(ref.instanceIdx);
@@ -180,7 +236,9 @@ function bucketRefs(refs: readonly TrafficDataEntityRef[]): Buckets {
 /**
  * Translate every entity in the Selection by the same `(dx, dy, dz)`
  * offset. Yaw-packed boxes' `.w` slots are preserved verbatim; lane rung
- * endpoints both shift by the same delta (rung stays a single segment).
+ * endpoints both shift by the same delta (rung stays a single segment);
+ * static vehicles get their `mTransform` translation column shifted while
+ * the rotation portion is preserved verbatim.
  *
  * Returns the original `model` reference on identity offset OR an empty
  * refs list so byte-for-byte BND2 writeback is preserved on a no-op
@@ -206,7 +264,7 @@ export function bulkTranslateTrafficEntities(
 		w: v.w,
 	});
 
-	// Hull-scope updates: junctions, lightTriggers, laneRungs.
+	// Hull-scope updates: junctions, lightTriggers, laneRungs, staticVehicles.
 	let hullsChanged = false;
 	const nextHulls = model.hulls.map((hull, hullIdx): TrafficHull => {
 		const bucket = buckets.hulls.get(hullIdx);
@@ -237,6 +295,15 @@ export function bulkTranslateTrafficEntities(
 				})
 			: hull.rungs;
 
+		const nextStaticVehicles = bucket.staticVehicleIdxs.size
+			? hull.staticTrafficVehicles.map((v, i): TrafficStaticVehicle => {
+					if (!bucket.staticVehicleIdxs.has(i)) return v;
+					const moved = translateStaticVehicleMatrix44(v, offset);
+					if (moved !== v) touched = true;
+					return moved;
+				})
+			: hull.staticTrafficVehicles;
+
 		if (!touched) return hull;
 		hullsChanged = true;
 		return {
@@ -244,6 +311,7 @@ export function bulkTranslateTrafficEntities(
 			junctions: nextJunctions,
 			lightTriggers: nextLightTriggers,
 			rungs: nextRungs,
+			staticTrafficVehicles: nextStaticVehicles,
 		};
 	});
 
@@ -289,7 +357,7 @@ export function bulkTranslateTrafficEntities(
 
 /**
  * Yaw-rotate every entity in the Selection around `pivot` by `theta`
- * radians. The composition rule (per issue #79):
+ * radians. The composition rule (per issue #79 + issue #78):
  *
  *   - Yaw-packed boxes: position `(x, y, z)` orbits the pivot in the XZ
  *     plane (Y unchanged); the W slot picks up `+ theta` (the gesture's
@@ -301,6 +369,12 @@ export function bulkTranslateTrafficEntities(
  *     plane (Y unchanged on each); the W slot on each endpoint is
  *     preserved verbatim (lane rungs don't carry their own yaw — W is an
  *     opaque slot here).
+ *
+ *   - Static vehicles: `mTransform` is pre-multiplied by `T(P) · Ry(theta)
+ *     · T(-P)`, orbiting the translation column around the pivot in XZ
+ *     AND pre-multiplying the rotation portion by a Y-axis rotation
+ *     matrix. Pitch / roll of the existing matrix are preserved (a yaw
+ *     delta doesn't touch them).
  *
  * Yaw direction follows the right-hand rule with thumb along world +Y, so
  * positive `theta` rotates +X towards +Z — same convention as the AI
@@ -335,6 +409,13 @@ export function bulkRotateTrafficEntitiesYaw(
 	};
 
 	const buckets = bucketRefs(refs);
+	// Y of the pivot doesn't affect a yaw rotation (the matrix is invariant
+	// under translation along its own axis), but the Matrix44 path needs a
+	// concrete 3D pivot to plug into `rotateStaticVehicleMatrix44`. Y=0 is
+	// fine: a Y-axis rotation around `(x, 0, z)` produces the same matrix
+	// as around `(x, any, z)`.
+	const sv3DPivot = { x: cx, y: 0, z: cz };
+	const sv3DEuler = { x: 0, y: theta, z: 0 };
 
 	let hullsChanged = false;
 	const nextHulls = model.hulls.map((hull, hullIdx): TrafficHull => {
@@ -371,6 +452,15 @@ export function bulkRotateTrafficEntitiesYaw(
 				})
 			: hull.rungs;
 
+		const nextStaticVehicles = bucket.staticVehicleIdxs.size
+			? hull.staticTrafficVehicles.map((v, i): TrafficStaticVehicle => {
+					if (!bucket.staticVehicleIdxs.has(i)) return v;
+					const moved = rotateStaticVehicleMatrix44(v, sv3DPivot, sv3DEuler);
+					if (moved !== v) touched = true;
+					return moved;
+				})
+			: hull.staticTrafficVehicles;
+
 		if (!touched) return hull;
 		hullsChanged = true;
 		return {
@@ -378,6 +468,7 @@ export function bulkRotateTrafficEntitiesYaw(
 			junctions: nextJunctions,
 			lightTriggers: nextLightTriggers,
 			rungs: nextRungs,
+			staticTrafficVehicles: nextStaticVehicles,
 		};
 	});
 
@@ -417,13 +508,182 @@ export function bulkRotateTrafficEntitiesYaw(
 }
 
 // =============================================================================
+// Bulk full-3D rotate (Matrix44 path — issue #78)
+// =============================================================================
+
+/**
+ * Rotate every entity in the Selection around `pivot` by the delta Euler
+ * `(rx, ry, rz)` in `STATIC_VEHICLE_DELTA_EULER_ORDER` (XYZ). This is the
+ * Matrix44 path for a Selection that supports full 3-axis rotation —
+ * typically a pure-static-vehicle Selection or a mixed Selection with
+ * another full-3D resource family (trigger boxes).
+ *
+ * Composition per kind:
+ *
+ *   - Static vehicles: `mTransform` is pre-multiplied by `T(P) · R(delta)
+ *     · T(-P)` so the translation column orbits the pivot AND the matrix's
+ *     rotation portion is composed with the gesture delta.
+ *
+ *   - Yaw-packed boxes (junction / lightTrigger / lightInstance / corona):
+ *     position orbits the pivot (XZ); the `.w` slot picks up `+ delta.y`
+ *     (the yaw component of the gesture). Pitch / roll are dropped on the
+ *     box itself because there's no slot to land them in — but the
+ *     auto-disable rule (`bulkTrafficDataAxes`) should already have grayed
+ *     those rings out if any yaw-packed sibling is in the Selection, so in
+ *     practice the gesture's `delta.x` / `delta.z` are zero anyway.
+ *
+ *   - Lane rungs: both endpoints rotate as a rigid pair through the full
+ *     3-axis delta. `.w` preserved verbatim.
+ *
+ * Returns the original `model` reference on identity delta OR empty refs.
+ */
+export function bulkRotateTrafficEntitiesMatrix44(
+	model: ParsedTrafficDataRetail,
+	refs: readonly TrafficDataEntityRef[],
+	pivot: { x: number; y: number; z: number },
+	deltaEuler: { x: number; y: number; z: number },
+): ParsedTrafficDataRetail {
+	if (deltaEuler.x === 0 && deltaEuler.y === 0 && deltaEuler.z === 0) return model;
+	if (refs.length === 0) return model;
+
+	// For yaw-packed siblings: the in-plane orbit + `.w` increment is
+	// driven by the Y component of the delta. The pitch/roll components are
+	// representationally dropped (auto-disable enforces this at the gizmo
+	// level — see `bulkTrafficDataAxes`).
+	const theta = deltaEuler.y;
+	const cosT = theta === 0 ? 1 : Math.cos(theta);
+	const sinT = theta === 0 ? 0 : Math.sin(theta);
+	const cx = pivot.x;
+	const cz = pivot.z;
+
+	const orbit = (v: Vec4, addToW: boolean): Vec4 => {
+		if (theta === 0) return v;
+		const ox = v.x - cx;
+		const oz = v.z - cz;
+		return {
+			x: ox * cosT - oz * sinT + cx,
+			y: v.y,
+			z: ox * sinT + oz * cosT + cz,
+			w: addToW ? v.w + theta : v.w,
+		};
+	};
+
+	const buckets = bucketRefs(refs);
+
+	let hullsChanged = false;
+	const nextHulls = model.hulls.map((hull, hullIdx): TrafficHull => {
+		const bucket = buckets.hulls.get(hullIdx);
+		if (!bucket) return hull;
+		let touched = false;
+
+		const nextStaticVehicles = bucket.staticVehicleIdxs.size
+			? hull.staticTrafficVehicles.map((v, i): TrafficStaticVehicle => {
+					if (!bucket.staticVehicleIdxs.has(i)) return v;
+					const moved = rotateStaticVehicleMatrix44(v, pivot, deltaEuler);
+					if (moved !== v) touched = true;
+					return moved;
+				})
+			: hull.staticTrafficVehicles;
+
+		const nextJunctions = bucket.junctionIdxs.size && theta !== 0
+			? hull.junctions.map((j, i): TrafficJunctionLogicBox => {
+					if (!bucket.junctionIdxs.has(i)) return j;
+					touched = true;
+					return { ...j, mPosition: orbit(j.mPosition, true) };
+				})
+			: hull.junctions;
+
+		const nextLightTriggers = bucket.lightTriggerIdxs.size && theta !== 0
+			? hull.lightTriggers.map((t, i): TrafficLightTrigger => {
+					if (!bucket.lightTriggerIdxs.has(i)) return t;
+					touched = true;
+					return { ...t, mPosPlusYRot: orbit(t.mPosPlusYRot, true) };
+				})
+			: hull.lightTriggers;
+
+		const nextRungs = bucket.laneRungIdxs.size && theta !== 0
+			? hull.rungs.map((r, i): TrafficLaneRung => {
+					if (!bucket.laneRungIdxs.has(i)) return r;
+					touched = true;
+					return {
+						maPoints: [
+							orbit(r.maPoints[0], false),
+							orbit(r.maPoints[1], false),
+						],
+					};
+				})
+			: hull.rungs;
+
+		if (!touched) return hull;
+		hullsChanged = true;
+		return {
+			...hull,
+			junctions: nextJunctions,
+			lightTriggers: nextLightTriggers,
+			rungs: nextRungs,
+			staticTrafficVehicles: nextStaticVehicles,
+		};
+	});
+
+	// Top-level traffic-light collection (only yaw-axis composition applies
+	// — these are yaw-packed Vec4s).
+	let tlcChanged = false;
+	let nextTrafficLights: TrafficLightCollection = model.trafficLights;
+	if (theta !== 0 && (buckets.lightInstances.size || buckets.coronas.size)) {
+		const tlc = model.trafficLights;
+		const nextPos = buckets.lightInstances.size
+			? tlc.posAndYRotations.map((v, i) => {
+					if (!buckets.lightInstances.has(i)) return v;
+					tlcChanged = true;
+					return orbit(v, true);
+				})
+			: tlc.posAndYRotations;
+		const nextCoronas = buckets.coronas.size
+			? tlc.coronaPositions.map((v, i) => {
+					if (!buckets.coronas.has(i)) return v;
+					tlcChanged = true;
+					return orbit(v, true);
+				})
+			: tlc.coronaPositions;
+		if (tlcChanged) {
+			nextTrafficLights = {
+				...tlc,
+				posAndYRotations: nextPos,
+				coronaPositions: nextCoronas,
+			};
+		}
+	}
+
+	if (!hullsChanged && !tlcChanged) return model;
+	return {
+		...model,
+		...(hullsChanged ? { hulls: nextHulls } : {}),
+		...(tlcChanged ? { trafficLights: nextTrafficLights } : {}),
+	};
+}
+
+// =============================================================================
 // Axes intersection contribution
 // =============================================================================
 
 /**
+ * Per-ref TransformAxes contribution. Static vehicles are the only Matrix44
+ * (full-3D) contributor in this module; every other kind is XZ-packed and
+ * contributes the yaw-only profile from `TRAFFIC_YAW_PACKED_AXES`. Used by
+ * `bulkTrafficDataAxes` to AND-intersect across a multi-Selection, and
+ * exported so the overlay can label individual refs in mixed contexts.
+ */
+export function trafficDataRefAxes(ref: TrafficDataEntityRef): TransformAxes {
+	if (ref.kind === 'staticVehicle') return TRANSFORM_AXES_FULL_3D;
+	return TRAFFIC_YAW_PACKED_AXES;
+}
+
+/**
  * Effective TransformAxes for a multi-Selection of traffic-data entities
- * covered by this module (junctions, lightTriggers, lightInstances,
- * coronas, laneRungs). All are XZ-packed per ADR-0011 — yaw-only.
+ * covered by this module. Pure static-vehicle (Matrix44) Selections get
+ * full 3-axis rotate. Any yaw-packed contributor (junction / lightTrigger
+ * / lightInstance / corona / laneRung) AND-collapses the rotate to yaw-
+ * only, per ADR-0011.
  *
  * Returns `null` for an empty refs list.
  */
@@ -431,5 +691,5 @@ export function bulkTrafficDataAxes(
 	refs: readonly TrafficDataEntityRef[],
 ): TransformAxes | null {
 	if (refs.length === 0) return null;
-	return TRAFFIC_YAW_PACKED_AXES;
+	return intersectTransformAxes(refs.map(trafficDataRefAxes));
 }

--- a/src/lib/core/trafficDataOps/index.ts
+++ b/src/lib/core/trafficDataOps/index.ts
@@ -2,14 +2,19 @@
 //
 // Re-exports every public symbol from the directory's sub-modules so that
 // external callers can keep `import { ... } from '@/lib/core/trafficDataOps'`
-// without caring which file the symbol lives in. Scope is yaw-packed boxes
-// (junction logic boxes, light triggers, traffic-light collection elements,
-// corona positions) plus lane rungs — every traffic entity whose spatial
-// data is XZ-packed per ADR-0011. Static traffic vehicles (Matrix44, full
-// 3D) live in their own module and are tracked by issue #78.
+// without caring which file the symbol lives in. Scope is the full
+// traffic-data resource family:
+//
+//   - Yaw-packed Vec4 entities (junction logic boxes, light triggers,
+//     traffic-light instances, corona positions) — XZ-packed per ADR-0011,
+//     yaw-only rotate (issue #79).
+//   - Lane rungs (two-endpoint segments) — also XZ-packed (issue #79).
+//   - Static traffic vehicles (Matrix44, full 3D) — the only family with a
+//     full rigid 4×4 transform; full 3-axis rotate (issue #78).
 
 export {
 	TRAFFIC_LANE_RUNG_AXES,
+	TRAFFIC_STATIC_VEHICLE_AXES,
 	TRAFFIC_YAW_PACKED_AXES,
 } from './transformAxes';
 export {
@@ -20,9 +25,18 @@ export {
 	translateLightTriggerRigid,
 } from './translateRigid';
 export {
+	rotateStaticVehicleMatrix44,
+	rotateStaticVehicleRigid,
+	STATIC_VEHICLE_DELTA_EULER_ORDER,
+	translateStaticVehicleMatrix44,
+	translateStaticVehicleRigid,
+} from './staticVehicleMatrix44';
+export {
+	bulkRotateTrafficEntitiesMatrix44,
 	bulkRotateTrafficEntitiesYaw,
 	bulkTrafficDataAxes,
 	bulkTranslateTrafficEntities,
+	trafficDataRefAxes,
 	trafficDataSelectionPivot,
 	type TrafficDataEntityRef,
 } from './bulk';

--- a/src/lib/core/trafficDataOps/staticVehicleMatrix44.test.ts
+++ b/src/lib/core/trafficDataOps/staticVehicleMatrix44.test.ts
@@ -1,0 +1,491 @@
+// Static-traffic-vehicle Matrix44 rigid ops — unit tests (issue #78).
+//
+// Covers the single-entity translate/rotate path, the `===`-identity
+// no-op contract that keeps BND2 byte-for-byte writeback alive, and the
+// cross-validation against the Vector3+Euler representation that ships
+// with `triggerDataOps` — the only sanity check on the sandwich-multiply
+// order (a wrong T(P)/R/T(-P) ordering produces visibly correct math on
+// isolated cases but fails the cross-validation as soon as the pivot ≠
+// the entity's own position).
+
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import type {
+	ParsedTrafficDataRetail,
+	TrafficHull,
+	TrafficStaticVehicle,
+} from '../trafficData';
+import {
+	rotateStaticVehicleMatrix44,
+	rotateStaticVehicleRigid,
+	STATIC_VEHICLE_DELTA_EULER_ORDER,
+	translateStaticVehicleMatrix44,
+	translateStaticVehicleRigid,
+	_internalForTests,
+} from './staticVehicleMatrix44';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+/**
+ * Build a `TrafficStaticVehicle` from a position + Euler rotation. The
+ * matrix is composed via `THREE.Matrix4.compose` so the storage layout
+ * matches what `readMatrix` consumes (column-major translation at indices
+ * [12], [13], [14]). Pad slots [3], [7], [11], [15] are forced to zero
+ * to mirror the on-disk Matrix44Affine convention.
+ */
+function makeStaticVehicle(
+	pos: { x: number; y: number; z: number },
+	euler: { x: number; y: number; z: number } = { x: 0, y: 0, z: 0 },
+): TrafficStaticVehicle {
+	const mat = new THREE.Matrix4().compose(
+		new THREE.Vector3(pos.x, pos.y, pos.z),
+		new THREE.Quaternion().setFromEuler(
+			new THREE.Euler(euler.x, euler.y, euler.z, STATIC_VEHICLE_DELTA_EULER_ORDER),
+		),
+		new THREE.Vector3(1, 1, 1),
+	);
+	const arr = mat.toArray();
+	arr[3] = 0; arr[7] = 0; arr[11] = 0; arr[15] = 0;
+	return {
+		mTransform: arr,
+		mFlowTypeID: 0,
+		mExistsAtAllChance: 0,
+		muFlags: 0,
+		_pad43: new Array(12).fill(0),
+	};
+}
+
+function makeHull(vehicles: TrafficStaticVehicle[]): TrafficHull {
+	return {
+		muNumSections: 0,
+		muNumSectionSpans: 0,
+		muNumJunctions: 0,
+		muNumStoplines: 0,
+		muNumNeighbours: 0,
+		muNumStaticTraffic: vehicles.length,
+		muNumVehicleAssets: 0,
+		_pad07: 0,
+		muNumRungs: 0,
+		muFirstTrafficLight: 0,
+		muLastTrafficLight: 0,
+		muNumLightTriggers: 0,
+		muNumLightTriggersStartData: 0,
+		sections: [],
+		rungs: [],
+		cumulativeRungLengths: [],
+		neighbours: [],
+		sectionSpans: [],
+		staticTrafficVehicles: vehicles,
+		sectionFlows: [],
+		junctions: [],
+		stopLines: [],
+		lightTriggers: [],
+		lightTriggerStartData: [],
+		lightTriggerJunctionLookup: [],
+		mauVehicleAssets: [],
+	};
+}
+
+function makeModel(hulls: TrafficHull[]): ParsedTrafficDataRetail {
+	return {
+		kind: 'v45',
+		muDataVersion: 45,
+		muSizeInBytes: 0,
+		pvs: {
+			mGridMin: { x: 0, y: 0, z: 0, w: 0 },
+			mCellSize: { x: 1, y: 1, z: 1, w: 0 },
+			mRecipCellSize: { x: 1, y: 1, z: 1, w: 0 },
+			muNumCells_X: 0,
+			muNumCells_Z: 0,
+			muNumCells: 0,
+			hullPvsSets: [],
+		},
+		hulls,
+		flowTypes: [],
+		killZoneIds: [],
+		killZones: [],
+		vehicleTypes: [],
+		vehicleTypesUpdate: [],
+		vehicleAssets: [],
+		vehicleTraits: [],
+		killZoneRegions: [],
+		trafficLights: {
+			posAndYRotations: [],
+			instanceIDs: [],
+			instanceTypes: [],
+			trafficLightTypes: [],
+			coronaTypes: [],
+			coronaPositions: [],
+			mauInstanceHashOffsets: [],
+			instanceHashTable: [],
+			instanceHashToIndexLookup: [],
+		},
+		paintColours: [],
+	};
+}
+
+/**
+ * Read the translation column out of a `mTransform`.
+ */
+function translationOf(v: TrafficStaticVehicle) {
+	return {
+		x: v.mTransform[12],
+		y: v.mTransform[13],
+		z: v.mTransform[14],
+	};
+}
+
+/**
+ * Read the upper-left 3×3 rotation portion of a `mTransform` and return
+ * the world-space `+X` direction it maps a local `(1, 0, 0)` to. That
+ * vector IS the vehicle's "facing direction" in the editor's Y-up frame
+ * — what the cross-validation test pins against the Vector3+Euler path.
+ */
+function facingOf(v: TrafficStaticVehicle): { x: number; y: number; z: number } {
+	const m = new THREE.Matrix4().fromArray(v.mTransform);
+	// Force the homogeneous w to 1 so the rotation portion is read clean
+	// (same patch the renderer applies — pad slots in the storage layout
+	// are zero, not the homogeneous 1).
+	const e = m.elements;
+	e[3] = 0; e[7] = 0; e[11] = 0; e[15] = 1;
+	const dir = new THREE.Vector3(1, 0, 0).transformDirection(m);
+	return { x: dir.x, y: dir.y, z: dir.z };
+}
+
+// =============================================================================
+// translateStaticVehicleMatrix44
+// =============================================================================
+
+describe('translateStaticVehicleMatrix44', () => {
+	it('updates the translation column and preserves the rotation portion', () => {
+		const v = makeStaticVehicle(
+			{ x: 10, y: 20, z: 30 },
+			{ x: 0.1, y: 0.5, z: 0.0 },
+		);
+		const before = v.mTransform.slice(0, 12); // rotation/scale portion
+		const next = translateStaticVehicleMatrix44(v, { x: 1, y: 2, z: 3 });
+		expect(translationOf(next)).toEqual({ x: 11, y: 22, z: 33 });
+		// Rotation portion (cols 0..2, slots [0..11]) untouched.
+		for (let i = 0; i < 12; i++) {
+			expect(next.mTransform[i]).toBe(before[i]);
+		}
+	});
+
+	it('returns the input vehicle reference (===) on identity offset', () => {
+		const v = makeStaticVehicle({ x: 0, y: 0, z: 0 });
+		expect(translateStaticVehicleMatrix44(v, { x: 0, y: 0, z: 0 })).toBe(v);
+	});
+
+	it('preserves the on-disk pad layout (zero at indices 3, 7, 11, 15)', () => {
+		const v = makeStaticVehicle({ x: 5, y: 0, z: 0 });
+		const next = translateStaticVehicleMatrix44(v, { x: 1, y: 1, z: 1 });
+		expect(next.mTransform[3]).toBe(0);
+		expect(next.mTransform[7]).toBe(0);
+		expect(next.mTransform[11]).toBe(0);
+		expect(next.mTransform[15]).toBe(0);
+	});
+});
+
+// =============================================================================
+// rotateStaticVehicleMatrix44
+// =============================================================================
+
+describe('rotateStaticVehicleMatrix44', () => {
+	it('rotation around the vehicle\'s own position leaves the translation column unchanged', () => {
+		const pos = { x: 7, y: 3, z: -5 };
+		const v = makeStaticVehicle(pos);
+		const next = rotateStaticVehicleMatrix44(v, pos, { x: 0, y: Math.PI / 4, z: 0 });
+		const t = translationOf(next);
+		expect(t.x).toBeCloseTo(pos.x, 6);
+		expect(t.y).toBeCloseTo(pos.y, 6);
+		expect(t.z).toBeCloseTo(pos.z, 6);
+	});
+
+	it('yaw-rotates the facing direction by exactly the delta', () => {
+		// Vehicle at origin, identity facing (+X). After Ry(π/2) under
+		// three.js's right-hand convention, facing should map to -Z (the
+		// trigger-box adapter uses this same convention — see
+		// `triggerDataOps/translateRigid.test.ts` for the matching
+		// expectation: applyQuaternion of (1,0,0) by yaw(pi/2) → (0,0,-1)).
+		const v = makeStaticVehicle({ x: 0, y: 0, z: 0 });
+		const next = rotateStaticVehicleMatrix44(
+			v,
+			{ x: 0, y: 0, z: 0 },
+			{ x: 0, y: Math.PI / 2, z: 0 },
+		);
+		const facing = facingOf(next);
+		expect(facing.x).toBeCloseTo(0, 5);
+		expect(facing.y).toBeCloseTo(0, 5);
+		expect(facing.z).toBeCloseTo(-1, 5);
+	});
+
+	it('rotation around an external pivot orbits the translation column', () => {
+		// Vehicle at (10, 0, 0), pivot at origin, yaw π/2 under three.js's
+		// right-hand convention: position lands at (0, 0, -10) (positive
+		// yaw rotates +X towards -Z).
+		const v = makeStaticVehicle({ x: 10, y: 0, z: 0 });
+		const next = rotateStaticVehicleMatrix44(
+			v,
+			{ x: 0, y: 0, z: 0 },
+			{ x: 0, y: Math.PI / 2, z: 0 },
+		);
+		const t = translationOf(next);
+		expect(t.x).toBeCloseTo(0, 5);
+		expect(t.y).toBeCloseTo(0, 5);
+		expect(t.z).toBeCloseTo(-10, 5);
+	});
+
+	it('rotation around an external pivot composes the rotation portion (facing rotates by delta)', () => {
+		// Vehicle at (10, 0, 0) with identity facing (+X). Yaw π/2 around
+		// origin under three.js's right-hand convention: position → (0, 0,
+		// -10), facing → (0, 0, -1). Vehicle orbits AND its own forward
+		// vector rotates by the same delta.
+		const v = makeStaticVehicle({ x: 10, y: 0, z: 0 });
+		const next = rotateStaticVehicleMatrix44(
+			v,
+			{ x: 0, y: 0, z: 0 },
+			{ x: 0, y: Math.PI / 2, z: 0 },
+		);
+		const facing = facingOf(next);
+		expect(facing.x).toBeCloseTo(0, 5);
+		expect(facing.z).toBeCloseTo(-1, 5);
+	});
+
+	it('returns the input vehicle reference (===) on identity rotate', () => {
+		const v = makeStaticVehicle({ x: 5, y: 5, z: 5 });
+		expect(
+			rotateStaticVehicleMatrix44(v, { x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 }),
+		).toBe(v);
+	});
+
+	it('no-op rotate produces a byte-identical mTransform on a fresh-built vehicle', () => {
+		// Composed via THREE.Matrix4.compose so the storage layout is
+		// already canonical; a no-op rotate returns ===-identity (asserted
+		// above), so the mTransform array is the SAME reference.
+		const v = makeStaticVehicle(
+			{ x: 1.5, y: 2.5, z: 3.5 },
+			{ x: 0.1, y: 0.2, z: 0.3 },
+		);
+		const next = rotateStaticVehicleMatrix44(
+			v,
+			{ x: 0, y: 0, z: 0 },
+			{ x: 0, y: 0, z: 0 },
+		);
+		expect(next.mTransform).toBe(v.mTransform);
+	});
+
+	it('preserves pairwise distances across a synthetic two-vehicle bulk rotate', () => {
+		// Two vehicles at (0,0,0) and (20,0,0). Rotate each around the
+		// midpoint pivot (10,0,0) by yaw π/3. Their separation must stay
+		// at 20 (rigid-body invariant).
+		const pivot = { x: 10, y: 0, z: 0 };
+		const a = makeStaticVehicle({ x: 0, y: 0, z: 0 });
+		const b = makeStaticVehicle({ x: 20, y: 0, z: 0 });
+		const a2 = rotateStaticVehicleMatrix44(a, pivot, { x: 0, y: Math.PI / 3, z: 0 });
+		const b2 = rotateStaticVehicleMatrix44(b, pivot, { x: 0, y: Math.PI / 3, z: 0 });
+		const ta = translationOf(a2);
+		const tb = translationOf(b2);
+		const dist = Math.hypot(tb.x - ta.x, tb.y - ta.y, tb.z - ta.z);
+		expect(dist).toBeCloseTo(20, 4);
+	});
+});
+
+// =============================================================================
+// Cross-validation against Vector3 + Euler representation
+// =============================================================================
+//
+// The most load-bearing test in this file. The Matrix44 rotate-around-
+// pivot rule is `M' = T(P) · R(delta) · T(-P) · M`. The Vector3+Euler
+// rule from `triggerDataOps` is:
+//
+//   newPos   = (oldPos - pivot).applyQuaternion(deltaQuat) + pivot
+//   newQuat  = deltaQuat · oldQuat
+//
+// Both representations describe the SAME rigid transform — for a vehicle
+// authored as `(pos, eulerXYZ)`, transforming it through either path
+// should produce identical world position AND facing direction. Wrong
+// sandwich-multiply order (e.g. `T(-P) · R · T(P) · M` or `M · T(-P) · R
+// · T(P)`) breaks this — the two paths drift apart as soon as `pivot ≠
+// pos`, which is exactly the bulk-rotate case.
+
+describe('Matrix44 path equals Vector3+Euler path (cross-validation)', () => {
+	// A "facing direction" is the world-space image of the local +X unit
+	// vector under the rotation portion. We compare both paths' resulting
+	// facing directions and translation columns.
+
+	function rotateViaEuler(
+		pos: { x: number; y: number; z: number },
+		euler: { x: number; y: number; z: number },
+		pivot: { x: number; y: number; z: number },
+		delta: { x: number; y: number; z: number },
+	): {
+		pos: { x: number; y: number; z: number };
+		facing: { x: number; y: number; z: number };
+	} {
+		const deltaQuat = new THREE.Quaternion().setFromEuler(
+			new THREE.Euler(delta.x, delta.y, delta.z, STATIC_VEHICLE_DELTA_EULER_ORDER),
+		);
+		const ownQuat = new THREE.Quaternion().setFromEuler(
+			new THREE.Euler(euler.x, euler.y, euler.z, STATIC_VEHICLE_DELTA_EULER_ORDER),
+		);
+		const pivotVec = new THREE.Vector3(pivot.x, pivot.y, pivot.z);
+		const newPos = new THREE.Vector3(pos.x, pos.y, pos.z)
+			.sub(pivotVec)
+			.applyQuaternion(deltaQuat)
+			.add(pivotVec);
+		const newQuat = deltaQuat.clone().multiply(ownQuat);
+		const facing = new THREE.Vector3(1, 0, 0).applyQuaternion(newQuat);
+		return {
+			pos: { x: newPos.x, y: newPos.y, z: newPos.z },
+			facing: { x: facing.x, y: facing.y, z: facing.z },
+		};
+	}
+
+	const cases: Array<{
+		name: string;
+		pos: { x: number; y: number; z: number };
+		euler: { x: number; y: number; z: number };
+		pivot: { x: number; y: number; z: number };
+		delta: { x: number; y: number; z: number };
+	}> = [
+		{
+			name: 'identity rotation does nothing',
+			pos: { x: 7, y: 11, z: 13 },
+			euler: { x: 0.1, y: 0.2, z: 0.3 },
+			pivot: { x: 0, y: 0, z: 0 },
+			delta: { x: 0, y: 0, z: 0 },
+		},
+		{
+			name: 'yaw π/2 around origin, identity-facing vehicle at (10, 0, 0)',
+			pos: { x: 10, y: 0, z: 0 },
+			euler: { x: 0, y: 0, z: 0 },
+			pivot: { x: 0, y: 0, z: 0 },
+			delta: { x: 0, y: Math.PI / 2, z: 0 },
+		},
+		{
+			name: 'yaw π/3 around external pivot, pre-rotated vehicle',
+			pos: { x: 25, y: 5, z: -10 },
+			euler: { x: 0, y: 0.5, z: 0 },
+			pivot: { x: 5, y: 0, z: 0 },
+			delta: { x: 0, y: Math.PI / 3, z: 0 },
+		},
+		{
+			name: 'pitch + yaw mix around external 3D pivot',
+			pos: { x: 12, y: 8, z: -4 },
+			euler: { x: 0.2, y: 0.6, z: -0.1 },
+			pivot: { x: 3, y: 2, z: 1 },
+			delta: { x: 0.4, y: -0.3, z: 0.0 },
+		},
+		{
+			name: 'full 3-axis delta around the vehicle\'s own position (pure spin)',
+			pos: { x: -8, y: 4, z: 16 },
+			euler: { x: 0.0, y: 0.0, z: 0.0 },
+			pivot: { x: -8, y: 4, z: 16 },
+			delta: { x: 0.2, y: 0.4, z: 0.6 },
+		},
+		{
+			name: 'full 3-axis delta around a far external pivot',
+			pos: { x: 100, y: 0, z: 0 },
+			euler: { x: 0.1, y: 0.2, z: 0.3 },
+			pivot: { x: 0, y: 0, z: 0 },
+			delta: { x: 0.3, y: 0.7, z: -0.4 },
+		},
+	];
+
+	for (const c of cases) {
+		it(c.name, () => {
+			const v = makeStaticVehicle(c.pos, c.euler);
+			const m44 = rotateStaticVehicleMatrix44(v, c.pivot, c.delta);
+			const m44Pos = translationOf(m44);
+			const m44Facing = facingOf(m44);
+			const euler = rotateViaEuler(c.pos, c.euler, c.pivot, c.delta);
+			expect(m44Pos.x).toBeCloseTo(euler.pos.x, 4);
+			expect(m44Pos.y).toBeCloseTo(euler.pos.y, 4);
+			expect(m44Pos.z).toBeCloseTo(euler.pos.z, 4);
+			expect(m44Facing.x).toBeCloseTo(euler.facing.x, 4);
+			expect(m44Facing.y).toBeCloseTo(euler.facing.y, 4);
+			expect(m44Facing.z).toBeCloseTo(euler.facing.z, 4);
+		});
+	}
+});
+
+// =============================================================================
+// ParsedTrafficDataRetail-scope wrappers
+// =============================================================================
+
+describe('translateStaticVehicleRigid (model-scope)', () => {
+	it('updates the addressed vehicle and preserves sibling references', () => {
+		const a = makeStaticVehicle({ x: 0, y: 0, z: 0 });
+		const b = makeStaticVehicle({ x: 5, y: 5, z: 5 });
+		const model = makeModel([makeHull([a, b])]);
+		const next = translateStaticVehicleRigid(model, 0, 0, { x: 1, y: 2, z: 3 });
+		expect(translationOf(next.hulls[0].staticTrafficVehicles[0])).toEqual({
+			x: 1, y: 2, z: 3,
+		});
+		// Sibling (===) untouched.
+		expect(next.hulls[0].staticTrafficVehicles[1]).toBe(b);
+	});
+
+	it('returns the input model (===) on identity offset', () => {
+		const v = makeStaticVehicle({ x: 0, y: 0, z: 0 });
+		const model = makeModel([makeHull([v])]);
+		expect(translateStaticVehicleRigid(model, 0, 0, { x: 0, y: 0, z: 0 })).toBe(model);
+	});
+
+	it('throws RangeError on out-of-range hull index', () => {
+		const model = makeModel([makeHull([makeStaticVehicle({ x: 0, y: 0, z: 0 })])]);
+		expect(() => translateStaticVehicleRigid(model, 99, 0, { x: 1, y: 0, z: 0 }))
+			.toThrow(RangeError);
+	});
+
+	it('throws RangeError on out-of-range vehicle index', () => {
+		const model = makeModel([makeHull([makeStaticVehicle({ x: 0, y: 0, z: 0 })])]);
+		expect(() => translateStaticVehicleRigid(model, 0, 99, { x: 1, y: 0, z: 0 }))
+			.toThrow(RangeError);
+	});
+});
+
+describe('rotateStaticVehicleRigid (model-scope)', () => {
+	it('returns the input model (===) on identity rotation', () => {
+		const v = makeStaticVehicle({ x: 0, y: 0, z: 0 });
+		const model = makeModel([makeHull([v])]);
+		expect(
+			rotateStaticVehicleRigid(model, 0, 0, { x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 }),
+		).toBe(model);
+	});
+
+	it('addresses the right vehicle and leaves siblings untouched', () => {
+		const a = makeStaticVehicle({ x: 5, y: 0, z: 0 });
+		const b = makeStaticVehicle({ x: 0, y: 0, z: 5 });
+		const model = makeModel([makeHull([a, b])]);
+		const next = rotateStaticVehicleRigid(
+			model,
+			0,
+			1,
+			{ x: 0, y: 0, z: 0 },
+			{ x: 0, y: Math.PI / 2, z: 0 },
+		);
+		expect(next.hulls[0].staticTrafficVehicles[0]).toBe(a);
+		const t = translationOf(next.hulls[0].staticTrafficVehicles[1]);
+		expect(t.x).toBeCloseTo(5, 5);
+		expect(t.z).toBeCloseTo(0, 5);
+	});
+});
+
+// =============================================================================
+// Internal helpers (exposed for the writeback contract)
+// =============================================================================
+
+describe('_internalForTests.writeMatrix', () => {
+	it('emits 16 elements with the pad slots [3], [7], [11], [15] forced to zero', () => {
+		const mat = new THREE.Matrix4().identity();
+		const arr = _internalForTests.writeMatrix(mat);
+		expect(arr.length).toBe(16);
+		expect(arr[3]).toBe(0);
+		expect(arr[7]).toBe(0);
+		expect(arr[11]).toBe(0);
+		expect(arr[15]).toBe(0);
+	});
+});

--- a/src/lib/core/trafficDataOps/staticVehicleMatrix44.ts
+++ b/src/lib/core/trafficDataOps/staticVehicleMatrix44.ts
@@ -1,0 +1,285 @@
+// Static-traffic-vehicle Matrix44 rigid ops (issue #78).
+//
+// Static traffic vehicles (`TrafficStaticVehicle.mTransform`) are the ONLY
+// WorldViewport resource family today whose pose is stored as a full 4×4
+// `Matrix44Affine` — every other resource is `Vector3 + Euler` (trigger
+// boxes) or yaw-packed in a Vec4's `.w` slot (junctions, light triggers,
+// lane rungs). Static vehicles are therefore fully 3D-rotation-capable
+// (pitch + yaw + roll), just like trigger boxes from issue #77.
+//
+// Matrix layout (load-bearing). The on-disk format is Criterion's
+// Matrix44Affine: 16 sequential f32s. Elements [12], [13], [14] hold the
+// translation column, with [15] = 1 (the homogeneous w). That places the
+// array in **column-major** order from three.js's perspective — and
+// `THREE.Matrix4.fromArray(mTransform)` maps it directly. The renderer at
+// `TrafficDataViewport.tsx` already relies on this (`mat.fromArray(...)`
+// followed by reading translation from `.elements[12..14]`). We adopt the
+// same convention here so the gizmo math composes directly against the
+// representation the viewport draws.
+//
+// Multiplication order (load-bearing). The rotate-around-pivot rule from
+// issue #78 is:
+//
+//   M' = T(P) · R(delta) · T(-P) · M
+//
+// i.e. **pre-multiply** the existing pose `M` by `T(P) · R(delta) · T(-P)`.
+// This rotates the vehicle's translation AROUND the pivot (orbiting) AND
+// pre-multiplies the existing rotation portion by `R(delta)` (so the
+// vehicle's facing direction picks up the gesture's rotation). The "pre"
+// part matters: `R(delta) · M` rotates the world that `M` lives in, not
+// `M`'s local frame. That's the convention three.js uses for
+// `Matrix4.premultiply(other)` and the rigid-body interpretation matches
+// the trigger-box adapter (`bulkRotateTriggerBoxes` from issue #77).
+//
+// Coordinate frame. Editor and viewport both use a Y-up, right-handed
+// frame (three.js convention). The in-memory `mTransform` is already in
+// that frame — the parser at `trafficData.ts:readStaticVehicle` reads
+// f32s 1:1 with no axis swap, and the renderer feeds the array straight
+// into `THREE.Matrix4.fromArray`. The `swapYZ: true` flag on the
+// `mTransform` field metadata is for the **inspector form** only (which
+// slot the form labels "Y" vs "Z"); it does NOT alter the in-memory
+// layout. So our matrix math operates in editor frame and writes back
+// the same float layout the parser produced — a no-op gesture trivially
+// round-trips byte-for-byte because we hand back the **same array
+// reference** (`===`-identity preserved).
+//
+// No-op contract. Both ops return the input `TrafficStaticVehicle`
+// reference verbatim on an identity gesture (translate zero / rotate
+// identity). The bulk wrapper in `./bulk.ts` then returns the input
+// `ParsedTrafficDataRetail` reference unchanged, so `trafficData.write`
+// emits bytes identical to the source file. This is the BND2 byte-for-
+// byte writeback invariant per ADR-0010.
+
+import * as THREE from 'three';
+import type {
+	ParsedTrafficDataRetail,
+	TrafficHull,
+	TrafficStaticVehicle,
+} from '../trafficData';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * Euler rotation order for the gesture's `(rx, ry, rz)` triple. Pinned to
+ * three.js's default 'XYZ' (intrinsic Tait–Bryan), same as the trigger-box
+ * adapter — every WorldViewport gizmo speaks the same Euler convention so
+ * a mixed Selection (static vehicle + trigger box) composes consistently.
+ *
+ * Note: this is the order for building the **delta** rotation matrix from
+ * a gesture, NOT the order for decomposing the result back. The Matrix44
+ * path doesn't decompose anything — we multiply 4×4 matrices and write
+ * the 16 floats back, sidestepping the Euler-representation collapse that
+ * the trigger-box compose-then-decompose path has.
+ */
+export const STATIC_VEHICLE_DELTA_EULER_ORDER: THREE.EulerOrder = 'XYZ';
+
+// =============================================================================
+// Helpers — Matrix44Affine ↔ THREE.Matrix4
+// =============================================================================
+
+/**
+ * Read the 16-float in-memory `mTransform` into a fresh `THREE.Matrix4`.
+ * The array is column-major (translation at indices 12/13/14) so
+ * `fromArray` maps elements directly. We force the bottom row to
+ * `[0, 0, 0, 1]` because the Matrix44Affine layout stores zero in the
+ * pad slots `[3], [7], [11], [15]` rather than the homogeneous `1`, and
+ * leaving slot `[15]` at zero would give a degenerate `w` on the
+ * homogeneous multiply (this matches the renderer's
+ * `AllStaticVehicleInstances` patch).
+ */
+function readMatrix(mTransform: readonly number[]): THREE.Matrix4 {
+	const m = new THREE.Matrix4().fromArray(mTransform);
+	const e = m.elements;
+	e[3] = 0;
+	e[7] = 0;
+	e[11] = 0;
+	e[15] = 1;
+	return m;
+}
+
+/**
+ * Serialize a `THREE.Matrix4` back into a 16-element `number[]` for
+ * storage. Preserves the column-major layout. The pad slots
+ * (`[3], [7], [11]`) and the homogeneous `[15]` are forced to zero to
+ * match the on-disk Matrix44Affine convention — the writer at
+ * `writeStaticVehicle` emits 16 f32s linearly and the original file's
+ * pad slots are zero. Patching slot 15 to zero is what keeps a no-op
+ * rotate byte-identical on writeback (a non-zero w would corrupt the
+ * bytes even if the rotation portion was unchanged).
+ */
+function writeMatrix(mat: THREE.Matrix4): number[] {
+	const arr = mat.toArray();
+	arr[3] = 0;
+	arr[7] = 0;
+	arr[11] = 0;
+	arr[15] = 0;
+	return arr;
+}
+
+/**
+ * Build the 3-axis rotation delta matrix from a gesture's Euler triple,
+ * in `STATIC_VEHICLE_DELTA_EULER_ORDER`. Returns the identity matrix
+ * trivially when all three axes are zero — callers should short-circuit
+ * before reaching this in the no-op path, but the trivial result is safe
+ * to compose either way.
+ */
+function buildRotationDeltaMatrix(deltaEuler: {
+	x: number;
+	y: number;
+	z: number;
+}): THREE.Matrix4 {
+	return new THREE.Matrix4().makeRotationFromEuler(
+		new THREE.Euler(
+			deltaEuler.x,
+			deltaEuler.y,
+			deltaEuler.z,
+			STATIC_VEHICLE_DELTA_EULER_ORDER,
+		),
+	);
+}
+
+// =============================================================================
+// Single-entity translate
+// =============================================================================
+
+/**
+ * Translate one static vehicle's `mTransform` by `(dx, dy, dz)`. Only the
+ * translation column (`[12], [13], [14]`) is updated; the rotation portion
+ * (`[0..11]`) is preserved verbatim. Returns the input vehicle reference
+ * verbatim on identity offset so byte-for-byte BND2 writeback survives.
+ */
+export function translateStaticVehicleMatrix44(
+	vehicle: TrafficStaticVehicle,
+	offset: { x: number; y: number; z: number },
+): TrafficStaticVehicle {
+	if (offset.x === 0 && offset.y === 0 && offset.z === 0) return vehicle;
+	const next = vehicle.mTransform.slice();
+	next[12] = (next[12] ?? 0) + offset.x;
+	next[13] = (next[13] ?? 0) + offset.y;
+	next[14] = (next[14] ?? 0) + offset.z;
+	return { ...vehicle, mTransform: next };
+}
+
+/**
+ * Rotate one static vehicle's `mTransform` around `pivot` by the delta
+ * Euler `(rx, ry, rz)` in `STATIC_VEHICLE_DELTA_EULER_ORDER`. The math:
+ *
+ *   M' = T(P) · R(delta) · T(-P) · M
+ *
+ * which pre-multiplies the existing pose by the pivot-anchored rotation —
+ * orbiting the translation column around `pivot` AND composing the
+ * rotation delta into the vehicle's own facing direction. Returns the
+ * input vehicle reference verbatim on an identity delta (all axes zero).
+ *
+ * Critical: the input vehicle is returned **by reference** on identity so
+ * the BND2 byte-for-byte writeback invariant survives a no-op gesture.
+ * Same contract as `translateStaticVehicleMatrix44` above.
+ */
+export function rotateStaticVehicleMatrix44(
+	vehicle: TrafficStaticVehicle,
+	pivot: { x: number; y: number; z: number },
+	deltaEuler: { x: number; y: number; z: number },
+): TrafficStaticVehicle {
+	if (deltaEuler.x === 0 && deltaEuler.y === 0 && deltaEuler.z === 0) return vehicle;
+
+	const M = readMatrix(vehicle.mTransform);
+	const R = buildRotationDeltaMatrix(deltaEuler);
+
+	// Sandwich: composed = T(P) · R · T(-P), then M' = composed · M.
+	// three.js's Matrix4.premultiply(X) computes `X · this`, so calling
+	// M.premultiply(T(-P)) yields T(-P) · M, then .premultiply(R) yields
+	// R · T(-P) · M, then .premultiply(T(P)) yields T(P) · R · T(-P) · M.
+	M.premultiply(new THREE.Matrix4().makeTranslation(-pivot.x, -pivot.y, -pivot.z));
+	M.premultiply(R);
+	M.premultiply(new THREE.Matrix4().makeTranslation(pivot.x, pivot.y, pivot.z));
+
+	return { ...vehicle, mTransform: writeMatrix(M) };
+}
+
+// =============================================================================
+// ParsedTrafficDataRetail-scope rigid ops
+// =============================================================================
+
+/**
+ * Translate one static vehicle's `mTransform` by `(dx, dy, dz)`. Returns
+ * the input `model` reference on identity offset or out-of-range refs.
+ *
+ * @throws RangeError if any index is out of range.
+ */
+export function translateStaticVehicleRigid(
+	model: ParsedTrafficDataRetail,
+	hullIdx: number,
+	vehicleIdx: number,
+	offset: { x: number; y: number; z: number },
+): ParsedTrafficDataRetail {
+	if (hullIdx < 0 || hullIdx >= model.hulls.length) {
+		throw new RangeError(
+			`hullIdx ${hullIdx} out of range [0, ${model.hulls.length})`,
+		);
+	}
+	const hull = model.hulls[hullIdx];
+	if (vehicleIdx < 0 || vehicleIdx >= hull.staticTrafficVehicles.length) {
+		throw new RangeError(
+			`vehicleIdx ${vehicleIdx} out of range [0, ${hull.staticTrafficVehicles.length})`,
+		);
+	}
+	if (offset.x === 0 && offset.y === 0 && offset.z === 0) return model;
+
+	const src = hull.staticTrafficVehicles[vehicleIdx];
+	const next = translateStaticVehicleMatrix44(src, offset);
+	if (next === src) return model;
+	const nextVehicles = hull.staticTrafficVehicles.map((v, i) =>
+		i === vehicleIdx ? next : v,
+	);
+	const nextHull: TrafficHull = { ...hull, staticTrafficVehicles: nextVehicles };
+	const nextHulls = model.hulls.map((h, i) => (i === hullIdx ? nextHull : h));
+	return { ...model, hulls: nextHulls };
+}
+
+/**
+ * Rotate one static vehicle's `mTransform` around `pivot` by the delta
+ * Euler. Returns the input `model` reference on identity delta.
+ *
+ * @throws RangeError if any index is out of range.
+ */
+export function rotateStaticVehicleRigid(
+	model: ParsedTrafficDataRetail,
+	hullIdx: number,
+	vehicleIdx: number,
+	pivot: { x: number; y: number; z: number },
+	deltaEuler: { x: number; y: number; z: number },
+): ParsedTrafficDataRetail {
+	if (hullIdx < 0 || hullIdx >= model.hulls.length) {
+		throw new RangeError(
+			`hullIdx ${hullIdx} out of range [0, ${model.hulls.length})`,
+		);
+	}
+	const hull = model.hulls[hullIdx];
+	if (vehicleIdx < 0 || vehicleIdx >= hull.staticTrafficVehicles.length) {
+		throw new RangeError(
+			`vehicleIdx ${vehicleIdx} out of range [0, ${hull.staticTrafficVehicles.length})`,
+		);
+	}
+	if (deltaEuler.x === 0 && deltaEuler.y === 0 && deltaEuler.z === 0) return model;
+
+	const src = hull.staticTrafficVehicles[vehicleIdx];
+	const next = rotateStaticVehicleMatrix44(src, pivot, deltaEuler);
+	if (next === src) return model;
+	const nextVehicles = hull.staticTrafficVehicles.map((v, i) =>
+		i === vehicleIdx ? next : v,
+	);
+	const nextHull: TrafficHull = { ...hull, staticTrafficVehicles: nextVehicles };
+	const nextHulls = model.hulls.map((h, i) => (i === hullIdx ? nextHull : h));
+	return { ...model, hulls: nextHulls };
+}
+
+// Internal-for-tests: expose the lowest-level matrix helpers so the
+// cross-validation test (Vector3 + Euler ↔ Matrix44) can pin the
+// representation conversion without re-implementing it.
+export const _internalForTests = {
+	readMatrix,
+	writeMatrix,
+	buildRotationDeltaMatrix,
+};

--- a/src/lib/core/trafficDataOps/transformAxes.ts
+++ b/src/lib/core/trafficDataOps/transformAxes.ts
@@ -1,7 +1,7 @@
 // Transform-axis profile for traffic-data resource entities.
 //
-// Per ADR-0011, every entity covered by this module has spatial data that
-// is XZ-packed in some way:
+// Per ADR-0011, most traffic-data entities are XZ-packed and therefore
+// yaw-only on rotate:
 //
 //   - Yaw-packed Vector4 boxes (junction logic boxes, light triggers,
 //     traffic-light collection elements, corona positions) carry `(x, y, z,
@@ -14,10 +14,15 @@
 //     repositioning a rung between two elevation tiers can shift it
 //     vertically — the inspector numeric fields can still edit Y directly.)
 //
-// Static traffic vehicles are full-3D `Matrix44` and live in a separate
-// module (issue #78) — they DO NOT auto-disable pitch or roll.
+// Static traffic vehicles (issue #78) are the exception — their pose is a
+// full `Matrix44Affine` so all three rotate axes have somewhere to land,
+// and the gizmo offers all three rings interactive when the Selection is
+// pure-static-vehicle (or mixed only with other full-3D contributors like
+// trigger boxes). The auto-disable intersection in
+// `intersectTransformAxes` collapses back to yaw-only as soon as a
+// yaw-packed sibling joins the Selection.
 
-import type { TransformAxes } from '../transformAxes';
+import { TRANSFORM_AXES_FULL_3D, type TransformAxes } from '../transformAxes';
 
 /**
  * Traffic yaw-packed Vector4 box / element: full 3-axis translate, yaw-only
@@ -38,3 +43,13 @@ export const TRAFFIC_LANE_RUNG_AXES: TransformAxes = {
 	translate: { x: true, y: true, z: true },
 	rotate: { x: false, y: true, z: false },
 };
+
+/**
+ * Traffic static vehicle (`mTransform` Matrix44Affine): full 3-axis
+ * translate AND full 3-axis rotate. Static vehicles are the only Matrix44
+ * resource in the traffic-data family — they have somewhere to land all
+ * three rotate axes (the rotation portion of the 4×4), so the gizmo
+ * exposes pitch, yaw, and roll rings whenever the Selection is purely
+ * static-vehicle or mixed only with other full-3D contributors.
+ */
+export const TRAFFIC_STATIC_VEHICLE_AXES: TransformAxes = TRANSFORM_AXES_FULL_3D;


### PR DESCRIPTION
Closes #78.

## Summary

Adds the Matrix44 resource adapter for the unified Bulk-transform gizmo. Static traffic vehicles (`TrafficStaticVehicle.mTransform`) are the only WorldViewport resource with a full 4x4 rigid transform, so this slice introduces the matrix sandwich-multiply path alongside the existing yaw-packed (#79) and Euler (#77) paths.

End-to-end behaviour:
- **Single-entity**: selecting one static vehicle anchors the gizmo at the translation column with all three rotate rings active.
- **Translate**: `M.translation += delta`; rotation portion preserved verbatim.
- **Rotate around pivot P**: `M' = T(P) * R(delta) * T(-P) * M` (pre-multiply). Position orbits the pivot AND the rotation portion is composed with the gesture delta.
- **Bulk**: pure-static-vehicle Selections rotate on all three axes. Mixed Selections (vehicle + yaw-packed sibling) AND-intersect to yaw-only per ADR-0011; the matrix44 path still runs but only picks up the yaw component (zero pitch/roll).
- **No-op gesture**: returns input model + vehicle references verbatim so BND2 byte-for-byte writeback survives.

## What's new

- `staticVehicleMatrix44.ts` — single-entity translate/rotate ops, model-scope wrappers, internal Matrix4 helpers exposed for tests.
- `bulk.ts` — `TrafficDataEntityRef` gains a `staticVehicle` variant; `bulkTranslateTrafficEntities`, `bulkRotateTrafficEntitiesYaw`, and the new `bulkRotateTrafficEntitiesMatrix44` all branch on it; pivot helper contributes the translation column; `bulkTrafficDataAxes` now AND-intersects per-ref so pure-vehicle Selections widen to full-3D rotate.
- `transformAxes.ts` — new `TRAFFIC_STATIC_VEHICLE_AXES = TRANSFORM_AXES_FULL_3D`.
- `TrafficDataOverlay.tsx` — folds static-vehicle picks (single-select + marquee-bulk) into `bulkRefs`; chooses the right axes profile + rotate dispatcher.

## Judgment calls

- **Matrix layout** — `mTransform` is column-major (translation at `[12], [13], [14]`), matching what `THREE.Matrix4.fromArray` consumes and what the renderer already uses (`AllStaticVehicleInstances`). The pad slots `[3], [7], [11], [15]` are zero in storage; we force them to zero on writeback to keep the on-disk byte layout identical on no-op.
- **swapYZ frame** — the `swapYZ: true` field metadata on `mTransform` is purely an inspector-form label flag (which slot the form calls "Y" vs "Z"). The parser at `trafficData.ts:readStaticVehicle` reads f32s 1:1 with no axis swap, and the viewport feeds the array straight into three.js. The in-memory model is therefore already in editor frame (Y-up); all gizmo math operates in Y-up, and a no-op produces byte-identical output trivially because we hand back the same array reference.
- **Multiplication order** — `Matrix4.premultiply(X)` is left-multiply (X · this). I apply T(-P), then R, then T(P) via three sequential `premultiply` calls so the composed result is `T(P) · R · T(-P) · M`. Cross-validation against the Vector3+Euler path catches an incorrect order.
- **Euler convention** — three.js's right-hand `Ry(pi/2)` sends +X to -Z. Matches the trigger-box adapter (`triggerDataOps`); my cross-validation reference also uses three.js quaternion math so the two paths are consistent by construction.

## Test plan

- [x] Translate single vehicle — position column updated, rotation column unchanged, ===-identity on no-op
- [x] Rotate single vehicle around own position — position unchanged, facing rotates by delta
- [x] Rotate single vehicle around external pivot — position orbits, rotation portion composes
- [x] **Cross-validation**: Matrix44 path vs Vector3+Euler representation across 6 cases (identity, yaw-only, pitched, full-3D, etc.) — facing direction + position match within 1e-4
- [x] Bulk rotate of N vehicles around common pivot — pairwise distances preserved (rigid-body invariant)
- [x] Mixed Selection (static vehicle + junction) AND-intersects to yaw-only
- [x] Pure static-vehicle Selection rotates all 3 axes
- [x] Static vehicle + trigger-box-stand-in (FULL_3D) keeps all 3 axes
- [x] No-op rotate returns SAME `mTransform` reference (BND2 byte-for-byte writeback)
- [x] `bulkRotateTrafficEntitiesYaw` and `bulkRotateTrafficEntitiesMatrix44` produce identical Matrix44 output when only `delta.y` is non-zero
- [x] `npx tsc --noEmit` clean, `npx eslint src/lib/core/trafficDataOps src/components/schema-editor/viewports/TrafficDataOverlay.tsx` clean (only pre-existing warnings)
- [x] Full suite: 1425 pass / 14 fail (matches baseline — all fixture ENOENTs)

40 new tests added (23 in `staticVehicleMatrix44.test.ts`, 17 in extended `bulk.test.ts`).

Out of scope (covered by other issues): trigger boxes (#77), other traffic-data resources (#79), pivot drag (#76), numeric panel (#81), polygon soup (#82), cross-Bundle (#80).

🤖 Generated with [Claude Code](https://claude.com/claude-code)