### PR TITLE
fix: rename stale pivotOverride → bulkPivotOverride in AISectionsOverlay

### DIFF
--- a/src/components/schema-editor/viewports/AISectionsOverlay.tsx
+++ b/src/components/schema-editor/viewports/AISectionsOverlay.tsx
@@ -456,7 +456,7 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 			// override wins if set (issue #81 numeric pivot edit), otherwise
 			// the live-derived bulk median. Pivot edits between gestures
 			// thereby move the rotation centre for the next gesture.
-			const pivot = bulkPivotRef.current ?? pivotOverride ?? bulkPivotLive;
+			const pivot = bulkPivotRef.current ?? bulkPivotOverride ?? bulkPivotLive;
 			if (!pivot) return null;
 			return { kind: 'bulk', entities: bulkRefs, pivot };
 		}
@@ -498,7 +498,7 @@ export const AISectionsOverlay: WorldOverlayComponent<ParsedAISectionsV12> = ({
 			default:
 				return null;
 		}
-	}, [isBulkActive, bulkRefs, bulkPivotLive, marker, pivotOverride]);
+	}, [isBulkActive, bulkRefs, bulkPivotLive, marker, bulkPivotOverride]);
 
 	// Snap is intentionally not applied to any bulk-transform path (CONTEXT.md
 	// / ADR-0009): cascade-off makes snap incoherent (snapping the source to


### PR DESCRIPTION
## Summary

- Two stale references to \`pivotOverride\` (the post-#96 merge missed them) crash the AI sections overlay on viewport mount: \`ReferenceError: pivotOverride is not defined\` as soon as any \`ai.dat\` resource loads.
- Both references live in the \`gizmoTarget\` useMemo where the bulk gizmo's effective pivot is resolved. The unified state is \`bulkPivotOverride\` (from #95's pivot-drag work, reused by #96's numeric panel).
- One-line fix on two sites: rename to \`bulkPivotOverride\`.

## Test plan

- [x] Typecheck clean
- [x] AISectionsOverlay tests pass (16/16)
- [ ] Open an \`ai.dat\` resource in the workspace — viewport mounts without the ReferenceError