### PR TITLE
feat(workspace): drag-to-reorder instances in the resource tree

### DIFF
--- a/src/components/workspace/WorkspaceHierarchy.reorder.ts
+++ b/src/components/workspace/WorkspaceHierarchy.reorder.ts
@@ -1,0 +1,136 @@
+// Drag-to-reorder helpers for record-list instance rows in the unified
+// Workspace tree (branch feat/prop-instance-reorder).
+//
+// The tree's list-item rows (`SchemaRow` whose `schemaPath` ends in a numeric
+// index — e.g. `['instances', 7]` for a PropInstanceData prop, `['triggers',
+// 3]` for a TriggerData entry) can be dragged up/down to reorder them within
+// their parent list. This module is the pure core: it has no React / DOM
+// dependency so the vitest `node` env exercises the index math and the
+// same-list guard directly, mirroring the WorldViewportComposition helper
+// tests.
+//
+// Domain (PropInstanceData, the primary driver): props are stored as one flat
+// `instances` array that the writer partitions into spatial `cells` by
+// position. Reordering the flat array is exactly the edit the user wants —
+// it changes which props fall in each cell's positional run, which fixes the
+// respawn/collectible order the Blender exporter gets wrong. We never touch
+// `cells`; the writer recomputes the partition (muStartIndex/muCount) from the
+// reordered array, and the total count is unchanged so the round-trip stays
+// valid. See docs/prop-instance-data-spec.md and
+// src/lib/core/propInstanceData.ts.
+
+import { updateAtPath, type NodePath } from '@/lib/schema/walk';
+
+// ---------------------------------------------------------------------------
+// Pure array move
+// ---------------------------------------------------------------------------
+
+// Move the element at `from` to `to`, returning a NEW array (structural
+// sharing — the source array is never mutated). `to` is the destination index
+// in the post-removal coordinate space, i.e. the index the moved item ends up
+// occupying. Out-of-range / no-op moves return a shallow copy so callers can
+// treat the result uniformly without an identity surprise.
+export function moveItem<T>(arr: readonly T[], from: number, to: number): T[] {
+	const next = arr.slice();
+	if (
+		from < 0 ||
+		from >= next.length ||
+		to < 0 ||
+		to >= next.length ||
+		from === to
+	) {
+		return next;
+	}
+	const [moved] = next.splice(from, 1);
+	next.splice(to, 0, moved);
+	return next;
+}
+
+// ---------------------------------------------------------------------------
+// Reorderable-row identification
+// ---------------------------------------------------------------------------
+
+// A schema row is a reorderable list item iff its path ends in a numeric
+// segment — that segment is its index inside the parent list, and everything
+// before it is the list path. `['instances', 7]` → list `['instances']`,
+// index 7. `['cells', 2, 'foo']` is NOT a list item (ends in a string), and a
+// top-level field like `['instances']` is the list itself, not an item.
+export type ListItemAddress = {
+	/** Path to the enclosing list (the row's `schemaPath` minus its last segment). */
+	listPath: NodePath;
+	/** Item's index within that list (the row's last path segment). */
+	index: number;
+};
+
+export function listItemAddress(schemaPath: NodePath): ListItemAddress | null {
+	if (schemaPath.length === 0) return null;
+	const last = schemaPath[schemaPath.length - 1];
+	if (typeof last !== 'number') return null;
+	return { listPath: schemaPath.slice(0, -1), index: last };
+}
+
+// ---------------------------------------------------------------------------
+// Drag payload + same-list guard
+// ---------------------------------------------------------------------------
+
+// What a drag carries. A drop is only honoured when the target row addresses
+// the SAME list in the SAME instance of the SAME resource in the SAME bundle —
+// reordering can't move an item across lists, instances, resources, or
+// bundles. The `index` differs between source and target (that's the move); the
+// rest must match exactly.
+export type ReorderDragSource = {
+	bundleId: string;
+	resourceKey: string;
+	/** Instance index of the resource (top-level multi-instance address). */
+	instanceIndex: number;
+	/** Path to the enclosing list within the instance's model. */
+	listPath: NodePath;
+	/** The dragged item's index within that list. */
+	itemIndex: number;
+};
+
+function samePath(a: NodePath, b: NodePath): boolean {
+	if (a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i++) {
+		if (a[i] !== b[i]) return false;
+	}
+	return true;
+}
+
+// True when `target` is a valid drop site for `source`: same bundle, resource,
+// instance, and list path. Index equality is intentionally NOT required — a
+// drop onto the row you started dragging is a no-op the caller can short-
+// circuit, but it's still a "same list" target.
+export function isSameReorderList(
+	source: ReorderDragSource,
+	target: Omit<ReorderDragSource, 'itemIndex'>,
+): boolean {
+	return (
+		source.bundleId === target.bundleId &&
+		source.resourceKey === target.resourceKey &&
+		source.instanceIndex === target.instanceIndex &&
+		samePath(source.listPath, target.listPath)
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Model reorder
+// ---------------------------------------------------------------------------
+
+// Produce the next instance model with the item at `from` moved to `to` inside
+// the list at `listPath`. Structural sharing throughout: `updateAtPath` clones
+// only the spine down to the list, and `moveItem` clones only the list array.
+// Returns the original `model` reference unchanged when the move is a no-op
+// (same index) so callers can skip a pointless write + history entry.
+export function reorderListInModel(
+	model: unknown,
+	listPath: NodePath,
+	from: number,
+	to: number,
+): unknown {
+	if (from === to) return model;
+	return updateAtPath(model, listPath, (current) => {
+		if (!Array.isArray(current)) return current;
+		return moveItem(current, from, to);
+	});
+}

--- a/src/components/workspace/WorkspaceHierarchy.tsx
+++ b/src/components/workspace/WorkspaceHierarchy.tsx
@@ -43,6 +43,12 @@ import {
 	type ResourceTypeFlatNode,
 	type SchemaFlatNode,
 } from './WorkspaceHierarchy.helpers';
+import {
+	isSameReorderList,
+	listItemAddress,
+	reorderListInModel,
+	type ReorderDragSource,
+} from './WorkspaceHierarchy.reorder';
 
 // Return the path the bulk-range "from" anchor should use. We read the
 // inspector's current schema path; if the current selection isn't on a
@@ -134,7 +140,8 @@ export type WorkspaceHierarchyProps = {
 };
 
 export function WorkspaceHierarchy({ onAddBundle }: WorkspaceHierarchyProps) {
-	const { bundles, selection, select, saveBundle, closeBundle } = useWorkspace();
+	const { bundles, selection, select, saveBundle, closeBundle, getResources, setResourceAt } =
+		useWorkspace();
 	// PSL bulk handle — null when no PSL is active. Drives the schema-row
 	// Ctrl/Shift-click semantics + the amber-accent highlight on bulk rows.
 	const bulk = useWorkspacePSLBulk();
@@ -266,6 +273,74 @@ export function WorkspaceHierarchy({ onAddBundle }: WorkspaceHierarchyProps) {
 		[select, bulk, aiBulk, triggerBulk, selection],
 	);
 
+	// ---------------------- Drag-to-reorder ----------------------
+	//
+	// HTML5 DnD on record-list instance rows (PropInstanceData props,
+	// TriggerData triggers, …). The active drag source + the current drop
+	// indicator (which row's pathKey + which edge) live here so the dragged
+	// row's identity is known across `onDragOver`/`onDrop` on a *different*
+	// row, and so we can paint a single top/bottom border on the hovered row.
+	const [dragSource, setDragSource] = useState<ReorderDragSource | null>(null);
+	const [dropTarget, setDropTarget] = useState<{
+		pathKey: string;
+		edge: 'top' | 'bottom';
+	} | null>(null);
+
+	const onReorderDragStart = useCallback((source: ReorderDragSource) => {
+		setDragSource(source);
+	}, []);
+
+	const onReorderDragEnd = useCallback(() => {
+		setDragSource(null);
+		setDropTarget(null);
+	}, []);
+
+	// Reorder commit: move the dragged item to its new slot within the SAME
+	// list and write the next instance model back through `setResourceAt`
+	// (one HistoryCommit, dirties the bundle). The drop index is computed in
+	// the post-removal coordinate space: dropping below a row that sits after
+	// the source means the gap shifts down by one once the source is pulled
+	// out. The same-list guard (bundle / resource / instance / listPath) runs
+	// before any of this — a mismatched drop is ignored upstream.
+	const onReorderDrop = useCallback(
+		(
+			target: Omit<ReorderDragSource, 'itemIndex'>,
+			targetItemIndex: number,
+			edge: 'top' | 'bottom',
+		) => {
+			const source = dragSource;
+			setDragSource(null);
+			setDropTarget(null);
+			if (!source) return;
+			if (!isSameReorderList(source, target)) return;
+
+			const from = source.itemIndex;
+			// Insertion slot in the original array, then adjust to the
+			// post-removal index space.
+			const insertBefore = edge === 'top' ? targetItemIndex : targetItemIndex + 1;
+			let to = insertBefore;
+			if (from < insertBefore) to -= 1;
+			if (to === from) return;
+
+			const model = getResources<unknown>(source.bundleId, source.resourceKey)[
+				source.instanceIndex
+			];
+			if (model == null) return;
+			const next = reorderListInModel(model, source.listPath, from, to);
+			if (next === model) return;
+			setResourceAt(source.bundleId, source.resourceKey, source.instanceIndex, next);
+			// Keep the selection on the moved item so the inspector follows it
+			// to its new slot (selection addresses by index, which just changed).
+			select({
+				bundleId: source.bundleId,
+				resourceKey: source.resourceKey,
+				index: source.instanceIndex,
+				path: [...source.listPath, to],
+			});
+		},
+		[dragSource, getResources, setResourceAt, select],
+	);
+
 	// ---------------------- Virtualizer ----------------------
 
 	const parentRef = useRef<HTMLDivElement>(null);
@@ -358,6 +433,12 @@ export function WorkspaceHierarchy({ onAddBundle }: WorkspaceHierarchyProps) {
 									pslBulkPathKeys={bulk?.bulkPathKeys ?? null}
 									aiBulkGetPathKeys={aiBulk?.getPathKeys ?? null}
 									aiBulkGetCount={aiBulk?.getCount ?? null}
+									dragSource={dragSource}
+									dropTarget={dropTarget}
+									onReorderDragStart={onReorderDragStart}
+									onReorderDragOverRow={setDropTarget}
+									onReorderDrop={onReorderDrop}
+									onReorderDragEnd={onReorderDragEnd}
 								/>
 							</div>
 						);
@@ -415,6 +496,26 @@ type HierarchyRowProps = {
 	/** Cheap count lookup for the resource-type-row Badge. Same null-vs-fn
 	 *  contract as `aiBulkGetPathKeys`. */
 	aiBulkGetCount: ((bundleId: string, index: number) => number) | null;
+	// ---- Drag-to-reorder (record-list instance rows only) ----
+	/** The currently-dragged list item, or null when no drag is in flight.
+	 *  A row consults this to decide whether it's a valid drop target. */
+	dragSource: ReorderDragSource | null;
+	/** The row + edge the drop indicator currently paints, or null. */
+	dropTarget: { pathKey: string; edge: 'top' | 'bottom' } | null;
+	/** Begin a drag from a reorderable row. */
+	onReorderDragStart: (source: ReorderDragSource) => void;
+	/** Update the drop indicator as the pointer moves over a row. */
+	onReorderDragOverRow: (
+		next: { pathKey: string; edge: 'top' | 'bottom' } | null,
+	) => void;
+	/** Commit a drop onto a row's `(target, itemIndex, edge)`. */
+	onReorderDrop: (
+		target: Omit<ReorderDragSource, 'itemIndex'>,
+		targetItemIndex: number,
+		edge: 'top' | 'bottom',
+	) => void;
+	/** End the drag (clears source + indicator). */
+	onReorderDragEnd: () => void;
 };
 
 function HierarchyRow(props: HierarchyRowProps) {
@@ -667,7 +768,35 @@ function SchemaRow({
 	onSelectSchema,
 	pslBulkPathKeys,
 	aiBulkGetPathKeys,
+	dragSource,
+	dropTarget,
+	onReorderDragStart,
+	onReorderDragOverRow,
+	onReorderDrop,
+	onReorderDragEnd,
 }: HierarchyRowProps & { node: SchemaFlatNode }) {
+	// A schema row is reorderable iff it's a record-list item (its path ends
+	// in a numeric index). Top-level list fields and record sub-fields aren't
+	// — only the leaf items move. `address` is the (listPath, index) split.
+	const address = listItemAddress(node.schemaPath);
+	const isReorderable = address != null;
+	const rowTarget = address
+		? {
+			bundleId: node.bundleId,
+			resourceKey: node.resourceKey,
+			instanceIndex: node.index,
+			listPath: address.listPath,
+		}
+		: null;
+	// This row is a *valid* drop site only while a drag from the SAME list is
+	// in flight — same bundle / resource / instance / listPath. Cross-list (or
+	// no-drag) hovers don't preventDefault, so the browser shows "no drop."
+	const isDropEligible =
+		rowTarget != null &&
+		dragSource != null &&
+		isSameReorderList(dragSource, rowTarget);
+	const dropEdge =
+		dropTarget?.pathKey === node.pathKey ? dropTarget.edge : null;
 	// Resolve the right bulk-path-key set for THIS row's resource. PSL is a
 	// single global Set today (one bulk active at a time); AI sections is
 	// per-(bundleId, index) so the same row in two different bundles can be
@@ -705,8 +834,74 @@ function SchemaRow({
 				!node.isSelected && isInBulk && 'bg-amber-500/10',
 				!node.isSelected && !isInBulk && node.isOnPath && 'bg-muted/30',
 				!node.isSelected && 'hover:bg-muted/40',
+				// Drop indicator: a primary-coloured border on the edge the
+				// dragged row would land against. Inset (negative margin) so the
+				// 2px line doesn't nudge the row's layout.
+				dropEdge === 'top' && 'border-t-2 border-t-primary -mt-px',
+				dropEdge === 'bottom' && 'border-b-2 border-b-primary -mb-px',
+				// Faintly dim the row being dragged so the user can see it lift.
+				dragSource != null &&
+					address != null &&
+					dragSource.bundleId === node.bundleId &&
+					dragSource.resourceKey === node.resourceKey &&
+					dragSource.instanceIndex === node.index &&
+					dragSource.itemIndex === address.index &&
+					'opacity-40',
 			)}
 			style={{ paddingLeft: node.depth * 12 + 4 }}
+			draggable={isReorderable}
+			onDragStart={
+				isReorderable && address
+					? (e) => {
+						// Mark this as a move so the cursor reflects reorder, not
+						// copy. `setData` is required for Firefox to start a drag
+						// at all — the value is unused (drag identity is held in
+						// React state, which survives across rows; the DataTransfer
+						// string would only carry within one drop).
+						e.dataTransfer.effectAllowed = 'move';
+						try {
+							e.dataTransfer.setData('text/plain', node.pathKey);
+						} catch {
+							/* some browsers throw on programmatic setData; ignore */
+						}
+						onReorderDragStart({
+							bundleId: node.bundleId,
+							resourceKey: node.resourceKey,
+							instanceIndex: node.index,
+							listPath: address.listPath,
+							itemIndex: address.index,
+						});
+					}
+					: undefined
+			}
+			onDragOver={
+				isDropEligible && address
+					? (e) => {
+						// preventDefault is what tells the browser this is a valid
+						// drop target (without it `onDrop` never fires). Pick the
+						// edge from the pointer's position within the row so the
+						// indicator lands above or below.
+						e.preventDefault();
+						e.dataTransfer.dropEffect = 'move';
+						const rect = e.currentTarget.getBoundingClientRect();
+						const edge: 'top' | 'bottom' =
+							e.clientY - rect.top < rect.height / 2 ? 'top' : 'bottom';
+						onReorderDragOverRow({ pathKey: node.pathKey, edge });
+					}
+					: undefined
+			}
+			onDrop={
+				isDropEligible && rowTarget && address
+					? (e) => {
+						e.preventDefault();
+						const rect = e.currentTarget.getBoundingClientRect();
+						const edge: 'top' | 'bottom' =
+							e.clientY - rect.top < rect.height / 2 ? 'top' : 'bottom';
+						onReorderDrop(rowTarget, address.index, edge);
+					}
+					: undefined
+			}
+			onDragEnd={isReorderable ? () => onReorderDragEnd() : undefined}
 			onClick={(e) => {
 				e.stopPropagation();
 				onSelectSchema(

--- a/src/components/workspace/__tests__/WorkspaceHierarchy.reorder.test.ts
+++ b/src/components/workspace/__tests__/WorkspaceHierarchy.reorder.test.ts
@@ -1,0 +1,198 @@
+// Pure-function tests for the drag-to-reorder core (branch
+// feat/prop-instance-reorder). The React/DOM DnD glue in
+// WorkspaceHierarchy.tsx isn't exercised here — our vitest env is `node` and
+// the repo has no DOM/R3F test infra (same rationale as the
+// WorldViewportComposition helper tests). The interesting behaviour is the
+// index math (`moveItem`, drop-index adjustment), the reorderable-row split,
+// the same-list guard, and the structural-sharing model rewrite.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+	isSameReorderList,
+	listItemAddress,
+	moveItem,
+	reorderListInModel,
+	type ReorderDragSource,
+} from '../WorkspaceHierarchy.reorder';
+
+// ---------------------------------------------------------------------------
+// moveItem
+// ---------------------------------------------------------------------------
+
+describe('moveItem', () => {
+	it('moves an element later in the array', () => {
+		expect(moveItem(['a', 'b', 'c', 'd'], 0, 2)).toEqual(['b', 'c', 'a', 'd']);
+	});
+
+	it('moves an element earlier in the array', () => {
+		expect(moveItem(['a', 'b', 'c', 'd'], 3, 1)).toEqual(['a', 'd', 'b', 'c']);
+	});
+
+	it('returns a structural copy without mutating the source', () => {
+		const src = ['a', 'b', 'c'];
+		const out = moveItem(src, 0, 2);
+		expect(out).not.toBe(src);
+		expect(src).toEqual(['a', 'b', 'c']); // source untouched
+		expect(out).toEqual(['b', 'c', 'a']);
+	});
+
+	it('is a no-op copy when from === to', () => {
+		const src = ['a', 'b', 'c'];
+		const out = moveItem(src, 1, 1);
+		expect(out).toEqual(['a', 'b', 'c']);
+		expect(out).not.toBe(src);
+	});
+
+	it('returns an unchanged copy for out-of-range indices', () => {
+		expect(moveItem(['a', 'b'], 5, 0)).toEqual(['a', 'b']);
+		expect(moveItem(['a', 'b'], 0, 5)).toEqual(['a', 'b']);
+		expect(moveItem(['a', 'b'], -1, 0)).toEqual(['a', 'b']);
+	});
+
+	it('handles adjacent swaps', () => {
+		expect(moveItem(['a', 'b'], 0, 1)).toEqual(['b', 'a']);
+		expect(moveItem(['a', 'b'], 1, 0)).toEqual(['b', 'a']);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// listItemAddress
+// ---------------------------------------------------------------------------
+
+describe('listItemAddress', () => {
+	it('splits a list-item path into list path + index', () => {
+		expect(listItemAddress(['instances', 7])).toEqual({
+			listPath: ['instances'],
+			index: 7,
+		});
+	});
+
+	it('handles nested list-item paths', () => {
+		expect(listItemAddress(['cells', 2, 'props', 4])).toEqual({
+			listPath: ['cells', 2, 'props'],
+			index: 4,
+		});
+	});
+
+	it('returns null for the empty path', () => {
+		expect(listItemAddress([])).toBeNull();
+	});
+
+	it('returns null when the path ends on a record field (string segment)', () => {
+		// The list field itself (`['instances']`) and record sub-fields aren't
+		// reorderable items — only the numeric leaves are.
+		expect(listItemAddress(['instances'])).toBeNull();
+		expect(listItemAddress(['cells', 2, 'muX'])).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// isSameReorderList — the same-list-only guard
+// ---------------------------------------------------------------------------
+
+describe('isSameReorderList', () => {
+	const source: ReorderDragSource = {
+		bundleId: 'TRK_UNIT_206.BUN',
+		resourceKey: 'propInstanceData',
+		instanceIndex: 0,
+		listPath: ['instances'],
+		itemIndex: 3,
+	};
+
+	function targetFrom(over: Partial<Omit<ReorderDragSource, 'itemIndex'>>) {
+		return {
+			bundleId: source.bundleId,
+			resourceKey: source.resourceKey,
+			instanceIndex: source.instanceIndex,
+			listPath: source.listPath,
+			...over,
+		};
+	}
+
+	it('accepts a drop on a sibling row in the same list (different index ok)', () => {
+		// Index intentionally NOT part of the guard — moving to a *different*
+		// index is the whole point.
+		expect(isSameReorderList(source, targetFrom({}))).toBe(true);
+	});
+
+	it('rejects a drop into a different list within the same instance', () => {
+		expect(isSameReorderList(source, targetFrom({ listPath: ['cells'] }))).toBe(false);
+	});
+
+	it('rejects a drop onto a different instance index', () => {
+		expect(isSameReorderList(source, targetFrom({ instanceIndex: 1 }))).toBe(false);
+	});
+
+	it('rejects a drop onto a different resource', () => {
+		expect(isSameReorderList(source, targetFrom({ resourceKey: 'triggerData' }))).toBe(
+			false,
+		);
+	});
+
+	it('rejects a drop into a different bundle', () => {
+		expect(isSameReorderList(source, targetFrom({ bundleId: 'OTHER.BUN' }))).toBe(false);
+	});
+
+	it('compares list paths element-by-element, not by reference', () => {
+		// A fresh array with the same contents must still match — the tree
+		// rebuilds path arrays every render, so reference equality would break
+		// every drop.
+		expect(isSameReorderList(source, targetFrom({ listPath: ['instances'] }))).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// reorderListInModel — structural-sharing model rewrite
+// ---------------------------------------------------------------------------
+
+describe('reorderListInModel', () => {
+	function model() {
+		return {
+			muZoneId: 206,
+			instances: [
+				{ muInstanceID: 100 },
+				{ muInstanceID: 101 },
+				{ muInstanceID: 102 },
+				{ muInstanceID: 103 },
+			],
+			// Cells must be untouched by a reorder — the writer recomputes the
+			// partition from the reordered flat array (PropInstanceData domain).
+			cells: [{ muX: 1, muStartIndex: 0, muCount: 4 }],
+		};
+	}
+
+	it('moves an instance within the flat array, leaving cells untouched', () => {
+		const before = model();
+		const after = reorderListInModel(before, ['instances'], 0, 2) as typeof before;
+		expect(after.instances.map((i) => i.muInstanceID)).toEqual([101, 102, 100, 103]);
+		// Cells array is reused by reference — only the `instances` spine was
+		// cloned (structural sharing).
+		expect(after.cells).toBe(before.cells);
+		// The unrelated header field is preserved.
+		expect(after.muZoneId).toBe(206);
+	});
+
+	it('does not mutate the source model', () => {
+		const before = model();
+		reorderListInModel(before, ['instances'], 3, 0);
+		expect(before.instances.map((i) => i.muInstanceID)).toEqual([100, 101, 102, 103]);
+	});
+
+	it('returns the SAME model reference for a no-op (from === to)', () => {
+		// Lets the caller skip a pointless setResourceAt + history entry.
+		const before = model();
+		expect(reorderListInModel(before, ['instances'], 1, 1)).toBe(before);
+	});
+
+	it('clones only the list spine, not unrelated branches', () => {
+		const before = model();
+		const after = reorderListInModel(before, ['instances'], 1, 3) as typeof before;
+		// New root + new instances array...
+		expect(after).not.toBe(before);
+		expect(after.instances).not.toBe(before.instances);
+		// ...but the cells branch is shared.
+		expect(after.cells).toBe(before.cells);
+		expect(after.instances.map((i) => i.muInstanceID)).toEqual([100, 102, 103, 101]);
+	});
+});


### PR DESCRIPTION
Adds **drag-to-reorder** for a resource's instance rows in the Workspace left tree — click a row, hold, drag up/down between the others to change the order.

### Why
PropInstanceData collectibles only work when props sit in a specific **order within their cell**, and the Blender exporter emits the wrong order with no toggle to fix it. This is the manual fix-up tool the user asked for (modelled on the trigger list layout).

### What
- **Generic** for any schema record-list item row, so it works for TriggerData triggers etc. too — props are the primary target.
- HTML5 drag-and-drop on the list-item rows with a top/bottom drop indicator. A plain click still selects (native DnD suppresses the click only on an actual drag).
- **Same-list-only guard** — a drag can't move an item into a different list, instance, resource, or bundle (the `dragover` cursor shows "no drop" otherwise).
- Commits via `setResourceAt` as **one undoable** `HistoryCommit`, with structural sharing (only the list spine is cloned). For PropInstanceData this reorders the flat `instances` array; `cells` are untouched and the writer recomputes the partition — exactly the order fix collectibles need.
- Pure reorder core (`moveItem` / `listItemAddress` / `isSameReorderList` / `reorderListInModel`) extracted to `WorkspaceHierarchy.reorder.ts` and **unit-tested (20 tests)**.

### Verification
- `WorkspaceHierarchy.reorder.test.ts` (20) + `WorldViewportComposition.test.ts` green; full workspace folder 200 passed; existing `WorkspaceHierarchy.test.ts` untouched. tsc clean on the changed files.
- **Verified live in the browser**: loaded a TRK unit, expanded a Prop Instance Data resource's `Instances`, dragged `#0` down past `#4` → the prop (id 467023) moved to its new slot, the rest shifted up, the tree re-rendered from the model, no console errors.

Builds on the PropInstanceData editor (#108, now on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)