### PR TITLE
fix(prop-instance): parse empty prop zones; stop null model from losing the WebGL context

### DIFF
--- a/src/components/common/ViewportErrorBoundary.tsx
+++ b/src/components/common/ViewportErrorBoundary.tsx
@@ -12,6 +12,12 @@ import { Button } from '@/components/ui/button';
 
 type Props = {
 	resetKey?: unknown;
+	/** Heading for the fallback card. Defaults to the 3D-viewport copy; the
+	 *  inspector pane overrides it so a caught inspector throw doesn't claim the
+	 *  viewport crashed. */
+	title?: string;
+	/** Body copy under the heading. Defaults to the 3D-viewport explanation. */
+	description?: string;
 	children: ReactNode;
 };
 
@@ -77,11 +83,12 @@ export class ViewportErrorBoundary extends Component<Props, State> {
 				<div className="max-w-3xl mx-auto rounded border border-destructive/40 bg-destructive/5 p-4 space-y-3">
 					<div className="flex items-start justify-between gap-3">
 						<div>
-							<h2 className="text-sm font-semibold text-destructive">3D viewport crashed</h2>
+							<h2 className="text-sm font-semibold text-destructive">
+								{this.props.title ?? '3D viewport crashed'}
+							</h2>
 							<p className="text-xs text-muted-foreground mt-1">
-								Something threw while rendering the 3D view. Please copy the details below and
-								send them to the developer — it helps pinpoint the bug. Try Reset or switching
-								to a different resource to keep working.
+								{this.props.description ??
+									'Something threw while rendering the 3D view. Please copy the details below and send them to the developer — it helps pinpoint the bug. Try Reset or switching to a different resource to keep working.'}
 							</p>
 						</div>
 						<div className="flex gap-1 shrink-0">

--- a/src/lib/core/__tests__/propInstanceData.test.ts
+++ b/src/lib/core/__tests__/propInstanceData.test.ts
@@ -96,3 +96,41 @@ describe('PropInstanceData gold file (example/BE_9F_C7_93.dat)', () => {
 		expect(bytesEqual(write1, write2)).toBe(true);
 	});
 });
+
+// ~40% of track units (172/427 in example/) ship an *empty* prop zone: no
+// props, no cells, with maInstances and maCells stored as null (0) rather than
+// the populated-layout 0x20. The parser must accept this all-zero shape instead
+// of throwing — a throw leaves a null model in the workspace, and clicking it
+// used to tear down the whole editor (and the WebGL context). Synthesised here
+// (rather than relying on an untracked example/ binary) so the regression is
+// pinned on every machine.
+describe('PropInstanceData empty prop zone (null pointers)', () => {
+	function emptyZoneBytes(zoneId: number): Uint8Array {
+		// 32-byte header + 32 bytes trailing zero pad = 64 bytes, mirroring the
+		// real empty-zone resource (e.g. example/TRK_UNIT0_GR.BNDL).
+		const bytes = new Uint8Array(64);
+		const dv = new DataView(bytes.buffer);
+		dv.setUint32(12, 32, true); // muSizeInBytes (stored, == header size here)
+		dv.setUint16(24, zoneId, true); // muZoneId
+		// Everything else — maCells, maInstances, counts — stays zero.
+		return bytes;
+	}
+
+	it('parses with zero instances/cells and null pointers', () => {
+		const model = parsePropInstanceData(emptyZoneBytes(7));
+		expect(model.instances.length).toBe(0);
+		expect(model.cells.length).toBe(0);
+		expect(model.muZoneId).toBe(7);
+		expect(model.muSizeInBytes).toBe(32);
+		// Trailing pad (header end → buffer end) is preserved verbatim, not the
+		// whole buffer — guards against the null maCells mis-seeking to offset 0.
+		expect(model._trailingPad.byteLength).toBe(32);
+	});
+
+	it('round-trips byte-for-byte (re-emits null pointers, not 0x20)', () => {
+		const original = emptyZoneBytes(7);
+		const rewritten = writePropInstanceData(parsePropInstanceData(original));
+		expect(rewritten.byteLength).toBe(original.byteLength);
+		expect(bytesEqual(rewritten, original)).toBe(true);
+	});
+});

--- a/src/lib/core/propInstanceData.ts
+++ b/src/lib/core/propInstanceData.ts
@@ -19,9 +19,12 @@
 //
 // Round-trip strategy:
 //  - The layout is rigid: header(32B) → instances(0x50 each, at 0x20) →
-//    cells(0x0C each) → all-zero tail. maInstances is always 0x20 and
-//    maCells = 0x20 + instances.length*0x50, so both pointers are recomputed on
-//    write rather than stored on the model. muNumberOfProps == instances.length.
+//    cells(0x0C each) → all-zero tail. maInstances/maCells are runtime pointers
+//    fixed up at load: maInstances = 0x20 and maCells = 0x20 + props*0x50 when
+//    those arrays are populated, but BOTH are null (0) for an empty prop zone
+//    (no props, no cells) — ~40% of track units ship that all-zero shape. So
+//    the pointers are recomputed from the array lengths on write (null when
+//    empty) rather than stored on the model. muNumberOfProps == instances.length.
 //  - muSizeInBytes does NOT track the buffer length (it is an internal stored
 //    field — gold fixture has len-32, others differ), and muNumberOfInstances is
 //    a larger logical count distinct from the stored record count. Both are
@@ -118,14 +121,16 @@ export function parsePropInstanceData(raw: Uint8Array, littleEndian = true): Par
 	r.readU16();                                  // 2 pad (0x1A)
 	r.readU32();                                  // 4 pad (0x1C) — header padded up to maInstances (0x20)
 
-	// The layout is rigid; bail loudly if a fixture violates it rather than
-	// silently producing a broken model that won't round-trip.
-	if (maInstances !== INSTANCES_OFFSET) {
+	// The layout is rigid; bail loudly if a populated fixture violates it rather
+	// than silently producing a broken model that won't round-trip. An empty
+	// prop zone is the exception — it stores null (0) pointers, so only validate
+	// each pointer when its array is actually present.
+	const instancesEnd = INSTANCES_OFFSET + muNumberOfProps * INSTANCE_RECORD_SIZE;
+	if (muNumberOfProps > 0 && maInstances !== INSTANCES_OFFSET) {
 		throw new Error(`PropInstanceData: maInstances is 0x${maInstances.toString(16)}, expected 0x20 (rigid layout)`);
 	}
-	const expectedMaCells = INSTANCES_OFFSET + muNumberOfProps * INSTANCE_RECORD_SIZE;
-	if (maCells !== expectedMaCells) {
-		throw new Error(`PropInstanceData: maCells is 0x${maCells.toString(16)}, expected 0x${expectedMaCells.toString(16)} for ${muNumberOfProps} props`);
+	if (muNumCells > 0 && maCells !== instancesEnd) {
+		throw new Error(`PropInstanceData: maCells is 0x${maCells.toString(16)}, expected 0x${instancesEnd.toString(16)} for ${muNumberOfProps} props`);
 	}
 
 	// --- Instances (80 bytes each, at 0x20) ---
@@ -157,8 +162,11 @@ export function parsePropInstanceData(raw: Uint8Array, littleEndian = true): Par
 	}
 
 	// --- Cells (12 bytes each, immediately after instances) ---
+	// Read from the layout offset, not the stored maCells pointer: the two are
+	// equal for populated zones (asserted above) but maCells is null (0) for an
+	// empty zone, so trusting it would mis-seek to offset 0.
 	const cells: PropCell[] = [];
-	r.position = maCells;
+	r.position = instancesEnd;
 	for (let i = 0; i < muNumCells; i++) {
 		const muX = r.readU16();
 		const muZ = r.readU16();
@@ -173,7 +181,7 @@ export function parsePropInstanceData(raw: Uint8Array, littleEndian = true): Par
 	}
 
 	// --- Trailing pad (all zero) — captured to reproduce the exact length. ---
-	const cellsEnd = maCells + muNumCells * CELL_RECORD_SIZE;
+	const cellsEnd = instancesEnd + muNumCells * CELL_RECORD_SIZE;
 	const _trailingPad = cellsEnd < raw.byteLength
 		? raw.slice(cellsEnd, raw.byteLength)
 		: new Uint8Array(0);
@@ -196,11 +204,16 @@ export function writePropInstanceData(model: ParsedPropInstanceData, littleEndia
 	const { instances, cells } = model;
 	const muNumberOfProps = instances.length;
 
-	// Recompute the rigid pointers from the layout (never trust stored values).
-	const maInstances = INSTANCES_OFFSET;
-	const maCells = INSTANCES_OFFSET + muNumberOfProps * INSTANCE_RECORD_SIZE;
-	const cellsEnd = maCells + cells.length * CELL_RECORD_SIZE;
+	// Layout offsets (where the arrays physically live) recomputed from the
+	// counts — never trust stored values.
+	const instancesEnd = INSTANCES_OFFSET + muNumberOfProps * INSTANCE_RECORD_SIZE;
+	const cellsEnd = instancesEnd + cells.length * CELL_RECORD_SIZE;
 	const totalSize = cellsEnd + model._trailingPad.byteLength;
+
+	// Stored pointers are null (0) when their array is empty — reproduces the
+	// all-zero header an empty prop zone ships, keeping the round-trip byte-exact.
+	const maInstances = muNumberOfProps > 0 ? INSTANCES_OFFSET : 0;
+	const maCells = cells.length > 0 ? instancesEnd : 0;
 
 	const w = new BinWriter(totalSize, littleEndian);
 
@@ -232,7 +245,7 @@ export function writePropInstanceData(model: ParsedPropInstanceData, littleEndia
 		w.writeU8(inst._pad4D[1]);
 		w.writeU8(inst._pad4D[2]);
 	}
-	if (w.offset !== maCells) throw new Error(`PropInstanceData writer: cells offset mismatch ${w.offset} vs ${maCells}`);
+	if (w.offset !== instancesEnd) throw new Error(`PropInstanceData writer: cells offset mismatch ${w.offset} vs ${instancesEnd}`);
 
 	// --- Cells (12 bytes each) — muStartIndex / muCount derived from the
 	// partition: each cell consumes the next muCount instances contiguously. We

--- a/src/lib/core/registry/handlers/propInstanceData.ts
+++ b/src/lib/core/registry/handlers/propInstanceData.ts
@@ -43,6 +43,11 @@ export const propInstanceDataHandler: ResourceHandler<ParsedPropInstanceData> = 
 	fixtures: [
 		{ bundle: 'example/TRK_UNIT9_GR.BNDL', expect: { parseOk: true, byteRoundTrip: true } },
 		{ bundle: 'example/TRK_UNIT10_GR.BNDL', expect: { parseOk: true, byteRoundTrip: true } },
+		// The empty-prop-zone shape (~40% of track units: no props, no cells,
+		// null pointers) is covered by a self-contained unit test in
+		// __tests__/propInstanceData.test.ts — it can't be a fixture here because
+		// the stress scenarios below edit instances[0] / the last cell, which an
+		// empty zone doesn't have.
 	],
 
 	stressScenarios: [

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -117,8 +117,16 @@ import type { NodePath } from '@/lib/schema/walk';
 // selection change in the world-family.
 function SelectedSchemaEditorProvider({
 	children,
+	fallback,
 }: {
 	children: React.ReactNode;
+	/** Rendered in place of `children` when the editor context can't be built
+	 *  (e.g. the selected instance failed to parse, so its model is null). Every
+	 *  caller passes provider-consuming children — rendering them bare would
+	 *  throw `useSchemaEditor must be used within a SchemaEditorProvider`, and
+	 *  in the un-boundaried inspector that uncaught throw tears down the whole
+	 *  React root, taking the WorldViewport's WebGL context with it. */
+	fallback?: React.ReactNode;
 }) {
 	const { bundles, selection, select, setResourceAt } = useWorkspace();
 	const level = selectionLevel(selection);
@@ -172,7 +180,12 @@ function SelectedSchemaEditorProvider({
 	);
 
 	if (!isInstanceOrSchema || !schema || data === undefined || !selection?.resourceKey) {
-		return <>{children}</>;
+		// Can't build the editor context for this selection. `children` always
+		// consumes `useSchemaEditor`, so render the fallback instead of letting
+		// the hook throw (see the `fallback` prop doc). `data === undefined`
+		// happens when the selected instance failed to parse — e.g. a resource
+		// whose parser threw, leaving a null slot in parsedResourcesAll.
+		return <>{fallback ?? null}</>;
 	}
 
 	return (
@@ -267,7 +280,13 @@ function CenterViewport() {
 		<ViewportErrorBoundary
 			resetKey={`${selection.bundleId}/${selection.resourceKey}/${selection.index}`}
 		>
-			<SelectedSchemaEditorProvider>
+			<SelectedSchemaEditorProvider
+				fallback={
+					<div className="h-full flex items-center justify-center text-xs text-muted-foreground p-4 text-center">
+						This {selection.resourceKey} instance couldn't be parsed — no viewport to show.
+					</div>
+				}
+			>
 				<ViewportPane />
 			</SelectedSchemaEditorProvider>
 		</ViewportErrorBoundary>
@@ -391,18 +410,35 @@ function RightInspector() {
 		selection.index != null &&
 		inspectorBundle != null;
 
+	// The inspector gets its own error boundary (the centre viewport already has
+	// one). Without it, any throw while rendering the schema form propagates
+	// uncaught and React 18 unmounts the entire root — which destroys the
+	// WorldViewport's <Canvas> and loses the WebGL context. Containing the throw
+	// here keeps the scene alive while the inspector shows the error.
 	return wrapWithBulk(
-		<SelectedSchemaEditorProvider>
-			{showAIImport && inspectorBundle && selection.index != null ? (
-				<AIImportInspectorWrapper
-					bundle={inspectorBundle}
-					index={selection.index}
-					setResourceAt={setResourceAt as never}
-				/>
-			) : (
-				<InspectorPanel />
-			)}
-		</SelectedSchemaEditorProvider>,
+		<ViewportErrorBoundary
+			resetKey={`${selection.bundleId}/${selection.resourceKey}/${selection.index}`}
+			title="Inspector crashed"
+			description="Something threw while rendering the inspector form. Copy the details below and send them to the developer. Try Reset or selecting a different resource to keep working."
+		>
+			<SelectedSchemaEditorProvider
+				fallback={
+					<div className="h-full flex items-center justify-center text-xs text-muted-foreground p-4 text-center">
+						This {selection.resourceKey} instance couldn't be parsed — nothing to edit.
+					</div>
+				}
+			>
+				{showAIImport && inspectorBundle && selection.index != null ? (
+					<AIImportInspectorWrapper
+						bundle={inspectorBundle}
+						index={selection.index}
+						setResourceAt={setResourceAt as never}
+					/>
+				) : (
+					<InspectorPanel />
+				)}
+			</SelectedSchemaEditorProvider>
+		</ViewportErrorBoundary>,
 	);
 }
 


### PR DESCRIPTION
## What & why

Loading a second track and clicking its **Prop Instance Data** could crash the whole editor with `useSchemaEditor must be used within a SchemaEditorProvider`, immediately followed by `THREE.WebGLRenderer: Context Lost`.

Two bugs, one chain:

1. **Parser rejected empty prop zones.** A sweep of all 427 `TRK_UNIT*_GR.BNDL` in `example/` shows **172 (≈40%)** ship an *empty* prop zone — no props, no cells — where `maInstances`/`maCells` are null (`0`) rather than the populated-layout `0x20`. `parsePropInstanceData` hard-asserted `maInstances === 0x20` and threw, leaving a **null** parsed model in the workspace.

2. **A null model tore down the whole app.** Selecting that instance made `SelectedSchemaEditorProvider` bail on `data === undefined` and render the provider-consuming `InspectorPanel` **without** the provider → uncaught `useSchemaEditor` throw. React 18 unmounts the entire root on an uncaught render error, which destroys the `WorldViewport`'s `<Canvas>` and loses the WebGL context. **The "Context Lost" was a consequence of the inspector throw, not an independent GPU bug** (confirmed by console ordering — the `useSchemaEditor` error fires first).

## Changes

- **`propInstanceData.ts`** — validate `maInstances`/`maCells` only when their array is non-empty; derive layout offsets from the record counts; read cells + trailing-pad from the layout offset rather than the (null) stored pointer. The writer re-emits null pointers for empty arrays so empty zones round-trip byte-exact.
- **`WorkspacePage.tsx`** — `SelectedSchemaEditorProvider` now renders a `fallback` instead of provider-consuming children when it can't build the context (every caller passes provider consumers, so bare children was always a latent crash). The inspector is wrapped in `ViewportErrorBoundary` like the centre viewport already is, so a future inspector throw can't kill the canvas.
- **`ViewportErrorBoundary.tsx`** — optional `title`/`description` props so the fallback reads correctly for the inspector.
- **test** — self-contained empty-zone parse + byte-exact round-trip regression (synthesised buffer, no untracked binary dependency).

## Verification

- **All 427 `example/` track units parse and round-trip byte-exact** (172 empty zones included) — previously 172 threw.
- Unit + registry suites green.
- **Browser, original repro:** loaded a populated track + an empty-zone track, selected the empty zone's Prop Instance Data → inspector renders the schema form, WebGL context stays alive, zero console errors.
- **Browser, stress test:** loaded three large populated tracks (TRK_UNIT400/381/380 — 240/594/240 props, all with track geometry) and cycled through each one's Prop Instance Data → no crash, WebGL context never lost.

## Follow-up (not in this PR)

`TrackGeometry` never disposes its decoded `BufferGeometry`/material on unmount; repeated load/close cycles of large tracks can leak GPU memory and eventually cause a *genuine* context loss. Independent of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)