### PR TITLE
fix(track): dispose decoded geometries + material on unmount

### DIFF
--- a/src/components/schema-editor/viewports/TrackGeometry.tsx
+++ b/src/components/schema-editor/viewports/TrackGeometry.tsx
@@ -17,6 +17,7 @@
 import { useMemo } from 'react';
 import * as THREE from 'three';
 import type { ParsedBundle } from '@/lib/core/types';
+import { useDisposeTrackGeometry } from '@/hooks/useDisposeTrackGeometry';
 import { decodeTrackGeometry, TRACK_MATERIAL_COLOR } from './trackGeometryDecode';
 
 // Behind the editable overlays. The track is map-scale backdrop; props and
@@ -48,6 +49,11 @@ export function TrackGeometry({
 			}),
 		[],
 	);
+
+	// R3F does not auto-dispose geometry/material passed via props — free them
+	// when a new bundle re-decodes or the component unmounts, or the GPU buffers
+	// leak across load/close cycles until the context is lost.
+	useDisposeTrackGeometry(meshes, material);
 
 	if (meshes.length === 0) return null;
 

--- a/src/components/schema-editor/viewports/__tests__/trackGeometry.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/trackGeometry.test.ts
@@ -7,13 +7,16 @@
 // props (inst0 sits near x≈-567, y≈371, z≈-2779 per the fixture findings in
 // docs/instance-list-spec.md).
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as THREE from 'three';
 import { parseBundle } from '@/lib/core/bundle';
 import {
 	decodeTrackGeometry,
+	disposeTrackGeometries,
 	instanceTransformToMatrix4,
+	type PlacedTrackMesh,
 } from '../trackGeometryDecode';
 
 const REPO_ROOT = path.resolve(__dirname, '../../../../..');
@@ -79,5 +82,38 @@ describe('decodeTrackGeometry (TRK_UNIT9_GR)', () => {
 		expect(e[12]).toBe(-567);
 		expect(e[13]).toBe(371);
 		expect(e[14]).toBe(-2779);
+	});
+});
+
+describe('disposeTrackGeometries', () => {
+	function placed(geometry: THREE.BufferGeometry): PlacedTrackMesh {
+		return { geometry, matrix: new THREE.Matrix4(), modelId: 0n, renderableId: 0n };
+	}
+
+	it('disposes each distinct geometry once', () => {
+		const a = new THREE.BufferGeometry();
+		const b = new THREE.BufferGeometry();
+		const spyA = vi.spyOn(a, 'dispose');
+		const spyB = vi.spyOn(b, 'dispose');
+
+		disposeTrackGeometries([placed(a), placed(b)]);
+
+		expect(spyA).toHaveBeenCalledTimes(1);
+		expect(spyB).toHaveBeenCalledTimes(1);
+	});
+
+	it('disposes a shared geometry exactly once across repeated placements', () => {
+		// The decode reuses one geometry for every placement of the same Model,
+		// so it appears in many PlacedTrackMesh entries — it must be freed once.
+		const shared = new THREE.BufferGeometry();
+		const spy = vi.spyOn(shared, 'dispose');
+
+		disposeTrackGeometries([placed(shared), placed(shared), placed(shared)]);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	it('is a no-op for an empty mesh list', () => {
+		expect(() => disposeTrackGeometries([])).not.toThrow();
 	});
 });

--- a/src/components/schema-editor/viewports/trackGeometryDecode.ts
+++ b/src/components/schema-editor/viewports/trackGeometryDecode.ts
@@ -252,6 +252,29 @@ export function decodeTrackGeometry(
 	return { meshes, instanceCount, resolvedModels };
 }
 
+/**
+ * Free the GPU buffers of every geometry in a decoded mesh list.
+ *
+ * The decode shares one BufferGeometry across all placements of a Model (see
+ * `geomCache` above — a track unit can place the same Model many times), so a
+ * single geometry object appears in many PlacedTrackMesh entries. Dedupe by
+ * identity so each is disposed exactly once.
+ *
+ * This exists because react-three-fiber only auto-disposes objects it builds
+ * declaratively from JSX args; geometry handed in via the `geometry` prop is
+ * the caller's to free. Without this, each load → close cycle of a large track
+ * (~440k verts for TRK9) leaks its buffers on the GPU until the context is
+ * lost. Pure (no React) so it can be unit-tested in node.
+ */
+export function disposeTrackGeometries(meshes: PlacedTrackMesh[]): void {
+	const seen = new Set<THREE.BufferGeometry>();
+	for (const m of meshes) {
+		if (seen.has(m.geometry)) continue;
+		seen.add(m.geometry);
+		m.geometry.dispose();
+	}
+}
+
 /** Shared grey material for the untextured track backdrop. */
 export const TRACK_MATERIAL_COLOR = 0x8a8f99;
 

--- a/src/hooks/useDisposeTrackGeometry.ts
+++ b/src/hooks/useDisposeTrackGeometry.ts
@@ -1,0 +1,31 @@
+// Tie the GPU lifetime of a decoded track's geometries + shared material to
+// the React lifetime of <TrackGeometry>.
+//
+// react-three-fiber only auto-disposes objects it constructs declaratively
+// from JSX args; the track hands pre-built BufferGeometry and a shared material
+// in via the `geometry`/`material` props, so neither is auto-freed. Without
+// this, every bundle load → close cycle (or any re-decode) leaks its buffers on
+// the GPU — a large track is ~440k verts (TRK9) — until enough accumulates to
+// trigger a real THREE.WebGLRenderer: Context Lost.
+//
+// The two resources have different lifetimes:
+//   - geometries belong to the current decode → free them when a new bundle
+//     re-decodes (the `meshes` identity changes) or on unmount.
+//   - the material is shared for the component's whole lifetime (memoized on
+//     []), so it only frees on unmount.
+
+import type * as THREE from 'three';
+import {
+	disposeTrackGeometries,
+	type PlacedTrackMesh,
+} from '@/components/schema-editor/viewports/trackGeometryDecode';
+import { useDisposeOnDepsChange } from './useDisposeOnDepsChange';
+import { useDisposeOnUnmount } from './useDisposeOnUnmount';
+
+export function useDisposeTrackGeometry(
+	meshes: PlacedTrackMesh[],
+	material: THREE.Material,
+): void {
+	useDisposeOnDepsChange(() => disposeTrackGeometries(meshes), [meshes]);
+	useDisposeOnUnmount(material);
+}


### PR DESCRIPTION
## Problem

`TrackGeometry` renders ~240 pre-built `THREE.BufferGeometry` per track via `geometry={m.geometry}` and a shared `MeshStandardMaterial` via `material={material}`. react-three-fiber only auto-disposes objects it constructs **declaratively from JSX args** — objects handed in via props are the caller's to free. So when a bundle is closed/unloaded (or if the `decodeTrackGeometry` memo recomputes), those geometries and the per-track material leak on the GPU.

A single track unit decodes to ~440k verts (TRK9). Repeated load/close cycles of large tracks accumulate enough GPU memory to trigger a real `THREE.WebGLRenderer: Context Lost`. (This is independent of the empty-prop-zone teardown crash fixed separately.)

## Fix

- **`disposeTrackGeometries(meshes)`** — pure helper in `trackGeometryDecode.ts`. Frees every geometry's GPU buffers, **deduped by identity** because the decode shares one `BufferGeometry` across all placements of a Model (`geomCache`), so a geometry appears in many `PlacedTrackMesh` entries. Node-testable.
- **`useDisposeTrackGeometry(meshes, material)`** — named hook in `src/hooks/` (per CLAUDE.md: no inline `useEffect`). Respects the two different lifetimes:
  - geometries belong to the current decode → freed when `meshes` identity changes (new bundle re-decodes) **or** on unmount, via the existing `useDisposeOnDepsChange`;
  - the shared material lives for the component's whole lifetime → freed only on unmount, via `useDisposeOnUnmount`.

Mirrors the disposal pattern already used by sibling viewports (`PolygonSoupListOverlay`, `RenderableViewport`).

## Verification

Unit tests (3 new specs: dedupe-once, shared-geometry-once, empty no-op) pass; typecheck clean on touched files.

Driven in the running app against real track bundles, measuring the live GPU geometry count (`WebGLRenderer.info.memory.geometries`):

**Single track (TRK9):** load → render uploads **212** geometries (241 draw calls, 20,982 tris). Hide (unmount) → **1**. Show → **212**. Bounded across cycles.

**Three tracks (TRK9 + TRK10 + TRK11):** all shown → **344** geometries (709 draw calls). Hiding each frees exactly its own share: 344 → 133 → 46 → **1**. Show all → **344**. Full hide-all/show-all cycle stays at peak 344 — **no growth**.

**Contrapositive (disposal disabled):** the count climbs **212 → 423 → 634**, ~211 leaked per cycle, unbounded — confirming the test is sensitive to the fix and reproducing the original leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)