### PR TITLE
feat: PropGraphicsList (0x10010) parser, editor, spec & world rendering

### DIFF
--- a/docs/prop-graphics-list-spec.md
+++ b/docs/prop-graphics-list-spec.md
@@ -1,0 +1,257 @@
+# Prop Graphics List (`PRP_GL__*`) — format spec
+
+**Resource type ID:** `0x10010` (= 65552)
+**Other names:** PropGraphicsList. **Filename pattern:** `PRP_GL__<trackUnitId>`.
+**Category:** Game-specific (Burnout Paradise). **Memory distribution:** Main memory only.
+**Imports:** **1 `Model` per prop + 1 `Model` per part** (`importCount == nProps + nParts`).
+**Source:** [Burnout wiki — Prop Graphics List](https://burnout.wiki/wiki/Prop_Graphics_List), captured 2026-06-09.
+**Related:** [`prop-instance-data-spec.md`](prop-instance-data-spec.md) (`0x10011`, places the prop instances this catalogue resolves to models), [`prop-types.md`](prop-types.md), [`instance-list-spec.md`](instance-list-spec.md) (same `Model*`-via-import pattern).
+
+Prop Graphics List is the per-track-unit **catalogue** that maps every prop **TYPE**
+placed in a track unit to the `Model` resource(s) the runtime spawns for it. There
+is exactly **one** PropGraphicsList per `TRK_UNIT*_GR.BNDL` bundle. It is the
+graphics-side companion to [Prop Instance Data](prop-instance-data-spec.md): Prop
+Instance Data (`0x10011`) places instances of a prop type into the world; this
+resource tells the runtime which mesh to draw for each type, plus which meshes to
+draw for each **destructible part** of that prop.
+
+The top-level resource is a `BrnPhysics::Props::PropGraphicsList`. It carries two
+parallel arrays:
+
+- **`PropGraphics`** — one entry per whole prop → its `Model` (the body mesh).
+- **`PropPartGraphics`** — one entry per prop **part** → its `Model` (a
+  destructible sub-piece, e.g. a billboard panel that breaks off). Parts are
+  grouped contiguously by owning prop; a `PropGraphics.mpParts` points at the
+  prop's first part.
+
+> **Counts are not symmetric with instances.** A PropGraphicsList enumerates prop
+> *types* (and their parts), not placed instances — so a track unit with hundreds
+> of instances may list only a handful of props. Across the corpus the max is 52
+> props / 82 parts; 172 of 427 units list nothing at all (empty list).
+
+## High-level model
+
+```
+PropGraphicsList (0x10010)
+  ├─ header (32 bytes, 32-bit layout, fields end at 0x18, padded to 0x20)
+  ├─ props:  PropGraphics[muNumberOfPropModels]       // at 0x20, 0x0C (12) bytes each
+  ├─ <align16 pad>
+  ├─ parts:  PropPartGraphics[muNumberOfPropPartModels]// at align16(propEnd), 0x0C (12) bytes each
+  └─ _tail:  <align16 pad> + inline BND2 import table  // importCount × 16 bytes, to end of payload
+```
+
+`mpaPropGraphics` and `mpaPropPartGraphics` are absolute byte offsets into the
+payload; both are **rigid** (always `0x20` and `align16(0x20 + nProps*0x0C)`) so on
+write they are **recomputed from the array lengths**, never trusted from disk.
+
+## On-disk structures (32-bit PC, little-endian — the only target)
+
+The wiki also documents a 64-bit (Paradise Remastered) layout; like
+propInstanceData / instanceList / streetData / trafficData we implement **32-bit
+PC LE only**. Console (BE) and 64-bit are out of scope.
+
+### `PropGraphicsList` header — 32 bytes
+
+| Offset | Size | Type | Name | Notes |
+|--------|------|------|------|-------|
+| 0x00 | 4 | u32 | `muSizeInBytes` | **stored field; does NOT consistently equal a derivable offset** — part-array end when parts exist (may be unaligned), `align16(prop-array end)` when no parts, `0x20` when empty. Preserve **verbatim**. |
+| 0x04 | 4 | u32 | `muZoneNumber` | PVS zone / track-unit id (editable) |
+| 0x08 | 4 | u32 | `muNumberOfPropModels` | count of stored `PropGraphics` records = `props.length` (recomputed on write) |
+| 0x0C | 1 | u8 | `muNumberOfPropPartModels` | count of stored `PropPartGraphics` records = `parts.length`. **u8 in a 4-byte slot** (u8 + 3 zero pad). Recomputed on write. |
+| 0x0D | 3 | — | padding | zero |
+| 0x10 | 4 | `PropGraphics*` | `mpaPropGraphics` | abs offset to prop array; **always `0x20`** when populated, `0` when empty. **Recomputed.** |
+| 0x14 | 4 | `PropPartGraphics*` | `mpaPropPartGraphics` | abs offset to part array; **always `align16(0x20 + nProps*0x0C)`** when parts exist, `0` otherwise. **Recomputed.** |
+| 0x18 | 8 | — | padding | zero — the header occupies a full 32 bytes; the meaningful fields stop at `0x18` and the block is zero-padded up to `0x20` (where `mpaPropGraphics` always points). |
+
+### `PropGraphics` — 12 bytes (`0x0C`) — at `0x20`
+
+| Offset | Size | Type | Name | Notes |
+|--------|------|------|------|-------|
+| 0x00 | 4 | u32 | `muTypeId` | prop type index (into [`prop-types.md`](prop-types.md)) |
+| 0x04 | 4 | `Model*` | `mpPropModel` | **`0x0` on disk** — a BND2 **import** (see below); the body mesh. Resolved via `getImportsByPtrOffset` keyed by this field's byte offset. Preserved verbatim. |
+| 0x08 | 4 | `PropPartGraphics*` | `mpParts` | resource-relative **internal pointer** to this prop's first part record; **`0` (NULL) when the prop has no parts**. Preserved verbatim. |
+
+### `PropPartGraphics` — 12 bytes (`0x0C`) — at `align16(0x20 + nProps*0x0C)`
+
+| Offset | Size | Type | Name | Notes |
+|--------|------|------|------|-------|
+| 0x00 | 4 | u32 | `muTypeId` | owning prop's type id |
+| 0x04 | 4 | u32 | `muPartId` | part index within the prop |
+| 0x08 | 4 | `Model*` | `mpPropModel` | **`0x0` on disk** — a BND2 **import**; the part's mesh. Resolved via `getImportsByPtrOffset`. Preserved verbatim. |
+
+## Model imports (`mpPropModel`) and the `mpParts` internal pointer
+
+`mpPropModel` (on **both** record types) is stored as `0x0` and resolved through
+the bundle's **import table** — exactly the same pattern as
+[`instance-list-spec.md`](instance-list-spec.md)'s `mpModel`. Each prop and each
+part has one import entry whose `offset` (the entry's `ptrOffset`) equals that
+record's `mpPropModel` field offset. `getImportsByPtrOffset(bundle.imports,
+bundle.resources, resourceIndex)` returns a `Map<number, bigint>` keyed by field
+offset (value is the Model's 64-bit `resourceId` as a `bigint`) — look up the
+record's field offset (`0x20 + i*0x0C + 0x04` for prop `i`; `mpaPropPartGraphics +
+j*0x0C + 0x08` for part `j`) to get the Model's `resourceId`. The Model resource may
+live in another bundle (shared/neighbour-chunk models are imported but not local).
+
+`mpParts` is **not** an import — it is an **internal, resource-relative pointer** to
+the prop's first `PropPartGraphics` record. Because parts are grouped contiguously
+by owning prop, a prop with parts points at its first one; a prop with **no** parts
+stores `mpParts == 0` (NULL). The parser never dereferences `mpParts` to read the
+structure (the part array is located via the recomputed `mpaPropPartGraphics`); it
+is preserved verbatim purely for byte-exactness.
+
+> The parser **never needs the import table** to decode the structure — the layout
+> is fully determined by the two counts. It captures the table verbatim in `_tail`
+> so the round-trip stays byte-exact and every Model import stays valid.
+
+## Inline import table (the BND2 import section, captured in `_tail`)
+
+After the last structural array, the payload is padded to a 16-byte boundary and
+then carries the resource's **inline BND2 import table**:
+
+- `importOffset == align16(muSizeInBytes)` — where the table starts.
+- `importCount == nProps + nParts` — **one Model import per prop, one per part**
+  (verified on all 427 resources). This is the wiki's "1 Model per prop, 1 per part".
+- Each entry is **16 bytes**: `{ u64 resourceId, u32 fieldOffset, u32 pad }`, where
+  `fieldOffset` is the byte offset of the `mpPropModel` field the import fills in.
+  (In the parsed `ImportEntry` model these are `resourceId: { low, high }`,
+  `offset`, `padding` — see `parseImportEntries` in
+  [`bundle/bundleEntry.ts`](../src/lib/core/bundle/bundleEntry.ts); the on-disk
+  layout is u32 low, u32 high, u32 offset, u32 padding, all little-endian.)
+- `payload length == align16(muSizeInBytes) + importCount*16`.
+
+The whole region (align pad + import table) is captured as `_tail` and re-emitted
+**verbatim**. This is why **field edits round-trip** but **adding/removing props or
+parts is out of scope**: changing the counts shifts every `mpPropModel` field
+offset, which would invalidate the captured table's `fieldOffset` values.
+
+## Real-fixture findings (verified 2026-06-09)
+
+Decoded against two real bundle-embedded resources via the CLI/registry extract path:
+
+| fixture | zone | raw bytes | nProps | nParts | `muSizeInBytes` | `mpaPropPartGraphics` | importCount | import-table bytes | `_tail` bytes |
+|---------|-----:|----------:|-------:|-------:|----------------:|----------------------:|------------:|-------------------:|--------------:|
+| `TRK_UNIT9_GR.BNDL` | 9 | 1776 | 10 | 52 | 784 | `0xA0` (160) | 62 | 992 | 992 |
+| `TRK_UNIT10_GR.BNDL` | 10 | 1616 | 9 | 47 | 708 | `0x90` (144) | 56 | 896 | 908 |
+
+Arithmetic check (self-consistent, confirms the invariants):
+
+```
+TRK9 : mpaPropPartGraphics = align16(0x20 + 10*0x0C) = align16(0x98) = 0xA0  ✓
+       importCount = 10+52 = 62 ; 62*16 = 992 ; align16(784)=784 ; 784+992 = 1776 = rawLen  ✓
+       muSizeInBytes 784 is already 16-aligned, so _tail = 0 pad + 992 table = 992.
+TRK10: mpaPropPartGraphics = align16(0x20 + 9*0x0C) = align16(0x8C) = 0x90  ✓
+       importCount =  9+47 = 56 ; 56*16 = 896 ; align16(708)=720 ; 720+896 = 1616 = rawLen  ✓
+       muSizeInBytes 708 is the unaligned part-array end; importOffset rounds it to 720, so
+       _tail = 12 pad (708→720) + 896 table = 908 (the parser captures pad+table, not just the table).
+```
+
+> **`_tail` ≠ import-table bytes when `muSizeInBytes` is unaligned.** `_tail` is everything
+> from the last array end to EOF, i.e. the align-pad **plus** the import table. When
+> `muSizeInBytes` is already 16-aligned (TRK9) the pad is empty and the two coincide; when it
+> is unaligned (TRK10) `_tail` is larger by the pad width. The writer re-emits `_tail` verbatim,
+> so it reproduces both regions in one shot.
+
+**Corpus distribution** (sweep of all `TRK_UNIT*_GR.BNDL` in `example/`):
+
+- **172 empty** (all-zero header, 32-byte payload, null pointers) / **254 populated**.
+- **22 props-with-no-parts** (a subset of populated; `nParts == 0`).
+- **0** parts-with-no-props, **0** bundles with more than one PGL.
+- Maxima: **52 props**, **82 parts**.
+
+**Byte-exact sweep result:** every PropGraphicsList that reaches the parser
+round-trips `writePropGraphicsList(parsePropGraphicsList(raw))` **byte-for-byte**
+(426/426 byte-exact pass, 0 fail). The parser/writer in
+[`src/lib/core/propGraphicsList.ts`](../src/lib/core/propGraphicsList.ts) needs no
+changes.
+
+**Confirmed invariants (all 254 populated resources, zero violations):**
+
+1. `mpaPropGraphics == 0x20` always.
+2. `mpaPropPartGraphics == align16(0x20 + nProps*0x0C)` whenever `nParts > 0`.
+3. `importCount == nProps + nParts` always.
+4. The header pad `[0x18, 0x20)` and the inter-array align pad `[propEnd,
+   mpaPropPartGraphics)` are **all zero** in every fixture.
+5. Every `mpPropModel` field is `0` on disk; the real id lives in the inline import
+   table, keyed by the field offset.
+6. A prop with no parts stores `mpParts == 0` (NULL) — it does **not** reuse a
+   neighbour's pointer or the part-array-end value.
+
+**Extractor false-positives (not PGL bugs):** `TRK_UNIT158_GR.BNDL` throws a
+spurious "incorrect header check" zlib error inside the bundle extractor's
+`isCompressed()` heuristic (a resource whose first two payload bytes coincidentally
+look like a zlib magic). `TRK_UNIT192_GR.BNDL` trips the same heuristic earlier, in
+`parseImportEntries`. Both are extractor/bundle-layer issues — the PGL payloads
+themselves are healthy and would round-trip byte-exact. Skip/tolerate them; neither
+is a parser bug.
+
+## Parsed model shape
+
+```ts
+type PropGraphics = {
+  muTypeId: number;    // u32 — prop type index (into prop-types)
+  mpPropModel: number; // u32 — Model* import, 0 on disk; resolved by field offset. Verbatim.
+  mpParts: number;     // u32 — internal pointer to first part (0 = no parts). Verbatim.
+};
+
+type PropPartGraphics = {
+  muTypeId: number;    // u32 — owning prop's type id
+  muPartId: number;    // u32 — part index within the prop
+  mpPropModel: number; // u32 — Model* import, 0 on disk; resolved by field offset. Verbatim.
+};
+
+type ParsedPropGraphicsList = {
+  muZoneNumber: number;     // u32 — PVS zone / track-unit id (editable)
+  muSizeInBytes: number;    // u32 — stored size; not a derivable offset (preserved verbatim, readOnly)
+  props: PropGraphics[];
+  parts: PropPartGraphics[];
+  _tail: Uint8Array;        // align16 pad + inline import table, end-of-arrays..EOF (verbatim)
+};
+```
+
+`muNumberOfPropModels` / `muNumberOfPropPartModels` are **not** stored on the model
+(they equal `props.length` / `parts.length`); the writer emits the array lengths.
+`mpaPropGraphics` / `mpaPropPartGraphics` are recomputed from those lengths.
+
+## Round-trip / writer strategy
+
+Byte-exact (`byteRoundTrip`) is achievable — the layout is rigid. Writer:
+
+1. **Header (32 bytes):** `muSizeInBytes` (**verbatim** — not a derivable offset);
+   `muZoneNumber`; `muNumberOfPropModels = props.length`; `muNumberOfPropPartModels
+   = parts.length & 0xff` (u8) + 3 pad; `mpaPropGraphics = props.length ? 0x20 : 0`;
+   `mpaPropPartGraphics = parts.length ? align16(0x20 + nProps*0x0C) : 0`; zero-pad
+   up to `0x20`.
+2. **PropGraphics:** for each, `muTypeId`; `mpPropModel` (**verbatim**, `0` on
+   disk); `mpParts` (**verbatim** internal pointer).
+3. **align16 pad → PropPartGraphics:** zero-pad to `mpaPropPartGraphics`, then for
+   each part `muTypeId`; `muPartId`; `mpPropModel` (**verbatim**, `0`).
+4. **`_tail`:** append verbatim (align pad + inline import table) → reproduces the
+   exact length and keeps every Model import valid.
+
+This mirrors the [`propInstanceData`](prop-instance-data-spec.md) / `zoneList`
+precedent (recompute pointers + counts, preserve verbatim stored-size and pad for
+byte-exactness). Because the inline import table is keyed by `mpPropModel` field
+offsets, **field edits** (zone id, a prop/part `muTypeId`, `muPartId`) round-trip,
+but **adding or removing props/parts is OUT of scope** — it would shift those field
+offsets and invalidate the captured table. `muSizeInBytes` is preserved verbatim
+with no validation against the recomputed layout, so it would be stale after a
+structural mutation (which is why such mutations are blocked).
+
+## Editor / resourcespec notes
+
+- `muZoneNumber` is the only freely-editable header field.
+- `muTypeId` (on both record types) → enum dropdown sourced from `PROP_TYPES` (same
+  table as [`prop-instance-data-spec.md`](prop-instance-data-spec.md)); `muPartId`
+  is a plain integer.
+- `mpPropModel` is `readOnly` in the editor — it is `0` on disk and the real Model
+  id is resolved from the import table at display/render time via
+  `getImportsByPtrOffset(bundle.imports, bundle.resources, resourceIndex)`, keyed by
+  the record's field offset. Surface the resolved Model `resourceId` in the tree
+  label so artists can see which mesh a prop/part maps to.
+- `mpParts`, `muSizeInBytes`, and `_tail` are `readOnly`/`hidden` round-trip-only
+  fields (`mpaPropGraphics`/`mpaPropPartGraphics` are derived and never modelled).
+- Tree labels: prop → `#i · <propTypeName> · model <resourceId> · parts <n>`; part →
+  `#j · part <muPartId> of <propTypeName> · model <resourceId>`.
+- Adding/removing props or parts must be disabled (`addable`/`removable` off) until
+  a future slice rebuilds the inline import table from scratch.
+```

--- a/src/components/schema-editor/viewports/PropGeometry.tsx
+++ b/src/components/schema-editor/viewports/PropGeometry.tsx
@@ -1,0 +1,214 @@
+// PropGeometry — renders a track unit's REAL prop meshes in the WorldViewport,
+// upgrading PropInstanceData's grey marker boxes to the actual prop geometry.
+//
+// Like <TrackGeometry>, this is NOT a pure overlay (ADR-0002): joining
+// PropInstanceData (positions + type) with PropGraphicsList (type → Model) and
+// decoding those Models needs the bundle's raw bytes + import table, not just a
+// parsed model. So the composition mounts it per-bundle, handing it the live
+// PropInstanceData model plus the raw bundle/buffer + the other loaded bundles
+// (prop Models live in GLOBALPROPS.BIN). The heavy Model decode is memoized on
+// the immutable bundle bytes; re-placing on a PropInstanceData edit is cheap.
+//
+// What renders:
+//   - one InstancedMesh per resolved Model geometry (grey, like the track), at
+//     each instance's transform — pickable (click → select the instance);
+//   - a marker-box fallback (the old behaviour) for instances whose Model isn't
+//     loaded — e.g. before GLOBALPROPS.BIN is opened, so the world still shows
+//     every prop;
+//   - the selected instance's outline + label + camera fly, reused from the
+//     PropInstanceData overlay so selection feels identical whether a prop drew
+//     as a real mesh or a fallback box.
+//
+// Because this owns the whole prop visual for a bundle that has a
+// PropGraphicsList, the composition does NOT also mount the box-only
+// PropInstanceDataOverlay for that bundle (which would double-draw).
+
+import { useCallback, useMemo, useRef } from 'react';
+import { type ThreeEvent } from '@react-three/fiber';
+import * as THREE from 'three';
+import type { ParsedBundle } from '@/lib/core/types';
+import type { ParsedPropInstanceData } from '@/lib/core/propInstanceData';
+import type { NodePath } from '@/lib/schema/walk';
+import { useUpdateInstancedMesh } from '@/lib/three/scene/useUpdateInstancedMesh';
+import { useDisposeOnDepsChange } from '@/hooks/useDisposeOnDepsChange';
+import { useDisposeOnUnmount } from '@/hooks/useDisposeOnUnmount';
+import {
+	decodePropTypeGeometry,
+	placeProps,
+	disposePropTypeGeometry,
+	type BundleSource,
+	type PropMeshGroup,
+} from './propGeometryDecode';
+import {
+	MARKER_GEO,
+	MARKER_MAT,
+	SelectedPropDecor,
+	FocusOnProp,
+	propTypeColor,
+	propInstanceMatrix,
+	propInstanceSelectionCodec,
+} from './PropInstanceDataOverlay';
+import { SELECTION_THEME, isDragRelease } from './selection';
+
+// A touch lighter / warmer than the track's grey (0x8a8f99) so props read as
+// distinct objects sitting on the road rather than blending into it.
+const PROP_MESH_COLOR = 0xb4b8c0;
+
+// ---------------------------------------------------------------------------
+// One instanced draw of a single resolved Model geometry
+// ---------------------------------------------------------------------------
+
+function PropMeshGroupMesh({
+	group,
+	material,
+	onPick,
+}: {
+	group: PropMeshGroup;
+	material: THREE.Material;
+	onPick: (instanceIndex: number) => void;
+}) {
+	const ref = useRef<THREE.InstancedMesh>(null!);
+	useUpdateInstancedMesh(
+		ref,
+		group.placements.length,
+		(mesh) => {
+			for (let i = 0; i < group.placements.length; i++) {
+				mesh.setMatrixAt(i, group.placements[i].matrix);
+			}
+		},
+		[group],
+	);
+	const onClick = useCallback(
+		(e: ThreeEvent<MouseEvent>) => {
+			e.stopPropagation();
+			if (isDragRelease(e.nativeEvent.clientX, e.nativeEvent.clientY)) return;
+			if (e.instanceId == null) return;
+			onPick(group.placements[e.instanceId].instanceIndex);
+		},
+		[group, onPick],
+	);
+	return <instancedMesh ref={ref} args={[group.geometry, material, group.placements.length]} onClick={onClick} />;
+}
+
+// ---------------------------------------------------------------------------
+// Marker-box fallback for instances whose Model didn't resolve
+// ---------------------------------------------------------------------------
+
+function PropFallbackBoxes({
+	pid,
+	indices,
+	selIdx,
+	onPick,
+}: {
+	pid: ParsedPropInstanceData;
+	indices: number[];
+	selIdx: number;
+	onPick: (instanceIndex: number) => void;
+}) {
+	const ref = useRef<THREE.InstancedMesh>(null!);
+	useUpdateInstancedMesh(
+		ref,
+		indices.length,
+		(mesh) => {
+			const mat = new THREE.Matrix4();
+			for (let k = 0; k < indices.length; k++) {
+				const i = indices[k];
+				propInstanceMatrix(pid.instances[i], mat);
+				mesh.setMatrixAt(k, mat);
+				const color = i === selIdx ? SELECTION_THEME.primary : propTypeColor(pid.instances[i].typeId);
+				mesh.setColorAt(k, color);
+			}
+		},
+		[pid, indices, selIdx],
+	);
+	const onClick = useCallback(
+		(e: ThreeEvent<MouseEvent>) => {
+			e.stopPropagation();
+			if (isDragRelease(e.nativeEvent.clientX, e.nativeEvent.clientY)) return;
+			if (e.instanceId == null) return;
+			onPick(indices[e.instanceId]);
+		},
+		[indices, onPick],
+	);
+	return <instancedMesh ref={ref} args={[MARKER_GEO, MARKER_MAT, indices.length]} onClick={onClick} />;
+}
+
+// ---------------------------------------------------------------------------
+// Prop layer
+// ---------------------------------------------------------------------------
+
+export function PropGeometry({
+	pid,
+	bundle,
+	buffer,
+	externals,
+	selectedPath,
+	onSelect,
+}: {
+	pid: ParsedPropInstanceData;
+	bundle: ParsedBundle;
+	buffer: ArrayBuffer;
+	externals: BundleSource[];
+	selectedPath: NodePath;
+	onSelect: (path: NodePath) => void;
+}) {
+	// Heavy: decode each prop type's Model once. Keyed on the immutable bundle
+	// bytes (+ the companion bundles), NOT the live `pid`, so editing a prop in
+	// the inspector re-places without re-decoding geometry.
+	const typeGeometry = useMemo(
+		() => decodePropTypeGeometry(bundle, buffer, externals),
+		[bundle, buffer, externals],
+	);
+	// Cheap: place the live instances against the decoded geometry.
+	const { groups, resolvedInstanceIndices } = useMemo(
+		() => placeProps(pid, typeGeometry),
+		[pid, typeGeometry],
+	);
+
+	const material = useMemo(
+		() =>
+			new THREE.MeshStandardMaterial({
+				color: PROP_MESH_COLOR,
+				side: THREE.DoubleSide,
+				roughness: 0.85,
+				metalness: 0.0,
+			}),
+		[],
+	);
+
+	// R3F doesn't free prop-fed geometry/material — tie them to this component's
+	// lifetime (geometry per decode, material for the whole lifetime).
+	useDisposeOnDepsChange(() => disposePropTypeGeometry(typeGeometry), [typeGeometry]);
+	useDisposeOnUnmount(material);
+
+	const unresolved = useMemo(() => {
+		const out: number[] = [];
+		for (let i = 0; i < pid.instances.length; i++) {
+			if (!resolvedInstanceIndices.has(i)) out.push(i);
+		}
+		return out;
+	}, [pid, resolvedInstanceIndices]);
+
+	const selIdx = useMemo(() => {
+		const sel = propInstanceSelectionCodec.pathToSelection(selectedPath);
+		return sel && sel.indices[0] < pid.instances.length ? sel.indices[0] : -1;
+	}, [selectedPath, pid]);
+
+	const onPick = useCallback((i: number) => onSelect(['instances', i]), [onSelect]);
+
+	if (pid.instances.length === 0) return null;
+	const selInst = selIdx >= 0 ? pid.instances[selIdx] : null;
+
+	return (
+		<>
+			<FocusOnProp data={pid} selectedPath={selectedPath} />
+			{groups.map((group, i) => (
+				<PropMeshGroupMesh key={i} group={group} material={material} onPick={onPick} />
+			))}
+			{unresolved.length > 0 && (
+				<PropFallbackBoxes pid={pid} indices={unresolved} selIdx={selIdx} onPick={onPick} />
+			)}
+			{selInst && <SelectedPropDecor inst={selInst} index={selIdx} />}
+		</>
+	);
+}

--- a/src/components/schema-editor/viewports/PropGeometry.tsx
+++ b/src/components/schema-editor/viewports/PropGeometry.tsx
@@ -196,6 +196,34 @@ export function PropGeometry({
 
 	const onPick = useCallback((i: number) => onSelect(['instances', i]), [onSelect]);
 
+	// When the selected prop draws as a real mesh, outline its actual bounding box
+	// (oriented by the instance transform) rather than the fixed marker box — so
+	// the selection box matches the prop's true shape (e.g. a wide flat fan, not a
+	// tall thin box). Falls back to undefined (→ marker box) for unresolved props.
+	const selOutline = useMemo<THREE.BufferGeometry | undefined>(() => {
+		if (selIdx < 0) return undefined;
+		const geoms = typeGeometry.get(pid.instances[selIdx].typeId);
+		if (!geoms || geoms.length === 0) return undefined;
+		const box = new THREE.Box3();
+		for (const g of geoms) {
+			g.computeBoundingBox();
+			if (g.boundingBox) box.union(g.boundingBox);
+		}
+		if (box.isEmpty()) return undefined;
+		const size = box.getSize(new THREE.Vector3());
+		const center = box.getCenter(new THREE.Vector3());
+		const bg = new THREE.BoxGeometry(
+			Math.max(size.x, 1e-3),
+			Math.max(size.y, 1e-3),
+			Math.max(size.z, 1e-3),
+		);
+		bg.translate(center.x, center.y, center.z); // the bbox may be off-origin in model space
+		const edges = new THREE.EdgesGeometry(bg);
+		bg.dispose();
+		return edges;
+	}, [selIdx, pid, typeGeometry]);
+	useDisposeOnDepsChange(() => selOutline?.dispose(), [selOutline]);
+
 	if (pid.instances.length === 0) return null;
 	const selInst = selIdx >= 0 ? pid.instances[selIdx] : null;
 
@@ -208,7 +236,7 @@ export function PropGeometry({
 			{unresolved.length > 0 && (
 				<PropFallbackBoxes pid={pid} indices={unresolved} selIdx={selIdx} onPick={onPick} />
 			)}
-			{selInst && <SelectedPropDecor inst={selInst} index={selIdx} />}
+			{selInst && <SelectedPropDecor inst={selInst} index={selIdx} outline={selOutline} />}
 		</>
 	);
 }

--- a/src/components/schema-editor/viewports/PropInstanceDataOverlay.tsx
+++ b/src/components/schema-editor/viewports/PropInstanceDataOverlay.tsx
@@ -103,12 +103,24 @@ const SELECTED_COLOR = '#' + SELECTION_THEME.primary.getHexString();
 // Selected-instance outline + label
 // ---------------------------------------------------------------------------
 
-export function SelectedPropDecor({ inst, index }: { inst: PropInstance; index: number }) {
+export function SelectedPropDecor({
+	inst,
+	index,
+	outline,
+}: {
+	inst: PropInstance;
+	index: number;
+	// Edges geometry to draw around the prop, in the prop's LOCAL frame (the
+	// instance transform is applied here). When a prop renders as a real mesh,
+	// PropGeometry passes the mesh's bounding-box edges so the outline matches the
+	// actual shape; omitted (the marker box) for the box-fallback / no-mesh case.
+	outline?: THREE.BufferGeometry;
+}) {
 	const matrix = useMemo(() => propInstanceMatrix(inst, new THREE.Matrix4()), [inst]);
 	const [x, y, z] = propInstancePosition(inst);
 	return (
 		<>
-			<lineSegments geometry={MARKER_EDGES_GEO} material={MARKER_EDGES_MAT} matrixAutoUpdate={false} matrix={matrix} />
+			<lineSegments geometry={outline ?? MARKER_EDGES_GEO} material={MARKER_EDGES_MAT} matrixAutoUpdate={false} matrix={matrix} />
 			{/* No distanceFactor: keep the label a constant screen size. With
 			    distanceFactor it scales by factor/cameraDistance, so flying the
 			    camera in close (FocusOnProp lands ~60 units away) ballooned it. */}

--- a/src/components/schema-editor/viewports/PropInstanceDataOverlay.tsx
+++ b/src/components/schema-editor/viewports/PropInstanceDataOverlay.tsx
@@ -84,11 +84,13 @@ export function propInstanceMatrix(inst: PropInstance, out: THREE.Matrix4): THRE
 // ---------------------------------------------------------------------------
 
 // A modest upright box: most props are signs / posts a few metres tall, and a
-// box driven by the instance matrix shows each prop's facing direction.
-const MARKER_GEO = new THREE.BoxGeometry(3, 4, 1.2);
+// box driven by the instance matrix shows each prop's facing direction. Exported
+// so the prop-mesh layer (<PropGeometry>) can reuse the exact same marker for
+// the props whose Model didn't resolve — the box is the fallback for those.
+export const MARKER_GEO = new THREE.BoxGeometry(3, 4, 1.2);
 // White base so per-instance setColorAt tints cleanly; Standard so the boxes
 // catch the WorldViewport lighting and read as solid 3D objects on the track.
-const MARKER_MAT = new THREE.MeshStandardMaterial({ roughness: 0.6, metalness: 0.05 });
+export const MARKER_MAT = new THREE.MeshStandardMaterial({ roughness: 0.6, metalness: 0.05 });
 
 // Selected-prop edge outline — depth-test off so it shows even when the box is
 // coincident with the road surface.
@@ -101,7 +103,7 @@ const SELECTED_COLOR = '#' + SELECTION_THEME.primary.getHexString();
 // Selected-instance outline + label
 // ---------------------------------------------------------------------------
 
-function SelectedPropDecor({ inst, index }: { inst: PropInstance; index: number }) {
+export function SelectedPropDecor({ inst, index }: { inst: PropInstance; index: number }) {
 	const matrix = useMemo(() => propInstanceMatrix(inst, new THREE.Matrix4()), [inst]);
 	const [x, y, z] = propInstancePosition(inst);
 	return (
@@ -133,7 +135,7 @@ function SelectedPropDecor({ inst, index }: { inst: PropInstance; index: number 
 // so the highlighted box is on-screen — same trick TrafficData's static
 // vehicles use (FocusOnVehicle). Only reacts to instance selections so browsing
 // other parts of the schema doesn't yank the camera.
-function FocusOnProp({ data, selectedPath }: { data: ParsedPropInstanceData; selectedPath: NodePath }) {
+export function FocusOnProp({ data, selectedPath }: { data: ParsedPropInstanceData; selectedPath: NodePath }) {
 	const { camera, controls } = useThree() as { camera: THREE.Camera; controls: { target: THREE.Vector3; update: () => void } | null };
 	const instances = data?.instances ?? [];
 	const target = useMemo<THREE.Vector3 | null>(() => {

--- a/src/components/schema-editor/viewports/__tests__/propGeometryDecode.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/propGeometryDecode.test.ts
@@ -1,0 +1,135 @@
+// propGeometryDecode — the PropInstanceData × PropGraphicsList × Model join
+// that turns prop placements into real meshes.
+//
+// `placeProps` is pure and machine-independent — tested with a synthetic
+// PropInstanceData + a fake type→geometry map. The catalogue resolution
+// (`buildPropTypeModelMap`) and the heavy decode are exercised against the real
+// TRK_UNIT9 bundle, skipped when that untracked binary is absent (same
+// convention as the parser gold tests).
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as THREE from 'three';
+
+import {
+	buildPropTypeModelMap,
+	decodePropTypeGeometry,
+	placeProps,
+	disposePropTypeGeometry,
+} from '../propGeometryDecode';
+import { parseBundle } from '@/lib/core/bundle';
+import { extractResourceRaw } from '@/lib/core/registry';
+import {
+	parsePropInstanceData,
+	type ParsedPropInstanceData,
+	type PropInstance,
+} from '@/lib/core/propInstanceData';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+const TRK9 = path.resolve(REPO_ROOT, 'example/TRK_UNIT9_GR.BNDL');
+
+function makeInstance(typeId: number, x: number, y: number, z: number): PropInstance {
+	const m = new Array(16).fill(0);
+	m[12] = x; m[13] = y; m[14] = z; m[15] = 1;
+	return {
+		mWorldTransform: m,
+		typeId,
+		flags: 0,
+		muInstanceID: 1,
+		muAlternativeType: 0xffff,
+		mn8RotSpeed: 0,
+		mn8MaxAngle: 0,
+		mn8MinAngle: 0,
+		_pad4D: [0, 0, 0],
+	};
+}
+
+function makePid(instances: PropInstance[]): ParsedPropInstanceData {
+	return {
+		muZoneId: 0,
+		muSizeInBytes: 0,
+		muNumberOfInstances: instances.length,
+		instances,
+		cells: [],
+		_trailingPad: new Uint8Array(0),
+	};
+}
+
+describe('placeProps (synthetic)', () => {
+	it('places resolved instances and partitions out the unresolved', () => {
+		const pid = makePid([
+			makeInstance(5, 10, 0, 0),
+			makeInstance(99, 20, 0, 0), // type 99 not in the catalogue → unresolved
+			makeInstance(5, 30, 0, 0),
+		]);
+		const geomA = new THREE.BufferGeometry();
+		const typeGeometry = new Map<number, THREE.BufferGeometry[]>([[5, [geomA]]]);
+
+		const { groups, resolvedInstanceIndices } = placeProps(pid, typeGeometry);
+
+		expect([...resolvedInstanceIndices].sort()).toEqual([0, 2]);
+		expect(groups).toHaveLength(1);
+		expect(groups[0].geometry).toBe(geomA);
+		// Both type-5 instances share the one geometry, placed at their transforms.
+		expect(groups[0].placements.map((p) => p.instanceIndex)).toEqual([0, 2]);
+		expect(groups[0].placements[0].matrix.elements[12]).toBe(10);
+		expect(groups[0].placements[1].matrix.elements[12]).toBe(30);
+	});
+
+	it('resolves nothing when the catalogue is empty (every prop falls back to a box)', () => {
+		const pid = makePid([makeInstance(5, 0, 0, 0), makeInstance(6, 0, 0, 0)]);
+		const { groups, resolvedInstanceIndices } = placeProps(pid, new Map());
+		expect(groups).toHaveLength(0);
+		expect(resolvedInstanceIndices.size).toBe(0);
+	});
+
+	it('shares one geometry across every placement of a multi-geometry model', () => {
+		const pid = makePid([makeInstance(7, 0, 0, 0), makeInstance(7, 5, 0, 0)]);
+		const g1 = new THREE.BufferGeometry();
+		const g2 = new THREE.BufferGeometry();
+		const { groups } = placeProps(pid, new Map([[7, [g1, g2]]]));
+		// Two geometries, each placed at both instances.
+		expect(groups).toHaveLength(2);
+		for (const g of groups) expect(g.placements).toHaveLength(2);
+	});
+});
+
+const hasTrk9 = fs.existsSync(TRK9);
+const describeTrk9 = hasTrk9 ? describe : describe.skip;
+
+describeTrk9('catalogue resolution + decode (example/TRK_UNIT9_GR.BNDL)', () => {
+	function load() {
+		const file = fs.readFileSync(TRK9);
+		const buffer = file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength) as ArrayBuffer;
+		const bundle = parseBundle(buffer);
+		const pidEntry = bundle.resources.find((r) => r.resourceTypeId === 0x10011)!;
+		const pid = parsePropInstanceData(extractResourceRaw(buffer, bundle, pidEntry));
+		return { bundle, buffer, pid };
+	}
+
+	it('maps every placed prop type to a Model id', () => {
+		const { bundle, buffer, pid } = load();
+		const map = buildPropTypeModelMap(bundle, buffer);
+		// TRK9's catalogue has 10 prop types; type 40 (0x28) → Model 0x12f7700a.
+		expect(map.size).toBe(10);
+		expect(map.get(40)).toBe(0x12f7700an);
+		// Every placed instance's type is in the catalogue (the join always hits).
+		const placedTypes = new Set(pid.instances.map((i) => i.typeId));
+		for (const t of placedTypes) expect(map.has(t)).toBe(true);
+	});
+
+	it('decodes locally-present prop Models to geometry without throwing', () => {
+		const { bundle, buffer, pid } = load();
+		// No companion bundles loaded — only props whose Model is local resolve;
+		// the rest fall back to boxes. The decode must be robust either way.
+		const typeGeometry = decodePropTypeGeometry(bundle, buffer, []);
+		for (const geoms of typeGeometry.values()) {
+			for (const g of geoms) expect(g).toBeInstanceOf(THREE.BufferGeometry);
+		}
+		const { resolvedInstanceIndices } = placeProps(pid, typeGeometry);
+		// Resolved is a subset of all instances (≥0; depends on which Models are local).
+		expect(resolvedInstanceIndices.size).toBeLessThanOrEqual(pid.instances.length);
+		expect(() => disposePropTypeGeometry(typeGeometry)).not.toThrow();
+	});
+});

--- a/src/components/schema-editor/viewports/propGeometryDecode.ts
+++ b/src/components/schema-editor/viewports/propGeometryDecode.ts
@@ -1,0 +1,203 @@
+// Prop geometry decode — turns a track unit's prop placements into real,
+// world-placed meshes for the WorldViewport (instead of the grey marker boxes).
+//
+// PropGraphicsList (0x10010) has no positions of its own — it is a catalogue
+// mapping each prop TYPE to its Model resource. Real prop meshes come from a
+// JOIN with PropInstanceData (0x10011), which carries the per-instance world
+// transform + the prop type:
+//
+//   PropInstanceData.instances[i]  → typeId + mWorldTransform (where)
+//     → PropGraphicsList: the PropGraphics entry whose muTypeId == typeId
+//     → its mpPropModel import (0 on disk) resolved via getImportsByPtrOffset
+//       at field offset (0x20 + propIndex*0x0C + 0x04)              → Model id
+//     → Model (0x2A) — in THIS bundle or a companion (GLOBALPROPS.BIN)
+//     → grey BufferGeometry (reusing the track decoder's Model→Renderable path)
+//     → placed at the instance's transform.
+//
+// The type→Model namespace match (PropInstanceData.typeId == PropGraphics
+// .muTypeId, both indexing prop-types) is verified across the fixtures: every
+// placed instance type appears in its unit's PropGraphicsList.
+//
+// Scope, like the track: grey untextured geometry only. Pure (no React / no
+// THREE materials) so the join can be unit-tested in node — the React layer
+// (PropGeometry.tsx) owns materials, picking, and the scene graph.
+//
+// Split into a HEAVY step (type → decoded geometry, stable for a bundle) and a
+// CHEAP step (placement from the live PropInstanceData), so editing a prop's
+// position re-places without re-decoding every Model.
+
+import * as THREE from 'three';
+import type { ParsedBundle, ResourceEntry } from '@/lib/core/types';
+import { getImportsByPtrOffset } from '@/lib/core/bundle';
+import { extractResourceSize, isCompressed, decompressData } from '@/lib/core/resourceManager';
+import {
+	parsePropGraphicsList,
+	PROP_GRAPHICS_LIST_TYPE_ID,
+} from '@/lib/core/propGraphicsList';
+import type { ParsedPropInstanceData } from '@/lib/core/propInstanceData';
+import type { ParsedVertexDescriptor } from '@/lib/core/renderable';
+import { findResourceById } from '@/lib/core/renderable';
+import { MODEL_TYPE_ID } from '@/lib/core/model';
+import { decodeModelGeometries, instanceTransformToMatrix4 } from './trackGeometryDecode';
+
+// PropGraphics array begins at 0x20; each record is 0x0C with mpPropModel at +4.
+const PROP_GRAPHICS_OFFSET = 0x20;
+const PROP_RECORD_SIZE = 0x0c;
+const PROP_MODEL_FIELD = 0x04;
+
+/** A bundle paired with its raw bytes — prop Models often live in a companion
+ *  bundle (GLOBALPROPS.BIN), so resolution searches these after the local one. */
+export type BundleSource = { bundle: ParsedBundle; buffer: ArrayBuffer };
+
+/** One instanced draw: a shared geometry plus every placement of it. */
+export type PropMeshGroup = {
+	geometry: THREE.BufferGeometry;
+	placements: { matrix: THREE.Matrix4; instanceIndex: number }[];
+};
+
+export type PlacedProps = {
+	groups: PropMeshGroup[];
+	/** PropInstanceData instance indices that resolved to a real mesh. The
+	 *  caller draws marker-box fallbacks for every other instance. */
+	resolvedInstanceIndices: Set<number>;
+};
+
+// ---------------------------------------------------------------------------
+// Raw extraction (block 0) — inlined to keep this module off the registry, the
+// same approach trackGeometryDecode uses.
+// ---------------------------------------------------------------------------
+
+function extractBlock0(buffer: ArrayBuffer, bundle: ParsedBundle, entry: ResourceEntry): Uint8Array | null {
+	const size = extractResourceSize(entry.sizeAndAlignmentOnDisk[0]);
+	if (size <= 0) return null;
+	const start = (bundle.header.resourceDataOffsets[0] + entry.diskOffsets[0]) >>> 0;
+	if (start + size > buffer.byteLength) return null;
+	let bytes: Uint8Array = new Uint8Array(buffer, start, size);
+	if (isCompressed(bytes)) bytes = decompressData(bytes) as Uint8Array;
+	return bytes;
+}
+
+// ---------------------------------------------------------------------------
+// Type → Model id map (from the bundle's PropGraphicsList + its import table)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build `prop typeId → Model resourceId` for a bundle's PropGraphicsList.
+ * Returns an empty map when the bundle has no PropGraphicsList. Throws are
+ * swallowed (a malformed catalogue just yields no prop meshes — the boxes
+ * remain), since this feeds a best-effort viewport, never an edit path.
+ */
+export function buildPropTypeModelMap(bundle: ParsedBundle, buffer: ArrayBuffer): Map<number, bigint> {
+	const map = new Map<number, bigint>();
+	const entry = bundle.resources.find((r) => r.resourceTypeId === PROP_GRAPHICS_LIST_TYPE_ID);
+	if (!entry) return map;
+	try {
+		const raw = extractBlock0(buffer, bundle, entry);
+		if (!raw) return map;
+		const pgl = parsePropGraphicsList(raw);
+		const index = bundle.resources.indexOf(entry);
+		const imports = getImportsByPtrOffset(bundle.imports, bundle.resources, index);
+		pgl.props.forEach((prop, i) => {
+			const id = imports.get(PROP_GRAPHICS_OFFSET + i * PROP_RECORD_SIZE + PROP_MODEL_FIELD);
+			if (id != null) map.set(prop.muTypeId, id);
+		});
+	} catch {
+		return map;
+	}
+	return map;
+}
+
+/** Find the bundle that actually holds a Model resource — local first, then the
+ *  companion bundles (prop Models live in GLOBALPROPS.BIN). */
+function findModelHome(modelId: bigint, local: BundleSource, externals: BundleSource[]): BundleSource | null {
+	const here = findResourceById(local.bundle, modelId);
+	if (here && here.resourceTypeId === MODEL_TYPE_ID) return local;
+	for (const ext of externals) {
+		const e = findResourceById(ext.bundle, modelId);
+		if (e && e.resourceTypeId === MODEL_TYPE_ID) return ext;
+	}
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// Heavy step: type → decoded geometry (stable for a bundle set)
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode each prop type used by `localBundle` to its grey geometries. The keys
+ * are exactly the types whose Model resolved AND yielded geometry — placement
+ * treats any instance whose type is absent here as "unresolved" (draw a box).
+ * Geometry is shared across types that map to the same Model.
+ */
+export function decodePropTypeGeometry(
+	localBundle: ParsedBundle,
+	localBuffer: ArrayBuffer,
+	externals: BundleSource[] = [],
+): Map<number, THREE.BufferGeometry[]> {
+	const local: BundleSource = { bundle: localBundle, buffer: localBuffer };
+	const typeToModel = buildPropTypeModelMap(localBundle, localBuffer);
+	const vdCache = new Map<bigint, ParsedVertexDescriptor | null>();
+	const byModel = new Map<string, THREE.BufferGeometry[]>();
+	const out = new Map<number, THREE.BufferGeometry[]>();
+
+	for (const [typeId, modelId] of typeToModel) {
+		const key = modelId.toString();
+		let geoms = byModel.get(key);
+		if (!geoms) {
+			const home = findModelHome(modelId, local, externals);
+			geoms = home
+				? decodeModelGeometries(home.buffer, home.bundle, modelId, vdCache).map((g) => g.geometry)
+				: [];
+			byModel.set(key, geoms);
+		}
+		if (geoms.length > 0) out.set(typeId, geoms);
+	}
+	return out;
+}
+
+// ---------------------------------------------------------------------------
+// Cheap step: place the live instances against the decoded geometry
+// ---------------------------------------------------------------------------
+
+/**
+ * Group the prop instances by the geometry they resolve to. Re-run on every
+ * PropInstanceData edit (it is cheap — no decode); the heavy
+ * `decodePropTypeGeometry` result is reused across edits.
+ */
+export function placeProps(
+	pid: ParsedPropInstanceData,
+	typeGeometry: Map<number, THREE.BufferGeometry[]>,
+): PlacedProps {
+	const byGeometry = new Map<THREE.BufferGeometry, PropMeshGroup>();
+	const resolvedInstanceIndices = new Set<number>();
+
+	pid.instances.forEach((inst, i) => {
+		const geoms = typeGeometry.get(inst.typeId);
+		if (!geoms || geoms.length === 0) return; // unresolved → box fallback
+		resolvedInstanceIndices.add(i);
+		const matrix = instanceTransformToMatrix4(inst.mWorldTransform);
+		for (const geometry of geoms) {
+			let group = byGeometry.get(geometry);
+			if (!group) {
+				group = { geometry, placements: [] };
+				byGeometry.set(geometry, group);
+			}
+			group.placements.push({ matrix, instanceIndex: i });
+		}
+	});
+
+	return { groups: [...byGeometry.values()], resolvedInstanceIndices };
+}
+
+/** Free the GPU buffers of every decoded prop geometry (dedupe by identity —
+ *  geometry is shared across instances and types that map to the same Model). */
+export function disposePropTypeGeometry(typeGeometry: Map<number, THREE.BufferGeometry[]>): void {
+	const seen = new Set<THREE.BufferGeometry>();
+	for (const geoms of typeGeometry.values()) {
+		for (const g of geoms) {
+			if (seen.has(g)) continue;
+			seen.add(g);
+			g.dispose();
+		}
+	}
+}

--- a/src/components/schema-editor/viewports/trackGeometryDecode.ts
+++ b/src/components/schema-editor/viewports/trackGeometryDecode.ts
@@ -168,6 +168,39 @@ function decodeRenderableGeometries(
 }
 
 /**
+ * Decode a Model (0x2A) resource — by its resourceId, within `bundle` — into
+ * grey geometries: Model → its Renderable (0xC) imports → BufferGeometry each.
+ * Returns [] when the Model isn't present in `bundle` (it may live in a
+ * companion bundle), isn't a Model, or yields no triangle-list geometry.
+ *
+ * Shared by the track decoder (each InstanceList entry's Model) and the prop
+ * decoder (each prop type's Model via PropGraphicsList). `bundle`/`buffer` are
+ * the Model's HOME bundle — for props that may differ from the bundle holding
+ * the PropGraphicsList, since prop Models live in GLOBALPROPS.BIN.
+ */
+export function decodeModelGeometries(
+	buffer: ArrayBuffer,
+	bundle: ParsedBundle,
+	modelId: bigint,
+	vdCache: Map<bigint, ParsedVertexDescriptor | null>,
+): { geometry: THREE.BufferGeometry; renderableId: bigint }[] {
+	const out: { geometry: THREE.BufferGeometry; renderableId: bigint }[] = [];
+	const modelEntry = findResourceById(bundle, modelId);
+	if (!modelEntry || modelEntry.resourceTypeId !== MODEL_TYPE_ID) return out;
+	const modelIndex = bundle.resources.indexOf(modelEntry);
+	const renderableIds = getImportIds(bundle.imports, bundle.resources, modelIndex);
+	for (const rid of renderableIds) {
+		const rEntry = findResourceById(bundle, rid);
+		if (!rEntry || rEntry.resourceTypeId !== RENDERABLE_TYPE_ID) continue;
+		const rIndex = bundle.resources.indexOf(rEntry);
+		for (const geometry of decodeRenderableGeometries(buffer, bundle, rEntry, rIndex, vdCache)) {
+			out.push({ geometry, renderableId: rid });
+		}
+	}
+	return out;
+}
+
+/**
  * Decode a track-unit bundle's InstanceList into world-placed grey geometries.
  *
  * Walks the first `muNumInstances` instances (the complete, renderable ones —

--- a/src/components/workspace/WorldViewportComposition.helpers.ts
+++ b/src/components/workspace/WorldViewportComposition.helpers.ts
@@ -42,6 +42,12 @@ export const WORLD_VIEWPORT_FAMILY_KEYS = [
 	// Props sit on the track surface; render them last so the markers draw on
 	// top of any co-loaded geometry (collision soups, AI/traffic lines).
 	'propInstanceData',
+	// PropGraphicsList has no overlay of its own (it is a type→Model catalogue,
+	// not spatial data) — it joins with PropInstanceData to draw real prop meshes
+	// via the per-bundle <PropGeometry> layer. It is in the family purely so that
+	// SELECTING it routes through the shared world scene (the track + props stay
+	// visible) instead of the single-overlay ViewportPane dead-end.
+	'propGraphicsList',
 ] as const;
 
 export type WorldViewportFamilyKey = typeof WORLD_VIEWPORT_FAMILY_KEYS[number];

--- a/src/components/workspace/WorldViewportComposition.test.ts
+++ b/src/components/workspace/WorldViewportComposition.test.ts
@@ -74,6 +74,10 @@ describe('WORLD_VIEWPORT_FAMILY_KEYS', () => {
 		expect([...WORLD_VIEWPORT_FAMILY_KEYS].sort()).toEqual([
 			'aiSections',
 			'polygonSoupList',
+			// PropGraphicsList has no overlay — it joins PropInstanceData to draw
+			// real prop meshes via <PropGeometry> — but is a family key so selecting
+			// it keeps the shared world scene mounted.
+			'propGraphicsList',
 			'propInstanceData',
 			'streetData',
 			'trafficData',

--- a/src/components/workspace/WorldViewportComposition.tsx
+++ b/src/components/workspace/WorldViewportComposition.tsx
@@ -49,11 +49,16 @@ import { useCallback, useMemo } from 'react';
 import { useWorkspace } from '@/context/WorkspaceContext';
 import { WorldViewport } from '@/components/schema-editor/viewports/WorldViewport';
 import { TrackGeometry } from '@/components/schema-editor/viewports/TrackGeometry';
+import { PropGeometry } from '@/components/schema-editor/viewports/PropGeometry';
 import { PolygonSoupListOverlay } from '@/components/schema-editor/viewports/PolygonSoupListOverlay';
 import { INSTANCE_LIST_TYPE_ID } from '@/lib/core/instanceList';
+import { PROP_GRAPHICS_LIST_TYPE_ID } from '@/lib/core/propGraphicsList';
 import { pickRenderBinding } from '@/lib/editor/bindings';
 import type { ParsedPolygonSoupList } from '@/lib/core/polygonSoupList';
+import type { ParsedPropInstanceData } from '@/lib/core/propInstanceData';
 import type { NodePath } from '@/lib/schema/walk';
+
+const EMPTY_PATH: NodePath = [];
 import type { WorkspaceContextValue } from '@/context/WorkspaceContext.types';
 import {
 	dedupePolygonSoupOverlays,
@@ -171,10 +176,22 @@ function WorldViewportCompositionInner({
 	// per-instance hides still drop their indexes from the lead's
 	// bundleSoups (the dedupe step reads the surviving set out of the
 	// post-filter list).
-	const overlays = useMemo(
-		() => dedupePolygonSoupOverlays(filterOverlaysByVisibility(listWorldOverlays(bundles), isVisible)),
-		[bundles, isVisible],
-	);
+	const overlays = useMemo(() => {
+		// A bundle with a PropGraphicsList draws its props as real meshes via
+		// <PropGeometry> below, which also owns the marker-box fallback + picking.
+		// Drop the box-only PropInstanceData overlay for those bundles so props
+		// don't double-draw (mesh + box). Bundles with PropInstanceData but no
+		// catalogue keep the box overlay.
+		const pglBundleIds = new Set(
+			bundles
+				.filter((b) => b.parsed.resources.some((r) => r.resourceTypeId === PROP_GRAPHICS_LIST_TYPE_ID))
+				.map((b) => b.id),
+		);
+		const list = filterOverlaysByVisibility(listWorldOverlays(bundles), isVisible).filter(
+			(d) => !(d.resourceKey === 'propInstanceData' && pglBundleIds.has(d.bundleId)),
+		);
+		return dedupePolygonSoupOverlays(list);
+	}, [bundles, isVisible]);
 
 	// Track-unit backdrop geometry: one <TrackGeometry> per loaded bundle that
 	// carries an InstanceList (0x23). Unlike overlays this needs the bundle's
@@ -194,6 +211,54 @@ function WorldViewportCompositionInner({
 					<TrackGeometry key={`track::${b.id}`} bundle={b.parsed} buffer={b.originalArrayBuffer} />
 				)),
 		[bundles, isVisible],
+	);
+
+	// Every loaded bundle paired with its bytes — prop Models live in companion
+	// bundles (GLOBALPROPS.BIN), so each <PropGeometry> resolves across all of
+	// them. Memoised on the bundle list so it stays stable across selection.
+	const allSources = useMemo(
+		() => bundles.map((b) => ({ bundle: b.parsed, buffer: b.originalArrayBuffer })),
+		[bundles],
+	);
+
+	// Real prop meshes: one <PropGeometry> per bundle that carries BOTH a
+	// PropGraphicsList (the type→Model catalogue) and a PropInstanceData (the
+	// placements). It joins them and draws the actual prop geometry (with a
+	// marker-box fallback for Models that aren't loaded yet), so the props look
+	// real instead of grey boxes. Selection routes back to the PropInstanceData
+	// instance so clicking a prop still works exactly as before.
+	const propChildren = useMemo(
+		() =>
+			bundles
+				.filter(
+					(b) =>
+						isVisible({ bundleId: b.id }) &&
+						isVisible({ bundleId: b.id, resourceKey: 'propInstanceData', index: 0 }) &&
+						b.parsed.resources.some((r) => r.resourceTypeId === PROP_GRAPHICS_LIST_TYPE_ID) &&
+						(b.parsedResourcesAll.get('propInstanceData')?.[0] ?? null) != null,
+				)
+				.map((b) => {
+					const pid = b.parsedResourcesAll.get('propInstanceData')![0] as ParsedPropInstanceData;
+					const externals = allSources.filter((s) => s.bundle !== b.parsed);
+					const selectedPath =
+						selection?.bundleId === b.id && selection.resourceKey === 'propInstanceData'
+							? selection.path
+							: EMPTY_PATH;
+					return (
+						<PropGeometry
+							key={`prop::${b.id}`}
+							pid={pid}
+							bundle={b.parsed}
+							buffer={b.originalArrayBuffer}
+							externals={externals}
+							selectedPath={selectedPath}
+							onSelect={(path) =>
+								select({ bundleId: b.id, resourceKey: 'propInstanceData', index: 0, path })
+							}
+						/>
+					);
+				}),
+		[bundles, allSources, isVisible, selection, select],
 	);
 
 	// Stable per-(bundleId, key, index) callback factories. We can't memoise
@@ -284,6 +349,7 @@ function WorldViewportCompositionInner({
 	return (
 		<WorldViewport>
 			{trackChildren}
+			{propChildren}
 			{children}
 		</WorldViewport>
 	);

--- a/src/lib/core/__tests__/propGraphicsList.test.ts
+++ b/src/lib/core/__tests__/propGraphicsList.test.ts
@@ -1,0 +1,224 @@
+// Coverage for parsePropGraphicsList / writePropGraphicsList (resource 0x10010).
+//
+// Two layers:
+//  - Synthesised payloads (always run): an empty list (null pointers) and a
+//    small populated list — machine-independent, pinned on every box.
+//  - A gold check against the real example/TRK_UNIT9_GR.BNDL bundle, skipped
+//    when that untracked binary is absent (same convention as registry.test.ts).
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+	parsePropGraphicsList,
+	writePropGraphicsList,
+	type ParsedPropGraphicsList,
+} from '../propGraphicsList';
+import { parseBundle } from '../bundle';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const TRK9_PATH = path.resolve(REPO_ROOT, 'example/TRK_UNIT9_GR.BNDL');
+const PROP_GRAPHICS_LIST = 0x10010;
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+// --- Synthesised: empty list (172/427 track units ship this all-zero shape) ---
+
+describe('PropGraphicsList empty list (null pointers)', () => {
+	function emptyBytes(zone: number): Uint8Array {
+		// 32-byte header only: muSizeInBytes = 0x20, both array pointers null.
+		const bytes = new Uint8Array(0x20);
+		const dv = new DataView(bytes.buffer);
+		dv.setUint32(0x00, 0x20, true); // muSizeInBytes
+		dv.setUint32(0x04, zone, true); // muZoneNumber
+		// counts + pointers stay zero.
+		return bytes;
+	}
+
+	it('parses zero props/parts with null pointers', () => {
+		const model = parsePropGraphicsList(emptyBytes(7));
+		expect(model.props.length).toBe(0);
+		expect(model.parts.length).toBe(0);
+		expect(model.muZoneNumber).toBe(7);
+		expect(model.muSizeInBytes).toBe(0x20);
+		expect(model._tail.byteLength).toBe(0);
+	});
+
+	it('round-trips byte-for-byte (re-emits null pointers, not 0x20)', () => {
+		const original = emptyBytes(7);
+		const rewritten = writePropGraphicsList(parsePropGraphicsList(original));
+		expect(rewritten.byteLength).toBe(original.byteLength);
+		expect(bytesEqual(rewritten, original)).toBe(true);
+	});
+});
+
+// --- Synthesised: a small populated list with a non-zero import-table tail ---
+
+describe('PropGraphicsList populated round-trip (synthesised)', () => {
+	// 2 props + 3 parts. mpaPropGraphics = 0x20, propEnd = 0x20 + 2*0x0C = 0x38,
+	// mpaPropPartGraphics = align16(0x38) = 0x40, partEnd = 0x40 + 3*0x0C = 0x64.
+	// Then an align pad to 0x70 + a fake import table of 5 entries × 16 = 80 bytes.
+	function buildBytes(): Uint8Array {
+		const partEnd = 0x40 + 3 * 0x0c; // 0x64
+		const importOffset = (partEnd + 15) & ~15; // 0x70
+		const importCount = 2 + 3;
+		const total = importOffset + importCount * 16; // 0x70 + 80 = 0xC0
+		const bytes = new Uint8Array(total);
+		const dv = new DataView(bytes.buffer);
+		dv.setUint32(0x00, partEnd, true);      // muSizeInBytes = part-array end
+		dv.setUint32(0x04, 55, true);           // muZoneNumber
+		dv.setUint32(0x08, 2, true);            // props
+		dv.setUint8(0x0c, 3);                   // parts (u8)
+		dv.setUint32(0x10, 0x20, true);         // mpaPropGraphics
+		dv.setUint32(0x14, 0x40, true);         // mpaPropPartGraphics
+		// props
+		dv.setUint32(0x20, 0xaa, true); dv.setUint32(0x24, 0, true); dv.setUint32(0x28, 0x40, true);
+		dv.setUint32(0x2c, 0xbb, true); dv.setUint32(0x30, 0, true); dv.setUint32(0x34, 0x40, true);
+		// parts (at 0x40)
+		dv.setUint32(0x40, 0xaa, true); dv.setUint32(0x44, 0, true); dv.setUint32(0x48, 0, true);
+		dv.setUint32(0x4c, 0xaa, true); dv.setUint32(0x50, 1, true); dv.setUint32(0x54, 0, true);
+		dv.setUint32(0x58, 0xbb, true); dv.setUint32(0x5c, 0, true); dv.setUint32(0x60, 0, true);
+		// fake import table (non-zero) so the tail capture is exercised
+		for (let i = 0; i < importCount; i++) {
+			dv.setUint32(importOffset + i * 16 + 0, 0x1000 + i, true); // resourceId low
+			dv.setUint32(importOffset + i * 16 + 8, 0x24 + i * 4, true); // field offset
+		}
+		return bytes;
+	}
+
+	it('decodes the structure and captures the non-zero tail', () => {
+		const model = parsePropGraphicsList(buildBytes());
+		expect(model.muZoneNumber).toBe(55);
+		expect(model.props.length).toBe(2);
+		expect(model.parts.length).toBe(3);
+		expect(model.props[0].muTypeId).toBe(0xaa);
+		expect(model.props[0].mpParts).toBe(0x40);
+		expect(model.parts[1].muPartId).toBe(1);
+		// tail = align pad (0x64→0x70) + 5×16 import table = 12 + 80 = 92 bytes.
+		expect(model._tail.byteLength).toBe(0xc0 - 0x64);
+		// and it is genuinely non-zero (the inline import table).
+		expect(model._tail.some((b) => b !== 0)).toBe(true);
+	});
+
+	it('round-trips byte-for-byte', () => {
+		const original = buildBytes();
+		const rewritten = writePropGraphicsList(parsePropGraphicsList(original));
+		expect(rewritten.byteLength).toBe(original.byteLength);
+		expect(bytesEqual(rewritten, original)).toBe(true);
+	});
+
+	it('survives a muZoneNumber / prop-type edit', () => {
+		const model = parsePropGraphicsList(buildBytes());
+		const edited: ParsedPropGraphicsList = {
+			...model,
+			muZoneNumber: 999,
+			props: model.props.map((p, i) => (i === 0 ? { ...p, muTypeId: 0x321 } : p)),
+		};
+		const re = parsePropGraphicsList(writePropGraphicsList(edited));
+		expect(re.muZoneNumber).toBe(999);
+		expect(re.props[0].muTypeId).toBe(0x321);
+		// the import-pointer fields and the tail are untouched.
+		expect(re.props[0].mpParts).toBe(0x40);
+		expect(bytesEqual(re._tail, model._tail)).toBe(true);
+	});
+});
+
+// --- Defensive guards (the writer regenerates pads as zero; reject layouts that
+//     would make that silently lossy, and reject a u8-overflowing part count) ---
+
+describe('PropGraphicsList layout guards', () => {
+	it('throws on a non-zero header pad [0x18,0x20)', () => {
+		const bytes = new Uint8Array(0x20);
+		new DataView(bytes.buffer).setUint32(0x00, 0x20, true); // muSizeInBytes
+		bytes[0x1c] = 0xab; // poison a header-pad byte
+		expect(() => parsePropGraphicsList(bytes)).toThrow(/header pad/);
+	});
+
+	it('throws on a non-zero inter-array pad between the prop and part arrays', () => {
+		// 1 prop (propEnd 0x2C) + 1 part (partsStart align16(0x2C)=0x30): the gap
+		// [0x2C,0x30) is regenerated as zero, so a non-zero byte there must fail.
+		const importOffset = 0x30 + 1 * 0x0c; // partEnd; aligned already
+		const total = importOffset + 2 * 16;  // 1 prop + 1 part imports
+		const bytes = new Uint8Array(total);
+		const dv = new DataView(bytes.buffer);
+		dv.setUint32(0x00, importOffset, true); // muSizeInBytes
+		dv.setUint32(0x08, 1, true);            // 1 prop
+		dv.setUint8(0x0c, 1);                   // 1 part
+		dv.setUint32(0x10, 0x20, true);         // mpaPropGraphics
+		dv.setUint32(0x14, 0x30, true);         // mpaPropPartGraphics
+		bytes[0x2c] = 0x99;                     // poison the inter-array gap
+		expect(() => parsePropGraphicsList(bytes)).toThrow(/inter-array pad/);
+	});
+
+	it('throws rather than truncate when a model carries more than 255 parts', () => {
+		const model: ParsedPropGraphicsList = {
+			muZoneNumber: 1,
+			muSizeInBytes: 0,
+			props: [{ muTypeId: 1, mpPropModel: 0, mpParts: 0 }],
+			parts: Array.from({ length: 300 }, (_, i) => ({ muTypeId: 1, muPartId: i, mpPropModel: 0 })),
+			_tail: new Uint8Array(0),
+		};
+		expect(() => writePropGraphicsList(model)).toThrow(/exceeds the u8/);
+	});
+});
+
+// --- Gold: the real TRK_UNIT9_GR.BNDL bundle (skipped when the binary is absent) ---
+
+const hasTrk9 = fs.existsSync(TRK9_PATH);
+const describeTrk9 = hasTrk9 ? describe : describe.skip;
+
+describeTrk9('PropGraphicsList gold (example/TRK_UNIT9_GR.BNDL)', () => {
+	function loadRaw(): Uint8Array {
+		const file = fs.readFileSync(TRK9_PATH);
+		const buffer = file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength);
+		const bundle = parseBundle(buffer as ArrayBuffer);
+		const entry = bundle.resources.find((r) => r.resourceTypeId === PROP_GRAPHICS_LIST)!;
+		return extractResourceRaw(buffer as ArrayBuffer, bundle, entry);
+	}
+
+	const raw = loadRaw();
+	const model = parsePropGraphicsList(raw);
+
+	it('decodes the header', () => {
+		expect(model.muZoneNumber).toBe(9);
+		expect(model.muSizeInBytes).toBe(784);
+		expect(model.props.length).toBe(10);
+		expect(model.parts.length).toBe(52);
+	});
+
+	it('decodes the first props (Model* are 0 on disk; mpParts is an internal pointer)', () => {
+		expect(model.props[0].muTypeId).toBe(0x28);
+		expect(model.props[0].mpPropModel).toBe(0);
+		expect(model.props[0].mpParts).toBe(0xa0);
+		expect(model.props[2].muTypeId).toBe(0x06);
+		expect(model.props[2].mpParts).toBe(0xd0);
+	});
+
+	it('decodes the first parts (grouped by owning prop type)', () => {
+		expect(model.parts[0].muTypeId).toBe(0x28);
+		expect(model.parts[0].muPartId).toBe(0);
+		expect(model.parts[1].muTypeId).toBe(0x28);
+		expect(model.parts[1].muPartId).toBe(1);
+		expect(model.parts[4].muTypeId).toBe(0x06);
+		expect(model.parts[4].muPartId).toBe(0);
+		expect(model.parts.every((p) => p.mpPropModel === 0)).toBe(true);
+	});
+
+	it('round-trips byte-for-byte', () => {
+		const rewritten = writePropGraphicsList(model);
+		expect(rewritten.byteLength).toBe(raw.byteLength);
+		expect(bytesEqual(rewritten, raw)).toBe(true);
+	});
+
+	it('writer is idempotent', () => {
+		const write1 = writePropGraphicsList(parsePropGraphicsList(raw));
+		const write2 = writePropGraphicsList(parsePropGraphicsList(write1));
+		expect(bytesEqual(write1, write2)).toBe(true);
+	});
+});

--- a/src/lib/core/propGraphicsList.ts
+++ b/src/lib/core/propGraphicsList.ts
@@ -1,0 +1,237 @@
+// PropGraphicsList parser and writer (resource type 0x10010,
+// BrnPhysics::Props::PropGraphicsList).
+//
+// A PropGraphicsList is the per-track-unit catalogue that maps every prop TYPE
+// placed in that unit (see PropInstanceData / 0x10011) to the Model resource(s)
+// the runtime spawns for it. It carries two parallel arrays:
+//  - PropGraphics:     one entry per whole prop  → its Model (the body mesh).
+//  - PropPartGraphics: one entry per prop PART   → its Model (a destructible
+//    sub-piece, e.g. a billboard panel that breaks off). Parts are grouped
+//    contiguously by owning prop; a PropGraphics.mpParts points at the prop's
+//    first part.
+//
+// The Model references are BND2 imports: on disk every mpPropModel pointer is 0,
+// and the real resource id lives in the bundle's INLINE import table (stored at
+// the tail of this resource's own payload). Imports are keyed by the byte offset
+// of the pointer field, so the renderer resolves them with getImportsByPtrOffset
+// — exactly like InstanceList's mpModel. The parser never needs the import table
+// to read the structure; it preserves it verbatim for byte-exact round-trip.
+//
+// Scope: 32-bit PC, little-endian. The wiki documents a 64-bit (Paradise
+// Remastered) layout too; like propInstanceData / instanceList / streetData we
+// implement 32-bit PC LE only.
+//
+// Round-trip strategy (byte-exact, grounded by sweeping all 427 PGL resources in
+// example/):
+//  - Layout is rigid: header(0x20) → PropGraphics[nProps] (0x0C each, at 0x20) →
+//    align16 pad → PropPartGraphics[nParts] (0x0C each) → align16 pad → inline
+//    import table (importCount*16) to end of payload. mpaPropGraphics is always
+//    0x20 and mpaPropPartGraphics is always align16(0x20 + nProps*0x0C), so both
+//    are recomputed from the counts on write (null/0 when their array is empty).
+//  - muSizeInBytes is a stored field that does NOT consistently equal a derivable
+//    offset (it is the part-array end when there are parts, but align16(prop-array
+//    end) when there are none), so it is preserved verbatim, mirroring
+//    propInstanceData.
+//  - mpPropModel (always 0) and mpParts (an internal resource-relative pointer)
+//    are preserved verbatim per record.
+//  - Everything from the end of the last array to the end of the payload (the
+//    align pad + the inline import table) is captured as _tail and re-emitted
+//    verbatim. This keeps every Model import valid as long as the prop/part
+//    counts are unchanged — so field edits round-trip, but adding/removing props
+//    or parts (which would shift the import-table field offsets) is out of scope.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type PropGraphics = {
+	muTypeId: number;    // u32 — prop type index (into the prop-types table)
+	// Model* import — 0 on disk; real id resolved from the import table by this
+	// field's byte offset. Preserved verbatim for round-trip.
+	mpPropModel: number; // u32
+	// Resource-relative pointer to this prop's first PropPartGraphics (0 when the
+	// prop has no parts). An internal pointer, preserved verbatim.
+	mpParts: number;     // u32
+};
+
+export type PropPartGraphics = {
+	muTypeId: number;    // u32 — owning prop's type id (always little endian per wiki)
+	muPartId: number;    // u32 — part index within the prop
+	// Model* import — 0 on disk; resolved from the import table. Verbatim.
+	mpPropModel: number; // u32
+};
+
+export type ParsedPropGraphicsList = {
+	muZoneNumber: number; // PVS zone / track-unit id (editable)
+	// Stored size field; does NOT consistently equal any derivable offset (it is
+	// the part-array end with parts, align16(prop-array end) without). Preserved
+	// verbatim so the writer reproduces the header byte-for-byte.
+	muSizeInBytes: number;
+	props: PropGraphics[];
+	parts: PropPartGraphics[];
+	// Bytes from the end of the last array to the end of the payload: an align16
+	// pad followed by the inline BND2 import table (one entry per prop + per part).
+	// Re-emitted verbatim — reproduces the exact length and keeps every Model
+	// import valid (the table is keyed by field offset).
+	_tail: Uint8Array;
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Resource type ID for BrnPhysics::Props::PropGraphicsList. */
+export const PROP_GRAPHICS_LIST_TYPE_ID = 0x10010;
+
+const HEADER_SIZE = 0x20;            // header fields end at 0x18, padded to 0x20
+const PROP_GRAPHICS_OFFSET = 0x20;   // mpaPropGraphics is always 0x20 when populated
+const PROP_RECORD_SIZE = 0x0c;       // PropGraphics
+const PART_RECORD_SIZE = 0x0c;       // PropPartGraphics
+
+const align16 = (x: number): number => (x + 15) & ~15;
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+export function parsePropGraphicsList(raw: Uint8Array, littleEndian = true): ParsedPropGraphicsList {
+	const r = new BinReader(raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength), littleEndian);
+
+	// --- Header (32 bytes) ---
+	const muSizeInBytes = r.readU32();
+	const muZoneNumber = r.readU32();
+	const muNumberOfPropModels = r.readU32();
+	const muNumberOfPropPartModels = r.readU8();
+	r.readU8(); r.readU8(); r.readU8();          // 3 pad (muNumberOfPropPartModels occupies a 4-byte slot)
+	const mpaPropGraphics = r.readU32();
+	const mpaPropPartGraphics = r.readU32();
+	// 0x18..0x20 is zero pad up to where PropGraphics begins (mpaPropGraphics).
+
+	// The layout is rigid; bail loudly if a populated fixture violates it rather
+	// than silently producing a model that won't round-trip. Empty lists store
+	// null (0) pointers, so only validate a pointer when its array is present.
+	const propGraphicsEnd = PROP_GRAPHICS_OFFSET + muNumberOfPropModels * PROP_RECORD_SIZE;
+	const partsStart = align16(propGraphicsEnd);
+	if (muNumberOfPropModels > 0 && mpaPropGraphics !== PROP_GRAPHICS_OFFSET) {
+		throw new Error(`PropGraphicsList: mpaPropGraphics is 0x${mpaPropGraphics.toString(16)}, expected 0x20 (rigid layout)`);
+	}
+	if (muNumberOfPropPartModels > 0 && mpaPropPartGraphics !== partsStart) {
+		throw new Error(`PropGraphicsList: mpaPropPartGraphics is 0x${mpaPropPartGraphics.toString(16)}, expected 0x${partsStart.toString(16)} for ${muNumberOfPropModels} props`);
+	}
+
+	// The header pad [0x18,0x20) and the align16 inter-array gap are regenerated
+	// as zero by the writer (not captured on the model), so a non-zero byte in
+	// either region would silently break the byte-exact round-trip. Both are zero
+	// in every fixture — assert it and fail loud, like the pointer checks above,
+	// rather than drop data on some unexpected layout.
+	for (let i = 0x18; i < HEADER_SIZE && i < raw.byteLength; i++) {
+		if (raw[i] !== 0) throw new Error(`PropGraphicsList: non-zero header pad at 0x${i.toString(16)} — layout not as expected`);
+	}
+	if (muNumberOfPropPartModels > 0) {
+		for (let i = propGraphicsEnd; i < partsStart; i++) {
+			if (raw[i] !== 0) throw new Error(`PropGraphicsList: non-zero inter-array pad at 0x${i.toString(16)} — layout not as expected`);
+		}
+	}
+
+	// --- PropGraphics (12 bytes each, at 0x20) ---
+	const props: PropGraphics[] = [];
+	r.position = PROP_GRAPHICS_OFFSET;
+	for (let i = 0; i < muNumberOfPropModels; i++) {
+		const muTypeId = r.readU32();
+		const mpPropModel = r.readU32();
+		const mpParts = r.readU32();
+		props.push({ muTypeId, mpPropModel, mpParts });
+	}
+
+	// --- PropPartGraphics (12 bytes each, at align16(propGraphicsEnd)) ---
+	const parts: PropPartGraphics[] = [];
+	r.position = partsStart;
+	for (let i = 0; i < muNumberOfPropPartModels; i++) {
+		const muTypeId = r.readU32();
+		const muPartId = r.readU32();
+		const mpPropModel = r.readU32();
+		parts.push({ muTypeId, muPartId, mpPropModel });
+	}
+
+	// --- Tail (align pad + inline import table) — captured verbatim. ---
+	const structuralEnd =
+		muNumberOfPropPartModels > 0
+			? partsStart + muNumberOfPropPartModels * PART_RECORD_SIZE
+			: muNumberOfPropModels > 0
+				? propGraphicsEnd
+				: HEADER_SIZE;
+	const _tail = structuralEnd < raw.byteLength
+		? raw.slice(structuralEnd, raw.byteLength)
+		: new Uint8Array(0);
+
+	return { muZoneNumber, muSizeInBytes, props, parts, _tail };
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+export function writePropGraphicsList(model: ParsedPropGraphicsList, littleEndian = true): Uint8Array {
+	const { props, parts } = model;
+	const nProps = props.length;
+	const nParts = parts.length;
+
+	// muNumberOfPropPartModels is a u8 on disk; refuse to silently truncate a
+	// model carrying >255 parts into a desynced count. Real fixtures top out at
+	// 82 parts — this only guards out-of-scope bulk edits that add parts.
+	if (nParts > 0xff) {
+		throw new Error(`PropGraphicsList: ${nParts} parts exceeds the u8 muNumberOfPropPartModels field (max 255)`);
+	}
+
+	// Layout offsets recomputed from the counts — never trust stored values.
+	const propGraphicsEnd = PROP_GRAPHICS_OFFSET + nProps * PROP_RECORD_SIZE;
+	const partsStart = align16(propGraphicsEnd);
+	const structuralEnd =
+		nParts > 0 ? partsStart + nParts * PART_RECORD_SIZE
+			: nProps > 0 ? propGraphicsEnd
+				: HEADER_SIZE;
+	const totalSize = structuralEnd + model._tail.byteLength;
+
+	// Stored pointers are null (0) when their array is empty — reproduces the
+	// all-zero header an empty list ships, keeping the round-trip byte-exact.
+	const mpaPropGraphics = nProps > 0 ? PROP_GRAPHICS_OFFSET : 0;
+	const mpaPropPartGraphics = nParts > 0 ? partsStart : 0;
+
+	const w = new BinWriter(totalSize, littleEndian);
+
+	// --- Header (32 bytes) ---
+	w.writeU32(model.muSizeInBytes);             // verbatim — not a derivable offset
+	w.writeU32(model.muZoneNumber);
+	w.writeU32(nProps);
+	w.writeU8(nParts & 0xff);
+	w.writeU8(0); w.writeU8(0); w.writeU8(0);    // 3 pad
+	w.writeU32(mpaPropGraphics);
+	w.writeU32(mpaPropPartGraphics);
+	while (w.offset < HEADER_SIZE) w.writeU8(0); // pad header up to 0x20
+	if (w.offset !== HEADER_SIZE) throw new Error(`PropGraphicsList writer: header offset mismatch ${w.offset} vs ${HEADER_SIZE}`);
+
+	// --- PropGraphics (12 bytes each) ---
+	for (const p of props) {
+		w.writeU32(p.muTypeId);
+		w.writeU32(p.mpPropModel);                // verbatim, 0 on disk
+		w.writeU32(p.mpParts);                     // verbatim internal pointer
+	}
+
+	// --- align16 pad → PropPartGraphics (12 bytes each) ---
+	if (nParts > 0) {
+		while (w.offset < partsStart) w.writeU8(0);
+		for (const q of parts) {
+			w.writeU32(q.muTypeId);
+			w.writeU32(q.muPartId);
+			w.writeU32(q.mpPropModel);             // verbatim, 0 on disk
+		}
+	}
+	if (w.offset !== structuralEnd) throw new Error(`PropGraphicsList writer: tail offset mismatch ${w.offset} vs ${structuralEnd}`);
+
+	// --- Tail (align pad + inline import table) — verbatim. ---
+	if (model._tail.byteLength > 0) w.writeBytes(model._tail);
+
+	return w.bytes;
+}

--- a/src/lib/core/registry/handlers/propGraphicsList.ts
+++ b/src/lib/core/registry/handlers/propGraphicsList.ts
@@ -1,0 +1,126 @@
+// PropGraphicsList registry handler — thin wrapper around
+// parsePropGraphicsList / writePropGraphicsList in
+// src/lib/core/propGraphicsList.ts.
+//
+// The low-level parser/writer live outside the registry so the registry never
+// imports from src/lib/core/bundle/index.ts (which could create a cycle).
+
+import {
+	parsePropGraphicsList,
+	writePropGraphicsList,
+	PROP_GRAPHICS_LIST_TYPE_ID,
+	type ParsedPropGraphicsList,
+} from '../../propGraphicsList';
+import type { ResourceHandler } from '../handler';
+
+// A prop-type id distinct from any low index the fixtures start with, so
+// 'edit-prop-type' actually changes the stored value.
+const STRESS_PROP_TYPE = 0x123;
+// A part id distinct from the low sequential ids parts carry on disk.
+const STRESS_PART_ID = 0x77;
+
+export const propGraphicsListHandler: ResourceHandler<ParsedPropGraphicsList> = {
+	typeId: PROP_GRAPHICS_LIST_TYPE_ID,
+	key: 'propGraphicsList',
+	name: 'Prop Graphics List',
+	description: 'Per-track-unit catalogue mapping each prop type (and destructible part) to its Model resource',
+	category: 'Data',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Prop_Graphics_List',
+
+	parseRaw(raw, ctx) {
+		return parsePropGraphicsList(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writePropGraphicsList(model, ctx.littleEndian);
+	},
+	describe(model) {
+		return `zone ${model.muZoneNumber}, props ${model.props.length}, parts ${model.parts.length}`;
+	},
+
+	fixtures: [
+		{ bundle: 'example/TRK_UNIT9_GR.BNDL', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/TRK_UNIT10_GR.BNDL', expect: { parseOk: true, byteRoundTrip: true } },
+		// The empty-list shape (172/427 track units: no props, no parts, null
+		// pointers, 32-byte payload) is covered by a self-contained unit test in
+		// __tests__/propGraphicsList.test.ts — it can't be a fixture here because
+		// the stress scenarios below edit props[0] / parts[0], which an empty list
+		// doesn't have.
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.props.length !== before.props.length) {
+					problems.push(`prop count ${after.props.length} != ${before.props.length}`);
+				}
+				if (after.parts.length !== before.parts.length) {
+					problems.push(`part count ${after.parts.length} != ${before.parts.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-zone-number',
+			description: 'change muZoneNumber to a marker and verify it survives round-trip',
+			mutate: (m) => ({ ...m, muZoneNumber: 4242 }),
+			verify: (_before, after) => {
+				const problems: string[] = [];
+				if (after.muZoneNumber !== 4242) problems.push(`muZoneNumber = ${after.muZoneNumber}, expected 4242`);
+				return problems;
+			},
+		},
+		{
+			name: 'edit-prop-type',
+			description: 'set props[0].muTypeId to a marker and verify it survives without perturbing the import pointers',
+			mutate: (m) => {
+				const props = m.props.slice();
+				props[0] = { ...props[0], muTypeId: STRESS_PROP_TYPE };
+				return { ...m, props };
+			},
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.props[0].muTypeId !== STRESS_PROP_TYPE) {
+					problems.push(`props[0].muTypeId = ${after.props[0].muTypeId}, expected ${STRESS_PROP_TYPE}`);
+				}
+				// mpPropModel (0 on disk) and mpParts must be untouched — they share
+				// the record and are preserved verbatim.
+				if (after.props[0].mpPropModel !== before.props[0].mpPropModel) {
+					problems.push(`props[0].mpPropModel changed to ${after.props[0].mpPropModel}`);
+				}
+				if (after.props[0].mpParts !== before.props[0].mpParts) {
+					problems.push(`props[0].mpParts changed to ${after.props[0].mpParts}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-part-type-and-id',
+			description: 'set parts[0].muTypeId / muPartId to markers and verify they survive',
+			mutate: (m) => {
+				if (m.parts.length === 0) return m;
+				const parts = m.parts.slice();
+				parts[0] = { ...parts[0], muTypeId: STRESS_PROP_TYPE, muPartId: STRESS_PART_ID };
+				return { ...m, parts };
+			},
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.parts.length === 0) return problems; // nothing to check on a parts-less list
+				if (after.parts[0].muTypeId !== STRESS_PROP_TYPE) {
+					problems.push(`parts[0].muTypeId = ${after.parts[0].muTypeId}, expected ${STRESS_PROP_TYPE}`);
+				}
+				if (after.parts[0].muPartId !== STRESS_PART_ID) {
+					problems.push(`parts[0].muPartId = ${after.parts[0].muPartId}, expected ${STRESS_PART_ID}`);
+				}
+				if (after.parts[0].mpPropModel !== before.parts[0].mpPropModel) {
+					problems.push(`parts[0].mpPropModel changed to ${after.parts[0].mpPropModel}`);
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/index.ts
+++ b/src/lib/core/registry/index.ts
@@ -30,6 +30,7 @@ import { graphicsSpecHandler } from './handlers/graphicsSpec';
 import { materialHandler } from './handlers/material';
 import { zoneListHandler } from './handlers/zoneList';
 import { propInstanceDataHandler } from './handlers/propInstanceData';
+import { propGraphicsListHandler } from './handlers/propGraphicsList';
 import { instanceListHandler } from './handlers/instanceList';
 import { textFileHandler } from './handlers/textFile';
 
@@ -57,6 +58,7 @@ export const registry: ResourceHandler[] = [
 	materialHandler,
 	zoneListHandler,
 	propInstanceDataHandler,
+	propGraphicsListHandler,
 	instanceListHandler,
 	textFileHandler,
 ];

--- a/src/lib/editor/profiles/propGraphicsList.ts
+++ b/src/lib/editor/profiles/propGraphicsList.ts
@@ -1,0 +1,11 @@
+import { defineProfile } from '../types';
+import type { ParsedPropGraphicsList } from '@/lib/core/propGraphicsList';
+import { propGraphicsListResourceSchema } from '@/lib/schema/resources/propGraphicsList';
+
+// Single-version data catalogue (no 3D overlay) — the schema alone drives the
+// inspector, so no render binding is registered in bindings.ts.
+export const propGraphicsListProfile = defineProfile<ParsedPropGraphicsList>({
+	kind: 'default',
+	displayName: 'Prop Graphics List',
+	schema: propGraphicsListResourceSchema,
+});

--- a/src/lib/editor/registry.ts
+++ b/src/lib/editor/registry.ts
@@ -19,6 +19,7 @@ import { iceTakeDictionaryProfile } from './profiles/iceTakeDictionary';
 import { playerCarColoursProfile } from './profiles/playerCarColours';
 import { polygonSoupListProfile } from './profiles/polygonSoupList';
 import { propInstanceDataProfile } from './profiles/propInstanceData';
+import { propGraphicsListProfile } from './profiles/propGraphicsList';
 import { renderableProfile } from './profiles/renderable';
 import { streetDataProfile } from './profiles/streetData';
 import { textureProfile } from './profiles/texture';
@@ -96,6 +97,11 @@ const ENTRIES: RegistryEntry[] = [
 		typeId: 0x10011,
 		key: 'propInstanceData',
 		profiles: [propInstanceDataProfile],
+	},
+	{
+		typeId: 0x10010,
+		key: 'propGraphicsList',
+		profiles: [propGraphicsListProfile],
 	},
 	{
 		typeId: 0x110,

--- a/src/lib/schema/resources/index.ts
+++ b/src/lib/schema/resources/index.ts
@@ -15,6 +15,7 @@ import { iceTakeDictionaryResourceSchema } from './iceTakeDictionary';
 import { instanceListResourceSchema } from './instanceList';
 import { playerCarColoursResourceSchema } from './playerCarColours';
 import { polygonSoupListResourceSchema } from './polygonSoupList';
+import { propGraphicsListResourceSchema } from './propGraphicsList';
 import { propInstanceDataResourceSchema } from './propInstanceData';
 import { renderableResourceSchema } from './renderable';
 import { streetDataResourceSchema } from './streetData';
@@ -31,6 +32,7 @@ const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	instanceList: instanceListResourceSchema,
 	playerCarColours: playerCarColoursResourceSchema,
 	polygonSoupList: polygonSoupListResourceSchema,
+	propGraphicsList: propGraphicsListResourceSchema,
 	propInstanceData: propInstanceDataResourceSchema,
 	renderable: renderableResourceSchema,
 	streetData: streetDataResourceSchema,

--- a/src/lib/schema/resources/propGraphicsList.test.ts
+++ b/src/lib/schema/resources/propGraphicsList.test.ts
@@ -1,0 +1,238 @@
+// Schema coverage tests for propGraphicsListResourceSchema.
+//
+// Coverage fixture: the real track-unit bundle example/TRK_UNIT9_GR.BNDL, from
+// which we extract the embedded PropGraphicsList resource (type 0x10010). That
+// model has both props (10) and parts (52), so it exercises every record type.
+// The binary is untracked, so the whole suite is skipped when it's absent —
+// same convention as the core gold test (fs.existsSync + describe.skip).
+//
+// Mirrors instanceList.test.ts: parse the model and walk it against the schema
+// asserting that
+//   - every record reference resolves to a registered type
+//   - walkResource visits every parsed field without throwing
+//   - no parsed field is undeclared in the schema, and no schema field is
+//     missing from the parsed data (parser/schema drift detector)
+//   - representative deep paths resolve with the expected field kinds
+//   - tree-label callbacks return sensible strings on real fixture data
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw } from '../../core/registry';
+import {
+	parsePropGraphicsList,
+	type ParsedPropGraphicsList,
+} from '../../core/propGraphicsList';
+
+import { propGraphicsListResourceSchema } from './propGraphicsList';
+import {
+	getAtPath,
+	resolveSchemaAtPath,
+	walkResource,
+	formatPath,
+} from '../walk';
+import type { FieldSchema } from '../types';
+
+// ---------------------------------------------------------------------------
+// Fixture loader
+// ---------------------------------------------------------------------------
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_9 = path.resolve(REPO_ROOT, 'example/TRK_UNIT9_GR.BNDL');
+const PROP_GRAPHICS_LIST_TYPE_ID = 0x10010;
+
+function loadBundleModel(fixturePath: string): ParsedPropGraphicsList {
+	const file = fs.readFileSync(fixturePath);
+	const buffer = file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength);
+	const bundle = parseBundle(buffer as ArrayBuffer, { strict: false });
+	const resource = bundle.resources.find((r) => r.resourceTypeId === PROP_GRAPHICS_LIST_TYPE_ID);
+	if (!resource) throw new Error(`${fixturePath} missing PropGraphicsList resource`);
+	const raw = extractResourceRaw(buffer as ArrayBuffer, bundle, resource);
+	return parsePropGraphicsList(raw);
+}
+
+// The fixture binary is untracked — skip the whole suite when it's absent.
+const hasFixture = fs.existsSync(BUNDLE_9);
+const describeFixture = hasFixture ? describe : describe.skip;
+
+const model = hasFixture ? loadBundleModel(BUNDLE_9) : (undefined as unknown as ParsedPropGraphicsList);
+
+describeFixture('propGraphicsListResourceSchema coverage — bundle TRK_UNIT9_GR.BNDL', () => {
+	it('fixture parses with non-trivial content', () => {
+		expect(model.props.length).toBeGreaterThan(0);
+		expect(model.parts.length).toBeGreaterThan(0);
+	});
+
+	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+		const missing: string[] = [];
+		for (const [recordName, rec] of Object.entries(propGraphicsListResourceSchema.registry)) {
+			for (const [fieldName, field] of Object.entries(rec.fields)) {
+				checkField(field, `${recordName}.${fieldName}`, missing);
+			}
+		}
+		if (missing.length > 0) {
+			throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+		}
+		function checkField(f: FieldSchema, where: string, out: string[]) {
+			if (f.kind === 'record') {
+				if (!propGraphicsListResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+				return;
+			}
+			if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+		}
+	});
+
+	it('walkResource visits every parsed field without throwing', () => {
+		let recordCount = 0;
+		let fieldCount = 0;
+		walkResource(propGraphicsListResourceSchema, model, (_p, _v, field, rec) => {
+			if (rec) recordCount++;
+			if (field) fieldCount++;
+		});
+		expect(recordCount).toBeGreaterThan(0);
+		expect(fieldCount).toBeGreaterThan(0);
+	});
+
+	it('no parsed record has fields absent from the schema', () => {
+		const missing: string[] = [];
+		walkResource(propGraphicsListResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const declared = new Set(Object.keys(rec.fields));
+			for (const key of Object.keys(value as Record<string, unknown>)) {
+				if (!declared.has(key)) {
+					missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(
+				`Schema is missing fields present in parsed data:\n  ${missing.slice(0, 20).join('\n  ')}${
+					missing.length > 20 ? `\n  ... +${missing.length - 20} more` : ''
+				}`,
+			);
+		}
+	});
+
+	it('every schema field is represented in the parsed data', () => {
+		const missing: string[] = [];
+		walkResource(propGraphicsListResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const obj = value as Record<string, unknown>;
+			for (const fieldName of Object.keys(rec.fields)) {
+				if (!(fieldName in obj)) {
+					missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(
+				`Schema declares fields missing from parsed data:\n  ${missing.slice(0, 20).join('\n  ')}${
+					missing.length > 20 ? `\n  ... +${missing.length - 20} more` : ''
+				}`,
+			);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Path resolution + field kinds
+// ---------------------------------------------------------------------------
+
+describe('propGraphicsList path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedPropGraphicsList');
+	});
+
+	it('resolves props[0] as a PropGraphics', () => {
+		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['props', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('PropGraphics');
+	});
+
+	it('resolves props[0].muTypeId as u32', () => {
+		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['props', 0, 'muTypeId']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('u32');
+	});
+
+	it('resolves parts[0] as a PropPartGraphics', () => {
+		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['parts', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('PropPartGraphics');
+	});
+
+	it('resolves parts[0].muPartId as u32', () => {
+		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['parts', 0, 'muPartId']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('u32');
+	});
+
+	it('resolves muZoneNumber as u32', () => {
+		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['muZoneNumber']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('u32');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tree labels
+// ---------------------------------------------------------------------------
+
+describeFixture('propGraphicsList tree labels', () => {
+	it('prop label includes the index and hex type id', () => {
+		// props[0] in TRK_UNIT9 has type id 0x28.
+		const prop = model.props[0];
+		const field = propGraphicsListResourceSchema.registry.ParsedPropGraphicsList.fields.props;
+		if (field.kind !== 'list') throw new Error('expected list');
+		const labelFn = field.itemLabel as (v: unknown, i: number) => string;
+		expect(labelFn(prop, 0)).toBe('#0 · type 0x28');
+	});
+
+	it('part label includes the index, hex type id, and part number', () => {
+		// parts[1] in TRK_UNIT9 is type 0x28, part 1.
+		const part = model.parts[1];
+		const field = propGraphicsListResourceSchema.registry.ParsedPropGraphicsList.fields.parts;
+		if (field.kind !== 'list') throw new Error('expected list');
+		const labelFn = field.itemLabel as (v: unknown, i: number) => string;
+		expect(labelFn(part, 1)).toBe('#1 · type 0x28 · part 1');
+	});
+
+	it('PropGraphics.label callback returns a non-empty string', () => {
+		const ctx = { root: model, resource: propGraphicsListResourceSchema };
+		const label = propGraphicsListResourceSchema.registry.PropGraphics.label!(
+			model.props[0] as unknown as Record<string, unknown>,
+			0,
+			ctx,
+		);
+		expect(typeof label).toBe('string');
+		expect(label.length).toBeGreaterThan(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Sanity: representative reads via getAtPath
+// ---------------------------------------------------------------------------
+
+describeFixture('propGraphicsList getAtPath', () => {
+	it('reads a prop type id as a number', () => {
+		const id = getAtPath(model, ['props', 0, 'muTypeId']);
+		expect(typeof id).toBe('number');
+		expect(Number.isFinite(id)).toBe(true);
+	});
+
+	it('reads props[0].mpPropModel as a number (0 on disk)', () => {
+		const mpModel = getAtPath(model, ['props', 0, 'mpPropModel']);
+		expect(mpModel).toBe(0);
+	});
+
+	it('reads a part Model pointer as 0 on disk', () => {
+		const mpModel = getAtPath(model, ['parts', 0, 'mpPropModel']);
+		expect(mpModel).toBe(0);
+	});
+});

--- a/src/lib/schema/resources/propGraphicsList.ts
+++ b/src/lib/schema/resources/propGraphicsList.ts
@@ -1,0 +1,197 @@
+// Hand-written schema for ParsedPropGraphicsList (resource type 0x10010).
+//
+// Mirrors the types in `src/lib/core/propGraphicsList.ts`. Keep these in
+// lockstep with the parser/writer — any field added to the parser needs a
+// matching entry here, or the schema walker reports it as drift.
+//
+// Domain: a PropGraphicsList is the per-track-unit catalogue mapping every prop
+// TYPE placed in that unit (see PropInstanceData / 0x10011) to the Model
+// resource(s) the runtime spawns for it. Two parallel arrays: one PropGraphics
+// per whole prop (its body Model) and one PropPartGraphics per destructible
+// sub-piece (e.g. a billboard panel that breaks off), grouped contiguously by
+// owning prop. The Model references are BND2 imports — every mpPropModel is 0 on
+// disk; the real resource id is resolved at render time from the inline import
+// table by the field's byte offset (same pattern as InstanceList's mpModel).
+// That import table lives in `_tail`, so adding/removing props or parts (which
+// would shift the table's field offsets) is out of scope; field edits are fine.
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaContext,
+	SchemaRegistry,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring instanceList.ts)
+// ---------------------------------------------------------------------------
+
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+// Raw byte buffer used for round-trip-only preservation fields. The default
+// form renderer hides custom fields without a registered component, which is
+// fine — users shouldn't edit these directly.
+const rawBytes = (): FieldSchema => ({ kind: 'custom', component: 'rawBytes' });
+
+const recordList = (
+	type: string,
+	itemLabel?: (item: unknown, index: number, ctx: SchemaContext) => string,
+): FieldSchema => ({
+	kind: 'list',
+	item: record(type),
+	// Add/remove is out of scope: a prop/part count change shifts the inline
+	// import table's field offsets, breaking every Model reference. Keep the
+	// arrays fixed-length so the inspector only exposes field edits.
+	addable: false,
+	removable: false,
+	itemLabel,
+});
+
+const hex = (n: number | undefined): string =>
+	n != null ? `0x${n.toString(16).toUpperCase()}` : '?';
+
+// ---------------------------------------------------------------------------
+// Tree-label helpers
+// ---------------------------------------------------------------------------
+
+function propLabel(prop: unknown, index: number): string {
+	try {
+		if (!prop || typeof prop !== 'object') return `#${index}`;
+		const p = prop as { muTypeId?: number };
+		return `#${index} · type ${hex(p.muTypeId)}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function partLabel(part: unknown, index: number): string {
+	try {
+		if (!part || typeof part !== 'object') return `#${index}`;
+		const p = part as { muTypeId?: number; muPartId?: number };
+		return `#${index} · type ${hex(p.muTypeId)} · part ${p.muPartId ?? '?'}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const PropGraphics: RecordSchema = {
+	name: 'PropGraphics',
+	description: 'One whole prop — its type id plus a (locally-zero) import pointer to the body Model the runtime spawns, and an internal pointer to the prop\'s first destructible part.',
+	fields: {
+		muTypeId: u32(),
+		mpPropModel: u32(),
+		mpParts: u32(),
+	},
+	fieldMetadata: {
+		muTypeId: {
+			label: 'Prop type',
+			description: 'Prop TYPE index (into the prop-types table). Identifies which prop placed in this track unit this Model catalogue entry is for.',
+		},
+		mpPropModel: {
+			label: 'Model pointer',
+			description: 'Import pointer to the body Model this prop spawns. Always 0 on disk — the real Model id is a BND2 import resolved at render time by the field offset, not stored in the payload. Preserved verbatim.',
+			readOnly: true,
+		},
+		mpParts: {
+			label: 'Parts pointer',
+			description: 'Internal resource-relative pointer to this prop\'s first PropPartGraphics (0 when the prop has no parts). Parts are grouped contiguously by owning prop; preserved verbatim.',
+			readOnly: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Identity', properties: ['muTypeId', 'mpPropModel', 'mpParts'] },
+	],
+	label: (value, index) => propLabel(value, index ?? 0),
+};
+
+const PropPartGraphics: RecordSchema = {
+	name: 'PropPartGraphics',
+	description: 'One destructible sub-piece of a prop (e.g. a billboard panel that breaks off) — the owning prop\'s type id, the part index within that prop, and a (locally-zero) import pointer to the part\'s Model.',
+	fields: {
+		muTypeId: u32(),
+		muPartId: u32(),
+		mpPropModel: u32(),
+	},
+	fieldMetadata: {
+		muTypeId: {
+			label: 'Prop type',
+			description: 'The owning prop\'s TYPE index. Parts are grouped contiguously by this value, matching the PropGraphics entry they belong to.',
+		},
+		muPartId: {
+			label: 'Part ID',
+			description: 'Index of this part within its owning prop (0, 1, 2, …). Identifies which destructible sub-piece this Model entry drives.',
+		},
+		mpPropModel: {
+			label: 'Model pointer',
+			description: 'Import pointer to this part\'s Model. Always 0 on disk — the real Model id is a BND2 import resolved at render time by the field offset. Preserved verbatim.',
+			readOnly: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Identity', properties: ['muTypeId', 'muPartId', 'mpPropModel'] },
+	],
+	label: (value, index) => partLabel(value, index ?? 0),
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedPropGraphicsList: RecordSchema = {
+	name: 'ParsedPropGraphicsList',
+	description: 'Root record for the PropGraphicsList resource (0x10010). Maps every prop TYPE placed in one track unit to its Model(s): a props array (one body Model per prop) plus a parts array (one Model per destructible sub-piece).',
+	fields: {
+		muZoneNumber: u32(),
+		muSizeInBytes: u32(),
+		props: recordList('PropGraphics', propLabel),
+		parts: recordList('PropPartGraphics', partLabel),
+		_tail: rawBytes(),
+	},
+	fieldMetadata: {
+		muZoneNumber: {
+			label: 'Zone number',
+			description: 'PVS zone / track-unit id this prop catalogue belongs to (e.g. 9). Editable.',
+		},
+		muSizeInBytes: {
+			label: 'Size in bytes',
+			description: 'Internal stored size field. Does NOT consistently equal a derivable offset (it is the part-array end when parts exist, but align16(prop-array end) when there are none); preserved verbatim so the writer reproduces the header byte-for-byte.',
+			readOnly: true,
+		},
+		props: {
+			label: 'Props',
+			description: 'One entry per whole prop type in this track unit, mapping it to its body Model. Fixed-length: adding/removing entries would shift the inline import table\'s field offsets and break every Model reference.',
+		},
+		parts: {
+			label: 'Parts',
+			description: 'One entry per destructible prop sub-piece, mapping it to its Model. Grouped contiguously by owning prop. Fixed-length for the same import-offset reason as props.',
+		},
+		_tail: {
+			label: 'Tail',
+			description: 'Bytes from the end of the last array to the end of the payload: an align16 pad followed by the inline BND2 import table (one entry per prop + per part). Re-emitted verbatim to reproduce the exact length and keep every Model import valid; users shouldn\'t edit this.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Header', properties: ['muZoneNumber', 'muSizeInBytes'] },
+		{ title: 'Props', properties: ['props'] },
+		{ title: 'Parts', properties: ['parts'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedPropGraphicsList,
+	PropGraphics,
+	PropPartGraphics,
+};
+
+export const propGraphicsListResourceSchema: ResourceSchema = {
+	key: 'propGraphicsList',
+	name: 'Prop Graphics List',
+	rootType: 'ParsedPropGraphicsList',
+	registry,
+};


### PR DESCRIPTION
Adds support for **`PropGraphicsList`** (`BrnPhysics::Props::PropGraphicsList`, resource type **`0x10010`**, `PRP_GL__*`) — the per-track-unit catalogue mapping each prop **type** (and destructible **part**) to its `Model` resource — and renders the props as **real meshes** in the world viewport.

## 1. Parser, schema & spec

Graphics-side companion to PropInstanceData (`0x10011`). On-disk payload (32-bit PC LE): `header(0x20)` -> `PropGraphics[nProps]x0x0C` -> align16 -> `PropPartGraphics[nParts]x0x0C` -> align16 pad + inline BND2 import table.

- `Model*` (`mpPropModel`) fields are **0 on disk**; real ids live in the resource's **inline import table**, keyed by field offset and resolved via `getImportsByPtrOffset` (same as InstanceList). `importCount == nProps + nParts` — the wiki's "1 Model per prop + 1 per part". Preserved verbatim in `_tail`, so field edits round-trip; add/remove of props/parts is out of scope.
- Core parser/writer, registry handler (TRK9/TRK10 `byteRoundTrip` fixtures + 4 stress scenarios), schema, editor profile, and `docs/prop-graphics-list-spec.md`.
- **Byte-exact round-trip across all 426 readable `example/TRK_UNIT*_GR.BNDL` fixtures** (0 failures).

## 2. Real prop meshes in the world viewport

Selecting a PropGraphicsList used to show "No viewport available" and blank the world. Now it keeps the world scene visible **and** draws each prop's actual geometry instead of grey boxes.

PropGraphicsList has no positions of its own, so the meshes come from a **join** with PropInstanceData: `PID.instance.typeId == PGL.PropGraphics.muTypeId` -> `mpPropModel` import -> Model (0x2A) -> Renderable (0xC) -> grey BufferGeometry, placed at the instance's world transform.

- `propGeometryDecode.ts` — pure, node-tested join, reusing the track decoder's Model->geometry path (`decodeModelGeometries`). Heavy type->geometry decode (memoised on immutable bytes) + cheap placement (re-runs on edits).
- `PropGeometry.tsx` — per-bundle layer (like `TrackGeometry`): one InstancedMesh per resolved Model + a **marker-box fallback** for Models that aren't loaded, plus picking and the reused selection outline / camera-fly.
- **Cross-bundle**: a TRK unit has ~18 local Models but imports ~62 — most prop Models live in `GLOBALPROPS.BIN`, so resolution searches every loaded bundle. With it loaded TRK9 resolves **71/71** instances; without it, 14/71 resolve and the rest fall back to boxes (world still shows every prop).
- Routing: `propGraphicsList` joins `WORLD_VIEWPORT_FAMILY_KEYS` (no overlay of its own) so selecting it routes through the shared world scene; the composition drops the box-only PropInstanceData overlay for catalogue-bearing bundles so props don't double-draw.

## Verification

- Round-trip + stress suites green; new prop-geometry decode tests green. Only failing tests in the repo are pre-existing `ENOENT` on the untracked `AI v6.DAT` fixture (unrelated).
- Workspace-tested in-browser across TRK9/10/149/0/100 (inspector renders correct data, zero console errors); with `GLOBALPROPS.BIN` loaded, props render as real meshes (oil drums, roadworks cones, gates) and clicking a prop selects its instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
