### PR TITLE
feat: StaticSoundMap (0x10016) parser, editor, and world overlay

### DIFF
--- a/src/components/schema-editor/viewports/StaticSoundMapOverlay.tsx
+++ b/src/components/schema-editor/viewports/StaticSoundMapOverlay.tsx
@@ -1,0 +1,196 @@
+// StaticSoundMapOverlay — WorldViewport overlay for ambient sound placements.
+//
+// Renders every StaticSoundEntity as a small sphere at its world position —
+// sounds have no orientation or footprint, so a fixed-size marker (not a
+// transform-driven box like props) is the honest representation. One
+// InstancedMesh draws the whole map; markers are tinted by the entity's
+// muTypeOrDistance so passby types (Tunnel/Camera/Collision) group visually.
+// Click picks an entity; the selected one gets a wireframe outline, an Html
+// label, and — when the value reads as an emitter distance — a ground ring
+// showing how far the sound carries.
+//
+// The map's role (emitter vs passby) is not in the model (meRootType lies),
+// so the ring uses the same best-effort heuristic as the schema's labels:
+// values beyond the passby enum (>= 19) are treated as metres. Retail passby
+// maps only use 9/10/12, retail emitter distances run 14–259, so the rare
+// 14–18 m emitter renders ringless rather than a passby ever growing a ring.
+//
+// Selection currency is the schema NodePath (ADR-0001): the overlay matches
+// `['entities', i, ...]` for highlight and emits `['entities', i]` on click.
+
+import { useCallback, useMemo, useRef } from 'react';
+import { Html } from '@react-three/drei';
+import { useThree, type ThreeEvent } from '@react-three/fiber';
+import * as THREE from 'three';
+import { PASSBY_TYPES, type ParsedStaticSoundMap, type StaticSoundEntity } from '@/lib/core/staticSoundMap';
+import { typeOrDistanceLabel } from '@/lib/schema/resources/staticSoundMap';
+import { useUpdateInstancedMesh } from '@/lib/three/scene/useUpdateInstancedMesh';
+import { useFlyCameraToTarget } from '@/lib/three/scene/useFlyCameraToTarget';
+import type { NodePath } from '@/lib/schema/walk';
+import type { WorldOverlayComponent } from './WorldViewport.types';
+import { defineSelectionCodec, SELECTION_THEME, isDragRelease, type Selection } from './selection';
+
+const KIND = 'staticSoundEntity';
+
+// ---------------------------------------------------------------------------
+// Path ↔ Selection codec (exported for tests)
+// ---------------------------------------------------------------------------
+
+/** Sub-paths inside an entity (e.g. `['entities', i, 'mPosition']`) collapse
+ *  to "this entity is selected". */
+export const staticSoundSelectionCodec = defineSelectionCodec({
+	pathToSelection: (path: NodePath): Selection | null => {
+		if (path.length < 2 || path[0] !== 'entities') return null;
+		const idx = path[1];
+		if (typeof idx !== 'number') return null;
+		return { kind: KIND, indices: [idx] };
+	},
+	selectionToPath: (sel: Selection): NodePath =>
+		sel.kind === KIND ? ['entities', sel.indices[0]] : [],
+});
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+/** Audible-distance reading of the dual-semantics u16 — null when the value
+ *  sits inside the passby enum and a metres reading would be a guess. */
+export function audibleRadius(ent: StaticSoundEntity): number | null {
+	return ent.muTypeOrDistance >= PASSBY_TYPES.length ? ent.muTypeOrDistance : null;
+}
+
+/** Stable per-value tint, golden-ratio hue step (same recipe as prop types):
+ *  passby maps get one colour per type, emitter maps a spread by distance. */
+export function soundEntityColor(typeOrDistance: number): THREE.Color {
+	const hue = ((typeOrDistance * 0.61803398875) % 1 + 1) % 1;
+	return new THREE.Color().setHSL(hue, 0.75, 0.6);
+}
+
+// ---------------------------------------------------------------------------
+// Shared GPU state — one geometry/material for every overlay instance.
+// ---------------------------------------------------------------------------
+
+// ~1.6 m radius: visible next to 3-4 m prop boxes without burying the track.
+const MARKER_GEO = new THREE.SphereGeometry(1.6, 16, 12);
+const MARKER_MAT = new THREE.MeshStandardMaterial({ roughness: 0.5, metalness: 0.05 });
+
+// Selected-entity outline — a sparse wireframe sphere; EdgesGeometry is useless
+// on smooth spheres (no hard edges), so wireframe it is. Depth-test off so the
+// highlight survives the marker sitting half-inside the road mesh.
+const OUTLINE_GEO = new THREE.WireframeGeometry(new THREE.SphereGeometry(2.2, 12, 8));
+const OUTLINE_MAT = new THREE.LineBasicMaterial({ color: 0xffffff, depthTest: false, transparent: true });
+
+// Unit ground circle scaled per-entity to the audible radius.
+const RING_GEO = (() => {
+	const pts: THREE.Vector3[] = [];
+	for (let i = 0; i <= 64; i++) {
+		const a = (i / 64) * Math.PI * 2;
+		pts.push(new THREE.Vector3(Math.cos(a), 0, Math.sin(a)));
+	}
+	return new THREE.BufferGeometry().setFromPoints(pts);
+})();
+const RING_MAT = new THREE.LineBasicMaterial({ color: 0x66ccff, transparent: true, opacity: 0.6 });
+
+const SELECTED_COLOR = '#' + SELECTION_THEME.primary.getHexString();
+
+// ---------------------------------------------------------------------------
+// Selected-entity outline + label + audible ring
+// ---------------------------------------------------------------------------
+
+export function SelectedSoundDecor({ ent, index }: { ent: StaticSoundEntity; index: number }) {
+	const { x, y, z } = ent.mPosition;
+	const radius = audibleRadius(ent);
+	return (
+		<>
+			<lineSegments geometry={OUTLINE_GEO} material={OUTLINE_MAT} position={[x, y, z]} />
+			{radius != null && (
+				<lineLoop geometry={RING_GEO} material={RING_MAT} position={[x, y, z]} scale={[radius, 1, radius]} />
+			)}
+			<Html position={[x, y, z]} center style={{ pointerEvents: 'none' }}>
+				<div style={{
+					background: 'rgba(0,0,0,0.8)', color: SELECTED_COLOR, padding: '2px 6px',
+					borderRadius: 4, fontSize: 10, whiteSpace: 'nowrap', fontFamily: 'monospace',
+					transform: 'translateY(-22px)',
+				}}>
+					#{index} {typeOrDistanceLabel(ent.muTypeOrDistance)} | snd {ent.muSoundIndex}
+				</div>
+			</Html>
+		</>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Camera auto-fit — same trick as FocusOnProp: fly over when an entity is
+// selected from the tree so the marker is actually on-screen.
+// ---------------------------------------------------------------------------
+
+export function FocusOnSound({ data, selectedPath }: { data: ParsedStaticSoundMap; selectedPath: NodePath }) {
+	const { camera, controls } = useThree() as { camera: THREE.Camera; controls: { target: THREE.Vector3; update: () => void } | null };
+	const entities = data?.entities ?? [];
+	const target = useMemo<THREE.Vector3 | null>(() => {
+		if (selectedPath.length < 2 || selectedPath[0] !== 'entities') return null;
+		const i = selectedPath[1];
+		if (typeof i !== 'number' || i >= entities.length) return null;
+		const { x, y, z } = entities[i].mPosition;
+		return new THREE.Vector3(x, y, z);
+	}, [entities, selectedPath]);
+	useFlyCameraToTarget(camera, controls, target, 60);
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// Overlay
+// ---------------------------------------------------------------------------
+
+export const StaticSoundMapOverlay: WorldOverlayComponent<ParsedStaticSoundMap> = ({
+	data, selectedPath, onSelect,
+}) => {
+	const entities = data?.entities ?? [];
+	const count = entities.length;
+	const meshRef = useRef<THREE.InstancedMesh>(null!);
+
+	const selIdx = useMemo(() => {
+		const sel = staticSoundSelectionCodec.pathToSelection(selectedPath);
+		return sel && sel.indices[0] < count ? sel.indices[0] : -1;
+	}, [selectedPath, count]);
+
+	useUpdateInstancedMesh(
+		meshRef,
+		count,
+		(mesh) => {
+			const mat = new THREE.Matrix4();
+			for (let i = 0; i < count; i++) {
+				const { x, y, z } = entities[i].mPosition;
+				mesh.setMatrixAt(i, mat.makeTranslation(x, y, z));
+				const color = i === selIdx ? SELECTION_THEME.primary : soundEntityColor(entities[i].muTypeOrDistance);
+				mesh.setColorAt(i, color);
+			}
+			if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+		},
+		[entities, count, selIdx],
+	);
+
+	const onClick = useCallback((e: ThreeEvent<MouseEvent>) => {
+		e.stopPropagation();
+		// Don't select when the click ends a camera orbit — see dragGuard.
+		if (isDragRelease(e.nativeEvent.clientX, e.nativeEvent.clientY)) return;
+		if (e.instanceId == null) return;
+		onSelect(staticSoundSelectionCodec.selectionToPath({ kind: KIND, indices: [e.instanceId] }));
+	}, [onSelect]);
+
+	if (count === 0) return null;
+
+	const selEnt = selIdx >= 0 ? entities[selIdx] : null;
+
+	return (
+		<>
+			<FocusOnSound data={data} selectedPath={selectedPath} />
+			<instancedMesh
+				ref={meshRef}
+				args={[MARKER_GEO, MARKER_MAT, count]}
+				onClick={onClick}
+			/>
+			{selEnt && <SelectedSoundDecor ent={selEnt} index={selIdx} />}
+		</>
+	);
+};

--- a/src/components/schema-editor/viewports/__tests__/StaticSoundMapOverlay.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/StaticSoundMapOverlay.test.ts
@@ -1,0 +1,67 @@
+// StaticSoundMapOverlay — overlay-level unit test.
+//
+// Covers the exported pure helpers (no DOM/R3F test infra in this repo —
+// same approach as PropInstanceDataOverlay.test.ts):
+//
+//   - the path↔selection codec round-trips `['entities', i]` and rejects
+//     anything that isn't an entity path,
+//   - `audibleRadius` only reads the dual-semantics u16 as metres when the
+//     value can't be a passby type (>= enum length),
+//   - `soundEntityColor` is deterministic and spreads distinct values apart.
+
+import { describe, it, expect } from 'vitest';
+import {
+	staticSoundSelectionCodec,
+	audibleRadius,
+	soundEntityColor,
+} from '../StaticSoundMapOverlay';
+import { PASSBY_TYPES, type StaticSoundEntity } from '@/lib/core/staticSoundMap';
+
+function makeEntity(typeOrDistance: number): StaticSoundEntity {
+	return { mPosition: { x: 10, y: 2, z: -30 }, muTypeOrDistance: typeOrDistance, muSoundIndex: 5 };
+}
+
+describe('staticSoundSelectionCodec', () => {
+	it('maps an entity path to a selection and back', () => {
+		const sel = staticSoundSelectionCodec.pathToSelection(['entities', 7]);
+		expect(sel).toEqual({ kind: 'staticSoundEntity', indices: [7] });
+		expect(staticSoundSelectionCodec.selectionToPath(sel!)).toEqual(['entities', 7]);
+	});
+
+	it('collapses a sub-path inside an entity to that entity', () => {
+		const sel = staticSoundSelectionCodec.pathToSelection(['entities', 3, 'mPosition']);
+		expect(sel).toEqual({ kind: 'staticSoundEntity', indices: [3] });
+	});
+
+	it('rejects non-entity paths', () => {
+		expect(staticSoundSelectionCodec.pathToSelection([])).toBeNull();
+		expect(staticSoundSelectionCodec.pathToSelection(['subRegions', 0])).toBeNull();
+		expect(staticSoundSelectionCodec.pathToSelection(['entities'])).toBeNull();
+	});
+});
+
+describe('audibleRadius', () => {
+	it('treats values beyond the passby enum as metres', () => {
+		expect(audibleRadius(makeEntity(86))).toBe(86);
+		expect(audibleRadius(makeEntity(PASSBY_TYPES.length))).toBe(PASSBY_TYPES.length);
+	});
+
+	it('refuses to guess for values inside the passby enum', () => {
+		// 12 = Collision in a passby map; a ring would be a lie half the time.
+		expect(audibleRadius(makeEntity(12))).toBeNull();
+		expect(audibleRadius(makeEntity(0))).toBeNull();
+	});
+});
+
+describe('soundEntityColor', () => {
+	it('is deterministic for the same value', () => {
+		expect(soundEntityColor(12).getHexString()).toBe(soundEntityColor(12).getHexString());
+	});
+
+	it('spreads the three retail passby types apart', () => {
+		const tunnel = soundEntityColor(9).getHexString();
+		const camera = soundEntityColor(10).getHexString();
+		const collision = soundEntityColor(12).getHexString();
+		expect(new Set([tunnel, camera, collision]).size).toBe(3);
+	});
+});

--- a/src/components/workspace/WorldViewportComposition.helpers.ts
+++ b/src/components/workspace/WorldViewportComposition.helpers.ts
@@ -48,6 +48,10 @@ export const WORLD_VIEWPORT_FAMILY_KEYS = [
 	// SELECTING it routes through the shared world scene (the track + props stay
 	// visible) instead of the single-overlay ViewportPane dead-end.
 	'propGraphicsList',
+	// Ambient-sound markers (two maps per track unit: emitter + passby). Last so
+	// the spheres draw on top of the track surface and prop meshes they annotate —
+	// placing audio relative to track sections is the whole editing use-case.
+	'staticSoundMap',
 ] as const;
 
 export type WorldViewportFamilyKey = typeof WORLD_VIEWPORT_FAMILY_KEYS[number];

--- a/src/components/workspace/WorldViewportComposition.test.ts
+++ b/src/components/workspace/WorldViewportComposition.test.ts
@@ -79,6 +79,9 @@ describe('WORLD_VIEWPORT_FAMILY_KEYS', () => {
 			// it keeps the shared world scene mounted.
 			'propGraphicsList',
 			'propInstanceData',
+			// Ambient-sound markers (emitter + passby per track unit) — placing
+			// audio relative to track sections needs the shared scene.
+			'staticSoundMap',
 			'streetData',
 			'trafficData',
 			'triggerData',

--- a/src/lib/core/__tests__/staticSoundMap.test.ts
+++ b/src/lib/core/__tests__/staticSoundMap.test.ts
@@ -1,0 +1,138 @@
+// Gold coverage for parseStaticSoundMap / writeStaticSoundMap.
+//
+// Every track unit carries TWO StaticSoundMap resources (emitter + passby) but
+// the auto-generated registry fixture suite only exercises the first resource
+// of a type per bundle — so this suite walks BOTH, pins hand-verified decoded
+// values from TRK_UNIT100, and covers the empty-map shape (TRK_UNIT0) that the
+// handler's entities[0] stress scenarios can't run on.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseStaticSoundMap, writeStaticSoundMap, PASSBY_TYPES } from '../staticSoundMap';
+import { parseBundle } from '../bundle';
+import { parseDebugDataFromXml, findDebugResourceById } from '../bundle/debugData';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const STATIC_SOUND_MAP_TYPE_ID = 0x10016;
+
+type ExtractedMap = { name: string; raw: Uint8Array };
+
+function loadMaps(bundleFile: string): ExtractedMap[] {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const debugResources = typeof bundle.debugData === 'string'
+		? parseDebugDataFromXml(bundle.debugData)
+		: [];
+	return bundle.resources
+		.filter((r) => r.resourceTypeId === STATIC_SOUND_MAP_TYPE_ID)
+		.map((r) => ({
+			name: findDebugResourceById(debugResources, r.resourceId.low.toString(16))?.name ?? '?',
+			raw: extractResourceRaw(buffer, bundle, r),
+		}));
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+describe('StaticSoundMap gold values (example/TRK_UNIT100_GR.BNDL)', () => {
+	const maps = loadMaps('example/TRK_UNIT100_GR.BNDL');
+
+	it('finds exactly two maps, emitter first, named by role', () => {
+		expect(maps.length).toBe(2);
+		expect(maps[0].name).toBe('TRK_UNIT100_Emitter');
+		expect(maps[1].name).toBe('TRK_UNIT100_Passby');
+	});
+
+	it('decodes the emitter map', () => {
+		const m = parseStaticSoundMap(maps[0].raw);
+		expect(m.mMin).toEqual({ x: 3400, y: -500 });
+		expect(m.mMax).toEqual({ x: 3450, y: -350 });
+		expect(m.mfSubRegionSize).toBe(50);
+		expect(m.miNumSubRegionsX).toBe(1);
+		expect(m.miNumSubRegionsZ).toBe(3);
+		expect(m.entities.length).toBe(2);
+		// Emitter semantics: muTypeOrDistance is the audible distance in metres.
+		expect(m.entities[0].mPosition.x).toBeCloseTo(3417.8, 1);
+		expect(m.entities[0].mPosition.y).toBeCloseTo(-32.9, 1);
+		expect(m.entities[0].mPosition.z).toBeCloseTo(-458.2, 1);
+		expect(m.entities[0].muTypeOrDistance).toBe(86);
+		expect(m.entities[0].muSoundIndex).toBe(14);
+		// rootType is 0 even though this is the emitter map — the role only
+		// exists in the debug name. Pin it so a "fix" trusting it gets caught.
+		expect(m.meRootType).toBe(0);
+	});
+
+	it('decodes the passby map', () => {
+		const m = parseStaticSoundMap(maps[1].raw);
+		expect(m.miNumSubRegionsX).toBe(4);
+		expect(m.miNumSubRegionsZ).toBe(8);
+		expect(m.entities.length).toBe(24);
+		// Passby semantics: muTypeOrDistance indexes PASSBY_TYPES.
+		expect(m.entities[0].muTypeOrDistance).toBe(12);
+		expect(PASSBY_TYPES[m.entities[0].muTypeOrDistance]).toBe('Collision');
+		expect(m.entities[0].muSoundIndex).toBe(7);
+		expect(m.subRegions.length).toBe(4 * 8);
+		expect(m.subRegions[0]).toEqual({ mi16First: 0, mi16Count: 2 });
+	});
+
+	it('subregion runs exactly cover the entity array', () => {
+		for (const { raw } of maps) {
+			const m = parseStaticSoundMap(raw);
+			let covered = 0;
+			for (const cell of m.subRegions) {
+				if (cell.mi16First >= 0) covered += cell.mi16Count;
+				else expect(cell.mi16Count).toBe(0);
+			}
+			expect(covered).toBe(m.entities.length);
+		}
+	});
+});
+
+describe('StaticSoundMap empty maps (example/TRK_UNIT0_GR.BNDL)', () => {
+	const maps = loadMaps('example/TRK_UNIT0_GR.BNDL');
+
+	it('parses the empty shape: 1x1 grid, no entities, [-1,0] cell', () => {
+		expect(maps.length).toBe(2);
+		for (const { raw } of maps) {
+			const m = parseStaticSoundMap(raw);
+			expect(m.entities.length).toBe(0);
+			expect(m.miNumSubRegionsX).toBe(1);
+			expect(m.miNumSubRegionsZ).toBe(1);
+			expect(m.subRegions).toEqual([{ mi16First: -1, mi16Count: 0 }]);
+			// Empty maps keep valid offsets (header 0x40 + 4-byte grid → pad to
+			// 0x50), unlike the null-pointer shape empty prop zones use.
+			expect(m._trailingPad.byteLength).toBe(0x50 - 0x44);
+		}
+	});
+});
+
+describe('StaticSoundMap round-trip', () => {
+	const bundles = [
+		'example/TRK_UNIT100_GR.BNDL',
+		'example/TRK_UNIT380_GR.BNDL',
+		'example/TRK_UNIT0_GR.BNDL',
+	];
+
+	for (const bundleFile of bundles) {
+		it(`round-trips both maps of ${bundleFile} byte-for-byte`, () => {
+			for (const { name, raw } of loadMaps(bundleFile)) {
+				const rewritten = writeStaticSoundMap(parseStaticSoundMap(raw));
+				expect(rewritten.byteLength, name).toBe(raw.byteLength);
+				expect(bytesEqual(rewritten, raw), name).toBe(true);
+			}
+		});
+	}
+
+	it('writer rejects a subregion array inconsistent with the grid dims', () => {
+		const m = parseStaticSoundMap(loadMaps(bundles[0])[0].raw);
+		const broken = { ...m, subRegions: m.subRegions.slice(0, -1) };
+		expect(() => writeStaticSoundMap(broken)).toThrow(/subregions/);
+	});
+});

--- a/src/lib/core/registry/handlers/staticSoundMap.ts
+++ b/src/lib/core/registry/handlers/staticSoundMap.ts
@@ -1,0 +1,181 @@
+// StaticSoundMap registry handler — thin wrapper around
+// parseStaticSoundMap / writeStaticSoundMap in src/lib/core/staticSoundMap.ts.
+//
+// Every track unit carries TWO of these (TRK_UNIT<N>_Emitter + _Passby), so
+// the handler ships a picker config. The role is only recoverable from the
+// debug name — meRootType is 0 in every retail resource — which the picker's
+// ctx.name surfaces.
+
+import {
+	parseStaticSoundMap,
+	writeStaticSoundMap,
+	PASSBY_TYPES,
+	type ParsedStaticSoundMap,
+} from '../../staticSoundMap';
+import type { ResourceHandler, PickerEntry } from '../handler';
+
+// A passby type guaranteed valid (index into PASSBY_TYPES) and distinct from
+// Collision (12), the most common retail value, so 'change-passby-type'
+// provably changes the value.
+const STRESS_PASSBY_TYPE = 9; // Tunnel
+
+function compareByName(a: PickerEntry<ParsedStaticSoundMap>, b: PickerEntry<ParsedStaticSoundMap>): number {
+	return a.ctx.name.localeCompare(b.ctx.name, undefined, { numeric: true });
+}
+
+export const staticSoundMapHandler: ResourceHandler<ParsedStaticSoundMap> = {
+	typeId: 0x10016,
+	key: 'staticSoundMap',
+	name: 'Static Sound Map',
+	description: 'Ambient sounds placed around a track unit — an emitter map (looping positional sounds) and a passby map (one-shot whooshes for lampposts, trees, bridges, …), each a grid-bucketed entity list',
+	category: 'Audio',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Static_Sound_Map',
+
+	parseRaw(raw, ctx) {
+		return parseStaticSoundMap(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeStaticSoundMap(model, ctx.littleEndian);
+	},
+	describe(model) {
+		return `entities ${model.entities.length}, grid ${model.miNumSubRegionsX}x${model.miNumSubRegionsZ}, cell ${model.mfSubRegionSize}m`;
+	},
+
+	picker: {
+		labelOf(model, { name }) {
+			if (model == null) {
+				return {
+					primary: name,
+					secondary: 'parse failed',
+					badges: [{ label: 'parse failed', tone: 'warn' }],
+				};
+			}
+			const role = name.endsWith('_Emitter') ? 'emitter' : name.endsWith('_Passby') ? 'passby' : null;
+			if (model.entities.length === 0) {
+				return {
+					primary: name,
+					secondary: 'no sounds',
+					badges: [{ label: 'empty', tone: 'muted' }],
+				};
+			}
+			return {
+				primary: name,
+				secondary: `${model.entities.length} sound${model.entities.length === 1 ? '' : 's'} · ${model.miNumSubRegionsX}×${model.miNumSubRegionsZ} grid`,
+				badges: role ? [{ label: role, tone: 'accent' as const }] : undefined,
+			};
+		},
+		sortKeys: [
+			{ id: 'name', label: 'Name (A→Z)', compare: compareByName },
+			{ id: 'index', label: 'Bundle order', compare: (a, b) => a.ctx.index - b.ctx.index },
+			{
+				id: 'entities-desc',
+				label: 'Sound count (high→low)',
+				compare: (a, b) => (b.model?.entities.length ?? -1) - (a.model?.entities.length ?? -1),
+			},
+		],
+		defaultSort: 'name',
+	},
+
+	fixtures: [
+		// The auto suite only exercises whichever map is first in bundle order —
+		// and that order is a coin flip across retail (217 emitter-first vs 210
+		// passby-first), another reason role can never be inferred from position.
+		// Both maps per bundle, plus the empty-map shape (e.g. TRK_UNIT0: 1x1
+		// grid, zero entities — which the entities[0] stress scenarios below
+		// can't run on), are covered in __tests__/staticSoundMap.test.ts.
+		{ bundle: 'example/TRK_UNIT100_GR.BNDL', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/TRK_UNIT380_GR.BNDL', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.entities.length !== before.entities.length) {
+					problems.push(`entity count ${after.entities.length} != ${before.entities.length}`);
+				}
+				if (after.subRegions.length !== before.subRegions.length) {
+					problems.push(`subregion count ${after.subRegions.length} != ${before.subRegions.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-entity-position',
+			description: 'translate entities[0] and verify the new coords survive round-trip',
+			mutate: (m) => {
+				const entities = m.entities.slice();
+				const { x, y, z } = entities[0].mPosition;
+				entities[0] = { ...entities[0], mPosition: { x: x + 10, y: y + 20, z: z + 30 } };
+				return { ...m, entities };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const a = afterMutate.entities[0].mPosition;
+				const b = afterReparse.entities[0].mPosition;
+				for (const axis of ['x', 'y', 'z'] as const) {
+					if (Math.abs(a[axis] - b[axis]) > 1e-3) problems.push(`pos.${axis} = ${b[axis]}, expected ${a[axis]}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'change-passby-type',
+			description: 'set entities[0].muTypeOrDistance to Tunnel and verify it survives alongside an untouched muSoundIndex',
+			mutate: (m) => {
+				const entities = m.entities.slice();
+				entities[0] = { ...entities[0], muTypeOrDistance: STRESS_PASSBY_TYPE };
+				return { ...m, entities };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.entities[0].muTypeOrDistance !== STRESS_PASSBY_TYPE) {
+					problems.push(`muTypeOrDistance = ${afterReparse.entities[0].muTypeOrDistance}, expected ${STRESS_PASSBY_TYPE} (${PASSBY_TYPES[STRESS_PASSBY_TYPE]})`);
+				}
+				// The two u16s share the packed Vector3Plus lane — editing one must
+				// not perturb the other.
+				if (afterReparse.entities[0].muSoundIndex !== afterMutate.entities[0].muSoundIndex) {
+					problems.push(`muSoundIndex changed to ${afterReparse.entities[0].muSoundIndex}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'remove-last-entity',
+			description: 'drop the final entity and shrink its owning subregion run; verify counts and grid consistency survive',
+			mutate: (m) => {
+				const entities = m.entities.slice(0, -1);
+				const removedIndex = m.entities.length - 1;
+				// Fix up the one cell whose run covered the removed entity — the
+				// grid stays consistent (runs are contiguous and non-overlapping).
+				const subRegions = m.subRegions.map((cell) => {
+					if (cell.mi16First < 0) return cell;
+					if (removedIndex >= cell.mi16First && removedIndex < cell.mi16First + cell.mi16Count) {
+						const count = cell.mi16Count - 1;
+						return { mi16First: count === 0 ? -1 : cell.mi16First, mi16Count: count };
+					}
+					return cell;
+				});
+				return { ...m, entities, subRegions };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.entities.length !== afterMutate.entities.length) {
+					problems.push(`entity count ${afterReparse.entities.length} != ${afterMutate.entities.length}`);
+				}
+				let covered = 0;
+				for (const cell of afterReparse.subRegions) {
+					if (cell.mi16First >= 0) covered += cell.mi16Count;
+				}
+				if (covered !== afterReparse.entities.length) {
+					problems.push(`grid covers ${covered} entities, expected ${afterReparse.entities.length}`);
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/index.ts
+++ b/src/lib/core/registry/index.ts
@@ -32,6 +32,7 @@ import { zoneListHandler } from './handlers/zoneList';
 import { propInstanceDataHandler } from './handlers/propInstanceData';
 import { propGraphicsListHandler } from './handlers/propGraphicsList';
 import { instanceListHandler } from './handlers/instanceList';
+import { staticSoundMapHandler } from './handlers/staticSoundMap';
 import { textFileHandler } from './handlers/textFile';
 
 export const registry: ResourceHandler[] = [
@@ -60,6 +61,7 @@ export const registry: ResourceHandler[] = [
 	propInstanceDataHandler,
 	propGraphicsListHandler,
 	instanceListHandler,
+	staticSoundMapHandler,
 	textFileHandler,
 ];
 

--- a/src/lib/core/staticSoundMap.ts
+++ b/src/lib/core/staticSoundMap.ts
@@ -1,0 +1,269 @@
+// StaticSoundMap parser and writer (resource type 0x10016).
+//
+// A StaticSoundMap places ambient sounds around a track unit. Every track unit
+// ships exactly two of these resources: an *emitter* map (looping positional
+// sounds — generators, surf, machinery) and a *passby* map (one-shot whooshes
+// triggered when the player flies past lampposts, trees, bridge pylons, …).
+// Which is which is NOT stored in the resource: meRootType is 0 (passby) in
+// every retail resource regardless of role, so the game (and steward's UI)
+// distinguish them by debug name suffix — TRK_UNIT<N>_Emitter / _Passby.
+//
+// Entities are bucketed into a coarse XZ grid of subregions (cell diameter
+// mfSubRegionSize, mMin/mMax bound the grid). Each SubRegionDescriptor owns a
+// contiguous run [mi16First, mi16First + mi16Count) of the entity array;
+// mi16First is -1 for an empty cell. The runtime culls by cell, so entity
+// order and the grid must stay consistent — the parser preserves the array
+// as-is and the writer never reorders.
+//
+// Each entity is one Vector3Plus: world X/Y/Z plus two u16s packed into the
+// fourth float's bytes. In a passby map the first u16 is the passby type
+// (PASSBY_TYPES below) and in an emitter map it is the audible distance in
+// metres; the second u16 indexes mPassbyBins / mWorldEmitterList in
+// BurnoutGlobalData (the AttribSys vault that owns the actual sound assets).
+//
+// Scope: 32-bit PC, little-endian, matching propInstanceData / streetData.
+// The wiki documents a 64-bit layout but notes all 64-bit variants shipped
+// empty (Remastered lost its static sounds on every platform except PC).
+//
+// Round-trip strategy: the layout is rigid — header(0x40) → entities(0x10
+// each, at 0x40) → subregions(0x4 each) → zero pad to 16-byte alignment.
+// mpEntities/mpSubRegions are file-relative offsets fixed up to pointers at
+// load; both stay valid (0x40) even in an empty map, unlike the null-pointer
+// shape empty prop zones use. Pointers are recomputed from array lengths on
+// write; the trailing pad is captured verbatim to reproduce the exact length.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Enumerations
+// =============================================================================
+
+// AttribSys::Enums::ePassbyTypes — the first packed u16 of a passby entity.
+// Emitter maps reuse that u16 as a distance, so this table only applies when
+// the resource's debug name ends in _Passby.
+export const PASSBY_TYPES = [
+	'PassbyAzimuth',
+	'PassbyPitch',
+	'PassbyCutoff',
+	'TrafficSmall',
+	'TrafficMedium',
+	'TrafficLarge',
+	'LampPost',
+	'Tree',
+	'Bridge',
+	'Tunnel',
+	'Camera',
+	'Misc',
+	'Collision',
+	'Overpass',
+	'Warehouse',
+	'Alley',
+	'StaticMetal',
+	'LargeOverheadObject',
+	'PassbyBoostOffset',
+] as const;
+
+export const STATIC_SOUND_ROOT_TYPE = {
+	PASSBY: 0,
+	EMITTER: 1,
+} as const;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// Vec values are {x,y(,z)} objects (not arrays) to match the repo-wide vec
+// convention the schema editor's Vec2Field/Vec3Field render — see
+// triggerData's Vector3. For the 2D grid bounds the renderer's "y" lane is
+// world Z; the schema labels them "(X, Z)" so the inspector stays honest.
+export type StaticSoundEntity = {
+	/** World position (f32 X, Y, Z) — first three lanes of the Vector3Plus. */
+	mPosition: { x: number; y: number; z: number };
+	/** Passby type (passby map) or audible distance in metres (emitter map). */
+	muTypeOrDistance: number; // u16
+	/** Index into mPassbyBins / mWorldEmitterList in BurnoutGlobalData. */
+	muSoundIndex: number; // u16
+};
+
+export type SubRegionDescriptor = {
+	/** Start index into the entity array; -1 = empty cell. */
+	mi16First: number;
+	/** Number of entities owned by this cell. */
+	mi16Count: number;
+};
+
+export type ParsedStaticSoundMap = {
+	/** Grid bounds — world X/Z (stored in the y lane). The maps are 2D; world Y never participates. */
+	mMin: { x: number; y: number };
+	mMax: { x: number; y: number };
+	// Unused vpu vector lanes of mMin/mMax (observed 0) — preserved verbatim so
+	// the round-trip stays byte-exact even if some resource stores junk there.
+	_minLanes23: { x: number; y: number };
+	_maxLanes23: { x: number; y: number };
+	/** Diameter of each grid cell (world units; retail uses 50). */
+	mfSubRegionSize: number;
+	miNumSubRegionsX: number;
+	miNumSubRegionsZ: number;
+	/** Flat X-major grid, miNumSubRegionsX * miNumSubRegionsZ cells. */
+	subRegions: SubRegionDescriptor[];
+	entities: StaticSoundEntity[];
+	// Always PASSBY (0) in retail, even for emitter maps — the role lives in
+	// the debug name. Preserved verbatim, not trusted for anything.
+	meRootType: number;
+	/** Header pad at 0x3C — preserved verbatim. */
+	_pad3C: number;
+	/** Zero pad from end-of-subregions to the 16-byte-aligned end. */
+	_trailingPad: Uint8Array;
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const HEADER_SIZE = 0x40;
+const ENTITY_RECORD_SIZE = 0x10;
+const SUBREGION_RECORD_SIZE = 0x4;
+// mpEntities is 0x40 in every retail resource, populated or empty — empty maps
+// keep valid pointers (1x1 grid, [-1,0] cell), unlike empty prop zones.
+const ENTITIES_OFFSET = HEADER_SIZE;
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+export function parseStaticSoundMap(raw: Uint8Array, littleEndian = true): ParsedStaticSoundMap {
+	const r = new BinReader(raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength), littleEndian);
+
+	// --- Header (0x40 bytes) ---
+	const minX = r.readF32();
+	const minZ = r.readF32();
+	const minL2 = r.readF32();
+	const minL3 = r.readF32();
+	const maxX = r.readF32();
+	const maxZ = r.readF32();
+	const maxL2 = r.readF32();
+	const maxL3 = r.readF32();
+	const mfSubRegionSize = r.readF32();
+	const mpSubRegions = r.readU32();
+	const miNumSubRegionsX = r.readI32();
+	const miNumSubRegionsZ = r.readI32();
+	const mpEntities = r.readU32();
+	const miNumEntities = r.readI32();
+	const meRootType = r.readU32();
+	const _pad3C = r.readU32();
+
+	// The layout is rigid; bail loudly on violations rather than silently
+	// producing a model that won't round-trip.
+	const entitiesEnd = ENTITIES_OFFSET + miNumEntities * ENTITY_RECORD_SIZE;
+	if (mpEntities !== ENTITIES_OFFSET) {
+		throw new Error(`StaticSoundMap: mpEntities is 0x${mpEntities.toString(16)}, expected 0x40 (rigid layout)`);
+	}
+	if (mpSubRegions !== entitiesEnd) {
+		throw new Error(`StaticSoundMap: mpSubRegions is 0x${mpSubRegions.toString(16)}, expected 0x${entitiesEnd.toString(16)} for ${miNumEntities} entities`);
+	}
+	const numCells = miNumSubRegionsX * miNumSubRegionsZ;
+	const subRegionsEnd = entitiesEnd + numCells * SUBREGION_RECORD_SIZE;
+	if (numCells < 0 || subRegionsEnd > raw.byteLength) {
+		throw new Error(`StaticSoundMap: ${miNumSubRegionsX}x${miNumSubRegionsZ} grid overruns the ${raw.byteLength}-byte resource`);
+	}
+
+	// --- Entities (0x10 each, at 0x40) ---
+	const entities: StaticSoundEntity[] = [];
+	r.position = ENTITIES_OFFSET;
+	for (let i = 0; i < miNumEntities; i++) {
+		const x = r.readF32();
+		const y = r.readF32();
+		const z = r.readF32();
+		const muTypeOrDistance = r.readU16();
+		const muSoundIndex = r.readU16();
+		entities.push({ mPosition: { x, y, z }, muTypeOrDistance, muSoundIndex });
+	}
+
+	// --- Subregion grid (4 bytes per cell, immediately after entities) ---
+	const subRegions: SubRegionDescriptor[] = [];
+	for (let i = 0; i < numCells; i++) {
+		const mi16First = r.readI16();
+		const mi16Count = r.readI16();
+		subRegions.push({ mi16First, mi16Count });
+	}
+
+	// --- Trailing pad (zeros to 16-byte alignment) — captured verbatim. ---
+	const _trailingPad = subRegionsEnd < raw.byteLength
+		? raw.slice(subRegionsEnd, raw.byteLength)
+		: new Uint8Array(0);
+
+	return {
+		mMin: { x: minX, y: minZ },
+		mMax: { x: maxX, y: maxZ },
+		_minLanes23: { x: minL2, y: minL3 },
+		_maxLanes23: { x: maxL2, y: maxL3 },
+		mfSubRegionSize,
+		miNumSubRegionsX,
+		miNumSubRegionsZ,
+		subRegions,
+		entities,
+		meRootType,
+		_pad3C,
+		_trailingPad,
+	};
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+export function writeStaticSoundMap(model: ParsedStaticSoundMap, littleEndian = true): Uint8Array {
+	const { entities, subRegions } = model;
+	const numCells = model.miNumSubRegionsX * model.miNumSubRegionsZ;
+	if (subRegions.length !== numCells) {
+		throw new Error(`StaticSoundMap writer: ${subRegions.length} subregions != ${model.miNumSubRegionsX}x${model.miNumSubRegionsZ} grid`);
+	}
+
+	// File-relative offsets recomputed from the array lengths, never stored.
+	const entitiesEnd = ENTITIES_OFFSET + entities.length * ENTITY_RECORD_SIZE;
+	const subRegionsEnd = entitiesEnd + subRegions.length * SUBREGION_RECORD_SIZE;
+	const totalSize = subRegionsEnd + model._trailingPad.byteLength;
+
+	const w = new BinWriter(totalSize, littleEndian);
+
+	// --- Header (0x40 bytes) ---
+	w.writeF32(model.mMin.x);
+	w.writeF32(model.mMin.y);
+	w.writeF32(model._minLanes23.x);
+	w.writeF32(model._minLanes23.y);
+	w.writeF32(model.mMax.x);
+	w.writeF32(model.mMax.y);
+	w.writeF32(model._maxLanes23.x);
+	w.writeF32(model._maxLanes23.y);
+	w.writeF32(model.mfSubRegionSize);
+	w.writeU32(entitiesEnd); // mpSubRegions
+	w.writeI32(model.miNumSubRegionsX);
+	w.writeI32(model.miNumSubRegionsZ);
+	w.writeU32(ENTITIES_OFFSET); // mpEntities
+	w.writeI32(entities.length);
+	w.writeU32(model.meRootType);
+	w.writeU32(model._pad3C);
+	if (w.offset !== HEADER_SIZE) throw new Error(`StaticSoundMap writer: header offset mismatch ${w.offset} vs ${HEADER_SIZE}`);
+
+	// --- Entities ---
+	for (const ent of entities) {
+		w.writeF32(ent.mPosition.x);
+		w.writeF32(ent.mPosition.y);
+		w.writeF32(ent.mPosition.z);
+		w.writeU16(ent.muTypeOrDistance);
+		w.writeU16(ent.muSoundIndex);
+	}
+	if (w.offset !== entitiesEnd) throw new Error(`StaticSoundMap writer: subregions offset mismatch ${w.offset} vs ${entitiesEnd}`);
+
+	// --- Subregion grid ---
+	for (const cell of subRegions) {
+		w.writeI16(cell.mi16First);
+		w.writeI16(cell.mi16Count);
+	}
+	if (w.offset !== subRegionsEnd) throw new Error(`StaticSoundMap writer: trailing-pad offset mismatch ${w.offset} vs ${subRegionsEnd}`);
+
+	// --- Trailing pad (verbatim) — reproduces the exact original length. ---
+	if (model._trailingPad.byteLength > 0) w.writeBytes(model._trailingPad);
+
+	return w.bytes;
+}

--- a/src/lib/editor/bindings.ts
+++ b/src/lib/editor/bindings.ts
@@ -25,6 +25,7 @@ import { AISectionsLegacyOverlay } from '@/components/aisections/AISectionsLegac
 import { AISectionsOverlay } from '@/components/aisections/AISectionsOverlay';
 import { PolygonSoupListOverlay } from '@/components/schema-editor/viewports/PolygonSoupListOverlay';
 import { PropInstanceDataOverlay } from '@/components/schema-editor/viewports/PropInstanceDataOverlay';
+import { StaticSoundMapOverlay } from '@/components/schema-editor/viewports/StaticSoundMapOverlay';
 import { StreetDataOverlay } from '@/components/schema-editor/viewports/StreetDataOverlay';
 import { TrafficDataOverlay } from '@/components/schema-editor/viewports/TrafficDataOverlay';
 import { TriggerDataOverlay } from '@/components/schema-editor/viewports/TriggerDataOverlay';
@@ -97,6 +98,11 @@ const BINDINGS: Record<string, Record<string, ProfileRenderBinding<unknown>>> = 
 	propInstanceData: {
 		default: {
 			overlay: PropInstanceDataOverlay as ProfileRenderBinding['overlay'],
+		},
+	},
+	staticSoundMap: {
+		default: {
+			overlay: StaticSoundMapOverlay as ProfileRenderBinding['overlay'],
 		},
 	},
 	challengeList: { default: { extensions: challengeListExtensions } },

--- a/src/lib/editor/profiles/staticSoundMap.ts
+++ b/src/lib/editor/profiles/staticSoundMap.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedStaticSoundMap } from '@/lib/core/staticSoundMap';
+import { staticSoundMapResourceSchema } from '@/lib/schema/resources/staticSoundMap';
+
+export const staticSoundMapProfile = defineProfile<ParsedStaticSoundMap>({
+	kind: 'default',
+	displayName: 'Static Sound Map',
+	schema: staticSoundMapResourceSchema,
+});

--- a/src/lib/editor/registry.ts
+++ b/src/lib/editor/registry.ts
@@ -21,6 +21,7 @@ import { polygonSoupListProfile } from './profiles/polygonSoupList';
 import { propInstanceDataProfile } from './profiles/propInstanceData';
 import { propGraphicsListProfile } from './profiles/propGraphicsList';
 import { renderableProfile } from './profiles/renderable';
+import { staticSoundMapProfile } from './profiles/staticSoundMap';
 import { streetDataProfile } from './profiles/streetData';
 import { textureProfile } from './profiles/texture';
 import {
@@ -102,6 +103,11 @@ const ENTRIES: RegistryEntry[] = [
 		typeId: 0x10010,
 		key: 'propGraphicsList',
 		profiles: [propGraphicsListProfile],
+	},
+	{
+		typeId: 0x10016,
+		key: 'staticSoundMap',
+		profiles: [staticSoundMapProfile],
 	},
 	{
 		typeId: 0x110,

--- a/src/lib/schema/resources/index.ts
+++ b/src/lib/schema/resources/index.ts
@@ -18,6 +18,7 @@ import { polygonSoupListResourceSchema } from './polygonSoupList';
 import { propGraphicsListResourceSchema } from './propGraphicsList';
 import { propInstanceDataResourceSchema } from './propInstanceData';
 import { renderableResourceSchema } from './renderable';
+import { staticSoundMapResourceSchema } from './staticSoundMap';
 import { streetDataResourceSchema } from './streetData';
 import { textureResourceSchema } from './texture';
 import { trafficDataResourceSchema } from './trafficData';
@@ -35,6 +36,7 @@ const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	propGraphicsList: propGraphicsListResourceSchema,
 	propInstanceData: propInstanceDataResourceSchema,
 	renderable: renderableResourceSchema,
+	staticSoundMap: staticSoundMapResourceSchema,
 	streetData: streetDataResourceSchema,
 	texture: textureResourceSchema,
 	trafficData: trafficDataResourceSchema,

--- a/src/lib/schema/resources/staticSoundMap.test.ts
+++ b/src/lib/schema/resources/staticSoundMap.test.ts
@@ -1,0 +1,159 @@
+// Schema coverage tests for staticSoundMapResourceSchema.
+//
+// Coverage fixture: example/TRK_UNIT100_GR.BNDL, which carries BOTH map roles
+// (TRK_UNIT100_Emitter + TRK_UNIT100_Passby). The same schema must cover both
+// because the on-disk shape is identical — only the debug name differs.
+//
+// Mirrors propInstanceData.test.ts: parse each model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseStaticSoundMap, type ParsedStaticSoundMap } from '../../core/staticSoundMap';
+
+import { staticSoundMapResourceSchema, typeOrDistanceLabel } from './staticSoundMap';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/TRK_UNIT100_GR.BNDL');
+const STATIC_SOUND_MAP_TYPE_ID = 0x10016;
+
+function loadBothModels(fixturePath: string): ParsedStaticSoundMap[] {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	return bundle.resources
+		.filter((r) => r.resourceTypeId === STATIC_SOUND_MAP_TYPE_ID)
+		.map((r) => parseStaticSoundMap(extractResourceRaw(buffer.buffer, bundle, r), ctx.littleEndian));
+}
+
+const models = loadBothModels(BUNDLE_FIXTURE);
+
+for (const [label, model] of [
+	['emitter map (resource 0)', models[0]],
+	['passby map (resource 1)', models[1]],
+] as const) {
+	describe(`staticSoundMapResourceSchema coverage — ${label}`, () => {
+		it('fixture parses with non-trivial content', () => {
+			expect(model.entities.length).toBeGreaterThan(0);
+			expect(model.subRegions.length).toBeGreaterThan(0);
+		});
+
+		it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+			const missing: string[] = [];
+			for (const [recordName, rec] of Object.entries(staticSoundMapResourceSchema.registry)) {
+				for (const [fieldName, field] of Object.entries(rec.fields)) {
+					checkField(field, `${recordName}.${fieldName}`, missing);
+				}
+			}
+			if (missing.length > 0) {
+				throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+			}
+			function checkField(f: FieldSchema, where: string, out: string[]) {
+				if (f.kind === 'record') {
+					if (!staticSoundMapResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+					return;
+				}
+				if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+			}
+		});
+
+		it('walkResource visits every parsed field without throwing', () => {
+			let recordCount = 0;
+			let fieldCount = 0;
+			walkResource(staticSoundMapResourceSchema, model, (_p, _v, field, rec) => {
+				if (rec) recordCount++;
+				if (field) fieldCount++;
+			});
+			expect(recordCount).toBeGreaterThan(0);
+			expect(fieldCount).toBeGreaterThan(0);
+		});
+
+		it('no parsed record has fields absent from the schema', () => {
+			const missing: string[] = [];
+			walkResource(staticSoundMapResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const declared = new Set(Object.keys(rec.fields));
+				for (const key of Object.keys(value as Record<string, unknown>)) {
+					if (!declared.has(key)) {
+						missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+
+		it('every schema field is represented in the parsed data', () => {
+			const missing: string[] = [];
+			walkResource(staticSoundMapResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const obj = value as Record<string, unknown>;
+				for (const fieldName of Object.keys(rec.fields)) {
+					if (!(fieldName in obj)) {
+						missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+	});
+}
+
+describe('staticSoundMap path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(staticSoundMapResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedStaticSoundMap');
+	});
+
+	it('resolves entities[0] as a StaticSoundEntity', () => {
+		const loc = resolveSchemaAtPath(staticSoundMapResourceSchema, ['entities', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('StaticSoundEntity');
+	});
+
+	it('resolves entities[0].mPosition as vec3', () => {
+		const loc = resolveSchemaAtPath(staticSoundMapResourceSchema, ['entities', 0, 'mPosition']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('vec3');
+	});
+
+	it('resolves subRegions[0].mi16First as read-only i16', () => {
+		const loc = resolveSchemaAtPath(staticSoundMapResourceSchema, ['subRegions', 0, 'mi16First']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('i16');
+	});
+
+	it('resolves mMin as vec2', () => {
+		const loc = resolveSchemaAtPath(staticSoundMapResourceSchema, ['mMin']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('vec2');
+	});
+});
+
+describe('typeOrDistanceLabel (dual-semantics u16)', () => {
+	it('labels values inside the passby enum with both readings', () => {
+		// 12 is Collision in a passby map but could be a 12 m radius in an
+		// emitter map — the label must not pretend to know the role.
+		expect(typeOrDistanceLabel(12)).toBe('Collision / 12 m');
+	});
+
+	it('labels values beyond the enum as emitter distances', () => {
+		expect(typeOrDistanceLabel(86)).toBe('86 m');
+	});
+});

--- a/src/lib/schema/resources/staticSoundMap.ts
+++ b/src/lib/schema/resources/staticSoundMap.ts
@@ -1,0 +1,245 @@
+// Hand-written schema for ParsedStaticSoundMap (resource type 0x10016).
+//
+// Mirrors the types in `src/lib/core/staticSoundMap.ts`. Keep these in
+// lockstep with the parser/writer — any field added to the parser needs a
+// matching entry here, or the schema walker reports it as drift.
+//
+// Domain: every track unit ships two StaticSoundMaps — an *emitter* map
+// (looping positional sounds) and a *passby* map (one-shot whooshes for
+// lampposts, trees, bridges, …). The role is NOT in the resource: meRootType
+// is 0 in every retail map, and bundle order is a coin flip, so only the
+// debug name (TRK_UNIT<N>_Emitter / _Passby) tells them apart. That is why
+// muTypeOrDistance can't be an enum here: the same u16 is a passby type in
+// one map and an audible distance in metres in the other.
+//
+// Entities are bucketed into a coarse XZ grid (subRegions): each cell owns a
+// contiguous run of the entity array. The grid is an acceleration structure
+// the game trusts — steward doesn't rebucket yet, so entity add/remove is
+// disabled and the grid fields are read-only. Moving an entity within ~a cell
+// (50 m) is safe; dragging it across the map leaves it culled by the stale
+// cell until a rebucket op exists.
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+} from '../types';
+import { PASSBY_TYPES } from '@/lib/core/staticSoundMap';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring propInstanceData.ts)
+// ---------------------------------------------------------------------------
+
+const f32 = (): FieldSchema => ({ kind: 'f32' });
+const i32 = (): FieldSchema => ({ kind: 'i32' });
+const i16 = (): FieldSchema => ({ kind: 'i16' });
+const u16 = (): FieldSchema => ({ kind: 'u16' });
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const vec2 = (): FieldSchema => ({ kind: 'vec2' });
+const vec3 = (): FieldSchema => ({ kind: 'vec3' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+const rawBytes = (): FieldSchema => ({ kind: 'custom', component: 'rawBytes' });
+
+const fixedRecordList = (
+	type: string,
+	itemLabel?: (item: unknown, index: number) => string,
+): FieldSchema => ({
+	kind: 'list',
+	item: record(type),
+	addable: false,
+	removable: false,
+	itemLabel: itemLabel ? (item, index) => itemLabel(item, index) : undefined,
+});
+
+// ---------------------------------------------------------------------------
+// Tree-label helpers
+// ---------------------------------------------------------------------------
+
+/** Best-effort reading of the dual-semantics u16: retail passby maps only use
+ *  Tunnel/Camera/Collision, retail emitter distances run 14–259 m. The label
+ *  shows both readings when ambiguous — the schema can't know the map's role. */
+export function typeOrDistanceLabel(value: number): string {
+	const name = value < PASSBY_TYPES.length ? PASSBY_TYPES[value] : null;
+	return name ? `${name} / ${value} m` : `${value} m`;
+}
+
+function entityLabel(ent: unknown, index: number): string {
+	try {
+		if (!ent || typeof ent !== 'object') return `#${index}`;
+		const e = ent as { mPosition?: { x?: number; z?: number }; muTypeOrDistance?: number; muSoundIndex?: number };
+		const x = e.mPosition?.x != null ? e.mPosition.x.toFixed(0) : '?';
+		const z = e.mPosition?.z != null ? e.mPosition.z.toFixed(0) : '?';
+		const t = e.muTypeOrDistance != null ? typeOrDistanceLabel(e.muTypeOrDistance) : '?';
+		return `#${index} · ${t} · snd ${e.muSoundIndex ?? '?'} · (${x}, ${z})`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function subRegionLabel(cell: unknown, index: number): string {
+	try {
+		if (!cell || typeof cell !== 'object') return `#${index}`;
+		const c = cell as { mi16First?: number; mi16Count?: number };
+		if (c.mi16First == null || c.mi16First < 0) return `#${index} · (empty)`;
+		return `#${index} · entities ${c.mi16First}..${c.mi16First + (c.mi16Count ?? 0)}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const StaticSoundEntity: RecordSchema = {
+	name: 'StaticSoundEntity',
+	description: 'One placed sound — a world position plus two u16s packed into the fourth float of the on-disk Vector3Plus. Their meaning depends on the map\'s role (see muTypeOrDistance).',
+	fields: {
+		mPosition: vec3(),
+		muTypeOrDistance: u16(),
+		muSoundIndex: u16(),
+	},
+	fieldMetadata: {
+		mPosition: {
+			label: 'Position',
+			description: 'World X/Y/Z where the sound lives. Safe to nudge; moving it more than a grid cell (~50 m) leaves it in a stale subregion until a rebucket op exists.',
+		},
+		muTypeOrDistance: {
+			label: 'Type / distance',
+			description: `Dual semantics, resolved by the map's debug name: in a _Passby map this is the passby type (retail uses 9 Tunnel, 10 Camera, 12 Collision; full table: ${PASSBY_TYPES.map((n, i) => `${i} ${n}`).join(', ')}); in an _Emitter map it is the audible distance in metres (retail range 14–259).`,
+		},
+		muSoundIndex: {
+			label: 'Sound index',
+			description: 'Index into mPassbyBins (passby) or mWorldEmitterList (emitter) in BurnoutGlobalData — the AttribSys vault that owns the actual sound assets.',
+		},
+	},
+	propertyGroups: [
+		{ title: 'Placement', properties: ['mPosition'] },
+		{ title: 'Sound', properties: ['muTypeOrDistance', 'muSoundIndex'] },
+	],
+	label: (value, index) => entityLabel(value, index ?? 0),
+};
+
+const SubRegionDescriptor: RecordSchema = {
+	name: 'SubRegionDescriptor',
+	description: 'One cell of the coarse XZ culling grid. Owns a contiguous run [first, first+count) of the entity array; first is -1 for an empty cell. Derived bucketing the game trusts — read-only until steward grows a rebucket op.',
+	fields: {
+		mi16First: i16(),
+		mi16Count: i16(),
+	},
+	fieldMetadata: {
+		mi16First: {
+			label: 'First entity',
+			description: 'Start index of this cell\'s run into the entity array; -1 = empty cell.',
+			readOnly: true,
+		},
+		mi16Count: {
+			label: 'Count',
+			description: 'Number of entities in this cell\'s run.',
+			readOnly: true,
+		},
+	},
+	label: (value, index) => subRegionLabel(value, index ?? 0),
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedStaticSoundMap: RecordSchema = {
+	name: 'ParsedStaticSoundMap',
+	description: 'Root record for the StaticSoundMap resource (0x10016): the ambient-sound placements for one track unit. Whether this is the emitter or the passby map lives ONLY in the resource\'s debug name — meRootType is 0 in every retail map.',
+	fields: {
+		mMin: vec2(),
+		mMax: vec2(),
+		mfSubRegionSize: f32(),
+		miNumSubRegionsX: i32(),
+		miNumSubRegionsZ: i32(),
+		entities: fixedRecordList('StaticSoundEntity', entityLabel),
+		subRegions: fixedRecordList('SubRegionDescriptor', subRegionLabel),
+		meRootType: u32(),
+		_minLanes23: vec2(),
+		_maxLanes23: vec2(),
+		_pad3C: u32(),
+		_trailingPad: rawBytes(),
+	},
+	fieldMetadata: {
+		mMin: {
+			label: 'Grid min (X, Z)',
+			description: 'Minimum world X/Z corner of the culling grid. Sounds only play when the player is inside the grid bounds.',
+			readOnly: true,
+		},
+		mMax: {
+			label: 'Grid max (X, Z)',
+			description: 'Maximum world X/Z corner of the culling grid.',
+			readOnly: true,
+		},
+		mfSubRegionSize: {
+			label: 'Cell size',
+			description: 'Diameter of each grid cell in world units. Retail always uses 50.',
+			readOnly: true,
+		},
+		miNumSubRegionsX: {
+			label: 'Grid cells X',
+			description: 'Grid width in cells. Read-only: resizing the grid requires rebucketing every entity.',
+			readOnly: true,
+		},
+		miNumSubRegionsZ: {
+			label: 'Grid cells Z',
+			description: 'Grid depth in cells.',
+			readOnly: true,
+		},
+		entities: {
+			label: 'Sounds',
+			description: 'Every placed sound, in disk order. The subregion grid indexes into this array by position, so order is load-bearing — adding/removing entities needs a rebucket op steward doesn\'t have yet.',
+		},
+		subRegions: {
+			label: 'Culling grid',
+			description: 'X-major flat grid of cells, each owning a contiguous entity run. Derived from entity positions at build time; preserved verbatim.',
+		},
+		meRootType: {
+			label: 'Root type',
+			description: 'ePassbyTypes root selector — 0 passby, 1 emitter on the wiki, but EVERY retail resource stores 0 regardless of role. Preserved verbatim, trusted for nothing.',
+			readOnly: true,
+		},
+		_minLanes23: {
+			label: 'mMin unused lanes',
+			description: 'Unused vpu vector lanes (always 0 in retail). Preserved for byte-exact round-trip.',
+			hidden: true,
+		},
+		_maxLanes23: {
+			label: 'mMax unused lanes',
+			description: 'Unused vpu vector lanes (always 0 in retail). Preserved for byte-exact round-trip.',
+			hidden: true,
+		},
+		_pad3C: {
+			label: 'pad +0x3C',
+			description: 'Header pad (always 0 in retail); preserved verbatim.',
+			hidden: true,
+		},
+		_trailingPad: {
+			label: 'Trailing pad',
+			description: 'Zero bytes padding the resource to 16-byte alignment. Re-emitted verbatim; users shouldn\'t edit this.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Grid', properties: ['mMin', 'mMax', 'mfSubRegionSize', 'miNumSubRegionsX', 'miNumSubRegionsZ'] },
+		{ title: 'Sounds', properties: ['entities'] },
+		{ title: 'Culling', properties: ['subRegions', 'meRootType'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedStaticSoundMap,
+	StaticSoundEntity,
+	SubRegionDescriptor,
+};
+
+export const staticSoundMapResourceSchema: ResourceSchema = {
+	key: 'staticSoundMap',
+	name: 'Static Sound Map',
+	rootType: 'ParsedStaticSoundMap',
+	registry,
+};


### PR DESCRIPTION
## What

Adds the full editing slice for **StaticSoundMap (0x10016)** — the ambient-sound placements every track unit carries as two resources: `TRK_UNIT<N>_Emitter` (looping positional sounds) and `TRK_UNIT<N>_Passby` (one-shot whooshes for lampposts, trees, bridges, …).

- **Parser/writer** (`src/lib/core/staticSoundMap.ts`): header 0x40 → entities (16-byte Vector3Plus) → subregion culling grid → alignment pad. Byte-exact round-trip.
- **Handler** with picker config, fixtures, and four stress scenarios (move entity, change passby type, remove last entity with grid fix-up, baseline).
- **Schema + editor profile**: positions and sound refs editable; the culling grid and grid dims are read-only and entity add/remove is disabled until a rebucket op exists (the grid is an acceleration structure the game trusts).
- **World overlay**: tinted sphere markers, selection outline + label, an audible-distance ground ring for emitter entities, fly-to-selection camera.
- **Workspace composition**: `staticSoundMap` joins `WORLD_VIEWPORT_FAMILY_KEYS`, so the markers render in the shared scene together with the track geometry and props (placing audio relative to track sections is the point of editing this resource), and the tree rows get visibility eye-toggles.

## Data findings (validated against retail)

Swept all 427 `TRK_UNIT*_GR.BNDL` bundles — **854/854 resources round-trip byte-exact**, and:

- `meRootType` is 0 (passby) in **every** retail resource regardless of role, and emitter/passby bundle order is a coin flip (217 vs 210) — the role lives only in the debug-XML name. The picker surfaces it from there.
- The packed u16 is dual-semantics: passby type in passby maps (retail only uses Tunnel/Camera/Collision), audible distance in metres in emitter maps (retail range 14–259 m, which **overlaps** the enum — so the UI never guesses the role from the value).
- Subregion runs exactly partition the entity array in every resource; empty maps keep valid offsets (1×1 grid, `[-1, 0]` cell) — unlike the null-pointer shape empty prop zones use.

## Tests

- Gold-value + round-trip + empty-shape suite walking **both** resources per bundle (the auto registry suite only sees the first of a type)
- Schema drift detection against both map roles
- Overlay codec/helper specs
- Registry fixture suite: parse, byte round-trip, describe, picker, stress scenarios — all green

Spec: https://burnout.wiki/wiki/Static_Sound_Map

🤖 Generated with [Claude Code](https://claude.com/claude-code)