### PR TITLE
feat: PropPhysics (0x1000F) parser, editor, and spec

### DIFF
--- a/src/lib/core/__tests__/propPhysics.test.ts
+++ b/src/lib/core/__tests__/propPhysics.test.ts
@@ -1,0 +1,134 @@
+// Gold coverage for parsePropPhysics / writePropPhysics against the single
+// retail fixture (example/PROPPHYSICS.BUNDLE — the only PropPhysics resource
+// in the game). Pins hand-verified decoded values, the PROP_TYPES index
+// alignment, the volume-type census that contradicts the wiki's "always box
+// volumes" note, and byte-exact round-trip + writer idempotence.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parsePropPhysics, writePropPhysics, VOLUME_TYPE } from '../propPhysics';
+import { PROP_TYPES } from '../propTypes';
+import { parseBundle } from '../bundle';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+function loadRaw(): Uint8Array {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, 'example/PROPPHYSICS.BUNDLE'));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const res = bundle.resources.find((r) => r.resourceTypeId === 0x1000f);
+	if (!res) throw new Error('fixture missing PropPhysics resource');
+	return extractResourceRaw(buffer, bundle, res);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+const raw = loadRaw();
+const model = parsePropPhysics(raw);
+
+describe('PropPhysics gold values (example/PROPPHYSICS.BUNDLE)', () => {
+	it('decodes the catalogue counts', () => {
+		expect(model.propTypes.length).toBe(247);
+		expect(model.propTypes.reduce((n, t) => n + t.parts.length, 0)).toBe(183);
+		const vols = model.propTypes.reduce(
+			(n, t) => n + t.volumes.length + t.parts.reduce((m, p) => m + p.volumes.length, 0),
+			0,
+		);
+		expect(vols).toBe(480);
+		// Remastered nulls the build timestamp.
+		expect(model.muTimeStamp).toBe(0);
+	});
+
+	it('every entry aligns with the PROP_TYPES table by index', () => {
+		// PropInstanceData.typeId indexes PROP_TYPES; this proves the same index
+		// addresses this catalogue, which is what makes cross-resource prop
+		// editing coherent.
+		expect(model.propTypes.length).toBe(PROP_TYPES.length);
+		for (let i = 0; i < PROP_TYPES.length; i++) {
+			// Compare as values — the wiki table strips leading zeros from ids.
+			expect(model.propTypes[i].mResourceId, `propTypes[${i}] resource id`).toBe(BigInt('0x' + PROP_TYPES[i].resourceId));
+			expect(model.propTypes[i].muSceneUriId, `propTypes[${i}] gamedb id`).toBe(PROP_TYPES[i].gameDbId);
+		}
+	});
+
+	it('decodes propTypes[6] (STU_gate01 — tilting gate with 2 breakable parts)', () => {
+		const t = model.propTypes[6];
+		expect(t.mfMass).toBe(150);
+		expect(t.mfSmashThreshold).toBe(30);
+		expect(t.mu8JointType).toBe(2); // Tilt
+		expect(t.parts.length).toBe(2);
+		expect(t.volumes.length).toBe(1);
+		expect(t.parts[0].volumes.length).toBe(1);
+		expect(t.parts[0].mfMass).toBe(1);
+	});
+
+	it('decodes propTypes[8] (billboard_overdrive_YELLOW — 19 parts)', () => {
+		const t = model.propTypes[8];
+		expect(t.mfMass).toBe(400);
+		expect(t.parts.length).toBe(19);
+	});
+
+	it('decodes a box volume with sensible half extents', () => {
+		const v = model.propTypes[0].volumes[0];
+		expect(v.vType).toBe(VOLUME_TYPE.BOX);
+		expect(v.mUnion[0]).toBeCloseTo(0.03, 2);
+		expect(v.mUnion[1]).toBeCloseTo(0.59, 2);
+		expect(v.mUnion[2]).toBeCloseTo(0.38, 2);
+		expect(v.muFlags).toBe(0x1); // VOLUMEFLAG_ISENABLED
+	});
+
+	it('volume-type census: the wiki\'s "always box volumes" note is wrong', () => {
+		const histo = new Map<number, number>();
+		for (const t of model.propTypes) {
+			for (const v of [...t.volumes, ...t.parts.flatMap((p) => p.volumes)]) {
+				histo.set(v.vType, (histo.get(v.vType) ?? 0) + 1);
+			}
+		}
+		expect(histo.get(VOLUME_TYPE.BOX)).toBe(442);
+		expect(histo.get(VOLUME_TYPE.CAPSULE)).toBe(37);
+		expect(histo.get(VOLUME_TYPE.SPHERE)).toBe(1);
+		expect(histo.size).toBe(3);
+	});
+
+	it('preserves the uninitialised pointers empty arrays store', () => {
+		// Prop types with no parts keep garbage (not null) in maParts — the
+		// writer must replay it verbatim for byte-exact output.
+		const noParts = model.propTypes.find((t) => t.parts.length === 0);
+		expect(noParts).toBeDefined();
+		expect(noParts!._rawPartsPtr).not.toBe(0);
+	});
+
+	it('round-trips byte-for-byte', () => {
+		const rewritten = writePropPhysics(model);
+		expect(rewritten.byteLength).toBe(raw.byteLength);
+		expect(bytesEqual(rewritten, raw)).toBe(true);
+	});
+
+	it('writer is idempotent', () => {
+		const write1 = writePropPhysics(parsePropPhysics(raw));
+		const write2 = writePropPhysics(parsePropPhysics(write1));
+		expect(bytesEqual(write1, write2)).toBe(true);
+	});
+});
+
+describe('PropPhysics writer guards', () => {
+	it('rejects a model that overflows the fixed volume table', () => {
+		const volume = model.propTypes[0].volumes[0];
+		const fat = {
+			...model,
+			propTypes: model.propTypes.map((t) => ({
+				...t,
+				// 247 types x 9 volumes > 2048 slots
+				volumes: Array.from({ length: 9 }, () => ({ ...volume, mTransform: volume.mTransform.slice(), mUnion: [...volume.mUnion] as [number, number, number] })),
+			})),
+		};
+		expect(() => writePropPhysics(fat)).toThrow(/overflow/);
+	});
+});

--- a/src/lib/core/propPhysics.ts
+++ b/src/lib/core/propPhysics.ts
@@ -1,0 +1,505 @@
+// PropPhysics parser and writer (resource type 0x1000F).
+//
+// The global prop-physics catalogue (PROPS/PROPPHYSICS.BUNDLE): one
+// PropTypeData per prop type holding collision attributes — mass, inertia,
+// speed thresholds for lean/move/smash (MPH), joint behaviour — plus the
+// rw::collision Volumes the prop collides with, and optional breakable
+// "parts" with their own mass/volumes. PropInstanceData (0x10011) placements
+// reference these entries by index: PropTypeData[i] is the physics of
+// PROP_TYPES[i] in propTypes.ts (verified: mResourceId / muSceneUriId match
+// the wiki prop-types table at every index, 247 entries both).
+//
+// The wiki claims the volumes "are always box volumes" — retail disagrees:
+// 442 boxes, 37 capsules, 1 sphere. The 12-byte type-specific union is
+// modeled as three f32 lanes with per-type meaning (box: hx/hy/hz half
+// extents; capsule: half height + 2 unused; sphere: all unused).
+//
+// On-disk layout (32-bit PC, little-endian):
+//   header 0x2C94: counts, muSizeInBytes (== total resource size), then three
+//   FIXED pointer tables — PropTypeData*[500] @0x10, PropPartTypeData*[300]
+//   @0x7E0, Volume*[2048] @0xC90 — and muTimeStamp @0x2C90 (0 in Remastered).
+//   Data region @0x2CA0 (12 pad bytes after the header), tiled exactly by the
+//   records in canonical order: for each prop type — PropTypeData(0x70), its
+//   parts(0x30 each), its own volumes(0x60 each), then each part's volumes in
+//   part order. Verified: the 910 retail records tile [0x2CA0, end) with zero
+//   gaps/overlaps, and the tables list records in that same file order.
+//
+// Round-trip strategy: every pointer is recomputed from the canonical layout
+// on write — the parser ASSERTS the stored pointers match the derived ones,
+// so a violating resource fails loudly instead of round-tripping wrong. The
+// one exception: records whose count is 0 store an UNINITIALISED pointer
+// (e.g. maParts = 0xfa62e800 garbage, not null) — preserved verbatim in
+// `_raw*Ptr` fields and re-emitted as-is for byte-exact output.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Enumerations
+// =============================================================================
+
+/** rw::collision::VolumeType — stored in the in-asset vTable slot. */
+export const VOLUME_TYPE = {
+	NULL: 0,
+	SPHERE: 1,
+	CAPSULE: 2,
+	TRIANGLE: 3,
+	BOX: 4,
+	CYLINDER: 5,
+	AGGREGATE: 6,
+} as const;
+
+export const VOLUME_TYPE_LABELS: Record<number, string> = {
+	0: 'Null',
+	1: 'Sphere',
+	2: 'Capsule',
+	3: 'Triangle',
+	4: 'Box',
+	5: 'Cylinder',
+	6: 'Aggregate',
+};
+
+/** rw::collision::VolumeFlag — only ISENABLED is seen in retail PropPhysics. */
+export const VOLUME_FLAGS = {
+	IS_ENABLED: 0x1,
+} as const;
+
+/** PropTypeData.mu8JointType. */
+export const PROP_JOINT_TYPES = [
+	{ value: 0, label: 'None' },
+	{ value: 1, label: 'Lean' },
+	{ value: 2, label: 'Tilt (E_TILT)' },
+] as const;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+type Vec3 = { x: number; y: number; z: number };
+
+export type PropPhysicsVolume = {
+	/** Matrix44Affine local transform (16 f32) — volume placement relative to the prop model. */
+	mTransform: number[];
+	/** rw::collision::VolumeType (in-asset vTable slot). Retail: box/capsule/sphere. */
+	vType: number;
+	/**
+	 * The 12-byte type-specific union as three f32 lanes.
+	 * Box: hx/hy/hz half extents. Capsule: half height, rest unused.
+	 * Sphere: all unused (size lives in mfRadius).
+	 */
+	mUnion: [number, number, number];
+	/** Sphere radius / capsule cap radius / box edge fattening. */
+	mfRadius: number;
+	muGroupID: number;
+	muSurfaceID: number;
+	/** rw::collision::VolumeFlag bits — 0x1 IS_ENABLED in retail. */
+	muFlags: number;
+};
+
+export type PropPartType = {
+	/** Positional offset of the part relative to the prop model. */
+	mOffset: Vec3;
+	/** Inertia (likely kg·m²). */
+	mInertia: Vec3;
+	/** Mass (kg). */
+	mfMass: number;
+	mfSphereRadius: number;
+	volumes: PropPhysicsVolume[];
+	/** Stored maCollisionVolumes — garbage (not null) when volumes is empty; preserved verbatim. */
+	_rawVolsPtr: number;
+	/** u8[3] record pad — preserved verbatim. */
+	_pad2D: [number, number, number];
+};
+
+export type PropPhysicsType = {
+	/** Location of the joint relative to the prop model. */
+	mJointLocator: Vec3;
+	/** Centre-of-mass offset. */
+	mCOMOffset: Vec3;
+	/** Inertia (likely kg·m²). */
+	mInertia: Vec3;
+	/** Model resource ID — matches PROP_TYPES[index].resourceId. */
+	mResourceId: bigint;
+	/** Mass (kg). */
+	mfMass: number;
+	mfSphereRadius: number;
+	/** Cosine of the maximum joint angle. */
+	mfMaxJointAngleCos: number;
+	/** Speed required to make the prop lean (MPH). */
+	mfLeanThreshold: number;
+	/** Speed required to move the prop (MPH). */
+	mfMoveThreshold: number;
+	/** Speed required to smash the prop (MPH). Only props with parts can be smashed. */
+	mfSmashThreshold: number;
+	/** Model GameDB ID — matches PROP_TYPES[index].gameDbId. */
+	muSceneUriId: number;
+	/** Always 0 in retail; seemingly unused. */
+	muMaxState: number;
+	/** PROP_JOINT_TYPES. */
+	mu8JointType: number;
+	/** 1 = is overhead sign. */
+	mu8ExtraTypeInfo: number;
+	parts: PropPartType[];
+	volumes: PropPhysicsVolume[];
+	/** Stored maCollisionVolumes / maParts — garbage when the array is empty; preserved verbatim. */
+	_rawVolsPtr: number;
+	_rawPartsPtr: number;
+	/** u8[15] record tail pad — preserved verbatim. */
+	_padTail: number[];
+};
+
+export type ParsedPropPhysics = {
+	propTypes: PropPhysicsType[];
+	/** time_t build stamp — 0 (null) in Remastered. */
+	muTimeStamp: number;
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const PROP_TABLE_OFFSET = 0x10;
+const PROP_TABLE_SLOTS = 500;
+const PART_TABLE_OFFSET = 0x7e0;
+const PART_TABLE_SLOTS = 300;
+const VOL_TABLE_OFFSET = 0xc90;
+const VOL_TABLE_SLOTS = 2048;
+const TIMESTAMP_OFFSET = 0x2c90;
+// Header ends 0x2C94; the data region starts at the next 16-byte boundary.
+const DATA_OFFSET = 0x2ca0;
+
+const PROP_RECORD_SIZE = 0x70;
+const PART_RECORD_SIZE = 0x30;
+const VOLUME_RECORD_SIZE = 0x60;
+const MATRIX_FLOATS = 16;
+const PROP_TAIL_PAD = 0xf;
+
+// =============================================================================
+// Layout derivation — shared by the parser (for asserts) and the writer.
+// =============================================================================
+
+/** Byte size of one prop type's canonical span: record + parts + all volumes. */
+function propSpanSize(t: { parts: { volumes: unknown[] }[]; volumes: unknown[] }): number {
+	const partVols = t.parts.reduce((n, p) => n + p.volumes.length, 0);
+	return (
+		PROP_RECORD_SIZE +
+		t.parts.length * PART_RECORD_SIZE +
+		(t.volumes.length + partVols) * VOLUME_RECORD_SIZE
+	);
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+function readVec3(r: BinReader, what: string): Vec3 {
+	const x = r.readF32();
+	const y = r.readF32();
+	const z = r.readF32();
+	const w = r.readF32();
+	// The vpu Vector3's unused fourth lane is 0 in every retail record. Bail
+	// loudly rather than silently dropping data the writer can't reproduce.
+	if (w !== 0) throw new Error(`PropPhysics: non-zero Vector3 pad lane in ${what} (${w})`);
+	return { x, y, z };
+}
+
+function readVolume(r: BinReader): PropPhysicsVolume {
+	const mTransform: number[] = [];
+	for (let i = 0; i < MATRIX_FLOATS; i++) mTransform.push(r.readF32());
+	const vType = r.readU32();
+	const mUnion: [number, number, number] = [r.readF32(), r.readF32(), r.readF32()];
+	const mfRadius = r.readF32();
+	const muGroupID = r.readU32();
+	const muSurfaceID = r.readU32();
+	const muFlags = r.readU32();
+	return { mTransform, vType, mUnion, mfRadius, muGroupID, muSurfaceID, muFlags };
+}
+
+export function parsePropPhysics(raw: Uint8Array, littleEndian = true): ParsedPropPhysics {
+	const r = new BinReader(raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength), littleEndian);
+
+	// --- Header counts ---
+	const numPropTypes = r.readU32();
+	const numVolumes = r.readU32();
+	const numParts = r.readU32();
+	const muSizeInBytes = r.readU32();
+	if (muSizeInBytes !== raw.byteLength) {
+		throw new Error(`PropPhysics: muSizeInBytes ${muSizeInBytes} != resource size ${raw.byteLength}`);
+	}
+	if (numPropTypes > PROP_TABLE_SLOTS || numParts > PART_TABLE_SLOTS || numVolumes > VOL_TABLE_SLOTS) {
+		throw new Error(`PropPhysics: counts ${numPropTypes}/${numParts}/${numVolumes} overflow the fixed tables`);
+	}
+
+	// --- Pointer tables (counts must occupy a contiguous prefix; rest null) ---
+	const readTable = (offset: number, slots: number, used: number, what: string): number[] => {
+		const ptrs: number[] = [];
+		r.position = offset;
+		for (let i = 0; i < slots; i++) {
+			const p = r.readU32();
+			if (i < used) {
+				if (p === 0) throw new Error(`PropPhysics: null ${what} table slot ${i} inside the used prefix`);
+				ptrs.push(p);
+			} else if (p !== 0) {
+				throw new Error(`PropPhysics: non-null ${what} table slot ${i} beyond count ${used}`);
+			}
+		}
+		return ptrs;
+	};
+	const propPtrs = readTable(PROP_TABLE_OFFSET, PROP_TABLE_SLOTS, numPropTypes, 'prop');
+	const partPtrs = readTable(PART_TABLE_OFFSET, PART_TABLE_SLOTS, numParts, 'part');
+	const volPtrs = readTable(VOL_TABLE_OFFSET, VOL_TABLE_SLOTS, numVolumes, 'volume');
+	r.position = TIMESTAMP_OFFSET;
+	const muTimeStamp = r.readU32();
+
+	// --- Records, walked in canonical layout order with stored-pointer asserts ---
+	let cursor = DATA_OFFSET;
+	let partTableIdx = 0;
+	let volTableIdx = 0;
+	const expectTableEntry = (table: number[], idx: number, off: number, what: string) => {
+		if (table[idx] !== off) {
+			throw new Error(`PropPhysics: ${what} table[${idx}] = 0x${(table[idx] ?? 0).toString(16)}, expected 0x${off.toString(16)} (canonical order violated)`);
+		}
+	};
+
+	const propTypes: PropPhysicsType[] = [];
+	for (let i = 0; i < numPropTypes; i++) {
+		expectTableEntry(propPtrs, i, cursor, 'prop');
+		r.position = cursor;
+		const mJointLocator = readVec3(r, `propType[${i}].mJointLocator`);
+		const mCOMOffset = readVec3(r, `propType[${i}].mCOMOffset`);
+		const mInertia = readVec3(r, `propType[${i}].mInertia`);
+		const mResourceId = r.readU64();
+		const mfMass = r.readF32();
+		const rawVolsPtr = r.readU32();
+		const rawPartsPtr = r.readU32();
+		const mfSphereRadius = r.readF32();
+		const mfMaxJointAngleCos = r.readF32();
+		const mfLeanThreshold = r.readF32();
+		const mfMoveThreshold = r.readF32();
+		const mfSmashThreshold = r.readF32();
+		const muSceneUriId = r.readU32();
+		const muMaxState = r.readU8();
+		const numOwnParts = r.readU8();
+		const numOwnVols = r.readU8();
+		const mu8JointType = r.readU8();
+		const mu8ExtraTypeInfo = r.readU8();
+		const _padTail: number[] = [];
+		for (let b = 0; b < PROP_TAIL_PAD; b++) _padTail.push(r.readU8());
+
+		// Canonical span layout: parts, then prop volumes, then per-part volumes.
+		const partsStart = cursor + PROP_RECORD_SIZE;
+		const propVolsStart = partsStart + numOwnParts * PART_RECORD_SIZE;
+		const partVolsStart = propVolsStart + numOwnVols * VOLUME_RECORD_SIZE;
+		if (numOwnParts > 0 && rawPartsPtr !== partsStart) {
+			throw new Error(`PropPhysics: propType[${i}] maParts 0x${rawPartsPtr.toString(16)} != derived 0x${partsStart.toString(16)}`);
+		}
+		if (numOwnVols > 0 && rawVolsPtr !== propVolsStart) {
+			throw new Error(`PropPhysics: propType[${i}] maCollisionVolumes 0x${rawVolsPtr.toString(16)} != derived 0x${propVolsStart.toString(16)}`);
+		}
+
+		// Parts (their volumes live after the prop's own volumes, in part order).
+		const parts: PropPartType[] = [];
+		let nextPartVols = partVolsStart;
+		let partVolsSoFar = 0;
+		for (let p = 0; p < numOwnParts; p++) {
+			const partOff = partsStart + p * PART_RECORD_SIZE;
+			expectTableEntry(partPtrs, partTableIdx++, partOff, 'part');
+			r.position = partOff;
+			const mOffset = readVec3(r, `propType[${i}].part[${p}].mOffset`);
+			const partInertia = readVec3(r, `propType[${i}].part[${p}].mInertia`);
+			const partMass = r.readF32();
+			const partRawVolsPtr = r.readU32();
+			const partSphereRadius = r.readF32();
+			const partNumVols = r.readU8();
+			const _pad2D: [number, number, number] = [r.readU8(), r.readU8(), r.readU8()];
+			if (partNumVols > 0 && partRawVolsPtr !== nextPartVols) {
+				throw new Error(`PropPhysics: propType[${i}].part[${p}] maCollisionVolumes 0x${partRawVolsPtr.toString(16)} != derived 0x${nextPartVols.toString(16)}`);
+			}
+			const volumes: PropPhysicsVolume[] = [];
+			for (let v = 0; v < partNumVols; v++) {
+				const volOff = nextPartVols + v * VOLUME_RECORD_SIZE;
+				expectTableEntry(volPtrs, volTableIdx + numOwnVols + partVolsSoFar + v, volOff, 'volume');
+				r.position = volOff;
+				volumes.push(readVolume(r));
+			}
+			nextPartVols += partNumVols * VOLUME_RECORD_SIZE;
+			partVolsSoFar += partNumVols;
+			parts.push({
+				mOffset,
+				mInertia: partInertia,
+				mfMass: partMass,
+				mfSphereRadius: partSphereRadius,
+				volumes,
+				_rawVolsPtr: partRawVolsPtr,
+				_pad2D,
+			});
+		}
+
+		// The prop's own volumes (they precede the part volumes on disk, and in
+		// the volume table).
+		const volumes: PropPhysicsVolume[] = [];
+		for (let v = 0; v < numOwnVols; v++) {
+			const volOff = propVolsStart + v * VOLUME_RECORD_SIZE;
+			expectTableEntry(volPtrs, volTableIdx + v, volOff, 'volume');
+			r.position = volOff;
+			volumes.push(readVolume(r));
+		}
+		volTableIdx += numOwnVols + parts.reduce((n, p) => n + p.volumes.length, 0);
+
+		const t: PropPhysicsType = {
+			mJointLocator,
+			mCOMOffset,
+			mInertia,
+			mResourceId,
+			mfMass,
+			mfSphereRadius,
+			mfMaxJointAngleCos,
+			mfLeanThreshold,
+			mfMoveThreshold,
+			mfSmashThreshold,
+			muSceneUriId,
+			muMaxState,
+			mu8JointType,
+			mu8ExtraTypeInfo,
+			parts,
+			volumes,
+			_rawVolsPtr: rawVolsPtr,
+			_rawPartsPtr: rawPartsPtr,
+			_padTail,
+		};
+		cursor += propSpanSize(t);
+		propTypes.push(t);
+	}
+
+	if (cursor !== raw.byteLength) {
+		throw new Error(`PropPhysics: records end at 0x${cursor.toString(16)}, expected 0x${raw.byteLength.toString(16)} (data region must tile exactly)`);
+	}
+	if (volTableIdx !== numVolumes || partTableIdx !== numParts) {
+		throw new Error(`PropPhysics: walked ${volTableIdx} volumes / ${partTableIdx} parts, header says ${numVolumes} / ${numParts}`);
+	}
+
+	return { propTypes, muTimeStamp };
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+function writeVec3(w: BinWriter, v: Vec3) {
+	w.writeF32(v.x);
+	w.writeF32(v.y);
+	w.writeF32(v.z);
+	w.writeF32(0);
+}
+
+function writeVolume(w: BinWriter, v: PropPhysicsVolume) {
+	for (let i = 0; i < MATRIX_FLOATS; i++) w.writeF32(v.mTransform[i] ?? 0);
+	w.writeU32(v.vType);
+	w.writeF32(v.mUnion[0]);
+	w.writeF32(v.mUnion[1]);
+	w.writeF32(v.mUnion[2]);
+	w.writeF32(v.mfRadius);
+	w.writeU32(v.muGroupID);
+	w.writeU32(v.muSurfaceID);
+	w.writeU32(v.muFlags);
+}
+
+export function writePropPhysics(model: ParsedPropPhysics, littleEndian = true): Uint8Array {
+	const { propTypes } = model;
+	const numParts = propTypes.reduce((n, t) => n + t.parts.length, 0);
+	const numVolumes = propTypes.reduce(
+		(n, t) => n + t.volumes.length + t.parts.reduce((m, p) => m + p.volumes.length, 0),
+		0,
+	);
+	if (propTypes.length > PROP_TABLE_SLOTS || numParts > PART_TABLE_SLOTS || numVolumes > VOL_TABLE_SLOTS) {
+		throw new Error(`PropPhysics writer: ${propTypes.length} types / ${numParts} parts / ${numVolumes} volumes overflow the fixed tables`);
+	}
+
+	const totalSize = DATA_OFFSET + propTypes.reduce((n, t) => n + propSpanSize(t), 0);
+	const w = new BinWriter(totalSize, littleEndian);
+
+	// --- Header counts ---
+	w.writeU32(propTypes.length);
+	w.writeU32(numVolumes);
+	w.writeU32(numParts);
+	w.writeU32(totalSize); // muSizeInBytes — equals the resource size in retail
+
+	// --- Pointer tables, derived from the canonical layout ---
+	const propOffsets: number[] = [];
+	const partOffsets: number[] = [];
+	const volOffsets: number[] = [];
+	{
+		let cursor = DATA_OFFSET;
+		for (const t of propTypes) {
+			propOffsets.push(cursor);
+			const partsStart = cursor + PROP_RECORD_SIZE;
+			const propVolsStart = partsStart + t.parts.length * PART_RECORD_SIZE;
+			for (let p = 0; p < t.parts.length; p++) partOffsets.push(partsStart + p * PART_RECORD_SIZE);
+			for (let v = 0; v < t.volumes.length; v++) volOffsets.push(propVolsStart + v * VOLUME_RECORD_SIZE);
+			let partVolCursor = propVolsStart + t.volumes.length * VOLUME_RECORD_SIZE;
+			for (const p of t.parts) {
+				for (let v = 0; v < p.volumes.length; v++) volOffsets.push(partVolCursor + v * VOLUME_RECORD_SIZE);
+				partVolCursor += p.volumes.length * VOLUME_RECORD_SIZE;
+			}
+			cursor += propSpanSize(t);
+		}
+	}
+	const writeTable = (offsets: number[], slots: number) => {
+		for (let i = 0; i < slots; i++) w.writeU32(offsets[i] ?? 0);
+	};
+	writeTable(propOffsets, PROP_TABLE_SLOTS);
+	writeTable(partOffsets, PART_TABLE_SLOTS);
+	writeTable(volOffsets, VOL_TABLE_SLOTS);
+	w.writeU32(model.muTimeStamp);
+	w.writeZeroes(DATA_OFFSET - 0x2c94); // header → data-region alignment pad
+	if (w.offset !== DATA_OFFSET) throw new Error(`PropPhysics writer: data offset mismatch ${w.offset}`);
+
+	// --- Records in canonical order ---
+	for (const t of propTypes) {
+		const recordStart = w.offset;
+		const partsStart = recordStart + PROP_RECORD_SIZE;
+		const propVolsStart = partsStart + t.parts.length * PART_RECORD_SIZE;
+		writeVec3(w, t.mJointLocator);
+		writeVec3(w, t.mCOMOffset);
+		writeVec3(w, t.mInertia);
+		w.writeU64(t.mResourceId);
+		w.writeF32(t.mfMass);
+		// Empty arrays keep their original (uninitialised) pointer bytes.
+		w.writeU32(t.volumes.length > 0 ? propVolsStart : t._rawVolsPtr);
+		w.writeU32(t.parts.length > 0 ? partsStart : t._rawPartsPtr);
+		w.writeF32(t.mfSphereRadius);
+		w.writeF32(t.mfMaxJointAngleCos);
+		w.writeF32(t.mfLeanThreshold);
+		w.writeF32(t.mfMoveThreshold);
+		w.writeF32(t.mfSmashThreshold);
+		w.writeU32(t.muSceneUriId);
+		w.writeU8(t.muMaxState);
+		w.writeU8(t.parts.length);
+		w.writeU8(t.volumes.length);
+		w.writeU8(t.mu8JointType);
+		w.writeU8(t.mu8ExtraTypeInfo);
+		for (let b = 0; b < PROP_TAIL_PAD; b++) w.writeU8(t._padTail[b] ?? 0);
+
+		let partVolCursor = propVolsStart + t.volumes.length * VOLUME_RECORD_SIZE;
+		const partVolStarts: number[] = [];
+		for (const p of t.parts) {
+			partVolStarts.push(partVolCursor);
+			partVolCursor += p.volumes.length * VOLUME_RECORD_SIZE;
+		}
+		t.parts.forEach((p, idx) => {
+			writeVec3(w, p.mOffset);
+			writeVec3(w, p.mInertia);
+			w.writeF32(p.mfMass);
+			w.writeU32(p.volumes.length > 0 ? partVolStarts[idx] : p._rawVolsPtr);
+			w.writeF32(p.mfSphereRadius);
+			w.writeU8(p.volumes.length);
+			w.writeU8(p._pad2D[0]);
+			w.writeU8(p._pad2D[1]);
+			w.writeU8(p._pad2D[2]);
+		});
+		for (const v of t.volumes) writeVolume(w, v);
+		for (const p of t.parts) for (const v of p.volumes) writeVolume(w, v);
+	}
+
+	if (w.offset !== totalSize) throw new Error(`PropPhysics writer: wrote ${w.offset} bytes, expected ${totalSize}`);
+	return w.bytes;
+}

--- a/src/lib/core/registry/handlers/propPhysics.ts
+++ b/src/lib/core/registry/handlers/propPhysics.ts
@@ -1,0 +1,139 @@
+// PropPhysics registry handler — thin wrapper around
+// parsePropPhysics / writePropPhysics in src/lib/core/propPhysics.ts.
+//
+// One resource in the whole game (PROPS/PROPPHYSICS.BUNDLE): the global
+// physics catalogue every PropInstanceData placement references by index.
+// PropTypeData[i] is the physics of PROP_TYPES[i] (propTypes.ts).
+
+import {
+	parsePropPhysics,
+	writePropPhysics,
+	VOLUME_TYPE,
+	type ParsedPropPhysics,
+} from '../../propPhysics';
+import type { ResourceHandler } from '../handler';
+
+// propTypes[0] (sig_warningchevron) carries 3 own volumes in retail — the
+// structural scenarios below lean on that shape.
+const STRESS_TYPE = 0;
+
+export const propPhysicsHandler: ResourceHandler<ParsedPropPhysics> = {
+	typeId: 0x1000f,
+	key: 'propPhysics',
+	name: 'Prop Physics',
+	description: 'Global prop collision-physics catalogue — per prop type: mass, inertia, lean/move/smash speed thresholds, joint behaviour, collision volumes, and breakable parts. PropInstanceData placements reference entries by index.',
+	category: 'Data',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Prop_Physics',
+
+	parseRaw(raw, ctx) {
+		return parsePropPhysics(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writePropPhysics(model, ctx.littleEndian);
+	},
+	describe(model) {
+		const parts = model.propTypes.reduce((n, t) => n + t.parts.length, 0);
+		const vols = model.propTypes.reduce(
+			(n, t) => n + t.volumes.length + t.parts.reduce((m, p) => m + p.volumes.length, 0),
+			0,
+		);
+		return `${model.propTypes.length} prop types, ${parts} parts, ${vols} volumes`;
+	},
+
+	fixtures: [
+		{ bundle: 'example/PROPPHYSICS.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.propTypes.length !== before.propTypes.length) {
+					problems.push(`prop type count ${after.propTypes.length} != ${before.propTypes.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-mass-and-smash',
+			description: 'change a prop type\'s mass and smash threshold and verify they survive round-trip',
+			mutate: (m) => {
+				const propTypes = m.propTypes.slice();
+				propTypes[STRESS_TYPE] = { ...propTypes[STRESS_TYPE], mfMass: 123.5, mfSmashThreshold: 42 };
+				return { ...m, propTypes };
+			},
+			verify: (_before, after) => {
+				const problems: string[] = [];
+				const t = after.propTypes[STRESS_TYPE];
+				if (Math.abs(t.mfMass - 123.5) > 1e-4) problems.push(`mfMass = ${t.mfMass}, expected 123.5`);
+				if (Math.abs(t.mfSmashThreshold - 42) > 1e-4) problems.push(`mfSmashThreshold = ${t.mfSmashThreshold}, expected 42`);
+				return problems;
+			},
+		},
+		{
+			name: 'resize-box-volume',
+			description: 'grow a box volume\'s half extents and verify the union lanes survive',
+			mutate: (m) => {
+				const propTypes = m.propTypes.slice();
+				const t = { ...propTypes[STRESS_TYPE], volumes: propTypes[STRESS_TYPE].volumes.slice() };
+				t.volumes[0] = { ...t.volumes[0], mUnion: [1.5, 2.5, 3.5] };
+				propTypes[STRESS_TYPE] = t;
+				return { ...m, propTypes };
+			},
+			verify: (_before, after) => {
+				const problems: string[] = [];
+				const v = after.propTypes[STRESS_TYPE].volumes[0];
+				if (v.vType !== VOLUME_TYPE.BOX) problems.push(`vType = ${v.vType}, expected box`);
+				if (Math.abs(v.mUnion[0] - 1.5) > 1e-4 || Math.abs(v.mUnion[1] - 2.5) > 1e-4 || Math.abs(v.mUnion[2] - 3.5) > 1e-4) {
+					problems.push(`mUnion = ${v.mUnion}, expected [1.5, 2.5, 3.5]`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'remove-last-volume',
+			description: 'drop a prop type\'s last volume — counts, pointer tables, and every later record\'s offsets are re-derived',
+			mutate: (m) => {
+				const propTypes = m.propTypes.slice();
+				const t = { ...propTypes[STRESS_TYPE], volumes: propTypes[STRESS_TYPE].volumes.slice(0, -1) };
+				propTypes[STRESS_TYPE] = t;
+				return { ...m, propTypes };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.propTypes[STRESS_TYPE].volumes.length !== afterMutate.propTypes[STRESS_TYPE].volumes.length) {
+					problems.push(`volume count ${afterReparse.propTypes[STRESS_TYPE].volumes.length} != ${afterMutate.propTypes[STRESS_TYPE].volumes.length}`);
+				}
+				// The last prop type must still parse identically — its records moved
+				// but every pointer was re-derived.
+				const last = afterReparse.propTypes.length - 1;
+				if (afterReparse.propTypes[last].mResourceId !== afterMutate.propTypes[last].mResourceId) {
+					problems.push('trailing prop type corrupted by the shifted layout');
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'clone-volume',
+			description: 'append a copy of a volume — the grown layout and tables must reparse cleanly',
+			mutate: (m) => {
+				const propTypes = m.propTypes.slice();
+				const src = propTypes[STRESS_TYPE];
+				const clone = { ...src.volumes[0], mTransform: src.volumes[0].mTransform.slice(), mUnion: [...src.volumes[0].mUnion] as [number, number, number] };
+				propTypes[STRESS_TYPE] = { ...src, volumes: [...src.volumes, clone] };
+				return { ...m, propTypes };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.propTypes[STRESS_TYPE].volumes.length !== afterMutate.propTypes[STRESS_TYPE].volumes.length) {
+					problems.push(`volume count ${afterReparse.propTypes[STRESS_TYPE].volumes.length} != ${afterMutate.propTypes[STRESS_TYPE].volumes.length}`);
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/index.ts
+++ b/src/lib/core/registry/index.ts
@@ -31,6 +31,7 @@ import { materialHandler } from './handlers/material';
 import { zoneListHandler } from './handlers/zoneList';
 import { propInstanceDataHandler } from './handlers/propInstanceData';
 import { propGraphicsListHandler } from './handlers/propGraphicsList';
+import { propPhysicsHandler } from './handlers/propPhysics';
 import { instanceListHandler } from './handlers/instanceList';
 import { staticSoundMapHandler } from './handlers/staticSoundMap';
 import { textFileHandler } from './handlers/textFile';
@@ -60,6 +61,7 @@ export const registry: ResourceHandler[] = [
 	zoneListHandler,
 	propInstanceDataHandler,
 	propGraphicsListHandler,
+	propPhysicsHandler,
 	instanceListHandler,
 	staticSoundMapHandler,
 	textFileHandler,

--- a/src/lib/editor/profiles/propPhysics.ts
+++ b/src/lib/editor/profiles/propPhysics.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedPropPhysics } from '@/lib/core/propPhysics';
+import { propPhysicsResourceSchema } from '@/lib/schema/resources/propPhysics';
+
+export const propPhysicsProfile = defineProfile<ParsedPropPhysics>({
+	kind: 'default',
+	displayName: 'Prop Physics',
+	schema: propPhysicsResourceSchema,
+});

--- a/src/lib/editor/registry.ts
+++ b/src/lib/editor/registry.ts
@@ -20,6 +20,7 @@ import { playerCarColoursProfile } from './profiles/playerCarColours';
 import { polygonSoupListProfile } from './profiles/polygonSoupList';
 import { propInstanceDataProfile } from './profiles/propInstanceData';
 import { propGraphicsListProfile } from './profiles/propGraphicsList';
+import { propPhysicsProfile } from './profiles/propPhysics';
 import { renderableProfile } from './profiles/renderable';
 import { staticSoundMapProfile } from './profiles/staticSoundMap';
 import { streetDataProfile } from './profiles/streetData';
@@ -108,6 +109,11 @@ const ENTRIES: RegistryEntry[] = [
 		typeId: 0x10016,
 		key: 'staticSoundMap',
 		profiles: [staticSoundMapProfile],
+	},
+	{
+		typeId: 0x1000f,
+		key: 'propPhysics',
+		profiles: [propPhysicsProfile],
 	},
 	{
 		typeId: 0x110,

--- a/src/lib/schema/resources/index.ts
+++ b/src/lib/schema/resources/index.ts
@@ -17,6 +17,7 @@ import { playerCarColoursResourceSchema } from './playerCarColours';
 import { polygonSoupListResourceSchema } from './polygonSoupList';
 import { propGraphicsListResourceSchema } from './propGraphicsList';
 import { propInstanceDataResourceSchema } from './propInstanceData';
+import { propPhysicsResourceSchema } from './propPhysics';
 import { renderableResourceSchema } from './renderable';
 import { staticSoundMapResourceSchema } from './staticSoundMap';
 import { streetDataResourceSchema } from './streetData';
@@ -35,6 +36,7 @@ const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	polygonSoupList: polygonSoupListResourceSchema,
 	propGraphicsList: propGraphicsListResourceSchema,
 	propInstanceData: propInstanceDataResourceSchema,
+	propPhysics: propPhysicsResourceSchema,
 	renderable: renderableResourceSchema,
 	staticSoundMap: staticSoundMapResourceSchema,
 	streetData: streetDataResourceSchema,

--- a/src/lib/schema/resources/propPhysics.test.ts
+++ b/src/lib/schema/resources/propPhysics.test.ts
@@ -1,0 +1,146 @@
+// Schema coverage tests for propPhysicsResourceSchema.
+//
+// Coverage fixture: example/PROPPHYSICS.BUNDLE — the one PropPhysics resource
+// in the game, which conveniently exercises every record shape (entries with
+// parts and without, all three retail volume types, empty volume arrays with
+// garbage pointers).
+//
+// Mirrors staticSoundMap.test.ts: walk the parsed model against the schema
+// asserting record references resolve, walkResource visits cleanly, no
+// parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parsePropPhysics, type ParsedPropPhysics } from '../../core/propPhysics';
+
+import { propPhysicsResourceSchema } from './propPhysics';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+function loadModel(): ParsedPropPhysics {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, 'example/PROPPHYSICS.BUNDLE'));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const res = bundle.resources.find((r) => r.resourceTypeId === 0x1000f);
+	if (!res) throw new Error('fixture missing PropPhysics resource');
+	return parsePropPhysics(extractResourceRaw(buffer, bundle, res), ctx.littleEndian);
+}
+
+const model = loadModel();
+
+describe('propPhysicsResourceSchema coverage', () => {
+	it('fixture parses with non-trivial content', () => {
+		expect(model.propTypes.length).toBe(247);
+		expect(model.propTypes.some((t) => t.parts.length > 0)).toBe(true);
+	});
+
+	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+		const missing: string[] = [];
+		for (const [recordName, rec] of Object.entries(propPhysicsResourceSchema.registry)) {
+			for (const [fieldName, field] of Object.entries(rec.fields)) {
+				checkField(field, `${recordName}.${fieldName}`, missing);
+			}
+		}
+		if (missing.length > 0) {
+			throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+		}
+		function checkField(f: FieldSchema, where: string, out: string[]) {
+			if (f.kind === 'record') {
+				if (!propPhysicsResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+				return;
+			}
+			if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+		}
+	});
+
+	it('walkResource visits every parsed field without throwing', () => {
+		let recordCount = 0;
+		let fieldCount = 0;
+		walkResource(propPhysicsResourceSchema, model, (_p, _v, field, rec) => {
+			if (rec) recordCount++;
+			if (field) fieldCount++;
+		});
+		expect(recordCount).toBeGreaterThan(0);
+		expect(fieldCount).toBeGreaterThan(0);
+	});
+
+	it('no parsed record has fields absent from the schema', () => {
+		const missing: string[] = [];
+		walkResource(propPhysicsResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const declared = new Set(Object.keys(rec.fields));
+			for (const key of Object.keys(value as Record<string, unknown>)) {
+				if (!declared.has(key)) {
+					missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.slice(0, 20).join('\n  ')}`);
+		}
+	});
+
+	it('every schema field is represented in the parsed data', () => {
+		const missing: string[] = [];
+		walkResource(propPhysicsResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const obj = value as Record<string, unknown>;
+			for (const fieldName of Object.keys(rec.fields)) {
+				if (!(fieldName in obj)) {
+					missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.slice(0, 20).join('\n  ')}`);
+		}
+	});
+});
+
+describe('propPhysics path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(propPhysicsResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedPropPhysics');
+	});
+
+	it('resolves propTypes[6] as a PropPhysicsType', () => {
+		const loc = resolveSchemaAtPath(propPhysicsResourceSchema, ['propTypes', 6]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('PropPhysicsType');
+	});
+
+	it('resolves propTypes[6].parts[0] as a PropPartType', () => {
+		const loc = resolveSchemaAtPath(propPhysicsResourceSchema, ['propTypes', 6, 'parts', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('PropPartType');
+	});
+
+	it('resolves propTypes[6].parts[0].volumes[0] as a PropPhysicsVolume', () => {
+		const loc = resolveSchemaAtPath(propPhysicsResourceSchema, ['propTypes', 6, 'parts', 0, 'volumes', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('PropPhysicsVolume');
+	});
+
+	it('resolves vType as an enum and mu8JointType as an enum', () => {
+		const v = resolveSchemaAtPath(propPhysicsResourceSchema, ['propTypes', 0, 'volumes', 0, 'vType']);
+		expect(v!.field?.kind).toBe('enum');
+		const j = resolveSchemaAtPath(propPhysicsResourceSchema, ['propTypes', 0, 'mu8JointType']);
+		expect(j!.field?.kind).toBe('enum');
+	});
+
+	it('resolves mResourceId as bigint', () => {
+		const loc = resolveSchemaAtPath(propPhysicsResourceSchema, ['propTypes', 0, 'mResourceId']);
+		expect(loc!.field?.kind).toBe('bigint');
+	});
+});

--- a/src/lib/schema/resources/propPhysics.ts
+++ b/src/lib/schema/resources/propPhysics.ts
@@ -1,0 +1,318 @@
+// Hand-written schema for ParsedPropPhysics (resource type 0x1000F).
+//
+// Mirrors the types in `src/lib/core/propPhysics.ts`. Keep these in lockstep
+// with the parser/writer — any field added to the parser needs a matching
+// entry here, or the schema walker reports it as drift.
+//
+// Domain: the global prop-physics catalogue (one resource in the whole game,
+// PROPS/PROPPHYSICS.BUNDLE). PropTypeData[i] is the physics of PROP_TYPES[i]
+// — the same index PropInstanceData placements store — so the tree labels
+// each entry with its prop name. Per entry: mass/inertia, the speed
+// thresholds that decide whether a hit prop leans, moves, or smashes (MPH),
+// joint behaviour, rw::collision volumes, and breakable parts with their own
+// mass and volumes.
+//
+// Entry add/remove is disabled: the catalogue index space is shared with
+// every PropInstanceData placement in the game, so inserting or removing an
+// entry would silently retarget every placed prop after it. Volumes/parts
+// within an entry are freely editable — the writer re-derives the whole
+// layout (pointers, tables, counts, size).
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+} from '../types';
+import { PROP_JOINT_TYPES, VOLUME_TYPE_LABELS } from '@/lib/core/propPhysics';
+import { propTypeLabel } from '@/lib/core/propTypes';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring propInstanceData.ts)
+// ---------------------------------------------------------------------------
+
+const u8 = (): FieldSchema => ({ kind: 'u8' });
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const f32 = (): FieldSchema => ({ kind: 'f32' });
+const vec3 = (): FieldSchema => ({ kind: 'vec3' });
+const matrix44 = (): FieldSchema => ({ kind: 'matrix44' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+const bigintId = (): FieldSchema => ({ kind: 'bigint', bytes: 8, hex: true });
+
+const fixedList = (item: FieldSchema, length: number): FieldSchema => ({
+	kind: 'list',
+	item,
+	minLength: length,
+	maxLength: length,
+	addable: false,
+	removable: false,
+});
+
+const recordList = (
+	type: string,
+	opts: { addable: boolean },
+	itemLabel?: (item: unknown, index: number) => string,
+): FieldSchema => ({
+	kind: 'list',
+	item: record(type),
+	addable: opts.addable,
+	removable: opts.addable,
+	itemLabel: itemLabel ? (item, index) => itemLabel(item, index) : undefined,
+});
+
+// ---------------------------------------------------------------------------
+// Enum tables
+// ---------------------------------------------------------------------------
+
+const VOLUME_TYPE_VALUES = Object.entries(VOLUME_TYPE_LABELS).map(([value, label]) => ({
+	value: Number(value),
+	label,
+}));
+
+const JOINT_TYPE_VALUES = PROP_JOINT_TYPES.map((j) => ({ value: j.value, label: j.label }));
+
+const EXTRA_TYPE_VALUES = [
+	{ value: 0, label: 'None' },
+	{ value: 1, label: 'Is overhead sign' },
+];
+
+const VOLUME_FLAG_BITS = [
+	{ mask: 0x1, label: 'Enabled (VOLUMEFLAG_ISENABLED)' },
+];
+
+// ---------------------------------------------------------------------------
+// Tree-label helpers
+// ---------------------------------------------------------------------------
+
+function propTypeEntryLabel(t: unknown, index: number): string {
+	try {
+		if (!t || typeof t !== 'object') return `#${index}`;
+		const e = t as { mfMass?: number; parts?: unknown[]; volumes?: unknown[] };
+		const bits = [`#${index} · ${propTypeLabel(index)}`];
+		if (e.mfMass != null) bits.push(`${e.mfMass} kg`);
+		if (e.parts?.length) bits.push(`${e.parts.length} part${e.parts.length === 1 ? '' : 's'}`);
+		return bits.join(' · ');
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function volumeLabel(v: unknown, index: number): string {
+	try {
+		if (!v || typeof v !== 'object') return `#${index}`;
+		const e = v as { vType?: number; mUnion?: number[]; mfRadius?: number };
+		const kind = VOLUME_TYPE_LABELS[e.vType ?? -1] ?? `type ${e.vType}`;
+		if (e.vType === 4 && e.mUnion) {
+			return `#${index} · Box ${e.mUnion.map((h) => (h * 2).toFixed(1)).join('×')} m`;
+		}
+		if (e.vType === 2 && e.mUnion) {
+			return `#${index} · Capsule h=${(e.mUnion[0] * 2).toFixed(1)} r=${(e.mfRadius ?? 0).toFixed(2)} m`;
+		}
+		return `#${index} · ${kind} r=${(e.mfRadius ?? 0).toFixed(2)} m`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function partLabel(p: unknown, index: number): string {
+	try {
+		if (!p || typeof p !== 'object') return `#${index}`;
+		const e = p as { mfMass?: number; volumes?: unknown[] };
+		return `#${index} · ${e.mfMass ?? '?'} kg · ${e.volumes?.length ?? 0} vol${e.volumes?.length === 1 ? '' : 's'}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const PropPhysicsVolume: RecordSchema = {
+	name: 'PropPhysicsVolume',
+	description: 'One rw::collision volume. The 12-byte type-specific union is exposed as three lanes whose meaning follows the volume type: Box — half extents X/Y/Z; Capsule — half height, rest unused; Sphere — all unused (size lives in Radius).',
+	fields: {
+		mTransform: matrix44(),
+		vType: { kind: 'enum', storage: 'u32', values: VOLUME_TYPE_VALUES },
+		mUnion: fixedList(f32(), 3),
+		mfRadius: f32(),
+		muGroupID: u32(),
+		muSurfaceID: u32(),
+		muFlags: { kind: 'flags', storage: 'u32', bits: VOLUME_FLAG_BITS },
+	},
+	fieldMetadata: {
+		mTransform: {
+			label: 'Local transform',
+			description: 'Matrix44Affine placing the volume relative to the prop model (translation in elements 12/13/14).',
+		},
+		vType: {
+			label: 'Volume type',
+			description: 'rw::collision::VolumeType. Retail PropPhysics uses Box (442), Capsule (37), and one Sphere — despite the wiki claiming box-only.',
+		},
+		mUnion: {
+			label: 'Type-specific lanes',
+			description: 'Box: half extents X/Y/Z (m). Capsule: [0] = half height, [1..2] unused. Sphere: unused.',
+		},
+		mfRadius: {
+			label: 'Radius',
+			description: 'Sphere radius / capsule cap radius / box edge fattening (m).',
+		},
+		muGroupID: { label: 'Group ID', description: 'Collision group tag (0 in retail PropPhysics).' },
+		muSurfaceID: { label: 'Surface ID', description: 'Material tag (0 in retail PropPhysics).' },
+		muFlags: { label: 'Flags', description: 'rw::collision::VolumeFlag bits; retail only sets Enabled.' },
+	},
+	propertyGroups: [
+		{ title: 'Shape', properties: ['vType', 'mUnion', 'mfRadius'] },
+		{ title: 'Placement', properties: ['mTransform'] },
+		{ title: 'Tags', properties: ['muGroupID', 'muSurfaceID', 'muFlags'] },
+	],
+	label: (value, index) => volumeLabel(value, index ?? 0),
+};
+
+const PropPartType: RecordSchema = {
+	name: 'PropPartType',
+	description: 'A breakable piece of the prop (sign face, gate arm, …) with its own mass, inertia, and collision volumes. Only props with parts can be smashed.',
+	fields: {
+		mOffset: vec3(),
+		mInertia: vec3(),
+		mfMass: f32(),
+		mfSphereRadius: f32(),
+		volumes: recordList('PropPhysicsVolume', { addable: true }, volumeLabel),
+		_rawVolsPtr: u32(),
+		_pad2D: fixedList(u8(), 3),
+	},
+	fieldMetadata: {
+		mOffset: { label: 'Offset', description: 'Positional offset relative to the prop model.' },
+		mInertia: { label: 'Inertia', description: 'Rotational inertia (likely kg·m²).' },
+		mfMass: { label: 'Mass', description: 'Mass in kg.' },
+		mfSphereRadius: { label: 'Sphere radius', description: 'Broad-phase culling sphere radius (m). Wiki: still under investigation.' },
+		volumes: { label: 'Collision volumes', description: 'The part\'s own collision volumes.' },
+		_rawVolsPtr: {
+			label: 'raw volume ptr',
+			description: 'Stored maCollisionVolumes pointer — uninitialised garbage when the part has no volumes; preserved verbatim for byte-exact round-trip.',
+			hidden: true,
+		},
+		_pad2D: { label: 'pad', description: 'Record pad bytes, preserved verbatim.', hidden: true },
+	},
+	propertyGroups: [
+		{ title: 'Physics', properties: ['mfMass', 'mInertia', 'mfSphereRadius'] },
+		{ title: 'Placement', properties: ['mOffset'] },
+		{ title: 'Collision', properties: ['volumes'] },
+	],
+	label: (value, index) => partLabel(value, index ?? 0),
+};
+
+const PropPhysicsType: RecordSchema = {
+	name: 'PropPhysicsType',
+	description: 'Collision physics for one prop type. The entry index is the same id PropInstanceData placements store (PROP_TYPES), which is why entries can\'t be inserted or removed — only edited.',
+	fields: {
+		mResourceId: bigintId(),
+		muSceneUriId: u32(),
+		mfMass: f32(),
+		mInertia: vec3(),
+		mCOMOffset: vec3(),
+		mJointLocator: vec3(),
+		mfSphereRadius: f32(),
+		mfLeanThreshold: f32(),
+		mfMoveThreshold: f32(),
+		mfSmashThreshold: f32(),
+		mu8JointType: { kind: 'enum', storage: 'u8', values: JOINT_TYPE_VALUES },
+		mfMaxJointAngleCos: f32(),
+		mu8ExtraTypeInfo: { kind: 'enum', storage: 'u8', values: EXTRA_TYPE_VALUES },
+		muMaxState: u8(),
+		volumes: recordList('PropPhysicsVolume', { addable: true }, volumeLabel),
+		parts: recordList('PropPartType', { addable: true }, partLabel),
+		_rawVolsPtr: u32(),
+		_rawPartsPtr: u32(),
+		_padTail: fixedList(u8(), 15),
+	},
+	fieldMetadata: {
+		mResourceId: {
+			label: 'Model resource ID',
+			description: 'The prop\'s Model resource — matches PROP_TYPES[index].resourceId. Changing it retargets which model this physics entry describes.',
+			readOnly: true,
+		},
+		muSceneUriId: { label: 'GameDB ID', description: 'Model GameDB id — matches PROP_TYPES[index].gameDbId.', readOnly: true },
+		mfMass: { label: 'Mass', description: 'Mass in kg.' },
+		mInertia: { label: 'Inertia', description: 'Rotational inertia (likely kg·m²).' },
+		mCOMOffset: { label: 'Centre of mass', description: 'Centre-of-mass offset relative to the prop model.' },
+		mJointLocator: { label: 'Joint locator', description: 'Where the joint sits relative to the prop model (the pivot for lean/tilt).' },
+		mfSphereRadius: { label: 'Sphere radius', description: 'Broad-phase culling sphere radius (m). Wiki: still under investigation.' },
+		mfLeanThreshold: { label: 'Lean threshold', description: 'Speed required to make the prop lean (MPH).' },
+		mfMoveThreshold: { label: 'Move threshold', description: 'Speed required to move the prop (MPH).' },
+		mfSmashThreshold: { label: 'Smash threshold', description: 'Speed required to smash the prop (MPH). Only props with parts can smash.' },
+		mu8JointType: { label: 'Joint type', description: 'How the prop reacts around its joint: none, lean, or tilt.' },
+		mfMaxJointAngleCos: { label: 'Max joint angle (cos)', description: 'Cosine of the maximum joint angle.' },
+		mu8ExtraTypeInfo: { label: 'Extra info', description: '1 = overhead sign.' },
+		muMaxState: { label: 'Max state', description: 'Always 0 in retail; seemingly unused.', readOnly: true },
+		volumes: { label: 'Collision volumes', description: 'The prop body\'s collision volumes.' },
+		parts: { label: 'Parts', description: 'Breakable parts, each with its own physics and volumes.' },
+		_rawVolsPtr: {
+			label: 'raw volume ptr',
+			description: 'Stored maCollisionVolumes pointer — garbage when there are no volumes; preserved verbatim.',
+			hidden: true,
+		},
+		_rawPartsPtr: {
+			label: 'raw parts ptr',
+			description: 'Stored maParts pointer — garbage when there are no parts; preserved verbatim.',
+			hidden: true,
+		},
+		_padTail: { label: 'pad', description: 'Record tail pad bytes, preserved verbatim.', hidden: true },
+	},
+	propertyGroups: [
+		{ title: 'Identity', properties: ['mResourceId', 'muSceneUriId'] },
+		{ title: 'Physics', properties: ['mfMass', 'mInertia', 'mCOMOffset', 'mfSphereRadius'] },
+		{ title: 'Thresholds', properties: ['mfLeanThreshold', 'mfMoveThreshold', 'mfSmashThreshold'] },
+		{ title: 'Joint', properties: ['mu8JointType', 'mJointLocator', 'mfMaxJointAngleCos', 'mu8ExtraTypeInfo', 'muMaxState'] },
+		{ title: 'Collision', properties: ['volumes', 'parts'] },
+	],
+	label: (value, index) => propTypeEntryLabel(value, index ?? 0),
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedPropPhysics: RecordSchema = {
+	name: 'ParsedPropPhysics',
+	description: 'Root record for the PropPhysics resource (0x1000F) — the game-wide prop collision-physics catalogue. Entries are indexed by the same prop-type id PropInstanceData placements use, so the list is fixed-length: edit entries, never insert or remove them.',
+	fields: {
+		propTypes: {
+			kind: 'list',
+			item: record('PropPhysicsType'),
+			addable: false,
+			removable: false,
+			itemLabel: (item, index) => propTypeEntryLabel(item, index),
+		},
+		muTimeStamp: u32(),
+	},
+	fieldMetadata: {
+		propTypes: {
+			label: 'Prop types',
+			description: 'One physics entry per prop type, indexed like PROP_TYPES. 247 entries in retail.',
+		},
+		muTimeStamp: {
+			label: 'Build timestamp',
+			description: 'time_t the catalogue was built; null (0) in Remastered.',
+			readOnly: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Catalogue', properties: ['propTypes'] },
+		{ title: 'Build', properties: ['muTimeStamp'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedPropPhysics,
+	PropPhysicsType,
+	PropPartType,
+	PropPhysicsVolume,
+};
+
+export const propPhysicsResourceSchema: ResourceSchema = {
+	key: 'propPhysics',
+	name: 'Prop Physics',
+	rootType: 'ParsedPropPhysics',
+	registry,
+};


### PR DESCRIPTION
> **Stacked on #115** — branched from `feat/static-sound-map` because both PRs register handlers/profiles in the same index files. GitHub will retarget this to `main` automatically once #115 merges.

## What

Adds the full editing slice for **PropPhysics (0x1000F)** — the game-wide prop collision-physics catalogue (`PROPS/PROPPHYSICS.BUNDLE`, the only resource of this type in the game). Per prop type: mass, inertia, the speed thresholds that decide whether a hit prop leans/moves/smashes (MPH), joint behaviour (none/lean/tilt), `rw::collision` volumes, and breakable parts with their own physics.

This completes the prop stack: **PropGraphicsList** (what a prop looks like) → **PropInstanceData** (where props sit) → **PropPhysics** (how props react).

- **Parser/writer** (`src/lib/core/propPhysics.ts`): header with three fixed pointer tables (500/300/2048 slots) + a data region in canonical order — prop record, its parts, its own volumes, then each part's volumes. The parser *asserts* the canonical layout (pointer derivation, table order, exact tiling — the 910 retail records tile the region with zero gaps), which is what lets the writer re-derive every pointer after structural edits.
- **Garbage-pointer preservation**: records with empty arrays store *uninitialised* pointers (e.g. `maParts = 0xfa62e800`), not null — preserved verbatim for byte-exact output.
- **Handler** with five stress scenarios, including structural volume add/remove (whole layout + tables re-derived, trailing entries verified intact).
- **Schema + editor profile**: entries labeled by prop name (`#6 · STU_gate01 · 150 kg · 2 parts`), physics/thresholds/volume shapes editable. The entry list is fixed-length — the index space is shared with every `PropInstanceData` placement in the game, so inserting/removing entries would silently retarget placed props.

## Data findings (pinned in tests)

- **Index alignment proven for all 247 entries**: `mResourceId` + `muSceneUriId` match the wiki prop-types table (`PROP_TYPES` in `propTypes.ts`) at every index — placements and physics share one id space.
- **The wiki's "always box volumes" note is wrong**: retail ships 442 boxes, **37 capsules, and 1 sphere**. The 12-byte type-specific union is modeled with per-type semantics.
- `muSizeInBytes` equals the resource size exactly (unlike PropInstanceData's), and the Remastered build nulls `muTimeStamp` as documented.

## Tests

- 10 gold tests: counts, STU_gate01/billboard decode, volume census, garbage-pointer preservation, byte round-trip + idempotence, table-overflow writer guard
- 11 schema tests: drift detection both directions, deep-path resolution down to `propTypes[6].parts[0].volumes[0]`
- Registry fixture suite: parse, byte round-trip, describe, 5 stress scenarios — all green

Spec: https://burnout.wiki/wiki/Prop_Physics · https://burnout.wiki/wiki/Collision_Volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)