### PR TITLE
feat: batch 1 — six resource types (Language, HudMessage, sequences, GuiPopup, WorldPainter2D)

### DIFF
--- a/src/lib/core/__tests__/guiPopup.test.ts
+++ b/src/lib/core/__tests__/guiPopup.test.ts
@@ -1,0 +1,224 @@
+// Gold coverage for parseGuiPopup / writeGuiPopup.
+//
+// example/POPUPS.PUP carries exactly one 0x1F resource that decompresses to
+// 21824 bytes — 111 popups. This suite pins hand-verified decoded values,
+// the data invariants the probe sweep established (CgsID derivation, params
+// counting, the constant garbage pads), byte-exact round-trip, writer
+// idempotence, and the popup-count growth paths the lone fixture can't show
+// (the pointer-array alignment pad changes with count).
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+	parseGuiPopup,
+	writeGuiPopup,
+	countMessageParamsUsed,
+	POPUP_STYLES,
+	POPUP_ICONS,
+	type GuiPopup,
+} from '../guiPopup';
+import { encodeCgsId } from '../cgsid';
+import { parseBundle } from '../bundle';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const GUI_POPUP_TYPE_ID = 0x1f;
+
+function loadRaw(bundleFile: string): Uint8Array {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const matches = bundle.resources.filter((r) => r.resourceTypeId === GUI_POPUP_TYPE_ID);
+	expect(matches.length).toBe(1);
+	return extractResourceRaw(buffer, bundle, matches[0]);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+const raw = loadRaw('example/POPUPS.PUP');
+const model = parseGuiPopup(raw);
+
+describe('GuiPopup gold values (example/POPUPS.PUP)', () => {
+	it('decompresses to 21824 bytes carrying 111 popups', () => {
+		expect(raw.byteLength).toBe(21824);
+		expect(model.popups.length).toBe(111);
+	});
+
+	it('decodes popup 0 — FLConfirmDel, an untitled online Yes/No confirm', () => {
+		const p = model.popups[0];
+		expect(p.macName).toBe('FLConfirmDel');
+		expect(p.mNameId).toBe(0x6c52c61194a130c0n);
+		expect(p.meStyle).toBe(5); // CrashNav online — OK/Cancel
+		expect(p.meIcon).toBe(0);
+		expect(p.macTitleId).toBe('');
+		expect(p.macMessageId).toBe('ONLINE_FRIENDS_CONFIRM_DELETE');
+		expect(p.maeMessageParams).toEqual([1, 0]); // one String param
+		expect(p.miMessageParamsUsed).toBe(1);
+		expect(p.macButton1Id).toBe('GENERAL_OPTION_YES');
+		expect(p.macButton2Id).toBe('GENERAL_OPTION_NO');
+		expect(p.meButton1Param).toBe(0);
+		expect(p.mbButton1ParamUsed).toBe(false);
+	});
+
+	it('decodes popup 5 — CNVidOptWarn, a buttonless warning-icon wait card', () => {
+		const p = model.popups[5];
+		expect(p.macName).toBe('CNVidOptWarn');
+		expect(p.meStyle).toBe(6); // In-game — wait
+		expect(p.meIcon).toBe(1); // Warning
+		expect(p.macTitleId).toBe('VIDEO_OPTION_CHANGE_WARN_TITLE');
+		expect(p.macMessageId).toBe('VIDEO_OPTION_CHANGE_WARN_BODY');
+		expect(p.macButton1Id).toBe('');
+		expect(p.macButton2Id).toBe('');
+	});
+
+	it('decodes popup 55 — CNOnlLchGame, a two-param message (String + String ID)', () => {
+		const p = model.popups[55];
+		expect(p.macName).toBe('CNOnlLchGame');
+		expect(p.maeMessageParams).toEqual([1, 2]);
+		expect(p.miMessageParamsUsed).toBe(2);
+	});
+
+	it('keeps tilde-prefixed Language keys verbatim', () => {
+		// Several retail keys start with '~' (meaning unconfirmed) — they must
+		// survive as plain text, not be treated as markup.
+		expect(model.popups[12].macMessageId).toBe('~ONLINE_SYNCHING_KICKED');
+	});
+
+	it('ends with PrizeTicket — the v1.9 island-era additions sit last', () => {
+		expect(model.popups[110].macName).toBe('PrizeTicket');
+	});
+
+	it('pins the style histogram (styles 0, 2, 3, and 13–15 are unused in retail)', () => {
+		const styles = new Map<number, number>();
+		for (const p of model.popups) styles.set(p.meStyle, (styles.get(p.meStyle) ?? 0) + 1);
+		expect(Object.fromEntries(styles)).toEqual({
+			1: 3, 4: 25, 5: 11, 6: 5, 7: 26, 8: 16, 9: 12, 10: 5, 11: 3, 12: 5,
+		});
+		for (const p of model.popups) {
+			expect(POPUP_STYLES.some((s) => s.value === p.meStyle)).toBe(true);
+			expect(POPUP_ICONS.some((s) => s.value === p.meIcon)).toBe(true);
+		}
+	});
+
+	it('uses the warning icon on 17 of 111 popups', () => {
+		expect(model.popups.filter((p) => p.meIcon === 1).length).toBe(17);
+	});
+});
+
+describe('GuiPopup data invariants (probe-swept across all 111 popups)', () => {
+	it('mNameId is always encodeCgsId(macName.toUpperCase())', () => {
+		for (const p of model.popups) {
+			expect(p.mNameId, p.macName).toBe(encodeCgsId(p.macName.toUpperCase()));
+		}
+	});
+
+	it('miMessageParamsUsed always equals the leading non-Unused param count', () => {
+		for (const p of model.popups) {
+			expect(p.miMessageParamsUsed, p.macName).toBe(countMessageParamsUsed(p.maeMessageParams));
+		}
+	});
+
+	it('button params are never used in retail', () => {
+		for (const p of model.popups) {
+			expect(p.meButton1Param).toBe(0);
+			expect(p.meButton2Param).toBe(0);
+			expect(p.mbButton1ParamUsed).toBe(false);
+			expect(p.mbButton2ParamUsed).toBe(false);
+		}
+	});
+
+	it('record pads carry the same bytes in every record: zero at +0x15, fixed garbage at +0xB1/+0xB9', () => {
+		for (const p of model.popups) {
+			expect(p._pad15).toEqual([0, 0, 0]);
+			// Uninitialised build-machine memory, identical across all 111
+			// records — the struct template was memcpy'd. Preserved verbatim.
+			expect(p._padB1).toEqual([0xf9, 0x4f, 0x00]);
+			expect(p._padB9).toEqual([0xdf, 0x9c, 0x00, 0xe0, 0x24, 0x9d, 0x00]);
+		}
+	});
+});
+
+describe('GuiPopup round-trip', () => {
+	it('round-trips byte-for-byte', () => {
+		const rewritten = writeGuiPopup(parseGuiPopup(raw));
+		expect(rewritten.byteLength).toBe(raw.byteLength);
+		expect(bytesEqual(rewritten, raw)).toBe(true);
+	});
+
+	it('writer is idempotent', () => {
+		const once = writeGuiPopup(parseGuiPopup(raw));
+		const twice = writeGuiPopup(parseGuiPopup(once));
+		expect(bytesEqual(once, twice)).toBe(true);
+	});
+});
+
+describe('GuiPopup writer layout recompute', () => {
+	function makePopup(macName: string): GuiPopup {
+		return {
+			mNameId: encodeCgsId(macName.toUpperCase()),
+			macName,
+			meStyle: 7,
+			meIcon: 0,
+			macTitleId: '',
+			macMessageId: 'PLACEHOLDER_TEMP_STRING',
+			maeMessageParams: [0, 0],
+			miMessageParamsUsed: 0,
+			macButton1Id: 'GENERAL_OPTION_OK',
+			meButton1Param: 0,
+			mbButton1ParamUsed: false,
+			macButton2Id: '',
+			meButton2Param: 0,
+			mbButton2ParamUsed: false,
+			_pad15: [0, 0, 0],
+			_padB1: [0, 0, 0],
+			_padB9: [0, 0, 0, 0, 0, 0, 0],
+		};
+	}
+
+	it('112 popups need no pointer-array pad (0x40 + 112*4 is already 16-aligned)', () => {
+		const grown = { popups: [...model.popups, makePopup('AddedOne')] };
+		const bytes = writeGuiPopup(grown);
+		expect(bytes.byteLength).toBe(0x200 + 112 * 0xc0);
+		const reparsed = parseGuiPopup(bytes);
+		expect(reparsed.popups.length).toBe(112);
+		expect(reparsed.popups[111].macName).toBe('AddedOne');
+		expect(reparsed.popups[0]).toEqual(model.popups[0]);
+	});
+
+	it('113 popups grow the pad to 12 bytes (parser re-accepts its own alignment)', () => {
+		const grown = { popups: [...model.popups, makePopup('AddedOne'), makePopup('AddedTwo')] };
+		const bytes = writeGuiPopup(grown);
+		expect(bytes.byteLength).toBe(0x210 + 113 * 0xc0);
+		expect(parseGuiPopup(bytes).popups.length).toBe(113);
+	});
+
+	it('shrinking to a handful of popups still round-trips through the parser', () => {
+		const small = { popups: model.popups.slice(0, 3) };
+		const bytes = writeGuiPopup(small);
+		const reparsed = parseGuiPopup(bytes);
+		expect(reparsed.popups).toEqual(small.popups);
+		expect(bytesEqual(writeGuiPopup(reparsed), bytes)).toBe(true);
+	});
+
+	it('rejects a macName that cannot fit char[13]', () => {
+		const broken = { popups: [{ ...model.popups[0], macName: 'ThirteenChars' }] };
+		expect(() => writeGuiPopup(broken)).toThrow(/macName/);
+	});
+
+	it('rejects a Language key that cannot fit char[32]', () => {
+		const broken = { popups: [{ ...model.popups[0], macMessageId: 'X'.repeat(32) }] };
+		expect(() => writeGuiPopup(broken)).toThrow(/macMessageId/);
+	});
+
+	it('rejects a popup count whose resource size overflows i16 miSizeOfPopupResource', () => {
+		// 170 records ≈ 33 KB > 0x7FFF — the header size field is int16_t.
+		const huge = { popups: Array.from({ length: 170 }, (_, i) => makePopup(`Huge${i}`)) };
+		expect(() => writeGuiPopup(huge)).toThrow(/miSizeOfPopupResource/);
+	});
+});

--- a/src/lib/core/__tests__/hudMessage.test.ts
+++ b/src/lib/core/__tests__/hudMessage.test.ts
@@ -1,0 +1,202 @@
+// Gold coverage for parseHudMessage / writeHudMessage.
+//
+// Retail ships exactly one HudMessage resource (HUDMESSAGES.HM — 308
+// messages, decompressing from a 10 KB bundle to 0x1C040 bytes). This suite
+// pins hand-verified decoded values, the retail-wide data invariants the
+// implementation leans on (CgsID derivation, parallel string/param lanes,
+// constant garbage pads), and byte-exact round-trip + writer idempotence.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+	parseHudMessage,
+	writeHudMessage,
+	HUD_MESSAGE_LINES,
+	HUD_MESSAGE_PARAMS_PER_LINE,
+	type ParsedHudMessage,
+} from '../hudMessage';
+import { encodeCgsId } from '../cgsid';
+import { parseBundle } from '../bundle';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const HUD_MESSAGE_TYPE_ID = 0x2c;
+
+function loadRaw(bundleFile: string): Uint8Array {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const resources = bundle.resources.filter((r) => r.resourceTypeId === HUD_MESSAGE_TYPE_ID);
+	expect(resources.length).toBe(1); // the fixture carries exactly one 0x2C
+	return extractResourceRaw(buffer, bundle, resources[0]);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+const raw = loadRaw('example/HUDMESSAGES.HM');
+const model = parseHudMessage(raw);
+
+describe('HudMessage gold values (example/HUDMESSAGES.HM)', () => {
+	it('decompresses to the size the header declares and holds 308 messages', () => {
+		expect(raw.byteLength).toBe(0x1c040);
+		expect(model.messages.length).toBe(308);
+	});
+
+	it('decodes message 0 (online boost-start ticker)', () => {
+		const m = model.messages[0];
+		expect(m.lines[0].macStringId).toBe('HUDMESSAGE_ONLINE_BOOST_STARTS');
+		expect(m.lines[1].macStringId).toBe('');
+		expect(m.lines[2].macStringId).toBe('');
+		expect(m.macMessageStyle).toBe('NeutralMessage');
+		expect(m.macDefaultIcon).toBe('invisible');
+		expect(m.macMessageId).toBe('AggDrBstStrt');
+		expect(m.mMessageIdHash).toBe(0x4e8166694cee92d0n);
+		expect(m.muAvailabilityBitSet).toBe(0x10); // online only
+		expect(m.mfDuration).toBe(2.5);
+		expect(m.mfTimeToWait).toBe(0.5);
+		expect(m.miPriority).toBe(0);
+		expect(m.miForceRemoveThreshold).toBe(0);
+		expect(m.meMessageGroup).toBe(3); // in-game messages
+		expect(m.lines.map((l) => l.miParamCount)).toEqual([1, 0, 0]);
+		expect(m.lines[0].maeParamTypes).toEqual([1, 0, 0, 0]); // one String param
+	});
+
+	it('decodes message 307 (reverse-gear driving tip)', () => {
+		const m = model.messages[307];
+		expect(m.lines[0].macStringId).toBe('REVERSE_TIP');
+		expect(m.macMessageId).toBe('ReverseTip');
+		expect(m.muAvailabilityBitSet).toBe(0x3f); // everywhere
+		expect(m.mfDuration).toBe(2);
+		expect(m.miPriority).toBe(50);
+		expect(m.lines.map((l) => l.miParamCount)).toEqual([0, 0, 0]);
+	});
+
+	it('decodes a three-line message (car awarded, message 13)', () => {
+		const m = model.messages[13];
+		expect(m.lines[0].macStringId).toBe('HUDMESSAGE_GENERIC1');
+		expect(m.lines[1].macStringId).toBe('CAR_AWARDED');
+		expect(m.lines[2].macStringId).toBe('POSTRACE_NEW_CAR_INSTRUCTIONS');
+	});
+});
+
+describe('HudMessage retail-wide invariants', () => {
+	it('every record fixes lines/param slots at the on-disk dimensions', () => {
+		for (const m of model.messages) {
+			expect(m.lines.length).toBe(HUD_MESSAGE_LINES);
+			for (const line of m.lines) {
+				expect(line.maeParamTypes.length).toBe(HUD_MESSAGE_PARAMS_PER_LINE);
+			}
+		}
+	});
+
+	it('mMessageIdHash is the CgsID of the uppercased message id in all 308 records', () => {
+		// The game fires messages by this hash; the schema's derive hook and
+		// the handler's rename scenario both rely on this exact relationship.
+		for (const m of model.messages) {
+			expect(m.mMessageIdHash, m.macMessageId).toBe(encodeCgsId(m.macMessageId.toUpperCase()));
+		}
+	});
+
+	it('message ids are unique and at most 12 chars', () => {
+		const ids = new Set(model.messages.map((m) => m.macMessageId));
+		expect(ids.size).toBe(model.messages.length);
+		for (const id of ids) expect(id.length).toBeLessThanOrEqual(12);
+	});
+
+	it('string/param lanes are parallel: params only appear on lines with a string id', () => {
+		// This is what justifies regrouping the wiki's three parallel arrays
+		// into per-line records.
+		for (const m of model.messages) {
+			for (const line of m.lines) {
+				if (line.miParamCount > 0) expect(line.macStringId).not.toBe('');
+				// Param slots are a packed prefix: non-Unused up to the count, Unused after.
+				line.maeParamTypes.forEach((p, idx) => {
+					if (idx < line.miParamCount) expect(p).not.toBe(0);
+					else expect(p).toBe(0);
+				});
+			}
+		}
+	});
+
+	it('retail uses param types Unused/String/Int/Float/StringId only (never Money/Time)', () => {
+		const used = new Set<number>();
+		for (const m of model.messages) {
+			for (const line of m.lines) line.maeParamTypes.forEach((p) => used.add(p));
+		}
+		expect([...used].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 6]);
+	});
+
+	it('retail groups are 1/2/3 (ALL never appears) and availability stays in the 6 defined bits', () => {
+		const groups = new Set(model.messages.map((m) => m.meMessageGroup));
+		expect([...groups].sort((a, b) => a - b)).toEqual([1, 2, 3]);
+		for (const m of model.messages) {
+			expect(m.muAvailabilityBitSet & ~0x3f).toBe(0);
+		}
+	});
+
+	it('second/third lines are genuinely used by retail (so the lanes are not dead)', () => {
+		const usingLine1 = model.messages.filter((m) => m.lines[1].macStringId !== '').length;
+		const usingLine2 = model.messages.filter((m) => m.lines[2].macStringId !== '').length;
+		expect(usingLine1).toBe(163);
+		expect(usingLine2).toBe(18);
+	});
+
+	it('record pads carry constant build-tool garbage, preserved verbatim', () => {
+		for (const m of model.messages) {
+			expect(m._padMessageId).toEqual([0xf9, 0x1c, 0x00]);
+			expect(m._padTail).toBe(0x001cf974);
+		}
+	});
+});
+
+describe('HudMessage round-trip', () => {
+	it('round-trips byte-for-byte', () => {
+		const rewritten = writeHudMessage(model);
+		expect(rewritten.byteLength).toBe(raw.byteLength);
+		expect(bytesEqual(rewritten, raw)).toBe(true);
+	});
+
+	it('writer is idempotent', () => {
+		const once = writeHudMessage(model);
+		const twice = writeHudMessage(parseHudMessage(once));
+		expect(bytesEqual(once, twice)).toBe(true);
+	});
+
+	it('shrinking and growing the catalogue keeps the layout self-consistent', () => {
+		// Pointer array length and the 128-byte section pads both depend on the
+		// count; reparse proves the writer recomputed them rather than copying.
+		for (const messages of [model.messages.slice(0, 5), [...model.messages, model.messages[0]]]) {
+			const reparsed = parseHudMessage(writeHudMessage({ messages }));
+			expect(reparsed.messages.length).toBe(messages.length);
+			expect(reparsed.messages[messages.length - 1].macMessageId).toBe(messages[messages.length - 1].macMessageId);
+		}
+	});
+
+	it('writer rejects a message with the wrong line count', () => {
+		const broken: ParsedHudMessage = {
+			messages: [{ ...model.messages[0], lines: model.messages[0].lines.slice(0, 2) }],
+		};
+		expect(() => writeHudMessage(broken)).toThrow(/lines/);
+	});
+
+	it('writer rejects a line with the wrong param-slot count', () => {
+		const m = model.messages[0];
+		const broken: ParsedHudMessage = {
+			messages: [{ ...m, lines: [{ ...m.lines[0], maeParamTypes: [1, 0, 0] }, m.lines[1], m.lines[2]] }],
+		};
+		expect(() => writeHudMessage(broken)).toThrow(/param slots/);
+	});
+
+	it('writer rejects an over-long message id (12 chars max + terminator)', () => {
+		const broken: ParsedHudMessage = {
+			messages: [{ ...model.messages[0], macMessageId: 'ThirteenChars' }],
+		};
+		expect(() => writeHudMessage(broken)).toThrow(/message id/);
+	});
+});

--- a/src/lib/core/__tests__/hudMessageSequences.test.ts
+++ b/src/lib/core/__tests__/hudMessageSequences.test.ts
@@ -1,0 +1,276 @@
+// Gold coverage for HudMessageSequence (0x2E) and HudMessageSequenceDictionary
+// (0x2F) — both live in the single retail bundle HUDMESSAGESEQUENCES.HMSC.
+//
+// The bundle carries SIX sequences but the auto-generated registry fixture
+// suite only exercises the first resource of a type per bundle — so this
+// suite walks ALL SIX, pins hand-verified decoded values, pins the
+// dictionary↔sequence name relationship, and covers the rigid-layout asserts
+// and structural edits (add/remove message, add/remove name).
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+	parseHudMessageSequence,
+	writeHudMessageSequence,
+	parseHudMessageSequenceDictionary,
+	writeHudMessageSequenceDictionary,
+	DEFAULT_MESSAGE_LENGTH_SECONDS,
+} from '../hudMessageSequences';
+import { encodeCgsId, decodeCgsId } from '../cgsid';
+import { parseBundle } from '../bundle';
+import { parseDebugDataFromXml, findDebugResourceById } from '../bundle/debugData';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FILE = 'example/HUDMESSAGESEQUENCES.HMSC';
+const SEQUENCE_TYPE_ID = 0x2e;
+const DICTIONARY_TYPE_ID = 0x2f;
+
+type Extracted = { name: string; raw: Uint8Array };
+
+function loadByType(typeId: number): Extracted[] {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, BUNDLE_FILE));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const debugResources = typeof bundle.debugData === 'string'
+		? parseDebugDataFromXml(bundle.debugData)
+		: [];
+	return bundle.resources
+		.filter((r) => r.resourceTypeId === typeId)
+		.map((r) => ({
+			name: findDebugResourceById(debugResources, r.resourceId.low.toString(16))?.name ?? '?',
+			raw: extractResourceRaw(buffer, bundle, r),
+		}));
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+// extractResourceRaw hands back a Node Buffer, whose .slice() is a VIEW —
+// mutating it would corrupt the shared fixture bytes for later tests. Always
+// copy before poking.
+const copyOf = (a: Uint8Array) => new Uint8Array(a);
+
+const sequences = loadByType(SEQUENCE_TYPE_ID);
+const dictionaries = loadByType(DICTIONARY_TYPE_ID);
+
+// Hand-verified from the probe: every sequence is the shared DTARMING message
+// followed by one per-trick award/failure message.
+const EXPECTED_SECOND_MESSAGE: Record<string, string> = {
+	'DTArmBtLk.hms': 'DTAWDBTLK',
+	'DTArmFail.hms': 'DTFAILARM',
+	'DTArmBtRd.hms': 'DTAWDBTRD',
+	'DTArmRvSt.hms': 'DTAWDRVST',
+	'DTArmDtLk.hms': 'DTAWDDTLK',
+	'DTArmSlow.hms': 'DTAWDDTSLOW', // 11 chars — exercises a near-full-width CgsID
+};
+
+describe('HudMessageSequence gold values (all six resources)', () => {
+	it('finds exactly six sequences in bundle order', () => {
+		expect(sequences.map((s) => s.name)).toEqual([
+			'DTArmBtLk.hms',
+			'DTArmFail.hms',
+			'DTArmBtRd.hms',
+			'DTArmRvSt.hms',
+			'DTArmDtLk.hms',
+			'DTArmSlow.hms',
+		]);
+	});
+
+	it('every raw resource is the fixed 0x1D0 bytes (0x1C8 struct + 8 pad)', () => {
+		for (const { name, raw } of sequences) {
+			expect(raw.byteLength, name).toBe(0x1d0);
+		}
+	});
+
+	for (const { name, raw } of sequences) {
+		it(`decodes ${name}`, () => {
+			const m = parseHudMessageSequence(raw);
+			expect(m.macSequenceId).toBe(name.replace(/\.hms$/, ''));
+			// The hash is derived data: uppercase-folded CgsID of the name.
+			expect(m.mSequenceIdHash).toBe(encodeCgsId(m.macSequenceId.toUpperCase()));
+			expect(m._pad15).toEqual([0, 0, 0]);
+			expect(m.miPriority).toBe(1);
+			expect(m.miParamCount).toBe(0);
+			expect(m.maeParams).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+			expect(m.messages.length).toBe(2);
+			for (const msg of m.messages) {
+				expect(msg.mfMessageLength).toBe(DEFAULT_MESSAGE_LENGTH_SECONDS);
+				expect(msg.maiParam1Ids).toEqual([-1, -1, -1, -1]);
+				expect(msg.maiParam2Ids).toEqual([-1, -1, -1, -1]);
+				expect(msg._pad2C).toBe(0);
+			}
+			expect(decodeCgsId(m.messages[0].mMessageId)).toBe('DTARMING');
+			expect(decodeCgsId(m.messages[1].mMessageId)).toBe(EXPECTED_SECOND_MESSAGE[name]);
+		});
+	}
+});
+
+describe('HudMessageSequenceDictionary gold values', () => {
+	it('finds exactly one dictionary', () => {
+		expect(dictionaries.length).toBe(1);
+		expect(dictionaries[0].name).toBe('HUDMESSAGESEQUENCES.hmsd');
+	});
+
+	it('decodes the six names in dictionary order (which differs from bundle order)', () => {
+		const m = parseHudMessageSequenceDictionary(dictionaries[0].raw);
+		expect(m.sequenceNames).toEqual([
+			'DTArmDtLk',
+			'DTArmSlow',
+			'DTArmRvSt',
+			'DTArmFail',
+			'DTArmBtRd',
+			'DTArmBtLk',
+		]);
+		expect(m._pad0C).toBe(0);
+	});
+
+	it('references every sequence by name: dictionary entries == macSequenceId set', () => {
+		const dict = parseHudMessageSequenceDictionary(dictionaries[0].raw);
+		const seqNames = sequences.map(({ raw }) => parseHudMessageSequence(raw).macSequenceId);
+		expect(new Set(dict.sequenceNames)).toEqual(new Set(seqNames));
+		expect(dict.sequenceNames.length).toBe(seqNames.length);
+	});
+});
+
+describe('HudMessageSequence round-trip', () => {
+	it('round-trips all six sequences byte-for-byte with an idempotent writer', () => {
+		for (const { name, raw } of sequences) {
+			const first = writeHudMessageSequence(parseHudMessageSequence(raw));
+			expect(bytesEqual(first, raw), name).toBe(true);
+			const second = writeHudMessageSequence(parseHudMessageSequence(first));
+			expect(bytesEqual(second, first), `${name} (idempotence)`).toBe(true);
+		}
+	});
+
+	it('round-trips the dictionary byte-for-byte with an idempotent writer', () => {
+		const raw = dictionaries[0].raw;
+		const first = writeHudMessageSequenceDictionary(parseHudMessageSequenceDictionary(raw));
+		expect(bytesEqual(first, raw)).toBe(true);
+		const second = writeHudMessageSequenceDictionary(parseHudMessageSequenceDictionary(first));
+		expect(bytesEqual(second, first)).toBe(true);
+	});
+});
+
+describe('HudMessageSequence rigid-layout asserts', () => {
+	it('rejects a non-default unused message slot instead of dropping it', () => {
+		const raw = copyOf(sequences[0].raw);
+		// msg slot 2 (first unused) starts at 0x48 + 2*0x30 = 0xA8; poke its id.
+		raw[0xa8] = 1;
+		expect(() => parseHudMessageSequence(raw)).toThrow(/unused message slot/);
+	});
+
+	it('rejects a wrong miResourceSize', () => {
+		const raw = copyOf(sequences[0].raw);
+		raw[0x1c] = 0;
+		expect(() => parseHudMessageSequence(raw)).toThrow(/miResourceSize/);
+	});
+
+	it('rejects a non-zero alignment-pad byte', () => {
+		const raw = copyOf(sequences[0].raw);
+		raw[0x1c8] = 1;
+		expect(() => parseHudMessageSequence(raw)).toThrow(/alignment-pad/);
+	});
+
+	it('rejects a truncated resource', () => {
+		expect(() => parseHudMessageSequence(copyOf(sequences[0].raw.subarray(0, 0x1c8)))).toThrow(/0x1d0/);
+	});
+
+	it('writer rejects more than 8 messages', () => {
+		const m = parseHudMessageSequence(sequences[0].raw);
+		const nine = { ...m, messages: Array.from({ length: 9 }, () => ({ ...m.messages[0] })) };
+		expect(() => writeHudMessageSequence(nine)).toThrow(/8 on-disk slots/);
+	});
+
+	it('writer rejects a wrong-size maeParams array', () => {
+		const m = parseHudMessageSequence(sequences[0].raw);
+		expect(() => writeHudMessageSequence({ ...m, maeParams: m.maeParams.slice(0, 7) })).toThrow(/maeParams/);
+	});
+
+	it('writer rejects a name longer than the char[13] field allows', () => {
+		const m = parseHudMessageSequence(sequences[0].raw);
+		expect(() => writeHudMessageSequence({ ...m, macSequenceId: 'ThirteenChars' })).toThrow(/12 chars/);
+	});
+});
+
+describe('HudMessageSequenceDictionary rigid-layout asserts', () => {
+	it('rejects a name pointer off the 13-byte stride', () => {
+		const raw = copyOf(dictionaries[0].raw);
+		raw[0x10] += 1; // ptr[0]: 0x28 → 0x29
+		expect(() => parseHudMessageSequenceDictionary(raw)).toThrow(/name pointer/);
+	});
+
+	it('rejects a wrong miResourceSize', () => {
+		const raw = copyOf(dictionaries[0].raw);
+		raw[0x0] = 0;
+		expect(() => parseHudMessageSequenceDictionary(raw)).toThrow(/miResourceSize/);
+	});
+
+	it('rejects a non-zero alignment-pad byte', () => {
+		const raw = copyOf(dictionaries[0].raw);
+		raw[raw.byteLength - 1] = 1;
+		expect(() => parseHudMessageSequenceDictionary(raw)).toThrow(/alignment-pad/);
+	});
+
+	it('writer rejects a name longer than the char[13] field allows', () => {
+		const m = parseHudMessageSequenceDictionary(dictionaries[0].raw);
+		const broken = { ...m, sequenceNames: [...m.sequenceNames, 'ThirteenChars'] };
+		expect(() => writeHudMessageSequenceDictionary(broken)).toThrow(/12 chars/);
+	});
+});
+
+describe('structural edits re-derive the layout', () => {
+	it('appending a message consumes a default slot and keeps the fixed size', () => {
+		const m = parseHudMessageSequence(sequences[0].raw);
+		const grown = {
+			...m,
+			messages: [
+				...m.messages,
+				{
+					mMessageId: encodeCgsId('GOLDTEST'),
+					mfMessageLength: 2.5,
+					maiParam1Ids: [-1, -1, -1, -1],
+					maiParam2Ids: [-1, -1, -1, -1],
+					_pad2C: 0,
+				},
+			],
+		};
+		const bytes = writeHudMessageSequence(grown);
+		expect(bytes.byteLength).toBe(0x1d0); // fixed-size struct — growth uses a slot, not bytes
+		const reparsed = parseHudMessageSequence(bytes);
+		expect(reparsed.messages.length).toBe(3);
+		expect(decodeCgsId(reparsed.messages[2].mMessageId)).toBe('GOLDTEST');
+		expect(reparsed.messages[2].mfMessageLength).toBe(2.5);
+	});
+
+	it('removing the last message regenerates a default-initialised slot', () => {
+		const m = parseHudMessageSequence(sequences[0].raw);
+		const bytes = writeHudMessageSequence({ ...m, messages: m.messages.slice(0, 1) });
+		const reparsed = parseHudMessageSequence(bytes); // would throw if the slot were stale
+		expect(reparsed.messages.length).toBe(1);
+		expect(decodeCgsId(reparsed.messages[0].mMessageId)).toBe('DTARMING');
+	});
+
+	it('appending a dictionary name grows size, count, pointers, and pad together', () => {
+		const m = parseHudMessageSequenceDictionary(dictionaries[0].raw);
+		const bytes = writeHudMessageSequenceDictionary({
+			...m,
+			sequenceNames: [...m.sequenceNames, 'GoldTestSeq'],
+		});
+		// 7 names: 0x10 header + 7*4 pointers + 7*13 names = 0x87, padded to 0x90.
+		expect(bytes.byteLength).toBe(0x90);
+		const reparsed = parseHudMessageSequenceDictionary(bytes);
+		expect(reparsed.sequenceNames).toEqual([...m.sequenceNames, 'GoldTestSeq']);
+	});
+
+	it('an empty dictionary writes and reparses as just the header', () => {
+		const bytes = writeHudMessageSequenceDictionary({ sequenceNames: [], _pad0C: 0 });
+		expect(bytes.byteLength).toBe(0x10);
+		expect(parseHudMessageSequenceDictionary(bytes).sequenceNames).toEqual([]);
+	});
+});

--- a/src/lib/core/__tests__/language.test.ts
+++ b/src/lib/core/__tests__/language.test.ts
@@ -1,0 +1,190 @@
+// Gold coverage for parseLanguage / writeLanguage.
+//
+// The handler declares three fixtures; this suite sweeps ALL 14 retail
+// language bundles, pins hand-verified decoded values, and pins the data
+// findings the wiki doesn't document: per-string zero pads, the trailing
+// all-'A' filler entry sizing every resource to 0xD4800, and the bundle 0008
+// Greek-id/Russian-content divergence.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseLanguage, writeLanguage, languageName } from '../language';
+import { parseBundle } from '../bundle';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const LANGUAGE_TYPE_ID = 0x27;
+
+function loadLanguageRaws(bundleFile: string): Uint8Array[] {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	return bundle.resources
+		.filter((r) => r.resourceTypeId === LANGUAGE_TYPE_ID)
+		.map((r) => extractResourceRaw(buffer, bundle, r));
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+// Hand-verified sweep pins: langId / entry count / count of entries carrying
+// the undocumented 3-zero-byte pad / decompressed resource size. 0001 and
+// 0006 were rebuilt later (newer file dates, zero pads, edited test strings)
+// and overshoot the otherwise-universal 0xD4800 size by 3 and 5 bytes.
+const SWEEP: Record<string, { langId: number; entries: number; padEntries: number; size: number }> = {
+	'0001': { langId: 7, entries: 7587, padEntries: 0, size: 870403 },
+	'0002': { langId: 8, entries: 7585, padEntries: 40, size: 870400 },
+	'0003': { langId: 10, entries: 7585, padEntries: 40, size: 870400 },
+	'0004': { langId: 22, entries: 7612, padEntries: 40, size: 870400 },
+	'0005': { langId: 15, entries: 7584, padEntries: 40, size: 870400 },
+	'0006': { langId: 11, entries: 7587, padEntries: 0, size: 870405 },
+	'0007': { langId: 16, entries: 8291, padEntries: 40, size: 870400 },
+	'0008': { langId: 12, entries: 7599, padEntries: 42, size: 870400 },
+	'0009': { langId: 19, entries: 7609, padEntries: 42, size: 870400 },
+	'0010': { langId: 4, entries: 7605, padEntries: 3, size: 870400 },
+	'0011': { langId: 14, entries: 7597, padEntries: 4, size: 870400 },
+	'0012': { langId: 2, entries: 7598, padEntries: 2, size: 870400 },
+	'0013': { langId: 3, entries: 7593, padEntries: 2, size: 870400 },
+	'0014': { langId: 24, entries: 7611, padEntries: 2, size: 870400 },
+};
+
+describe('Language gold values (example/LANGUAGE/0002.BUNDLE — retail English UK)', () => {
+	const raw = loadLanguageRaws('example/LANGUAGE/0002.BUNDLE')[0];
+	const m = parseLanguage(raw);
+
+	it('decodes the header', () => {
+		expect(m.meLanguageID).toBe(8);
+		expect(languageName(m.meLanguageID)).toBe('English (UK)');
+		expect(m.entries.length).toBe(7585);
+	});
+
+	it('pins hand-verified entries', () => {
+		expect(m.entries[0]).toEqual({ muHash: 0x7e1c1cc8, text: 'No motion blur.', _padAfter: 0 });
+		expect(m.entries[1]).toEqual({ muHash: 0x38442737, text: 'L', _padAfter: 0 });
+		expect(m.entries[2]).toEqual({ muHash: 0x3dc635cf, text: 'CAMERA RIGHT', _padAfter: 0 });
+		expect(m.entries[7583]).toEqual({ muHash: 0xf12fd364, text: 'Maguire (south by lighthouse)', _padAfter: 0 });
+	});
+
+	it('pins the first padded entry (3 zero bytes after the terminator)', () => {
+		expect(m.entries[780]._padAfter).toBe(3);
+		// Pads are exactly 0 or 3 in retail — never any other width.
+		const widths = new Set(m.entries.map((e) => e._padAfter));
+		expect([...widths].sort()).toEqual([0, 3]);
+	});
+
+	it('ends with the all-A filler entry sizing the resource to 0xD4800', () => {
+		const filler = m.entries[m.entries.length - 1];
+		expect(filler.muHash).toBe(0);
+		expect(filler.text).toMatch(/^A+$/);
+		expect(raw.byteLength).toBe(0xd4800);
+	});
+});
+
+describe('Language gold values (example/LANGUAGE/0008.BUNDLE — wiki divergence)', () => {
+	const m = parseLanguage(loadLanguageRaws('example/LANGUAGE/0008.BUNDLE')[0]);
+
+	it('stores meLanguageID 12 (E_LANGUAGE_GREEK on the wiki) but contains Russian', () => {
+		expect(m.meLanguageID).toBe(12);
+		expect(m.entries[0].text).toBe('Откл. эффект размытия.');
+	});
+});
+
+describe('Language gold values (example/LANGUAGE/0007.BUNDLE — Japanese multibyte)', () => {
+	const m = parseLanguage(loadLanguageRaws('example/LANGUAGE/0007.BUNDLE')[0]);
+
+	it('decodes multibyte UTF-8 and re-encodes it byte-exact', () => {
+		expect(m.meLanguageID).toBe(16);
+		expect(m.entries[0].text).toBe('モーションブラーがかかりません。');
+	});
+});
+
+describe('Language 14-bundle sweep', () => {
+	for (const [num, exp] of Object.entries(SWEEP)) {
+		const bundleFile = `example/LANGUAGE/${num}.BUNDLE`;
+
+		it(`${bundleFile}: pins, invariants, byte-exact round-trip, idempotence`, () => {
+			const raws = loadLanguageRaws(bundleFile);
+			// One Language resource per bundle — pinned so a multi-resource
+			// bundle would force this suite to widen its coverage.
+			expect(raws.length).toBe(1);
+			const raw = raws[0];
+			expect(raw.byteLength).toBe(exp.size);
+
+			const m = parseLanguage(raw);
+			expect(m.meLanguageID).toBe(exp.langId);
+			expect(m.entries.length).toBe(exp.entries);
+			expect(m.entries.filter((e) => e._padAfter > 0).length).toBe(exp.padEntries);
+
+			// "No motion blur" is entry 0 in every retail bundle — the hash is
+			// the cross-language key, so it matches across all 14.
+			expect(m.entries[0].muHash).toBe(0x7e1c1cc8);
+
+			// Hashes are unique; 0 appears exactly once, on the trailing filler.
+			const hashes = new Set(m.entries.map((e) => e.muHash));
+			expect(hashes.size).toBe(m.entries.length);
+			const filler = m.entries[m.entries.length - 1];
+			expect(filler.muHash).toBe(0);
+			expect(filler.text).toMatch(/^A+$/);
+
+			const written = writeLanguage(m);
+			expect(written.byteLength).toBe(raw.byteLength);
+			expect(bytesEqual(written, raw)).toBe(true);
+
+			const rewritten = writeLanguage(parseLanguage(written));
+			expect(bytesEqual(rewritten, written)).toBe(true);
+		});
+	}
+});
+
+describe('Language parser/writer guards', () => {
+	const raw = loadLanguageRaws('example/LANGUAGE/0002.BUNDLE')[0];
+	// extractResourceRaw can hand back a Node Buffer, whose .slice() is a VIEW —
+	// copy explicitly so mutations can't leak into the shared fixture bytes.
+	const copyOf = (bytes: Uint8Array) => new Uint8Array(bytes);
+
+	it('parser rejects a non-0xC mpEntries', () => {
+		const broken = copyOf(raw);
+		new DataView(broken.buffer).setUint32(8, 0x10, true);
+		expect(() => parseLanguage(broken)).toThrow(/mpEntries/);
+	});
+
+	it('parser rejects a truncated resource', () => {
+		expect(() => parseLanguage(copyOf(raw).subarray(0, 8))).toThrow(/smaller than/);
+	});
+
+	it('parser rejects an entry count overrunning the resource', () => {
+		const broken = copyOf(raw).subarray(0, 0x100);
+		expect(() => parseLanguage(broken)).toThrow(/overrun|contiguous|terminator/);
+	});
+
+	it('parser rejects non-zero bytes hiding in a pad', () => {
+		const broken = copyOf(raw);
+		const m = parseLanguage(raw);
+		// entries[780] carries a 3-byte pad; find its blob position and poison it.
+		const blobStart = 0xc + m.entries.length * 8;
+		let off = blobStart;
+		const encoder = new TextEncoder();
+		for (let i = 0; i <= 780; i++) off += encoder.encode(m.entries[i].text).length + 1 + m.entries[i]._padAfter;
+		broken[off - 1] = 0x41; // last pad byte of entries[780]
+		expect(() => parseLanguage(broken)).toThrow(/pad after entry 780/);
+	});
+
+	it('writer rejects text with an embedded NUL', () => {
+		const m = parseLanguage(raw);
+		const entries = m.entries.slice();
+		entries[0] = { ...entries[0], text: 'bad\0string' };
+		expect(() => writeLanguage({ ...m, entries })).toThrow(/embedded NUL/);
+	});
+
+	it('writer rejects a negative _padAfter', () => {
+		const m = parseLanguage(raw);
+		const entries = m.entries.slice();
+		entries[0] = { ...entries[0], _padAfter: -1 };
+		expect(() => writeLanguage({ ...m, entries })).toThrow(/_padAfter/);
+	});
+});

--- a/src/lib/core/__tests__/worldPainter2D.test.ts
+++ b/src/lib/core/__tests__/worldPainter2D.test.ts
@@ -1,0 +1,161 @@
+// Gold coverage for parseWorldPainter2D / writeWorldPainter2D.
+//
+// Fixture: example/DISTRICTS.DAT — a 2,560-byte bundle whose single 0x30
+// resource decompresses 42x to 98,336 bytes (the map is mostly long runs of
+// the same district). Pins hand-verified decoded values from a byte-level
+// probe: the BinaryFile wrapper offsets, the 384x256 grid dims, individual
+// cells located on the downsampled ASCII render, and the exact value
+// histogram (all 23 v1.9/Remastered districts in use + 41,449 0xFF cells).
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+	parseWorldPainter2D,
+	writeWorldPainter2D,
+	DISTRICT_NAMES,
+	INVALID_CELL,
+} from '../worldPainter2D';
+import { parseBundle } from '../bundle';
+import { parseDebugDataFromXml, findDebugResourceById } from '../bundle/debugData';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const WORLD_PAINTER_2D_TYPE_ID = 0x30;
+
+type ExtractedMap = { name: string; raw: Uint8Array };
+
+function loadMaps(bundleFile: string): ExtractedMap[] {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const debugResources = typeof bundle.debugData === 'string'
+		? parseDebugDataFromXml(bundle.debugData)
+		: [];
+	return bundle.resources
+		.filter((r) => r.resourceTypeId === WORLD_PAINTER_2D_TYPE_ID)
+		.map((r) => ({
+			name: findDebugResourceById(debugResources, r.resourceId.low.toString(16))?.name ?? '?',
+			raw: extractResourceRaw(buffer, bundle, r),
+		}));
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+const maps = loadMaps('example/DISTRICTS.DAT');
+
+describe('WorldPainter2D gold values (example/DISTRICTS.DAT)', () => {
+	it('finds exactly one map, named Districts', () => {
+		expect(maps.length).toBe(1);
+		expect(maps[0].name).toBe('Districts');
+		expect(maps[0].raw.byteLength).toBe(98336);
+	});
+
+	it('decodes the wrapper and grid header', () => {
+		const m = parseWorldPainter2D(maps[0].raw);
+		// 384x256 — the post-v1.0 grid (Big Surf Island widened the map).
+		expect(m.muWidth).toBe(384);
+		expect(m.muHeight).toBe(256);
+		expect(m.cells.length).toBe(384 * 256);
+		// Wrapper pad (0x8..0xF) and trailing 16-byte-alignment pad are zero.
+		expect(m._wrapperPad.length).toBe(8);
+		expect(m._wrapperPad.every((b) => b === 0)).toBe(true);
+		expect(m._trailingPad.length).toBe(98336 - 0x10 - 4 - 384 * 256);
+		expect(m._trailingPad.length).toBe(12);
+		expect(m._trailingPad.every((b) => b === 0)).toBe(true);
+	});
+
+	it('decodes hand-verified cells (row-major from the north-west corner)', () => {
+		const m = parseWorldPainter2D(maps[0].raw);
+		const cell = (x: number, y: number) => m.cells[y * m.muWidth + x];
+		expect(cell(100, 100)).toBe(4); // Eastern Shore
+		expect(cell(200, 128)).toBe(14); // Downtown
+		expect(cell(300, 60)).toBe(21); // South Coast (Big Surf Island, east side)
+		expect(cell(50, 200)).toBe(12); // Lone Peaks (White Mountain, west side)
+		// All four map corners are ocean / out of bounds.
+		expect(cell(0, 0)).toBe(INVALID_CELL);
+		expect(cell(383, 0)).toBe(INVALID_CELL);
+		expect(cell(0, 255)).toBe(INVALID_CELL);
+		expect(cell(383, 255)).toBe(INVALID_CELL);
+	});
+
+	it('uses exactly the 23 v1.9/Remastered district values plus 0xFF', () => {
+		const m = parseWorldPainter2D(maps[0].raw);
+		const hist = new Map<number, number>();
+		for (const v of m.cells) hist.set(v, (hist.get(v) ?? 0) + 1);
+		expect(hist.size).toBe(24);
+		for (let d = 0; d < DISTRICT_NAMES.length; d++) {
+			expect(hist.get(d) ?? 0, `district ${d} ${DISTRICT_NAMES[d]}`).toBeGreaterThan(0);
+		}
+		// No value falls between the last district and the 0xFF sentinel — in
+		// particular the enum's E_DISTRICT_INVALID (23) never appears on disk.
+		expect(hist.get(INVALID_CELL)).toBe(41449);
+		expect(hist.get(23)).toBeUndefined();
+		// Largest and smallest painted districts, pinned from the probe.
+		expect(hist.get(12)).toBe(6170); // Lone Peaks
+		expect(hist.get(18)).toBe(687); // Paradise Keys Bridge
+	});
+
+	it('DISTRICT_NAMES matches the BrnWorld::EDistrict wiki table', () => {
+		expect(DISTRICT_NAMES.length).toBe(23);
+		expect(DISTRICT_NAMES[0]).toBe('Ocean View');
+		expect(DISTRICT_NAMES[14]).toBe('Downtown');
+		expect(DISTRICT_NAMES[22]).toBe("Perren's Point");
+	});
+});
+
+describe('WorldPainter2D round-trip', () => {
+	it('round-trips byte-for-byte', () => {
+		const rewritten = writeWorldPainter2D(parseWorldPainter2D(maps[0].raw));
+		expect(rewritten.byteLength).toBe(maps[0].raw.byteLength);
+		expect(bytesEqual(rewritten, maps[0].raw)).toBe(true);
+	});
+
+	it('writer is idempotent', () => {
+		const write1 = writeWorldPainter2D(parseWorldPainter2D(maps[0].raw));
+		const write2 = writeWorldPainter2D(parseWorldPainter2D(write1));
+		expect(bytesEqual(write2, write1)).toBe(true);
+	});
+
+	it('edited cells survive a round-trip', () => {
+		const m = parseWorldPainter2D(maps[0].raw);
+		const cells = m.cells.slice();
+		cells[100 * m.muWidth + 100] = 16; // Eastern Shore cell → Motor City
+		const reparsed = parseWorldPainter2D(writeWorldPainter2D({ ...m, cells }));
+		expect(reparsed.cells[100 * m.muWidth + 100]).toBe(16);
+	});
+
+	it('writer rejects a cell array inconsistent with the grid dims', () => {
+		const m = parseWorldPainter2D(maps[0].raw);
+		expect(() => writeWorldPainter2D({ ...m, cells: m.cells.slice(0, -1) })).toThrow(/cells/);
+	});
+});
+
+describe('WorldPainter2D rigid-layout asserts', () => {
+	// Uint8Array.from, NOT .slice(): extractResourceRaw returns a Node Buffer
+	// when zlib decompresses, and Buffer.prototype.slice aliases the shared
+	// bytes — mutating a "copy" would corrupt every other test's fixture.
+	it('rejects a wrapper whose data offset is not 0x10', () => {
+		const broken = Uint8Array.from(maps[0].raw);
+		broken[4] = 0x20;
+		expect(() => parseWorldPainter2D(broken)).toThrow(/mu32DataOffset/);
+	});
+
+	it('rejects a wrapper whose data size disagrees with the resource size', () => {
+		const broken = Uint8Array.from(maps[0].raw);
+		broken[0] = 0x00; // 0x18010 → 0x18000
+		expect(() => parseWorldPainter2D(broken)).toThrow(/mu32DataSize/);
+	});
+
+	it('rejects grid dims that overrun the resource', () => {
+		const broken = Uint8Array.from(maps[0].raw);
+		broken[0x12] = 0xff; // muHeight 256 → 0x1FF rows
+		broken[0x13] = 0x01;
+		expect(() => parseWorldPainter2D(broken)).toThrow(/overruns/);
+	});
+});

--- a/src/lib/core/guiPopup.ts
+++ b/src/lib/core/guiPopup.ts
@@ -1,0 +1,339 @@
+// GuiPopup parser and writer (resource type 0x1F).
+//
+// Card-styled popup messages the game shows at specific moments — leaving an
+// online room, confirming a friend delete, video-option warnings, the
+// FreeBurn splash cards. One resource game-wide, in GUI/POPUPS.PUP.
+//
+// Text is NOT stored here: macTitleId / macMessageId / macButton*Id are
+// char[32] ASCII KEYS into the Language resource's string table (e.g.
+// 'ONLINE_FRIENDS_CONFIRM_DELETE'), unlike resources that reference language
+// strings by numeric id. Some retail keys carry a '~' prefix (e.g.
+// '~ONLINE_SYNCHING_KICKED'); its runtime meaning is unconfirmed. An empty
+// key means "no title" / "no button". mNameId is the popup's CgsID — always
+// encodeCgsId(macName.toUpperCase()) in retail (all 111 popups verified) —
+// which is what game code uses to summon a popup by name.
+//
+// On-disk layout (32-bit PC, little-endian):
+//   header 0x8 : mppPopupData u32 (always 0x40), miPopupCount i16,
+//                miSizeOfPopupResource i16 — the TOTAL resource byte size
+//                (21824 in retail), not the size of one popup as the wiki
+//                field name suggests. Zero pad to 0x40.
+//   0x40       : u32 file-relative record offsets ×count (fixed up to
+//                GuiPopup* pointers at load), zero-padded to a 16-byte
+//                boundary. The lone retail fixture (111 popups) pads 4 bytes;
+//                8-byte alignment would produce identical bytes there, so 16
+//                is a choice — it matches bundle resource alignment and the
+//                parser/writer agree on it either way.
+//   records    : GuiPopup ×count, 0xC0 each, contiguous in pointer order,
+//                tiling exactly to the end of the resource.
+//
+// Round-trip strategy: the layout is rigid — every offset is recomputed from
+// popups.length on write and the parser THROWS if stored pointers disagree.
+// String buffers are asserted NUL-terminated with all-zero tails (true for
+// every retail string), so the writer's zero-fill is byte-exact. The record
+// pads at +0x15 (zero in retail), +0xB1 and +0xB9 (the SAME uninitialised
+// garbage bytes f9 4f 00 / df 9c 00 e0 24 9d 00 in all 111 retail records —
+// build-machine memory copied into every struct) are preserved verbatim in
+// _-prefixed fields.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Enumerations
+// =============================================================================
+
+// CgsGui::PopupStyle — selects the popup frame, placement, and button bar.
+// CrashNav styles render in the front-end nav, InGame styles over gameplay;
+// "wait" variants have no buttons (dismissed by code), splash styles (9) are
+// the full-screen online mode cards. Values 14/15 are the v1.9+ Big Surf
+// Island additions (the v1.0–1.8 enum ended at 13 = Custom).
+export const POPUP_STYLES = [
+	{ value: 0, label: 'CrashNav — wait', description: 'E_POPUPSTYLE_CRASHNAV_WAIT' },
+	{ value: 1, label: 'CrashNav — OK', description: 'E_POPUPSTYLE_CRASHNAV_OK' },
+	{ value: 2, label: 'CrashNav — OK/Cancel', description: 'E_POPUPSTYLE_CRASHNAV_OKCANCEL' },
+	{ value: 3, label: 'CrashNav online — wait', description: 'E_POPUPSTYLE_CRASHNAV_ONLINE_WAIT' },
+	{ value: 4, label: 'CrashNav online — OK', description: 'E_POPUPSTYLE_CRASHNAV_ONLINE_OK' },
+	{ value: 5, label: 'CrashNav online — OK/Cancel', description: 'E_POPUPSTYLE_CRASHNAV_ONLINE_OKCANCEL' },
+	{ value: 6, label: 'In-game — wait', description: 'E_POPUPSTYLE_INGAME_WAIT' },
+	{ value: 7, label: 'In-game — OK', description: 'E_POPUPSTYLE_INGAME_OK' },
+	{ value: 8, label: 'In-game — OK/Cancel', description: 'E_POPUPSTYLE_INGAME_OKCANCEL' },
+	{ value: 9, label: 'In-game online — splash', description: 'E_POPUPSTYLE_INGAME_ONLINE_WAIT' },
+	{ value: 10, label: 'In-game online — OK', description: 'E_POPUPSTYLE_INGAME_ONLINE_OK' },
+	{ value: 11, label: 'In-game online — OK/Cancel', description: 'E_POPUPSTYLE_INGAME_ONLINE_OKCANCEL' },
+	{ value: 12, label: 'Enter FreeBurn', description: 'E_POPUPSTYLE_INGAME_ONLINE_ENTER_FREEBURN' },
+	{ value: 13, label: 'Custom', description: 'E_POPUPSTYLE_CUSTOM' },
+	{ value: 14, label: 'Island — enter (in-game)', description: 'v1.9+ IslandPopUp; name unknown on the wiki' },
+	{ value: 15, label: 'Island — buy (in-game)', description: 'v1.9+ IslandPopUp; name unknown on the wiki' },
+] as const;
+
+export const POPUP_ICONS = [
+	{ value: 0, label: 'Invisible', description: 'E_POPUPICONS_INVISIBLE' },
+	{ value: 1, label: 'Warning', description: 'E_POPUPICONS_WARNING' },
+] as const;
+
+export const POPUP_PARAM_TYPES = [
+	{ value: 0, label: 'Unused', description: 'E_POPUPPARAMTYPES_UNUSED' },
+	{ value: 1, label: 'String', description: 'E_POPUPPARAMTYPES_STRING — runtime substitutes a raw string' },
+	{ value: 2, label: 'String ID', description: 'E_POPUPPARAMTYPES_STRING_ID — runtime substitutes another Language string' },
+] as const;
+
+export function popupStyleLabel(value: number): string {
+	return POPUP_STYLES.find((s) => s.value === value)?.label ?? `style ${value}`;
+}
+
+/**
+ * miMessageParamsUsed as retail derives it: the count of leading non-Unused
+ * entries in maeMessageParams. Holds for all 111 retail popups — including
+ * the (1,2) / (2,2) two-param messages and the (2,0) one-param ones.
+ */
+export function countMessageParamsUsed(params: readonly [number, number]): number {
+	return params[0] === 0 ? 0 : params[1] === 0 ? 1 : 2;
+}
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type GuiPopup = {
+	/** CgsID — base-40 packed macName.toUpperCase(); how code summons the popup. */
+	mNameId: bigint;
+	/** Debug name, max 12 chars (char[13] with NUL). */
+	macName: string;
+	/** POPUP_STYLES — frame, placement, and button bar. */
+	meStyle: number;
+	/** POPUP_ICONS. */
+	meIcon: number;
+	/** Language string key for the title; '' = untitled popup. */
+	macTitleId: string;
+	/** Language string key for the body text. */
+	macMessageId: string;
+	/** POPUP_PARAM_TYPES ×2 — how runtime fills the message's %1/%2 slots. */
+	maeMessageParams: [number, number];
+	/** Count of leading non-Unused entries in maeMessageParams (see countMessageParamsUsed). */
+	miMessageParamsUsed: number;
+	/** Language string key for button 1's caption; '' = no button. */
+	macButton1Id: string;
+	/** POPUP_PARAM_TYPES — always Unused (0) in retail. */
+	meButton1Param: number;
+	/** Always false in retail. */
+	mbButton1ParamUsed: boolean;
+	/** Language string key for button 2's caption; '' = no second button. */
+	macButton2Id: string;
+	/** POPUP_PARAM_TYPES — always Unused (0) in retail. */
+	meButton2Param: number;
+	/** Always false in retail. */
+	mbButton2ParamUsed: boolean;
+	/** Record pad at +0x15 (zero in retail) — preserved verbatim. */
+	_pad15: [number, number, number];
+	/** Record pad at +0xB1 — uninitialised garbage (f9 4f 00 in every retail record); preserved verbatim. */
+	_padB1: [number, number, number];
+	/** Record pad at +0xB9 — uninitialised garbage (df 9c 00 e0 24 9d 00 in every retail record); preserved verbatim. */
+	_padB9: number[];
+};
+
+export type ParsedGuiPopup = {
+	popups: GuiPopup[];
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const HEADER_SIZE = 0x8;
+// mppPopupData is 0x40 in retail — the 8-byte header is padded out, likely so
+// the pointer array starts on a cache-line boundary.
+const PTR_ARRAY_OFFSET = 0x40;
+const RECORD_SIZE = 0xc0;
+const NAME_BUF = 13;
+const KEY_BUF = 32;
+// miSizeOfPopupResource is int16_t on the wiki; keep the written size positive
+// under that reading. Caps the resource at ~165 popups.
+const MAX_RESOURCE_SIZE = 0x7fff;
+
+function align16(n: number): number {
+	return (n + 15) & ~15;
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+function readFixedCString(r: BinReader, len: number, what: string): string {
+	let s = '';
+	let seenNul = false;
+	for (let i = 0; i < len; i++) {
+		const b = r.readU8();
+		if (!seenNul) {
+			if (b === 0) seenNul = true;
+			else s += String.fromCharCode(b);
+		} else if (b !== 0) {
+			// A non-zero tail would be silently dropped by the zero-filling
+			// writer — bail so round-trip stays provably byte-exact.
+			throw new Error(`GuiPopup: ${what} has residue byte 0x${b.toString(16)} after its NUL terminator`);
+		}
+	}
+	if (!seenNul) throw new Error(`GuiPopup: ${what} is not NUL-terminated within ${len} bytes`);
+	return s;
+}
+
+function readBool8(r: BinReader, what: string): boolean {
+	const b = r.readU8();
+	if (b !== 0 && b !== 1) throw new Error(`GuiPopup: ${what} is 0x${b.toString(16)}, expected a 0/1 bool`);
+	return b === 1;
+}
+
+export function parseGuiPopup(raw: Uint8Array, littleEndian = true): ParsedGuiPopup {
+	const r = new BinReader(raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength), littleEndian);
+
+	// --- GuiPopupResource header ---
+	const mppPopupData = r.readU32();
+	const miPopupCount = r.readI16();
+	const miSizeOfPopupResource = r.readU16();
+	if (mppPopupData !== PTR_ARRAY_OFFSET) {
+		throw new Error(`GuiPopup: mppPopupData is 0x${mppPopupData.toString(16)}, expected 0x40 (rigid layout)`);
+	}
+	if (miPopupCount < 0) throw new Error(`GuiPopup: negative popup count ${miPopupCount}`);
+	if (miSizeOfPopupResource !== raw.byteLength) {
+		throw new Error(`GuiPopup: miSizeOfPopupResource ${miSizeOfPopupResource} != resource size ${raw.byteLength}`);
+	}
+	for (let i = HEADER_SIZE; i < PTR_ARRAY_OFFSET; i++) {
+		if (raw[i] !== 0) throw new Error(`GuiPopup: non-zero header pad byte at 0x${i.toString(16)}`);
+	}
+
+	// --- Pointer array (file-relative offsets) + alignment pad ---
+	const recordsStart = align16(PTR_ARRAY_OFFSET + miPopupCount * 4);
+	if (recordsStart + miPopupCount * RECORD_SIZE !== raw.byteLength) {
+		throw new Error(`GuiPopup: ${miPopupCount} records should end at 0x${(recordsStart + miPopupCount * RECORD_SIZE).toString(16)}, resource is 0x${raw.byteLength.toString(16)}`);
+	}
+	r.position = PTR_ARRAY_OFFSET;
+	for (let i = 0; i < miPopupCount; i++) {
+		const ptr = r.readU32();
+		const expected = recordsStart + i * RECORD_SIZE;
+		if (ptr !== expected) {
+			throw new Error(`GuiPopup: mppPopupData[${i}] = 0x${ptr.toString(16)}, expected 0x${expected.toString(16)} (canonical order violated)`);
+		}
+	}
+	for (let i = PTR_ARRAY_OFFSET + miPopupCount * 4; i < recordsStart; i++) {
+		if (raw[i] !== 0) throw new Error(`GuiPopup: non-zero pointer-array pad byte at 0x${i.toString(16)}`);
+	}
+
+	// --- GuiPopup records (0xC0 each, contiguous) ---
+	const popups: GuiPopup[] = [];
+	for (let i = 0; i < miPopupCount; i++) {
+		const start = recordsStart + i * RECORD_SIZE;
+		r.position = start;
+		const mNameId = r.readU64();
+		const macName = readFixedCString(r, NAME_BUF, `popup[${i}].macName`);
+		const _pad15: [number, number, number] = [r.readU8(), r.readU8(), r.readU8()];
+		const meStyle = r.readU32();
+		const meIcon = r.readU32();
+		const macTitleId = readFixedCString(r, KEY_BUF, `popup[${i}].macTitleId`);
+		const macMessageId = readFixedCString(r, KEY_BUF, `popup[${i}].macMessageId`);
+		const maeMessageParams: [number, number] = [r.readU32(), r.readU32()];
+		const miMessageParamsUsed = r.readI32();
+		const macButton1Id = readFixedCString(r, KEY_BUF, `popup[${i}].macButton1Id`);
+		const meButton1Param = r.readU32();
+		const mbButton1ParamUsed = readBool8(r, `popup[${i}].mbButton1ParamUsed`);
+		const macButton2Id = readFixedCString(r, KEY_BUF, `popup[${i}].macButton2Id`);
+		const _padB1: [number, number, number] = [r.readU8(), r.readU8(), r.readU8()];
+		const meButton2Param = r.readU32();
+		const mbButton2ParamUsed = readBool8(r, `popup[${i}].mbButton2ParamUsed`);
+		const _padB9: number[] = [];
+		for (let b = 0; b < 7; b++) _padB9.push(r.readU8());
+		if (r.position !== start + RECORD_SIZE) {
+			throw new Error(`GuiPopup: popup[${i}] decoded ${r.position - start} bytes, record is 0x${RECORD_SIZE.toString(16)}`);
+		}
+		popups.push({
+			mNameId,
+			macName,
+			meStyle,
+			meIcon,
+			macTitleId,
+			macMessageId,
+			maeMessageParams,
+			miMessageParamsUsed,
+			macButton1Id,
+			meButton1Param,
+			mbButton1ParamUsed,
+			macButton2Id,
+			meButton2Param,
+			mbButton2ParamUsed,
+			_pad15,
+			_padB1,
+			_padB9,
+		});
+	}
+
+	return { popups };
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+function writeFixedCString(w: BinWriter, str: string, len: number, what: string): void {
+	if (str.length > len - 1) {
+		throw new Error(`GuiPopup writer: ${what} "${str}" is ${str.length} chars, max ${len - 1} for a char[${len}]`);
+	}
+	for (let i = 0; i < len; i++) {
+		const code = i < str.length ? str.charCodeAt(i) : 0;
+		if (code > 0xff) throw new Error(`GuiPopup writer: ${what} has a non-byte character (code ${code})`);
+		w.writeU8(code);
+	}
+}
+
+export function writeGuiPopup(model: ParsedGuiPopup, littleEndian = true): Uint8Array {
+	const { popups } = model;
+	// File-relative offsets recomputed from the popup count, never stored.
+	const recordsStart = align16(PTR_ARRAY_OFFSET + popups.length * 4);
+	const totalSize = recordsStart + popups.length * RECORD_SIZE;
+	if (totalSize > MAX_RESOURCE_SIZE) {
+		throw new Error(`GuiPopup writer: ${popups.length} popups produce ${totalSize} bytes, overflowing the i16 miSizeOfPopupResource field (max ${MAX_RESOURCE_SIZE})`);
+	}
+
+	const w = new BinWriter(totalSize, littleEndian);
+
+	// --- Header + pad to the pointer array ---
+	w.writeU32(PTR_ARRAY_OFFSET);
+	w.writeI16(popups.length);
+	w.writeI16(totalSize); // miSizeOfPopupResource — the whole resource size
+	w.writeZeroes(PTR_ARRAY_OFFSET - HEADER_SIZE);
+
+	// --- Pointer array + alignment pad ---
+	for (let i = 0; i < popups.length; i++) w.writeU32(recordsStart + i * RECORD_SIZE);
+	w.writeZeroes(recordsStart - w.offset);
+	if (w.offset !== recordsStart) throw new Error(`GuiPopup writer: records offset mismatch ${w.offset} vs ${recordsStart}`);
+
+	// --- Records ---
+	popups.forEach((p, i) => {
+		const start = w.offset;
+		w.writeU64(p.mNameId);
+		writeFixedCString(w, p.macName, NAME_BUF, `popup[${i}].macName`);
+		w.writeU8(p._pad15[0]);
+		w.writeU8(p._pad15[1]);
+		w.writeU8(p._pad15[2]);
+		w.writeU32(p.meStyle);
+		w.writeU32(p.meIcon);
+		writeFixedCString(w, p.macTitleId, KEY_BUF, `popup[${i}].macTitleId`);
+		writeFixedCString(w, p.macMessageId, KEY_BUF, `popup[${i}].macMessageId`);
+		w.writeU32(p.maeMessageParams[0]);
+		w.writeU32(p.maeMessageParams[1]);
+		w.writeI32(p.miMessageParamsUsed);
+		writeFixedCString(w, p.macButton1Id, KEY_BUF, `popup[${i}].macButton1Id`);
+		w.writeU32(p.meButton1Param);
+		w.writeU8(p.mbButton1ParamUsed ? 1 : 0);
+		writeFixedCString(w, p.macButton2Id, KEY_BUF, `popup[${i}].macButton2Id`);
+		w.writeU8(p._padB1[0]);
+		w.writeU8(p._padB1[1]);
+		w.writeU8(p._padB1[2]);
+		w.writeU32(p.meButton2Param);
+		w.writeU8(p.mbButton2ParamUsed ? 1 : 0);
+		for (let b = 0; b < 7; b++) w.writeU8(p._padB9[b] ?? 0);
+		if (w.offset !== start + RECORD_SIZE) {
+			throw new Error(`GuiPopup writer: popup[${i}] wrote ${w.offset - start} bytes, record is 0x${RECORD_SIZE.toString(16)}`);
+		}
+	});
+
+	if (w.offset !== totalSize) throw new Error(`GuiPopup writer: wrote ${w.offset} bytes, expected ${totalSize}`);
+	return w.bytes;
+}

--- a/src/lib/core/hudMessage.ts
+++ b/src/lib/core/hudMessage.ts
@@ -1,0 +1,332 @@
+// HudMessage parser and writer (resource type 0x2C, CgsGui::GuiHudMessageResource).
+//
+// The in-game HUD message catalogue: every message the HUD can flash at the
+// player ("TAKEDOWN!", road-rule beaten, challenge complete, …), triggered by
+// gameplay events and styled positive/negative/neutral. Retail ships exactly
+// ONE resource of this type, in HUDMESSAGES.HM (308 messages). The related
+// HudMessageList (0x2D) was a dev-only name index dropped in early 2007 and
+// never shipped.
+//
+// Each message has up to three text lines. The wiki documents them as three
+// parallel arrays (maacStringId[3], maiParamCount[3], maaeParams[3][4]); this
+// model regroups them into `lines[3]` records because the lanes are strictly
+// parallel — verified: in all 308 retail messages, every lane with
+// miParamCount > 0 has a non-empty string id on the same lane. A line's
+// macStringId is a SYMBOLIC id into the Language (0x27) string table
+// (e.g. 'HUDMESSAGE_GENERIC1'); the game hashes it at runtime to find the
+// translated text. Params are printf-style substitution slots whose types
+// (HUD_MESSAGE_PARAM_TYPES) the triggering code must satisfy.
+//
+// mMessageIdHash is NOT free data: it equals encodeCgsId(macMessageId
+// .toUpperCase()) in every retail record (308/308 verified). The game looks
+// messages up by this CgsID, so editors must keep it in sync — the schema
+// layer derives it on macMessageId edits; the writer emits the model value
+// verbatim so untouched files stay byte-exact.
+//
+// On-disk layout (32-bit PC, little-endian; the only platform with a
+// retail fixture):
+//   0x00 GuiHudMessageData** mppHudMessageData  — file-relative, always 0x80
+//   0x04 i32 miSizeOfHudMessageResource         — == total resource size
+//   0x08 i32 miHudMessageCount
+//   0x0C..0x80   zero pad
+//   0x80         pointer array, count × u32, each → one record
+//   …zero pad to the next 128-byte boundary…
+//   recordsStart contiguous GuiHudMessageData records, 0x170 bytes each,
+//                tiling exactly to the end of the resource
+// With a single retail fixture the section alignment can't be fully
+// disambiguated (0x80/0x580 fit both align-128 and "fixed 0x80 + align-64");
+// the writer uses align-128 for both, which reproduces the fixture, and the
+// parser asserts the derived offsets so violations fail loudly.
+//
+// Round-trip strategy: pointers/sizes/counts are recomputed from the array on
+// write. All char arrays are zero-filled after the terminator in retail (the
+// parser asserts this rather than silently dropping bytes). The two pad slots
+// inside each record are NOT zero — they hold constant build-tool heap
+// garbage (f9 1c 00 at +0x10D, 74 f9 1c 00 at +0x16C in every retail record)
+// — preserved verbatim per record in _-prefixed fields.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Enumerations
+// =============================================================================
+
+/** CgsGui::HudMessageAvailableFields — muAvailabilityBitSet bits. */
+export const HUD_MESSAGE_AVAILABILITY_FLAGS = [
+	{ mask: 0x01, label: 'Race', description: 'Available in Race events' },
+	{ mask: 0x02, label: 'Road Rage', description: 'Available in Road Rage events' },
+	{ mask: 0x04, label: 'Showtime', description: 'Available in Showtime' },
+	{ mask: 0x08, label: 'Offline', description: 'Available offline' },
+	{ mask: 0x10, label: 'Online', description: 'Available online' },
+	{ mask: 0x20, label: 'In crash', description: 'Available while crashed' },
+] as const;
+
+/** CgsGui::HudMessageGroup — retail uses 1/2/3; ALL (0) never appears. */
+export const HUD_MESSAGE_GROUPS = [
+	{ value: 0, label: 'All' },
+	{ value: 1, label: 'Online live revenge' },
+	{ value: 2, label: 'Online dirty tricks' },
+	{ value: 3, label: 'In-game messages' },
+] as const;
+
+/** CgsGui::HudMessageParamTypes — retail uses Unused/String/Int/Float/StringId;
+ *  Money and Time are defined by the game but appear in no retail message. */
+export const HUD_MESSAGE_PARAM_TYPES = [
+	{ value: 0, label: 'Unused' },
+	{ value: 1, label: 'String' },
+	{ value: 2, label: 'Int' },
+	{ value: 3, label: 'Float' },
+	{ value: 4, label: 'Money' },
+	{ value: 5, label: 'Time' },
+	{ value: 6, label: 'StringId' },
+] as const;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type HudMessageLine = {
+	/** Language (0x27) string id, e.g. 'HUDMESSAGE_GENERIC1'. '' = unused line. */
+	macStringId: string;
+	/** Number of leading maeParamTypes entries actually consumed (0–4). */
+	miParamCount: number;
+	/** Always 4 slots — HUD_MESSAGE_PARAM_TYPES values, Unused (0) past miParamCount. */
+	maeParamTypes: number[];
+};
+
+export type HudMessage = {
+	/** Always exactly 3 lines (fixed-size on disk); unused lines have '' ids. */
+	lines: HudMessageLine[];
+	/** GUI style key controlling colour/placement, e.g. 'PosMessageBott01'. */
+	macMessageStyle: string;
+	/** Icon key, 'invisible' for none, 'EventSpecific' to follow the event. */
+	macDefaultIcon: string;
+	/** Trigger id the game fires messages by, ≤12 chars, e.g. 'AggDrBstStrt'. */
+	macMessageId: string;
+	/** CgsID — equals encodeCgsId(macMessageId.toUpperCase()) in all retail
+	 *  records. The game looks messages up by this, so keep it in sync. */
+	mMessageIdHash: bigint;
+	/** HUD_MESSAGE_AVAILABILITY_FLAGS bit set. */
+	muAvailabilityBitSet: number;
+	/** Time the message displays, in seconds. */
+	mfDuration: number;
+	/** Wait before displaying, in seconds. */
+	mfTimeToWait: number;
+	/** Percent priority (0–100) for the message queue. */
+	miPriority: number;
+	/** Priority threshold (0–100) below which a queued message is dropped. */
+	miForceRemoveThreshold: number;
+	/** HUD_MESSAGE_GROUPS value. */
+	meMessageGroup: number;
+	/** 3 garbage bytes after macMessageId's nul (constant f9 1c 00 in retail) — verbatim. */
+	_padMessageId: [number, number, number];
+	/** u32 record tail garbage (constant 0x001cf974 in retail) — verbatim. */
+	_padTail: number;
+};
+
+export type ParsedHudMessage = {
+	messages: HudMessage[];
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const HEADER_SIZE = 0xc;
+const PTR_ARRAY_OFFSET = 0x80;
+const SECTION_ALIGN = 128;
+const RECORD_SIZE = 0x170;
+export const HUD_MESSAGE_LINES = 3;
+export const HUD_MESSAGE_PARAMS_PER_LINE = 4;
+const STRING_ID_CAP = 64;
+const STYLE_CAP = 32;
+const ICON_CAP = 32;
+const MESSAGE_ID_CAP = 13; // 12 chars + nul
+
+function align(offset: number, to: number): number {
+	const mod = offset % to;
+	return mod === 0 ? offset : offset + (to - mod);
+}
+
+function recordsOffsetFor(count: number): number {
+	return align(PTR_ARRAY_OFFSET + count * 4, SECTION_ALIGN);
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+/** Reads a nul-terminated string from a fixed char array, asserting the bytes
+ *  after the terminator are zero — true of every retail field, and required
+ *  for the writer's zero-fill to round-trip byte-exact. */
+function readZeroPaddedString(raw: Uint8Array, offset: number, cap: number, what: string): string {
+	const bytes = raw.subarray(offset, offset + cap);
+	let nul = bytes.indexOf(0);
+	if (nul < 0) nul = cap;
+	for (let i = nul + 1; i < cap; i++) {
+		if (bytes[i] !== 0) {
+			throw new Error(`HudMessage: non-zero byte after terminator in ${what} at +0x${(offset + i).toString(16)}`);
+		}
+	}
+	return new TextDecoder().decode(bytes.subarray(0, nul));
+}
+
+function assertZeroRange(raw: Uint8Array, start: number, end: number, what: string) {
+	for (let i = start; i < end; i++) {
+		if (raw[i] !== 0) {
+			throw new Error(`HudMessage: non-zero ${what} pad byte at 0x${i.toString(16)}`);
+		}
+	}
+}
+
+export function parseHudMessage(raw: Uint8Array, littleEndian = true): ParsedHudMessage {
+	const r = new BinReader(raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength), littleEndian);
+
+	// --- Header ---
+	const mppHudMessageData = r.readU32();
+	const miSizeOfHudMessageResource = r.readI32();
+	const miHudMessageCount = r.readI32();
+	if (mppHudMessageData !== PTR_ARRAY_OFFSET) {
+		throw new Error(`HudMessage: mppHudMessageData is 0x${mppHudMessageData.toString(16)}, expected 0x${PTR_ARRAY_OFFSET.toString(16)} (rigid layout)`);
+	}
+	if (miSizeOfHudMessageResource !== raw.byteLength) {
+		throw new Error(`HudMessage: miSizeOfHudMessageResource ${miSizeOfHudMessageResource} != resource size ${raw.byteLength}`);
+	}
+	const recordsStart = recordsOffsetFor(miHudMessageCount);
+	if (miHudMessageCount < 0 || recordsStart + miHudMessageCount * RECORD_SIZE !== raw.byteLength) {
+		throw new Error(`HudMessage: ${miHudMessageCount} records don't tile [0x${recordsStart.toString(16)}, 0x${raw.byteLength.toString(16)})`);
+	}
+	assertZeroRange(raw, HEADER_SIZE, PTR_ARRAY_OFFSET, 'header');
+	assertZeroRange(raw, PTR_ARRAY_OFFSET + miHudMessageCount * 4, recordsStart, 'pointer-array');
+
+	// --- Pointer array (each entry must point at the canonical record slot) ---
+	r.position = PTR_ARRAY_OFFSET;
+	for (let i = 0; i < miHudMessageCount; i++) {
+		const p = r.readU32();
+		const expected = recordsStart + i * RECORD_SIZE;
+		if (p !== expected) {
+			throw new Error(`HudMessage: record pointer [${i}] = 0x${p.toString(16)}, expected 0x${expected.toString(16)} (canonical order violated)`);
+		}
+	}
+
+	// --- Records (0x170 each) ---
+	const messages: HudMessage[] = [];
+	for (let i = 0; i < miHudMessageCount; i++) {
+		const base = recordsStart + i * RECORD_SIZE;
+		const lines: HudMessageLine[] = [];
+		for (let s = 0; s < HUD_MESSAGE_LINES; s++) {
+			lines.push({
+				macStringId: readZeroPaddedString(raw, base + s * STRING_ID_CAP, STRING_ID_CAP, `message[${i}].lines[${s}].macStringId`),
+				miParamCount: 0, // filled from the parallel lane below
+				maeParamTypes: [],
+			});
+		}
+		const macMessageStyle = readZeroPaddedString(raw, base + 0xc0, STYLE_CAP, `message[${i}].macMessageStyle`);
+		const macDefaultIcon = readZeroPaddedString(raw, base + 0xe0, ICON_CAP, `message[${i}].macDefaultIcon`);
+		const macMessageId = readZeroPaddedString(raw, base + 0x100, MESSAGE_ID_CAP, `message[${i}].macMessageId`);
+		const _padMessageId: [number, number, number] = [raw[base + 0x10d], raw[base + 0x10e], raw[base + 0x10f]];
+
+		r.position = base + 0x110;
+		const mMessageIdHash = r.readU64();
+		const muAvailabilityBitSet = r.readU32();
+		const mfDuration = r.readF32();
+		const mfTimeToWait = r.readF32();
+		const miPriority = r.readI32();
+		const miForceRemoveThreshold = r.readI32();
+		const meMessageGroup = r.readI32();
+		for (let s = 0; s < HUD_MESSAGE_LINES; s++) lines[s].miParamCount = r.readI32();
+		for (let s = 0; s < HUD_MESSAGE_LINES; s++) {
+			for (let p = 0; p < HUD_MESSAGE_PARAMS_PER_LINE; p++) lines[s].maeParamTypes.push(r.readU32());
+		}
+		const _padTail = r.readU32();
+		if (r.position !== base + RECORD_SIZE) {
+			throw new Error(`HudMessage: record[${i}] decoded ${r.position - base} bytes, expected 0x${RECORD_SIZE.toString(16)}`);
+		}
+
+		messages.push({
+			lines,
+			macMessageStyle,
+			macDefaultIcon,
+			macMessageId,
+			mMessageIdHash,
+			muAvailabilityBitSet,
+			mfDuration,
+			mfTimeToWait,
+			miPriority,
+			miForceRemoveThreshold,
+			meMessageGroup,
+			_padMessageId,
+			_padTail,
+		});
+	}
+
+	return { messages };
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+function checkedString(value: string, cap: number, what: string): string {
+	// cap - 1 leaves room for the terminator BinWriter.writeFixedString adds.
+	if (new TextEncoder().encode(value).length > cap - 1) {
+		throw new Error(`HudMessage writer: ${what} "${value}" exceeds ${cap - 1} bytes`);
+	}
+	return value;
+}
+
+export function writeHudMessage(model: ParsedHudMessage, littleEndian = true): Uint8Array {
+	const { messages } = model;
+	const recordsStart = recordsOffsetFor(messages.length);
+	const totalSize = recordsStart + messages.length * RECORD_SIZE;
+	const w = new BinWriter(totalSize, littleEndian);
+
+	// --- Header + zero pad to the pointer array ---
+	w.writeU32(PTR_ARRAY_OFFSET);
+	w.writeI32(totalSize);
+	w.writeI32(messages.length);
+	w.writeZeroes(PTR_ARRAY_OFFSET - HEADER_SIZE);
+
+	// --- Pointer array (recomputed), zero pad to the record region ---
+	for (let i = 0; i < messages.length; i++) w.writeU32(recordsStart + i * RECORD_SIZE);
+	w.writeZeroes(recordsStart - w.offset);
+	if (w.offset !== recordsStart) throw new Error(`HudMessage writer: records offset mismatch ${w.offset} vs ${recordsStart}`);
+
+	// --- Records ---
+	messages.forEach((m, i) => {
+		if (m.lines.length !== HUD_MESSAGE_LINES) {
+			throw new Error(`HudMessage writer: message[${i}] has ${m.lines.length} lines, the on-disk record holds exactly ${HUD_MESSAGE_LINES}`);
+		}
+		const base = w.offset;
+		for (const line of m.lines) {
+			w.writeFixedString(checkedString(line.macStringId, STRING_ID_CAP, `message[${i}] string id`), STRING_ID_CAP);
+		}
+		w.writeFixedString(checkedString(m.macMessageStyle, STYLE_CAP, `message[${i}] style`), STYLE_CAP);
+		w.writeFixedString(checkedString(m.macDefaultIcon, ICON_CAP, `message[${i}] icon`), ICON_CAP);
+		w.writeFixedString(checkedString(m.macMessageId, MESSAGE_ID_CAP, `message[${i}] message id`), MESSAGE_ID_CAP);
+		w.writeU8(m._padMessageId[0]);
+		w.writeU8(m._padMessageId[1]);
+		w.writeU8(m._padMessageId[2]);
+		w.writeU64(m.mMessageIdHash);
+		w.writeU32(m.muAvailabilityBitSet);
+		w.writeF32(m.mfDuration);
+		w.writeF32(m.mfTimeToWait);
+		w.writeI32(m.miPriority);
+		w.writeI32(m.miForceRemoveThreshold);
+		w.writeI32(m.meMessageGroup);
+		for (const line of m.lines) w.writeI32(line.miParamCount);
+		for (const line of m.lines) {
+			if (line.maeParamTypes.length !== HUD_MESSAGE_PARAMS_PER_LINE) {
+				throw new Error(`HudMessage writer: message[${i}] line has ${line.maeParamTypes.length} param slots, the on-disk record holds exactly ${HUD_MESSAGE_PARAMS_PER_LINE}`);
+			}
+			for (const p of line.maeParamTypes) w.writeU32(p);
+		}
+		w.writeU32(m._padTail);
+		if (w.offset !== base + RECORD_SIZE) {
+			throw new Error(`HudMessage writer: record[${i}] wrote ${w.offset - base} bytes, expected 0x${RECORD_SIZE.toString(16)}`);
+		}
+	});
+
+	if (w.offset !== totalSize) throw new Error(`HudMessage writer: wrote ${w.offset} bytes, expected ${totalSize}`);
+	return w.bytes;
+}

--- a/src/lib/core/hudMessageSequences.ts
+++ b/src/lib/core/hudMessageSequences.ts
@@ -1,0 +1,310 @@
+// HudMessageSequence (0x2E) + HudMessageSequenceDictionary (0x2F) parsers
+// and writers. Both types live in a single retail bundle —
+// HUDMESSAGESEQUENCES.HMSC — six sequences plus one dictionary listing them.
+//
+// A sequence is an ordered set of HUD message CgsIDs the game displays one
+// after another (each with its own on-screen duration). The feature is a
+// leftover from early development: the six retail sequences are all "DT*"
+// (online Dirty Tricks) arming flows — message[0] is always DTARMING and
+// message[1] the per-trick award/failure message. The type was removed from
+// Remastered on PS4 but reintroduced in the PC and Switch releases.
+//
+// The dictionary references sequences BY NAME: its char[13] entries are
+// exactly the macSequenceId strings of the 0x2E resources in the same
+// bundle (verified — set equality holds in retail). A sequence's
+// mSequenceIdHash is derived data: encodeCgsId(macSequenceId.toUpperCase())
+// reproduces every retail hash, so CgsID hashing is uppercase-folded.
+//
+// On-disk layout (32-bit PC, little-endian; both resources pad with zeros
+// to 16-byte alignment, and the stored miResourceSize EXCLUDES that pad):
+//   0x2E — fixed 0x1C8 struct (raw 0x1D0): CgsID hash, char[13] name,
+//   3 pad bytes, miPriority, miResourceSize (always 0x1C8), miParamCount,
+//   HudMessageParamTypes[8], miMessageCount, then a FIXED array of 8
+//   message slots (0x30 each). Slots beyond miMessageCount are not zeroed —
+//   they carry the default-initialised pattern (id 0, length 5 s, all eight
+//   param ids -1), which the parser asserts and the writer regenerates.
+//   0x2F — miResourceSize, count, mppcResources (file-relative, always
+//   0x10 — the wiki doesn't document the 4 pad bytes at 0xC that precede
+//   the pointer array), count u32 name pointers, then the char[13] names
+//   packed back-to-back (unaligned 13-byte stride).
+//
+// Round-trip strategy: counts, sizes, and name pointers are recomputed from
+// the arrays on write; the parser asserts the stored values match the rigid
+// layout (throwing instead of mis-parsing) so the writer's recomputation is
+// provably byte-exact. Pads observed 0 are asserted 0 (tails) or preserved
+// verbatim in _-prefixed fields (header pads), matching propPhysics.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Enumerations
+// =============================================================================
+
+// CgsGui::HudMessageParamTypes — element type of maeParams. Retail sequences
+// use no parameters (miParamCount 0, every slot UNUSED). The COUNT sentinel
+// (7) is not a real value and is deliberately omitted.
+export const HUD_MESSAGE_PARAM_TYPES = [
+	{ value: 0, label: 'Unused' },
+	{ value: 1, label: 'String' },
+	{ value: 2, label: 'Int' },
+	{ value: 3, label: 'Float' },
+	{ value: 4, label: 'Money' },
+	{ value: 5, label: 'Time' },
+	{ value: 6, label: 'String ID' },
+] as const;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type HudMessageSequenceMessage = {
+	/** CgsID of the HUD Message to display (uppercase-folded name hash). */
+	mMessageId: bigint;
+	/** Time to display the message in seconds. Retail always uses 5. */
+	mfMessageLength: number; // f32
+	/** Parameter IDs 1 — always -1 in retail (sequences pass no params). */
+	maiParam1Ids: number[]; // i32[4]
+	/** Parameter IDs 2 — always -1 in retail. */
+	maiParam2Ids: number[]; // i32[4]
+	/** Record pad at +0x2C — preserved verbatim (0 in retail). */
+	_pad2C: number; // u32
+};
+
+export type ParsedHudMessageSequence = {
+	/** CgsID — equals encodeCgsId(macSequenceId.toUpperCase()) in every retail resource. */
+	mSequenceIdHash: bigint;
+	/** Sequence name, max 12 chars (char[13] on disk, NUL-padded). */
+	macSequenceId: string;
+	/** Name-field alignment pad at 0x15 — preserved verbatim (0 in retail). */
+	_pad15: [number, number, number];
+	/** Always 1 in retail. */
+	miPriority: number;
+	/** Number of used maeParams slots. Always 0 in retail. */
+	miParamCount: number;
+	/** HudMessageParamTypes[8] — fixed array; all Unused (0) in retail. */
+	maeParams: number[];
+	/** The active messages (first miMessageCount of the 8 on-disk slots). */
+	messages: HudMessageSequenceMessage[];
+};
+
+export type ParsedHudMessageSequenceDictionary = {
+	/** Sequence names (each ≤ 12 chars) — the macSequenceId of every 0x2E resource in the bundle. */
+	sequenceNames: string[];
+	/** Undocumented header pad at 0xC, before the pointer array — preserved verbatim (0 in retail). */
+	_pad0C: number;
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+// char[13]: 12 usable chars + NUL — same cap CgsID encoding has.
+const NAME_FIELD_SIZE = 13;
+export const MAX_NAME_CHARS = NAME_FIELD_SIZE - 1;
+export const SEQUENCE_MESSAGE_SLOTS = 8;
+export const SEQUENCE_PARAM_SLOTS = 8;
+const MESSAGE_RECORD_SIZE = 0x30;
+const MESSAGES_OFFSET = 0x48;
+// miResourceSize stores the struct size, NOT the padded resource size.
+const SEQ_STRUCT_SIZE = MESSAGES_OFFSET + SEQUENCE_MESSAGE_SLOTS * MESSAGE_RECORD_SIZE; // 0x1C8
+const DICT_PTR_ARRAY_OFFSET = 0x10;
+export const DEFAULT_MESSAGE_LENGTH_SECONDS = 5;
+
+const align16 = (n: number) => (n + 15) & ~15;
+
+// =============================================================================
+// Shared helpers
+// =============================================================================
+
+function decodeFixedName(bytes: Uint8Array, what: string): string {
+	const nul = bytes.indexOf(0);
+	if (nul === -1) {
+		throw new Error(`HudMessageSequences: ${what} is not NUL-terminated within ${bytes.length} bytes`);
+	}
+	for (let i = nul + 1; i < bytes.length; i++) {
+		if (bytes[i] !== 0) {
+			throw new Error(`HudMessageSequences: ${what} has non-zero bytes after the NUL terminator`);
+		}
+	}
+	return String.fromCharCode(...bytes.subarray(0, nul));
+}
+
+function assertZeroTail(raw: Uint8Array, from: number, what: string) {
+	for (let i = from; i < raw.byteLength; i++) {
+		if (raw[i] !== 0) {
+			throw new Error(`HudMessageSequences: ${what} has a non-zero alignment-pad byte at 0x${i.toString(16)}`);
+		}
+	}
+}
+
+// =============================================================================
+// HudMessageSequence (0x2E)
+// =============================================================================
+
+export function parseHudMessageSequence(raw: Uint8Array, littleEndian = true): ParsedHudMessageSequence {
+	if (raw.byteLength !== align16(SEQ_STRUCT_SIZE)) {
+		throw new Error(`HudMessageSequence: resource is 0x${raw.byteLength.toString(16)} bytes, expected 0x${align16(SEQ_STRUCT_SIZE).toString(16)} (fixed-size struct + 16-byte alignment pad)`);
+	}
+	const r = new BinReader(raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength), littleEndian);
+
+	const mSequenceIdHash = r.readU64();
+	const macSequenceId = decodeFixedName(raw.subarray(0x8, 0x8 + NAME_FIELD_SIZE), 'macSequenceId');
+	r.position = 0x15;
+	const _pad15: [number, number, number] = [r.readU8(), r.readU8(), r.readU8()];
+	const miPriority = r.readI32();
+	const miResourceSize = r.readI32();
+	if (miResourceSize !== SEQ_STRUCT_SIZE) {
+		throw new Error(`HudMessageSequence: miResourceSize is 0x${miResourceSize.toString(16)}, expected 0x${SEQ_STRUCT_SIZE.toString(16)} (rigid fixed-size layout)`);
+	}
+	const miParamCount = r.readI32();
+	const maeParams: number[] = [];
+	for (let i = 0; i < SEQUENCE_PARAM_SLOTS; i++) maeParams.push(r.readI32());
+	const miMessageCount = r.readI32();
+	if (miMessageCount < 0 || miMessageCount > SEQUENCE_MESSAGE_SLOTS) {
+		throw new Error(`HudMessageSequence: miMessageCount ${miMessageCount} outside 0..${SEQUENCE_MESSAGE_SLOTS}`);
+	}
+
+	const messages: HudMessageSequenceMessage[] = [];
+	for (let slot = 0; slot < SEQUENCE_MESSAGE_SLOTS; slot++) {
+		r.position = MESSAGES_OFFSET + slot * MESSAGE_RECORD_SIZE;
+		const mMessageId = r.readU64();
+		const mfMessageLength = r.readF32();
+		const maiParam1Ids = [r.readI32(), r.readI32(), r.readI32(), r.readI32()];
+		const maiParam2Ids = [r.readI32(), r.readI32(), r.readI32(), r.readI32()];
+		const _pad2C = r.readU32();
+		if (slot < miMessageCount) {
+			messages.push({ mMessageId, mfMessageLength, maiParam1Ids, maiParam2Ids, _pad2C });
+		} else {
+			// Unused slots are default-initialised, not zeroed: length 5 s and
+			// param ids -1 with only the id cleared. The writer regenerates this
+			// pattern, so any deviation must fail the parse instead of being
+			// silently dropped.
+			const isDefault = mMessageId === 0n
+				&& mfMessageLength === DEFAULT_MESSAGE_LENGTH_SECONDS
+				&& maiParam1Ids.every((v) => v === -1)
+				&& maiParam2Ids.every((v) => v === -1)
+				&& _pad2C === 0;
+			if (!isDefault) {
+				throw new Error(`HudMessageSequence: unused message slot ${slot} deviates from the default-initialised pattern`);
+			}
+		}
+	}
+
+	assertZeroTail(raw, SEQ_STRUCT_SIZE, 'HudMessageSequence');
+
+	return { mSequenceIdHash, macSequenceId, _pad15, miPriority, miParamCount, maeParams, messages };
+}
+
+export function writeHudMessageSequence(model: ParsedHudMessageSequence, littleEndian = true): Uint8Array {
+	if (model.macSequenceId.length > MAX_NAME_CHARS) {
+		throw new Error(`HudMessageSequence writer: macSequenceId "${model.macSequenceId}" exceeds ${MAX_NAME_CHARS} chars`);
+	}
+	if (model.maeParams.length !== SEQUENCE_PARAM_SLOTS) {
+		throw new Error(`HudMessageSequence writer: maeParams has ${model.maeParams.length} entries, the on-disk array is fixed at ${SEQUENCE_PARAM_SLOTS}`);
+	}
+	if (model.messages.length > SEQUENCE_MESSAGE_SLOTS) {
+		throw new Error(`HudMessageSequence writer: ${model.messages.length} messages exceed the fixed ${SEQUENCE_MESSAGE_SLOTS} on-disk slots`);
+	}
+
+	const totalSize = align16(SEQ_STRUCT_SIZE);
+	const w = new BinWriter(totalSize, littleEndian);
+	w.writeU64(model.mSequenceIdHash);
+	w.writeFixedString(model.macSequenceId, NAME_FIELD_SIZE);
+	for (const b of model._pad15) w.writeU8(b);
+	w.writeI32(model.miPriority);
+	w.writeI32(SEQ_STRUCT_SIZE); // miResourceSize — excludes the alignment pad
+	w.writeI32(model.miParamCount);
+	for (const p of model.maeParams) w.writeI32(p);
+	w.writeI32(model.messages.length); // miMessageCount
+
+	for (let slot = 0; slot < SEQUENCE_MESSAGE_SLOTS; slot++) {
+		const msg = model.messages[slot];
+		if (msg) {
+			if (msg.maiParam1Ids.length !== 4 || msg.maiParam2Ids.length !== 4) {
+				throw new Error(`HudMessageSequence writer: messages[${slot}] param-id arrays must each have exactly 4 entries`);
+			}
+			w.writeU64(msg.mMessageId);
+			w.writeF32(msg.mfMessageLength);
+			for (const v of msg.maiParam1Ids) w.writeI32(v);
+			for (const v of msg.maiParam2Ids) w.writeI32(v);
+			w.writeU32(msg._pad2C);
+		} else {
+			w.writeU64(0n);
+			w.writeF32(DEFAULT_MESSAGE_LENGTH_SECONDS);
+			for (let i = 0; i < 8; i++) w.writeI32(-1);
+			w.writeU32(0);
+		}
+	}
+
+	if (w.offset !== SEQ_STRUCT_SIZE) {
+		throw new Error(`HudMessageSequence writer: struct ends at 0x${w.offset.toString(16)}, expected 0x${SEQ_STRUCT_SIZE.toString(16)}`);
+	}
+	w.writeZeroes(totalSize - SEQ_STRUCT_SIZE);
+	return w.bytes;
+}
+
+// =============================================================================
+// HudMessageSequenceDictionary (0x2F)
+// =============================================================================
+
+export function parseHudMessageSequenceDictionary(raw: Uint8Array, littleEndian = true): ParsedHudMessageSequenceDictionary {
+	const r = new BinReader(raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength), littleEndian);
+	const miResourceSize = r.readI32();
+	const numSequences = r.readI32();
+	const mppcResources = r.readU32();
+	const _pad0C = r.readU32();
+	if (mppcResources !== DICT_PTR_ARRAY_OFFSET) {
+		throw new Error(`HudMessageSequenceDictionary: mppcResources is 0x${mppcResources.toString(16)}, expected 0x${DICT_PTR_ARRAY_OFFSET.toString(16)} (rigid layout)`);
+	}
+	const namesStart = DICT_PTR_ARRAY_OFFSET + numSequences * 4;
+	const structSize = namesStart + numSequences * NAME_FIELD_SIZE;
+	if (numSequences < 0 || miResourceSize !== structSize) {
+		throw new Error(`HudMessageSequenceDictionary: miResourceSize 0x${miResourceSize.toString(16)} != derived 0x${structSize.toString(16)} for ${numSequences} names`);
+	}
+	if (raw.byteLength !== align16(structSize)) {
+		throw new Error(`HudMessageSequenceDictionary: resource is 0x${raw.byteLength.toString(16)} bytes, expected 0x${align16(structSize).toString(16)} (struct + 16-byte alignment pad)`);
+	}
+
+	const sequenceNames: string[] = [];
+	for (let i = 0; i < numSequences; i++) {
+		const ptr = r.readU32();
+		const expected = namesStart + i * NAME_FIELD_SIZE;
+		if (ptr !== expected) {
+			throw new Error(`HudMessageSequenceDictionary: name pointer [${i}] is 0x${ptr.toString(16)}, expected 0x${expected.toString(16)} (names pack at a 13-byte stride)`);
+		}
+	}
+	for (let i = 0; i < numSequences; i++) {
+		const at = namesStart + i * NAME_FIELD_SIZE;
+		sequenceNames.push(decodeFixedName(raw.subarray(at, at + NAME_FIELD_SIZE), `sequenceNames[${i}]`));
+	}
+
+	assertZeroTail(raw, structSize, 'HudMessageSequenceDictionary');
+
+	return { sequenceNames, _pad0C };
+}
+
+export function writeHudMessageSequenceDictionary(model: ParsedHudMessageSequenceDictionary, littleEndian = true): Uint8Array {
+	for (const name of model.sequenceNames) {
+		if (name.length > MAX_NAME_CHARS) {
+			throw new Error(`HudMessageSequenceDictionary writer: name "${name}" exceeds ${MAX_NAME_CHARS} chars`);
+		}
+	}
+	const count = model.sequenceNames.length;
+	const namesStart = DICT_PTR_ARRAY_OFFSET + count * 4;
+	const structSize = namesStart + count * NAME_FIELD_SIZE;
+	const totalSize = align16(structSize);
+
+	const w = new BinWriter(totalSize, littleEndian);
+	w.writeI32(structSize); // miResourceSize — excludes the alignment pad
+	w.writeI32(count);
+	w.writeU32(DICT_PTR_ARRAY_OFFSET); // mppcResources
+	w.writeU32(model._pad0C);
+	for (let i = 0; i < count; i++) w.writeU32(namesStart + i * NAME_FIELD_SIZE);
+	for (const name of model.sequenceNames) w.writeFixedString(name, NAME_FIELD_SIZE);
+
+	if (w.offset !== structSize) {
+		throw new Error(`HudMessageSequenceDictionary writer: struct ends at 0x${w.offset.toString(16)}, expected 0x${structSize.toString(16)}`);
+	}
+	w.writeZeroes(totalSize - structSize);
+	return w.bytes;
+}

--- a/src/lib/core/language.ts
+++ b/src/lib/core/language.ts
@@ -1,0 +1,233 @@
+// Language parser and writer (resource type 0x27).
+//
+// One Language resource per language bundle (LANGUAGE/0001–0014.BUNDLE) holds
+// the game's localised strings: a u32 hash of the untranslated string ID maps
+// to a NUL-terminated UTF-8 translation. The same hash appears in every
+// language bundle, so a single string ID resolves in all 14 languages.
+//
+// On-disk layout (32-bit PC, little-endian), verified against all 14 retail
+// bundles:
+//   0x0  meLanguageID  u32   ELanguage value (see ELANGUAGE below)
+//   0x4  muSize        u32   entry count
+//   0x8  mpEntries     u32   file-relative offset of the entry table — 0xC in
+//                            every retail resource (fixed up to a pointer at load)
+//   0xC  entries[muSize]     { muHash u32, mpString u32 } — mpString is a
+//                            file-relative offset into the string blob
+//   then the string blob: NUL-terminated UTF-8, running to the exact end of
+//   the resource (no trailing pad after the last NUL).
+//
+// Facts the wiki doesn't tell you (grounded by the 14-bundle sweep):
+// - Entries are ordered by string offset (strictly increasing), NOT by hash.
+// - Hashes are unique within a bundle; 0x7E1C1CC8 ("No motion blur") happens
+//   to be entry 0 in all 14 retail bundles.
+// - Some strings (0–42 per bundle) are followed by exactly 3 extra zero bytes
+//   after their terminator — preserved per-entry in `_padAfter`.
+// - The LAST entry of every bundle has hash 0x00000000 and a filler string of
+//   repeated 'A' characters sized so the resource hits exactly 0xD4800
+//   (870,400) bytes — presumably so any language fits one fixed allocation.
+//   Two bundles (0001 US, 0006 DE — rebuilt later, newer file dates) overshoot
+//   by 3/5 bytes. The filler parses as a normal entry; editors should leave it
+//   alone or shrink it to compensate for grown strings.
+// - Bundle 0008 stores meLanguageID 12 (E_LANGUAGE_GREEK on the wiki) but its
+//   strings are Russian — the wiki's enum label and retail content disagree.
+//
+// Round-trip strategy: string offsets are never stored in the model — the
+// parser asserts the stored table is contiguous (entry 0 starts right after
+// the table; each next offset equals the previous string's end + 1 + pad,
+// with pad bytes all zero) and the writer rebuilds every offset from the
+// re-encoded strings. UTF-8 is decoded with a fatal TextDecoder, so malformed
+// input throws instead of silently re-encoding different bytes.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Enumerations
+// =============================================================================
+
+/** CgsLanguage::Sku::ELanguage — meLanguageID values. Retail PC ships the 14
+ *  bundles noted below; the other ids exist in the enum but never on disk. */
+export const ELANGUAGE = [
+	{ value: 0, label: 'Arabic' },
+	{ value: 1, label: 'Chinese' },
+	{ value: 2, label: 'Chinese (Simplified)' }, // bundle 0012
+	{ value: 3, label: 'Chinese (Traditional)' }, // bundle 0013
+	{ value: 4, label: 'Czech' }, // bundle 0010
+	{ value: 5, label: 'Danish' },
+	{ value: 6, label: 'Dutch' },
+	{ value: 7, label: 'English (US)' }, // bundle 0001
+	{ value: 8, label: 'English (UK)' }, // bundle 0002
+	{ value: 9, label: 'Finnish' },
+	{ value: 10, label: 'French' }, // bundle 0003
+	{ value: 11, label: 'German' }, // bundle 0006
+	// The wiki names value 12 E_LANGUAGE_GREEK, but retail bundle 0008 (the
+	// only resource storing 12) contains Russian strings.
+	{ value: 12, label: 'Greek (retail: Russian)' }, // bundle 0008
+	{ value: 13, label: 'Hebrew' },
+	{ value: 14, label: 'Hungarian' }, // bundle 0011
+	{ value: 15, label: 'Italian' }, // bundle 0005
+	{ value: 16, label: 'Japanese' }, // bundle 0007
+	{ value: 17, label: 'Korean' },
+	{ value: 18, label: 'Norwegian' },
+	{ value: 19, label: 'Polish' }, // bundle 0009
+	{ value: 20, label: 'Portuguese (Brazil)' },
+	{ value: 21, label: 'Portuguese (Portugal)' },
+	{ value: 22, label: 'Spanish' }, // bundle 0004
+	{ value: 23, label: 'Swedish' },
+	{ value: 24, label: 'Thai' }, // bundle 0014
+] as const;
+
+export function languageName(id: number): string {
+	return ELANGUAGE.find((l) => l.value === id)?.label ?? `language ${id}`;
+}
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type LanguageEntry = {
+	/** u32 hash of the untranslated string ID — the lookup key the game uses.
+	 *  Same hash in every language bundle. 0x00000000 marks the filler entry. */
+	muHash: number;
+	/** The translated string (decoded UTF-8, no terminator). */
+	text: string;
+	/** Extra zero bytes after this string's NUL terminator (0 or 3 in retail) —
+	 *  preserved verbatim so the round-trip stays byte-exact. */
+	_padAfter: number;
+};
+
+export type ParsedLanguage = {
+	/** ELanguage value — which language this bundle carries. */
+	meLanguageID: number;
+	/** All strings in disk (string-blob) order, filler entry included. */
+	entries: LanguageEntry[];
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const HEADER_SIZE = 0xc;
+const ENTRY_RECORD_SIZE = 0x8;
+// mpEntries is 0xC in every retail resource — the table follows the header
+// immediately, and the blob follows the table immediately.
+const ENTRIES_OFFSET = HEADER_SIZE;
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+export function parseLanguage(raw: Uint8Array, littleEndian = true): ParsedLanguage {
+	if (raw.byteLength < HEADER_SIZE) {
+		throw new Error(`Language: resource is ${raw.byteLength} bytes, smaller than the 0xC header`);
+	}
+	const r = new BinReader(raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength), littleEndian);
+
+	const meLanguageID = r.readU32();
+	const muSize = r.readU32();
+	const mpEntries = r.readU32();
+	if (mpEntries !== ENTRIES_OFFSET) {
+		throw new Error(`Language: mpEntries is 0x${mpEntries.toString(16)}, expected 0xC (rigid layout)`);
+	}
+	const blobStart = ENTRIES_OFFSET + muSize * ENTRY_RECORD_SIZE;
+	if (blobStart > raw.byteLength) {
+		throw new Error(`Language: ${muSize} entries overrun the ${raw.byteLength}-byte resource`);
+	}
+
+	// Decode with fatal=true: malformed UTF-8 would silently re-encode to
+	// different bytes and break the round-trip, so it must throw here instead.
+	const decoder = new TextDecoder('utf-8', { fatal: true });
+
+	const table: { muHash: number; mpString: number }[] = [];
+	for (let i = 0; i < muSize; i++) {
+		table.push({ muHash: r.readU32(), mpString: r.readU32() });
+	}
+
+	// Walk the table asserting the derived layout matches the stored one: the
+	// blob must tile [blobStart, end) exactly with string+NUL+pad runs in table
+	// order, because the writer rebuilds every offset from that assumption.
+	const entries: LanguageEntry[] = [];
+	let cursor = blobStart;
+	for (let i = 0; i < muSize; i++) {
+		const { muHash, mpString } = table[i];
+		if (mpString !== cursor) {
+			throw new Error(`Language: entry ${i} string offset 0x${mpString.toString(16)} != derived 0x${cursor.toString(16)} (blob must be contiguous in table order)`);
+		}
+		let end = mpString;
+		while (end < raw.byteLength && raw[end] !== 0) end++;
+		if (end >= raw.byteLength) {
+			throw new Error(`Language: entry ${i} string at 0x${mpString.toString(16)} is missing its NUL terminator`);
+		}
+		let text: string;
+		try {
+			text = decoder.decode(raw.subarray(mpString, end));
+		} catch {
+			throw new Error(`Language: entry ${i} string at 0x${mpString.toString(16)} is not valid UTF-8`);
+		}
+
+		// Pad runs to the next entry's stored offset (or the resource end for
+		// the last entry). Anything non-zero there would be an unreferenced
+		// string the model can't represent — fail loudly.
+		const next = i + 1 < muSize ? table[i + 1].mpString : raw.byteLength;
+		const _padAfter = next - (end + 1);
+		if (_padAfter < 0) {
+			throw new Error(`Language: entry ${i} string overlaps entry ${i + 1} (ends 0x${(end + 1).toString(16)}, next starts 0x${next.toString(16)})`);
+		}
+		for (let b = end + 1; b < next; b++) {
+			if (raw[b] !== 0) {
+				throw new Error(`Language: non-zero byte 0x${raw[b].toString(16)} in the pad after entry ${i}`);
+			}
+		}
+		entries.push({ muHash, text, _padAfter });
+		cursor = next;
+	}
+	if (cursor !== raw.byteLength) {
+		throw new Error(`Language: blob ends at 0x${cursor.toString(16)}, expected 0x${raw.byteLength.toString(16)} (must tile exactly)`);
+	}
+
+	return { meLanguageID, entries };
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+export function writeLanguage(model: ParsedLanguage, littleEndian = true): Uint8Array {
+	const { entries } = model;
+	const encoder = new TextEncoder();
+
+	const encoded: Uint8Array[] = entries.map((e, i) => {
+		if (e.text.includes('\0')) {
+			throw new Error(`Language writer: entry ${i} text contains an embedded NUL — the blob is NUL-terminated, so the string would truncate in game`);
+		}
+		if (!Number.isInteger(e._padAfter) || e._padAfter < 0) {
+			throw new Error(`Language writer: entry ${i} _padAfter ${e._padAfter} must be a non-negative integer`);
+		}
+		return encoder.encode(e.text);
+	});
+
+	const blobStart = ENTRIES_OFFSET + entries.length * ENTRY_RECORD_SIZE;
+	const blobSize = encoded.reduce((n, bytes, i) => n + bytes.length + 1 + entries[i]._padAfter, 0);
+	const w = new BinWriter(blobStart + blobSize, littleEndian);
+
+	w.writeU32(model.meLanguageID);
+	w.writeU32(entries.length);
+	w.writeU32(ENTRIES_OFFSET);
+
+	// Table — offsets rebuilt from the encoded lengths, never trusted from the
+	// model (variable-length strings shift everything after an edit).
+	let cursor = blobStart;
+	for (let i = 0; i < entries.length; i++) {
+		w.writeU32(entries[i].muHash);
+		w.writeU32(cursor);
+		cursor += encoded[i].length + 1 + entries[i]._padAfter;
+	}
+	if (w.offset !== blobStart) throw new Error(`Language writer: blob offset mismatch ${w.offset} vs ${blobStart}`);
+
+	for (let i = 0; i < entries.length; i++) {
+		w.writeBytes(encoded[i]);
+		w.writeZeroes(1 + entries[i]._padAfter);
+	}
+	if (w.offset !== cursor) throw new Error(`Language writer: wrote ${w.offset} bytes, expected ${cursor}`);
+
+	return w.bytes;
+}

--- a/src/lib/core/registry/handlers/guiPopup.ts
+++ b/src/lib/core/registry/handlers/guiPopup.ts
@@ -1,0 +1,153 @@
+// GuiPopup registry handler — thin wrapper around parseGuiPopup /
+// writeGuiPopup in src/lib/core/guiPopup.ts.
+//
+// One resource game-wide (GUI/POPUPS.PUP), exactly one 0x1F per bundle, so
+// no picker config. The writer recomputes the whole layout from the popup
+// count, so popups can be added/removed freely — the add-popup scenario
+// below exercises the pointer-array growth and alignment-pad recompute.
+
+import {
+	parseGuiPopup,
+	writeGuiPopup,
+	countMessageParamsUsed,
+	type ParsedGuiPopup,
+	type GuiPopup,
+} from '../../guiPopup';
+import { encodeCgsId } from '../../cgsid';
+import type { ResourceHandler } from '../handler';
+
+// 13 = E_POPUPSTYLE_CUSTOM — valid and absent from retail POPUPS.PUP (which
+// uses 1 and 4–12), so 'change-style' provably changes the value.
+const STRESS_STYLE = 13;
+
+function makeStressPopup(macName: string): GuiPopup {
+	return {
+		mNameId: encodeCgsId(macName.toUpperCase()),
+		macName,
+		meStyle: 7, // In-game — OK
+		meIcon: 0,
+		macTitleId: 'PLACEHOLDER_TEMP_STRING',
+		macMessageId: 'PLACEHOLDER_TEMP_STRING',
+		maeMessageParams: [0, 0],
+		miMessageParamsUsed: 0,
+		macButton1Id: 'GENERAL_OPTION_OK',
+		meButton1Param: 0,
+		mbButton1ParamUsed: false,
+		macButton2Id: '',
+		meButton2Param: 0,
+		mbButton2ParamUsed: false,
+		_pad15: [0, 0, 0],
+		_padB1: [0, 0, 0],
+		_padB9: [0, 0, 0, 0, 0, 0, 0],
+	};
+}
+
+export const guiPopupHandler: ResourceHandler<ParsedGuiPopup> = {
+	typeId: 0x1f,
+	key: 'guiPopup',
+	name: 'GUI Popup',
+	description: 'Card-styled in-game popup messages (POPUPS.PUP) — per popup: a CgsID name code summons it by, a style/icon, and Language string keys for title, message, and up to two buttons',
+	category: 'Data',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/GUI_Popup',
+
+	parseRaw(raw, ctx) {
+		return parseGuiPopup(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeGuiPopup(model, ctx.littleEndian);
+	},
+	describe(model) {
+		const withButtons = model.popups.filter((p) => p.macButton1Id !== '').length;
+		return `${model.popups.length} popups (${withButtons} with buttons)`;
+	},
+
+	fixtures: [
+		{ bundle: 'example/POPUPS.PUP', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.popups.length !== before.popups.length) {
+					problems.push(`popup count ${after.popups.length} != ${before.popups.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-message-id',
+			description: 'retarget popups[0] at a different Language string key and verify the title is untouched',
+			mutate: (m) => {
+				const popups = m.popups.slice();
+				popups[0] = { ...popups[0], macMessageId: 'PLACEHOLDER_TEMP_STRING' };
+				return { ...m, popups };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.popups[0].macMessageId !== 'PLACEHOLDER_TEMP_STRING') {
+					problems.push(`macMessageId = "${afterReparse.popups[0].macMessageId}"`);
+				}
+				if (afterReparse.popups[0].macTitleId !== afterMutate.popups[0].macTitleId) {
+					problems.push(`macTitleId changed to "${afterReparse.popups[0].macTitleId}"`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'change-style',
+			description: 'set popups[0].meStyle to Custom (13) and verify it survives round-trip',
+			mutate: (m) => {
+				const popups = m.popups.slice();
+				popups[0] = { ...popups[0], meStyle: STRESS_STYLE };
+				return { ...m, popups };
+			},
+			verify: (_afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.popups[0].meStyle !== STRESS_STYLE) {
+					problems.push(`meStyle = ${afterReparse.popups[0].meStyle}, expected ${STRESS_STYLE}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'rename-popup',
+			description: 'rename popups[0] and recompute its CgsID the way retail derives it (uppercased macName)',
+			mutate: (m) => {
+				const popups = m.popups.slice();
+				popups[0] = { ...popups[0], macName: 'StressRename', mNameId: encodeCgsId('STRESSRENAME') };
+				return { ...m, popups };
+			},
+			verify: (_afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const p = afterReparse.popups[0];
+				if (p.macName !== 'StressRename') problems.push(`macName = "${p.macName}"`);
+				if (p.mNameId !== encodeCgsId('STRESSRENAME')) {
+					problems.push(`mNameId = 0x${p.mNameId.toString(16)}, expected encodeCgsId('STRESSRENAME')`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'add-popup',
+			description: 'append a popup — grows the pointer array and recomputes the alignment pad, header count, and size',
+			mutate: (m) => ({ ...m, popups: [...m.popups, makeStressPopup('StressAdd')] }),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.popups.length !== afterMutate.popups.length) {
+					problems.push(`popup count ${afterReparse.popups.length} != ${afterMutate.popups.length}`);
+				}
+				const added = afterReparse.popups[afterReparse.popups.length - 1];
+				if (added.macName !== 'StressAdd') problems.push(`added popup macName = "${added.macName}"`);
+				if (added.miMessageParamsUsed !== countMessageParamsUsed(added.maeMessageParams)) {
+					problems.push('added popup miMessageParamsUsed inconsistent with maeMessageParams');
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/hudMessage.ts
+++ b/src/lib/core/registry/handlers/hudMessage.ts
@@ -1,0 +1,138 @@
+// HudMessage registry handler — thin wrapper around
+// parseHudMessage / writeHudMessage in src/lib/core/hudMessage.ts.
+//
+// Retail ships exactly ONE resource of this type (HUDMESSAGES.HM, 308
+// messages), so no picker config. The game fires messages by mMessageIdHash,
+// which must stay equal to encodeCgsId(macMessageId.toUpperCase()) — the
+// rename scenario below keeps the pair in sync the way the schema layer does.
+
+import { parseHudMessage, writeHudMessage, type ParsedHudMessage } from '../../hudMessage';
+import { encodeCgsId } from '../../cgsid';
+import type { ResourceHandler } from '../handler';
+
+// ≤12 chars and absent from retail, so the rename scenario provably changes
+// both the id and its derived CgsID.
+const STRESS_MESSAGE_ID = 'StewardTest';
+
+export const hudMessageHandler: ResourceHandler<ParsedHudMessage> = {
+	typeId: 0x2c,
+	key: 'hudMessage',
+	name: 'HUD Message',
+	description: 'The in-game HUD message catalogue — every message the HUD can flash at the player (takedowns, road rules, challenges, …), each with up to three Language-string lines, a display style, an icon, and availability rules',
+	category: 'Data',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/HUD_Message',
+
+	parseRaw(raw, ctx) {
+		return parseHudMessage(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeHudMessage(model, ctx.littleEndian);
+	},
+	describe(model) {
+		const styles = new Set(model.messages.map((m) => m.macMessageStyle)).size;
+		return `${model.messages.length} messages, ${styles} styles`;
+	},
+
+	fixtures: [
+		{ bundle: 'example/HUDMESSAGES.HM', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.messages.length !== before.messages.length) {
+					problems.push(`message count ${after.messages.length} != ${before.messages.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-timing-and-availability',
+			description: 'change messages[0] duration/wait and availability bits; verify they survive round-trip',
+			mutate: (m) => {
+				const messages = m.messages.slice();
+				messages[0] = { ...messages[0], mfDuration: 9.25, mfTimeToWait: 1.5, muAvailabilityBitSet: 0x2d };
+				return { ...m, messages };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const a = afterMutate.messages[0];
+				const b = afterReparse.messages[0];
+				if (b.mfDuration !== a.mfDuration) problems.push(`mfDuration = ${b.mfDuration}, expected ${a.mfDuration}`);
+				if (b.mfTimeToWait !== a.mfTimeToWait) problems.push(`mfTimeToWait = ${b.mfTimeToWait}, expected ${a.mfTimeToWait}`);
+				if (b.muAvailabilityBitSet !== a.muAvailabilityBitSet) {
+					problems.push(`muAvailabilityBitSet = 0x${b.muAvailabilityBitSet.toString(16)}, expected 0x${a.muAvailabilityBitSet.toString(16)}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'rename-message-id',
+			description: 'rename messages[0] and recompute its CgsID the way the game expects; verify both survive',
+			mutate: (m) => {
+				const messages = m.messages.slice();
+				messages[0] = {
+					...messages[0],
+					macMessageId: STRESS_MESSAGE_ID,
+					mMessageIdHash: encodeCgsId(STRESS_MESSAGE_ID.toUpperCase()),
+				};
+				return { ...m, messages };
+			},
+			verify: (_afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const b = afterReparse.messages[0];
+				if (b.macMessageId !== STRESS_MESSAGE_ID) problems.push(`macMessageId = "${b.macMessageId}"`);
+				if (b.mMessageIdHash !== encodeCgsId(STRESS_MESSAGE_ID.toUpperCase())) {
+					problems.push(`mMessageIdHash = 0x${b.mMessageIdHash.toString(16)} out of sync with the id`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'remove-last-message',
+			description: 'drop the final message; the pointer array, section pads, and size header must all shrink consistently',
+			mutate: (m) => ({ ...m, messages: m.messages.slice(0, -1) }),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.messages.length !== afterMutate.messages.length) {
+					problems.push(`message count ${afterReparse.messages.length} != ${afterMutate.messages.length}`);
+				}
+				const last = afterReparse.messages[afterReparse.messages.length - 1];
+				const expected = afterMutate.messages[afterMutate.messages.length - 1];
+				if (last.macMessageId !== expected.macMessageId) {
+					problems.push(`last message is "${last.macMessageId}", expected "${expected.macMessageId}"`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'append-cloned-message',
+			description: 'append a renamed clone of messages[0]; grows the pointer array across the 128-byte section alignment',
+			mutate: (m) => {
+				const clone = {
+					...m.messages[0],
+					lines: m.messages[0].lines.map((l) => ({ ...l, maeParamTypes: l.maeParamTypes.slice() })),
+					macMessageId: STRESS_MESSAGE_ID,
+					mMessageIdHash: encodeCgsId(STRESS_MESSAGE_ID.toUpperCase()),
+				};
+				return { ...m, messages: [...m.messages, clone] };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.messages.length !== afterMutate.messages.length) {
+					problems.push(`message count ${afterReparse.messages.length} != ${afterMutate.messages.length}`);
+				}
+				const last = afterReparse.messages[afterReparse.messages.length - 1];
+				if (last.macMessageId !== STRESS_MESSAGE_ID) {
+					problems.push(`appended message id "${last.macMessageId}", expected "${STRESS_MESSAGE_ID}"`);
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/hudMessageSequence.ts
+++ b/src/lib/core/registry/handlers/hudMessageSequence.ts
@@ -1,0 +1,189 @@
+// HudMessageSequence registry handler — thin wrapper around
+// parseHudMessageSequence / writeHudMessageSequence in
+// src/lib/core/hudMessageSequences.ts.
+//
+// The one retail bundle (HUDMESSAGESEQUENCES.HMSC) carries SIX sequences,
+// so the handler ships a picker config. Every retail sequence is a Dirty
+// Tricks arming flow: DTARMING followed by the per-trick award/failure
+// message — the picker's secondary text surfaces that chain.
+
+import {
+	parseHudMessageSequence,
+	writeHudMessageSequence,
+	SEQUENCE_MESSAGE_SLOTS,
+	DEFAULT_MESSAGE_LENGTH_SECONDS,
+	type ParsedHudMessageSequence,
+} from '../../hudMessageSequences';
+import { decodeCgsId, encodeCgsId } from '../../cgsid';
+import type { ResourceHandler, PickerEntry } from '../handler';
+
+function compareByName(a: PickerEntry<ParsedHudMessageSequence>, b: PickerEntry<ParsedHudMessageSequence>): number {
+	return a.ctx.name.localeCompare(b.ctx.name, undefined, { numeric: true });
+}
+
+function messageChain(model: ParsedHudMessageSequence): string {
+	return model.messages.map((m) => decodeCgsId(m.mMessageId) || '∅').join(' → ');
+}
+
+export const hudMessageSequenceHandler: ResourceHandler<ParsedHudMessageSequence> = {
+	typeId: 0x2e,
+	key: 'hudMessageSequence',
+	name: 'HUD Message Sequence',
+	description: 'Ordered set of HUD message IDs displayed in sequence, each with its own duration — a dev-era feature whose six retail resources are all online Dirty Tricks arming flows',
+	category: 'Data',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/HUD_Message_Sequence',
+	notes: 'Only used in early development builds; retail ships six DT* sequences in HUDMESSAGESEQUENCES.HMSC. Removed from Remastered on PS4 but reintroduced on PC and Switch.',
+
+	parseRaw(raw, ctx) {
+		return parseHudMessageSequence(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeHudMessageSequence(model, ctx.littleEndian);
+	},
+	describe(model) {
+		return `"${model.macSequenceId}": ${model.messages.length} message${model.messages.length === 1 ? '' : 's'} (${messageChain(model)}), priority ${model.miPriority}`;
+	},
+
+	picker: {
+		labelOf(model, { name }) {
+			if (model == null) {
+				return {
+					primary: name,
+					secondary: 'parse failed',
+					badges: [{ label: 'parse failed', tone: 'warn' }],
+				};
+			}
+			if (model.messages.length === 0) {
+				return {
+					primary: model.macSequenceId,
+					secondary: 'no messages',
+					badges: [{ label: 'empty', tone: 'muted' }],
+				};
+			}
+			return {
+				primary: model.macSequenceId,
+				secondary: messageChain(model),
+			};
+		},
+		sortKeys: [
+			{ id: 'name', label: 'Name (A→Z)', compare: compareByName },
+			{ id: 'index', label: 'Bundle order', compare: (a, b) => a.ctx.index - b.ctx.index },
+			{
+				id: 'messages-desc',
+				label: 'Message count (high→low)',
+				compare: (a, b) => (b.model?.messages.length ?? -1) - (a.model?.messages.length ?? -1),
+			},
+		],
+		defaultSort: 'name',
+		searchText(model, ctx) {
+			if (model == null) return ctx.name;
+			return `${model.macSequenceId} ${messageChain(model)}`;
+		},
+	},
+
+	fixtures: [
+		// The auto suite only exercises the first sequence in bundle order
+		// (DTArmBtLk). All six, plus the dictionary↔sequence name relationship,
+		// are covered in __tests__/hudMessageSequences.test.ts.
+		{ bundle: 'example/HUDMESSAGESEQUENCES.HMSC', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.messages.length !== before.messages.length) {
+					problems.push(`message count ${after.messages.length} != ${before.messages.length}`);
+				}
+				if (after.macSequenceId !== before.macSequenceId) {
+					problems.push(`macSequenceId "${after.macSequenceId}" != "${before.macSequenceId}"`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-message-length',
+			description: 'change messages[0] display duration from the retail 5 s and verify it survives round-trip',
+			mutate: (m) => {
+				const messages = m.messages.slice();
+				messages[0] = { ...messages[0], mfMessageLength: 7.5 };
+				return { ...m, messages };
+			},
+			verify: (_before, after) => {
+				const problems: string[] = [];
+				if (Math.abs(after.messages[0].mfMessageLength - 7.5) > 1e-4) {
+					problems.push(`mfMessageLength = ${after.messages[0].mfMessageLength}, expected 7.5`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'rename-sequence',
+			description: 'rename the sequence and update its hash the way the schema derive hook does; both must survive',
+			mutate: (m) => ({
+				...m,
+				macSequenceId: 'StressSeq',
+				mSequenceIdHash: encodeCgsId('STRESSSEQ'),
+			}),
+			verify: (_before, after) => {
+				const problems: string[] = [];
+				if (after.macSequenceId !== 'StressSeq') {
+					problems.push(`macSequenceId "${after.macSequenceId}", expected "StressSeq"`);
+				}
+				// The hash is uppercase-folded — pin the relationship so a writer
+				// regression that re-encodes the mixed-case name gets caught.
+				if (after.mSequenceIdHash !== encodeCgsId('STRESSSEQ')) {
+					problems.push(`mSequenceIdHash 0x${after.mSequenceIdHash.toString(16)} != encodeCgsId('STRESSSEQ')`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'append-message',
+			description: 'append a third message — miMessageCount is recomputed and one default slot is consumed',
+			mutate: (m) => ({
+				...m,
+				messages: [
+					...m.messages,
+					{
+						mMessageId: encodeCgsId('STRESSMSG'),
+						mfMessageLength: DEFAULT_MESSAGE_LENGTH_SECONDS,
+						maiParam1Ids: [-1, -1, -1, -1],
+						maiParam2Ids: [-1, -1, -1, -1],
+						_pad2C: 0,
+					},
+				],
+			}),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.messages.length !== afterMutate.messages.length) {
+					problems.push(`message count ${afterReparse.messages.length} != ${afterMutate.messages.length}`);
+				}
+				if (afterReparse.messages.length > SEQUENCE_MESSAGE_SLOTS) {
+					problems.push(`message count overflows the fixed ${SEQUENCE_MESSAGE_SLOTS} slots`);
+				}
+				const last = afterReparse.messages[afterReparse.messages.length - 1];
+				if (last.mMessageId !== encodeCgsId('STRESSMSG')) {
+					problems.push(`appended message id 0x${last.mMessageId.toString(16)} != encodeCgsId('STRESSMSG')`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'remove-last-message',
+			description: 'drop the final message — its slot must reparse as default-initialised, not stale',
+			mutate: (m) => ({ ...m, messages: m.messages.slice(0, -1) }),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.messages.length !== afterMutate.messages.length) {
+					problems.push(`message count ${afterReparse.messages.length} != ${afterMutate.messages.length}`);
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/hudMessageSequenceDictionary.ts
+++ b/src/lib/core/registry/handlers/hudMessageSequenceDictionary.ts
@@ -1,0 +1,102 @@
+// HudMessageSequenceDictionary registry handler — thin wrapper around
+// parseHudMessageSequenceDictionary / writeHudMessageSequenceDictionary in
+// src/lib/core/hudMessageSequences.ts.
+//
+// One resource in the whole game (HUDMESSAGESEQUENCES.HMSC): the name list
+// the game uses to enumerate the bundle's HudMessageSequence (0x2E)
+// resources. Entries reference sequences BY NAME — each char[13] entry is
+// the macSequenceId of one 0x2E resource, so renaming a sequence without
+// updating its dictionary entry orphans it.
+
+import {
+	parseHudMessageSequenceDictionary,
+	writeHudMessageSequenceDictionary,
+	type ParsedHudMessageSequenceDictionary,
+} from '../../hudMessageSequences';
+import type { ResourceHandler } from '../handler';
+
+export const hudMessageSequenceDictionaryHandler: ResourceHandler<ParsedHudMessageSequenceDictionary> = {
+	typeId: 0x2f,
+	key: 'hudMessageSequenceDictionary',
+	name: 'HUD Message Sequence Dictionary',
+	description: 'Name list enumerating every HUD Message Sequence in the bundle — entries are the sequences\' macSequenceId strings, referenced by name',
+	category: 'Data',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/HUD_Message_Sequence_Dictionary',
+	notes: 'Same on-disk shape as the HUD Message List (0x30) per the wiki. The single retail resource lists the six DT* Dirty Tricks sequences.',
+
+	parseRaw(raw, ctx) {
+		return parseHudMessageSequenceDictionary(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeHudMessageSequenceDictionary(model, ctx.littleEndian);
+	},
+	describe(model) {
+		return `${model.sequenceNames.length} sequence name${model.sequenceNames.length === 1 ? '' : 's'}: ${model.sequenceNames.join(', ')}`;
+	},
+
+	fixtures: [
+		{ bundle: 'example/HUDMESSAGESEQUENCES.HMSC', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.sequenceNames.length !== before.sequenceNames.length) {
+					problems.push(`name count ${after.sequenceNames.length} != ${before.sequenceNames.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'rename-entry',
+			description: 'rename the first entry and verify it survives round-trip with its siblings untouched',
+			mutate: (m) => {
+				const sequenceNames = m.sequenceNames.slice();
+				sequenceNames[0] = 'StressSeq';
+				return { ...m, sequenceNames };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.sequenceNames[0] !== 'StressSeq') {
+					problems.push(`sequenceNames[0] "${afterReparse.sequenceNames[0]}", expected "StressSeq"`);
+				}
+				if (afterReparse.sequenceNames.length !== afterMutate.sequenceNames.length) {
+					problems.push(`name count ${afterReparse.sequenceNames.length} != ${afterMutate.sequenceNames.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'append-name',
+			description: 'append an entry — size, count, every name pointer, and the alignment pad are all re-derived',
+			mutate: (m) => ({ ...m, sequenceNames: [...m.sequenceNames, 'StressSeqNew'] }),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.sequenceNames.length !== afterMutate.sequenceNames.length) {
+					problems.push(`name count ${afterReparse.sequenceNames.length} != ${afterMutate.sequenceNames.length}`);
+				}
+				if (afterReparse.sequenceNames[afterReparse.sequenceNames.length - 1] !== 'StressSeqNew') {
+					problems.push('appended name did not survive round-trip');
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'remove-last-name',
+			description: 'drop the final entry — the shrunken pointer array and name pool must reparse cleanly',
+			mutate: (m) => ({ ...m, sequenceNames: m.sequenceNames.slice(0, -1) }),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.sequenceNames.length !== afterMutate.sequenceNames.length) {
+					problems.push(`name count ${afterReparse.sequenceNames.length} != ${afterMutate.sequenceNames.length}`);
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/language.ts
+++ b/src/lib/core/registry/handlers/language.ts
@@ -1,0 +1,147 @@
+// Language registry handler — thin wrapper around parseLanguage /
+// writeLanguage in src/lib/core/language.ts.
+//
+// Each of the 14 LANGUAGE/<NNNN>.BUNDLE files carries exactly one Language
+// resource, so no picker is needed. The fixtures below are three
+// representative bundles (retail UK, Japanese for heavy multibyte, the
+// Russian-content bundle with the most pad entries); the gold test in
+// __tests__/language.test.ts sweeps all 14.
+
+import {
+	parseLanguage,
+	writeLanguage,
+	languageName,
+	type ParsedLanguage,
+} from '../../language';
+import type { ResourceHandler } from '../handler';
+
+// Hash with no retail collision risk for the add-entry scenario (retail hashes
+// are unique per bundle and 0 is reserved for the filler entry).
+const STRESS_NEW_HASH = 0xdeadbeef;
+const STRESS_TEXT = 'Edited ünïcøde string ✓';
+
+export const languageHandler: ResourceHandler<ParsedLanguage> = {
+	typeId: 0x27,
+	key: 'language',
+	name: 'Language',
+	description: 'Localised game strings for one language — UTF-8 translations keyed by a u32 hash of the untranslated string ID; the same hash resolves in every language bundle',
+	category: 'Data',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Language',
+
+	parseRaw(raw, ctx) {
+		return parseLanguage(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeLanguage(model, ctx.littleEndian);
+	},
+	describe(model) {
+		return `${languageName(model.meLanguageID)} · ${model.entries.length} strings`;
+	},
+
+	fixtures: [
+		{ bundle: 'example/LANGUAGE/0002.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/LANGUAGE/0007.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/LANGUAGE/0008.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.entries.length !== before.entries.length) {
+					problems.push(`entry count ${after.entries.length} != ${before.entries.length}`);
+				}
+				if (after.meLanguageID !== before.meLanguageID) {
+					problems.push(`meLanguageID ${after.meLanguageID} != ${before.meLanguageID}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-string',
+			description: 'replace entries[0].text with a longer multibyte string — every later offset must shift correctly',
+			mutate: (m) => {
+				const entries = m.entries.slice();
+				entries[0] = { ...entries[0], text: STRESS_TEXT };
+				return { ...m, entries };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.entries[0].text !== STRESS_TEXT) {
+					problems.push(`entries[0].text = ${JSON.stringify(afterReparse.entries[0].text)}, expected ${JSON.stringify(STRESS_TEXT)}`);
+				}
+				// The neighbour right after the grown string is the first one whose
+				// offset moved — it must survive untouched.
+				if (afterReparse.entries[1].text !== afterMutate.entries[1].text) {
+					problems.push(`entries[1].text changed to ${JSON.stringify(afterReparse.entries[1].text)}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'change-hash',
+			description: 'rekey entries[1] to a new hash and verify it survives alongside untouched text',
+			mutate: (m) => {
+				const entries = m.entries.slice();
+				entries[1] = { ...entries[1], muHash: STRESS_NEW_HASH };
+				return { ...m, entries };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.entries[1].muHash !== STRESS_NEW_HASH) {
+					problems.push(`entries[1].muHash = 0x${afterReparse.entries[1].muHash.toString(16)}, expected 0x${STRESS_NEW_HASH.toString(16)}`);
+				}
+				if (afterReparse.entries[1].text !== afterMutate.entries[1].text) {
+					problems.push(`entries[1].text changed to ${JSON.stringify(afterReparse.entries[1].text)}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'add-entry',
+			description: 'insert a new string before the trailing filler entry and verify count + content survive',
+			mutate: (m) => {
+				const entries = m.entries.slice();
+				entries.splice(entries.length - 1, 0, { muHash: STRESS_NEW_HASH, text: STRESS_TEXT, _padAfter: 0 });
+				return { ...m, entries };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.entries.length !== afterMutate.entries.length) {
+					problems.push(`entry count ${afterReparse.entries.length} != ${afterMutate.entries.length}`);
+				}
+				const added = afterReparse.entries[afterReparse.entries.length - 2];
+				if (added.muHash !== STRESS_NEW_HASH || added.text !== STRESS_TEXT) {
+					problems.push(`inserted entry came back as hash 0x${added.muHash.toString(16)} text ${JSON.stringify(added.text)}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'remove-entry',
+			description: 'drop entries[2] and verify the count shrinks and both neighbours survive',
+			mutate: (m) => {
+				const entries = m.entries.slice();
+				entries.splice(2, 1);
+				return { ...m, entries };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.entries.length !== afterMutate.entries.length) {
+					problems.push(`entry count ${afterReparse.entries.length} != ${afterMutate.entries.length}`);
+				}
+				for (const i of [1, 2]) {
+					if (afterReparse.entries[i].muHash !== afterMutate.entries[i].muHash
+						|| afterReparse.entries[i].text !== afterMutate.entries[i].text) {
+						problems.push(`entries[${i}] changed after removal`);
+					}
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/worldPainter2D.ts
+++ b/src/lib/core/registry/handlers/worldPainter2D.ts
@@ -1,0 +1,136 @@
+// WorldPainter2D registry handler — thin wrapper around
+// parseWorldPainter2D / writeWorldPainter2D in src/lib/core/worldPainter2D.ts.
+//
+// One resource per bundle (DISTRICTS.DAT carries a single map named
+// "Districts"), so no picker. Whether the cells are district indices or
+// ambience indices is only recoverable from the debug name — the container
+// is identical.
+
+import {
+	parseWorldPainter2D,
+	writeWorldPainter2D,
+	DISTRICT_NAMES,
+	INVALID_CELL,
+	type ParsedWorldPainter2D,
+} from '../../worldPainter2D';
+import type { ResourceHandler } from '../handler';
+
+function firstPaintedIndex(m: ParsedWorldPainter2D): number {
+	for (let i = 0; i < m.cells.length; i++) {
+		if (m.cells[i] !== INVALID_CELL) return i;
+	}
+	throw new Error('WorldPainter2D stress: fixture has no painted cells to mutate');
+}
+
+function cellsMismatch(a: ParsedWorldPainter2D, b: ParsedWorldPainter2D): string[] {
+	const problems: string[] = [];
+	if (b.cells.length !== a.cells.length) {
+		problems.push(`cell count ${b.cells.length} != ${a.cells.length}`);
+		return problems;
+	}
+	for (let i = 0; i < a.cells.length; i++) {
+		if (a.cells[i] !== b.cells[i]) {
+			problems.push(`cells[${i}] = ${b.cells[i]}, expected ${a.cells[i]}`);
+			if (problems.length >= 5) return problems;
+		}
+	}
+	return problems;
+}
+
+export const worldPainter2DHandler: ResourceHandler<ParsedWorldPainter2D> = {
+	typeId: 0x30,
+	key: 'worldPainter2D',
+	name: 'World Painter 2D',
+	description: 'Dense 2D byte grid painted over the world map — one district (or ambience) index per map cell, 0xFF where nothing is painted. DISTRICTS.DAT maps every cell to a BrnWorld::EDistrict.',
+	category: 'Data',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/World_Painter_2D',
+
+	parseRaw(raw, ctx) {
+		return parseWorldPainter2D(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeWorldPainter2D(model, ctx.littleEndian);
+	},
+	describe(model) {
+		let painted = 0;
+		const seen = new Set<number>();
+		for (const v of model.cells) {
+			if (v !== INVALID_CELL) {
+				painted++;
+				seen.add(v);
+			}
+		}
+		return `${model.muWidth}x${model.muHeight} grid, ${painted} painted cells, ${seen.size} indices in use`;
+	},
+
+	fixtures: [
+		{ bundle: 'example/DISTRICTS.DAT', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems = cellsMismatch(before, after);
+				if (after.muWidth !== before.muWidth || after.muHeight !== before.muHeight) {
+					problems.push(`grid ${after.muWidth}x${after.muHeight} != ${before.muWidth}x${before.muHeight}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'repaint-cell',
+			description: 'cycle the first painted cell to the next district index and verify it survives round-trip',
+			mutate: (m) => {
+				const cells = m.cells.slice();
+				const i = firstPaintedIndex(m);
+				cells[i] = (cells[i] + 1) % DISTRICT_NAMES.length;
+				return { ...m, cells };
+			},
+			verify: cellsMismatch,
+		},
+		{
+			name: 'erase-cell',
+			description: 'set the first painted cell to 0xFF (no district) and verify the sentinel survives',
+			mutate: (m) => {
+				const cells = m.cells.slice();
+				cells[firstPaintedIndex(m)] = INVALID_CELL;
+				return { ...m, cells };
+			},
+			// cellsMismatch already proves the 0xFF sentinel byte survived at the
+			// erased index — nothing role-specific to re-verify.
+			verify: cellsMismatch,
+		},
+		{
+			name: 'paint-block',
+			description: 'flood an 8x8 block at the grid centre with Motor City (16) and verify every cell of the block',
+			mutate: (m) => {
+				const cells = m.cells.slice();
+				const cx = m.muWidth >> 1;
+				const cy = m.muHeight >> 1;
+				for (let dy = 0; dy < 8; dy++) {
+					for (let dx = 0; dx < 8; dx++) cells[(cy + dy) * m.muWidth + (cx + dx)] = 16;
+				}
+				return { ...m, cells };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems = cellsMismatch(afterMutate, afterReparse);
+				const cx = afterReparse.muWidth >> 1;
+				const cy = afterReparse.muHeight >> 1;
+				for (let dy = 0; dy < 8; dy++) {
+					for (let dx = 0; dx < 8; dx++) {
+						const i = (cy + dy) * afterReparse.muWidth + (cx + dx);
+						if (afterReparse.cells[i] !== 16) {
+							problems.push(`block cell (${cx + dx}, ${cy + dy}) = ${afterReparse.cells[i]}, expected 16`);
+							return problems;
+						}
+					}
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/index.ts
+++ b/src/lib/core/registry/index.ts
@@ -34,6 +34,7 @@ import { propGraphicsListHandler } from './handlers/propGraphicsList';
 import { propPhysicsHandler } from './handlers/propPhysics';
 import { instanceListHandler } from './handlers/instanceList';
 import { staticSoundMapHandler } from './handlers/staticSoundMap';
+import { languageHandler } from './handlers/language';
 import { textFileHandler } from './handlers/textFile';
 
 export const registry: ResourceHandler[] = [
@@ -64,6 +65,7 @@ export const registry: ResourceHandler[] = [
 	propPhysicsHandler,
 	instanceListHandler,
 	staticSoundMapHandler,
+	languageHandler,
 	textFileHandler,
 ];
 

--- a/src/lib/core/registry/index.ts
+++ b/src/lib/core/registry/index.ts
@@ -38,6 +38,7 @@ import { languageHandler } from './handlers/language';
 import { hudMessageHandler } from './handlers/hudMessage';
 import { hudMessageSequenceHandler } from './handlers/hudMessageSequence';
 import { hudMessageSequenceDictionaryHandler } from './handlers/hudMessageSequenceDictionary';
+import { guiPopupHandler } from './handlers/guiPopup';
 import { textFileHandler } from './handlers/textFile';
 
 export const registry: ResourceHandler[] = [
@@ -72,6 +73,7 @@ export const registry: ResourceHandler[] = [
 	hudMessageHandler,
 	hudMessageSequenceHandler,
 	hudMessageSequenceDictionaryHandler,
+	guiPopupHandler,
 	textFileHandler,
 ];
 

--- a/src/lib/core/registry/index.ts
+++ b/src/lib/core/registry/index.ts
@@ -36,6 +36,8 @@ import { instanceListHandler } from './handlers/instanceList';
 import { staticSoundMapHandler } from './handlers/staticSoundMap';
 import { languageHandler } from './handlers/language';
 import { hudMessageHandler } from './handlers/hudMessage';
+import { hudMessageSequenceHandler } from './handlers/hudMessageSequence';
+import { hudMessageSequenceDictionaryHandler } from './handlers/hudMessageSequenceDictionary';
 import { textFileHandler } from './handlers/textFile';
 
 export const registry: ResourceHandler[] = [
@@ -68,6 +70,8 @@ export const registry: ResourceHandler[] = [
 	staticSoundMapHandler,
 	languageHandler,
 	hudMessageHandler,
+	hudMessageSequenceHandler,
+	hudMessageSequenceDictionaryHandler,
 	textFileHandler,
 ];
 

--- a/src/lib/core/registry/index.ts
+++ b/src/lib/core/registry/index.ts
@@ -35,6 +35,7 @@ import { propPhysicsHandler } from './handlers/propPhysics';
 import { instanceListHandler } from './handlers/instanceList';
 import { staticSoundMapHandler } from './handlers/staticSoundMap';
 import { languageHandler } from './handlers/language';
+import { hudMessageHandler } from './handlers/hudMessage';
 import { textFileHandler } from './handlers/textFile';
 
 export const registry: ResourceHandler[] = [
@@ -66,6 +67,7 @@ export const registry: ResourceHandler[] = [
 	instanceListHandler,
 	staticSoundMapHandler,
 	languageHandler,
+	hudMessageHandler,
 	textFileHandler,
 ];
 

--- a/src/lib/core/registry/index.ts
+++ b/src/lib/core/registry/index.ts
@@ -39,6 +39,7 @@ import { hudMessageHandler } from './handlers/hudMessage';
 import { hudMessageSequenceHandler } from './handlers/hudMessageSequence';
 import { hudMessageSequenceDictionaryHandler } from './handlers/hudMessageSequenceDictionary';
 import { guiPopupHandler } from './handlers/guiPopup';
+import { worldPainter2DHandler } from './handlers/worldPainter2D';
 import { textFileHandler } from './handlers/textFile';
 
 export const registry: ResourceHandler[] = [
@@ -74,6 +75,7 @@ export const registry: ResourceHandler[] = [
 	hudMessageSequenceHandler,
 	hudMessageSequenceDictionaryHandler,
 	guiPopupHandler,
+	worldPainter2DHandler,
 	textFileHandler,
 ];
 

--- a/src/lib/core/worldPainter2D.ts
+++ b/src/lib/core/worldPainter2D.ts
@@ -1,0 +1,187 @@
+// WorldPainter2D parser and writer (resource type 0x30).
+//
+// A WorldPainter2D resource is a dense 2D byte grid painted over the world
+// map: one byte per map cell naming which district (DISTRICTS.DAT, fixture
+// here) or ambience zone (AMBIENCES, same container with a different palette)
+// that cell belongs to. The runtime (CgsWorld::WorldMap2D) scales the grid
+// over the world using HARDCODED origin/size values — no world bounds are
+// stored in the resource. Row 0 is the map's north edge and x grows eastward:
+// in retail DISTRICTS the White Mountain districts (11–13) hug the west
+// columns and the Big Surf Island districts (18–22) the east columns.
+//
+// On-disk layout (32-bit PC, little-endian):
+//   0x00 u32 mu32DataSize    — bytes after mu32DataOffset, INCLUDING the
+//                              trailing alignment pad (0x18010 in retail)
+//   0x04 u32 mu32DataOffset  — 0x10 in retail
+//   0x08 u8[8]               — pad to the 16-byte data offset (zero in retail)
+//   0x10 u16 muWidth         — 384 in retail v1.4+ (256 in v1.0)
+//   0x12 u16 muHeight        — 256
+//   0x14 u8[w*h]             — row-major cell grid
+//   ...  u8[]                — zero pad to a 16-byte-aligned total
+//
+// Wiki divergence: the World_Painter_2D page tables muWidth/muHeight at
+// offset 0x0. That ignores the CgsResource::BinaryFileResource wrapper its
+// own note mentions ("begin with a Binary File resource") — the real file
+// offsets are +0x10. The wiki's BinaryFile page documents only 8 header
+// bytes; the observed mu32DataOffset of 0x10 shows the header is padded to
+// 16 bytes, and mu32DataSize counts the trailing pad (4 + 384*256 + 12).
+//
+// Cell values in DISTRICTS.DAT are BrnWorld::EDistrict indices 0..22 — all
+// 23 valid districts of the v1.9/Remastered enum, including the Big Surf
+// Island five — plus 0xFF for "no district". The enum's own invalid marker
+// is E_DISTRICT_VALID_COUNT (23), but on disk invalid is always 0xFF (the
+// wiki documents this substitution). 42% of retail cells are 0xFF (ocean
+// and out-of-bounds margins).
+//
+// Round-trip strategy: the layout is rigid — the parser THROWS when the
+// stored wrapper fields disagree with the derived ones instead of silently
+// mis-parsing. mu32DataSize/mu32DataOffset are recomputed on write; the
+// wrapper pad and trailing pad are preserved verbatim for byte-exact output.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Enumerations
+// =============================================================================
+
+// BrnWorld::EDistrict, v1.9/Remastered revision (the only one matching the
+// 0..22 values observed in retail DISTRICTS.DAT). Earlier revisions stop at
+// 17 (v1.0–1.3) or call 18–20 "Island 1/2/3" (v1.4–1.8). Only meaningful for
+// the Districts resource — an Ambiences resource reuses the container with
+// ambience indices instead.
+export const DISTRICT_NAMES = [
+	'Ocean View',
+	'West Acres',
+	'Twin Bridges',
+	'Big Surf Beach',
+	'Eastern Shore',
+	'Hillside Pass',
+	'Heartbreak Hills',
+	'Rockridge Cliffs',
+	'South Bay',
+	'Park Vale',
+	'Paradise Wharf',
+	'Crystal Summit',
+	'Lone Peaks',
+	'Sunset Valley',
+	'Downtown',
+	'River City',
+	'Motor City',
+	'Waterfront',
+	'Paradise Keys Bridge',
+	'North Beach',
+	'Midtown',
+	'South Coast',
+	"Perren's Point",
+] as const;
+
+/** On-disk "no district here" — NOT the enum's E_DISTRICT_INVALID (23). */
+export const INVALID_CELL = 0xff;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type ParsedWorldPainter2D = {
+	/** Grid width in cells (cells per row). Retail v1.4+: 384. */
+	muWidth: number; // u16
+	/** Grid height in cells (number of rows). Retail: 256. */
+	muHeight: number; // u16
+	/**
+	 * Row-major muWidth*muHeight cell bytes, row 0 = north edge, x eastward.
+	 * Each byte is a DISTRICT_NAMES index (Districts) or an ambience index
+	 * (Ambiences); 0xFF = cell belongs to nothing.
+	 */
+	cells: Uint8Array;
+	/** BinaryFile wrapper bytes 0x8..0xF (zero in retail) — preserved verbatim. */
+	_wrapperPad: Uint8Array;
+	/** Zero pad from end-of-grid to the 16-byte-aligned end — preserved verbatim. */
+	_trailingPad: Uint8Array;
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+// CgsResource::BinaryFileResource header: 8 documented bytes padded out to
+// the 16-byte mu32DataOffset every retail resource stores.
+const WRAPPER_FIELDS_SIZE = 0x8;
+const DATA_OFFSET = 0x10;
+const GRID_HEADER_SIZE = 0x4; // muWidth + muHeight
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+export function parseWorldPainter2D(raw: Uint8Array, littleEndian = true): ParsedWorldPainter2D {
+	if (raw.byteLength < DATA_OFFSET + GRID_HEADER_SIZE) {
+		throw new Error(`WorldPainter2D: ${raw.byteLength}-byte resource is smaller than the wrapper + grid header`);
+	}
+	// One ArrayBuffer copy up front; the model's byte fields slice from it.
+	// Slicing `raw` directly would alias when raw is a Node Buffer (zlib
+	// decompression output) — Buffer.prototype.slice returns a view.
+	const copy = raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength);
+	const bytes = new Uint8Array(copy);
+	const r = new BinReader(copy, littleEndian);
+
+	// --- BinaryFile wrapper ---
+	const mu32DataSize = r.readU32();
+	const mu32DataOffset = r.readU32();
+	// The layout is rigid; bail loudly on violations rather than silently
+	// producing a model that won't round-trip.
+	if (mu32DataOffset !== DATA_OFFSET) {
+		throw new Error(`WorldPainter2D: mu32DataOffset is 0x${mu32DataOffset.toString(16)}, expected 0x10 (rigid layout)`);
+	}
+	if (mu32DataSize !== raw.byteLength - DATA_OFFSET) {
+		throw new Error(`WorldPainter2D: mu32DataSize ${mu32DataSize} != ${raw.byteLength - DATA_OFFSET} (resource size minus data offset)`);
+	}
+	const _wrapperPad = bytes.slice(WRAPPER_FIELDS_SIZE, DATA_OFFSET);
+
+	// --- Grid ---
+	r.position = DATA_OFFSET;
+	const muWidth = r.readU16();
+	const muHeight = r.readU16();
+	const gridEnd = DATA_OFFSET + GRID_HEADER_SIZE + muWidth * muHeight;
+	if (gridEnd > raw.byteLength) {
+		throw new Error(`WorldPainter2D: ${muWidth}x${muHeight} grid overruns the ${raw.byteLength}-byte resource`);
+	}
+	const cells = bytes.slice(DATA_OFFSET + GRID_HEADER_SIZE, gridEnd);
+
+	// --- Trailing pad (zeros to 16-byte alignment) — captured verbatim. ---
+	const _trailingPad = gridEnd < raw.byteLength ? bytes.slice(gridEnd, raw.byteLength) : new Uint8Array(0);
+
+	return { muWidth, muHeight, cells, _wrapperPad, _trailingPad };
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+export function writeWorldPainter2D(model: ParsedWorldPainter2D, littleEndian = true): Uint8Array {
+	if (model.cells.byteLength !== model.muWidth * model.muHeight) {
+		throw new Error(`WorldPainter2D writer: ${model.cells.byteLength} cells != ${model.muWidth}x${model.muHeight} grid`);
+	}
+	if (model._wrapperPad.byteLength !== DATA_OFFSET - WRAPPER_FIELDS_SIZE) {
+		throw new Error(`WorldPainter2D writer: wrapper pad is ${model._wrapperPad.byteLength} bytes, expected ${DATA_OFFSET - WRAPPER_FIELDS_SIZE}`);
+	}
+
+	const totalSize = DATA_OFFSET + GRID_HEADER_SIZE + model.cells.byteLength + model._trailingPad.byteLength;
+	const w = new BinWriter(totalSize, littleEndian);
+
+	// --- BinaryFile wrapper (sizes recomputed, never stored) ---
+	w.writeU32(totalSize - DATA_OFFSET); // mu32DataSize — includes the trailing pad
+	w.writeU32(DATA_OFFSET);
+	w.writeBytes(model._wrapperPad);
+	if (w.offset !== DATA_OFFSET) throw new Error(`WorldPainter2D writer: data offset mismatch ${w.offset} vs ${DATA_OFFSET}`);
+
+	// --- Grid ---
+	w.writeU16(model.muWidth);
+	w.writeU16(model.muHeight);
+	w.writeBytes(model.cells);
+
+	// --- Trailing pad (verbatim) — reproduces the exact original length. ---
+	if (model._trailingPad.byteLength > 0) w.writeBytes(model._trailingPad);
+
+	if (w.offset !== totalSize) throw new Error(`WorldPainter2D writer: wrote ${w.offset} bytes, expected ${totalSize}`);
+	return w.bytes;
+}

--- a/src/lib/editor/profiles/guiPopup.ts
+++ b/src/lib/editor/profiles/guiPopup.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedGuiPopup } from '@/lib/core/guiPopup';
+import { guiPopupResourceSchema } from '@/lib/schema/resources/guiPopup';
+
+export const guiPopupProfile = defineProfile<ParsedGuiPopup>({
+	kind: 'default',
+	displayName: 'GUI Popup',
+	schema: guiPopupResourceSchema,
+});

--- a/src/lib/editor/profiles/hudMessage.ts
+++ b/src/lib/editor/profiles/hudMessage.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedHudMessage } from '@/lib/core/hudMessage';
+import { hudMessageResourceSchema } from '@/lib/schema/resources/hudMessage';
+
+export const hudMessageProfile = defineProfile<ParsedHudMessage>({
+	kind: 'default',
+	displayName: 'HUD Message',
+	schema: hudMessageResourceSchema,
+});

--- a/src/lib/editor/profiles/hudMessageSequence.ts
+++ b/src/lib/editor/profiles/hudMessageSequence.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedHudMessageSequence } from '@/lib/core/hudMessageSequences';
+import { hudMessageSequenceResourceSchema } from '@/lib/schema/resources/hudMessageSequence';
+
+export const hudMessageSequenceProfile = defineProfile<ParsedHudMessageSequence>({
+	kind: 'default',
+	displayName: 'HUD Message Sequence',
+	schema: hudMessageSequenceResourceSchema,
+});

--- a/src/lib/editor/profiles/hudMessageSequenceDictionary.ts
+++ b/src/lib/editor/profiles/hudMessageSequenceDictionary.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedHudMessageSequenceDictionary } from '@/lib/core/hudMessageSequences';
+import { hudMessageSequenceDictionaryResourceSchema } from '@/lib/schema/resources/hudMessageSequenceDictionary';
+
+export const hudMessageSequenceDictionaryProfile = defineProfile<ParsedHudMessageSequenceDictionary>({
+	kind: 'default',
+	displayName: 'HUD Message Sequence Dictionary',
+	schema: hudMessageSequenceDictionaryResourceSchema,
+});

--- a/src/lib/editor/profiles/language.ts
+++ b/src/lib/editor/profiles/language.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedLanguage } from '@/lib/core/language';
+import { languageResourceSchema } from '@/lib/schema/resources/language';
+
+export const languageProfile = defineProfile<ParsedLanguage>({
+	kind: 'default',
+	displayName: 'Language',
+	schema: languageResourceSchema,
+});

--- a/src/lib/editor/profiles/worldPainter2D.ts
+++ b/src/lib/editor/profiles/worldPainter2D.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedWorldPainter2D } from '@/lib/core/worldPainter2D';
+import { worldPainter2DResourceSchema } from '@/lib/schema/resources/worldPainter2D';
+
+export const worldPainter2DProfile = defineProfile<ParsedWorldPainter2D>({
+	kind: 'default',
+	displayName: 'World Painter 2D',
+	schema: worldPainter2DResourceSchema,
+});

--- a/src/lib/editor/registry.ts
+++ b/src/lib/editor/registry.ts
@@ -15,6 +15,7 @@
 
 import { aiSectionsV12Profile, aiSectionsV4Profile, aiSectionsV6Profile } from './profiles/aiSections';
 import { challengeListProfile } from './profiles/challengeList';
+import { guiPopupProfile } from './profiles/guiPopup';
 import { hudMessageProfile } from './profiles/hudMessage';
 import { hudMessageSequenceProfile } from './profiles/hudMessageSequence';
 import { hudMessageSequenceDictionaryProfile } from './profiles/hudMessageSequenceDictionary';
@@ -138,6 +139,11 @@ const ENTRIES: RegistryEntry[] = [
 		typeId: 0x2f,
 		key: 'hudMessageSequenceDictionary',
 		profiles: [hudMessageSequenceDictionaryProfile],
+	},
+	{
+		typeId: 0x1f,
+		key: 'guiPopup',
+		profiles: [guiPopupProfile],
 	},
 	{
 		typeId: 0x110,

--- a/src/lib/editor/registry.ts
+++ b/src/lib/editor/registry.ts
@@ -15,6 +15,7 @@
 
 import { aiSectionsV12Profile, aiSectionsV4Profile, aiSectionsV6Profile } from './profiles/aiSections';
 import { challengeListProfile } from './profiles/challengeList';
+import { hudMessageProfile } from './profiles/hudMessage';
 import { iceTakeDictionaryProfile } from './profiles/iceTakeDictionary';
 import { languageProfile } from './profiles/language';
 import { playerCarColoursProfile } from './profiles/playerCarColours';
@@ -120,6 +121,11 @@ const ENTRIES: RegistryEntry[] = [
 		typeId: 0x27,
 		key: 'language',
 		profiles: [languageProfile],
+	},
+	{
+		typeId: 0x2c,
+		key: 'hudMessage',
+		profiles: [hudMessageProfile],
 	},
 	{
 		typeId: 0x110,

--- a/src/lib/editor/registry.ts
+++ b/src/lib/editor/registry.ts
@@ -16,6 +16,7 @@
 import { aiSectionsV12Profile, aiSectionsV4Profile, aiSectionsV6Profile } from './profiles/aiSections';
 import { challengeListProfile } from './profiles/challengeList';
 import { iceTakeDictionaryProfile } from './profiles/iceTakeDictionary';
+import { languageProfile } from './profiles/language';
 import { playerCarColoursProfile } from './profiles/playerCarColours';
 import { polygonSoupListProfile } from './profiles/polygonSoupList';
 import { propInstanceDataProfile } from './profiles/propInstanceData';
@@ -114,6 +115,11 @@ const ENTRIES: RegistryEntry[] = [
 		typeId: 0x1000f,
 		key: 'propPhysics',
 		profiles: [propPhysicsProfile],
+	},
+	{
+		typeId: 0x27,
+		key: 'language',
+		profiles: [languageProfile],
 	},
 	{
 		typeId: 0x110,

--- a/src/lib/editor/registry.ts
+++ b/src/lib/editor/registry.ts
@@ -37,6 +37,7 @@ import {
 } from './profiles/trafficData';
 import { triggerDataProfile } from './profiles/triggerData';
 import { vehicleListProfile } from './profiles/vehicleList';
+import { worldPainter2DProfile } from './profiles/worldPainter2D';
 import { zoneListProfile } from './profiles/zoneList';
 import type { EditorProfile } from './types';
 import {
@@ -144,6 +145,11 @@ const ENTRIES: RegistryEntry[] = [
 		typeId: 0x1f,
 		key: 'guiPopup',
 		profiles: [guiPopupProfile],
+	},
+	{
+		typeId: 0x30,
+		key: 'worldPainter2D',
+		profiles: [worldPainter2DProfile],
 	},
 	{
 		typeId: 0x110,

--- a/src/lib/editor/registry.ts
+++ b/src/lib/editor/registry.ts
@@ -16,6 +16,8 @@
 import { aiSectionsV12Profile, aiSectionsV4Profile, aiSectionsV6Profile } from './profiles/aiSections';
 import { challengeListProfile } from './profiles/challengeList';
 import { hudMessageProfile } from './profiles/hudMessage';
+import { hudMessageSequenceProfile } from './profiles/hudMessageSequence';
+import { hudMessageSequenceDictionaryProfile } from './profiles/hudMessageSequenceDictionary';
 import { iceTakeDictionaryProfile } from './profiles/iceTakeDictionary';
 import { languageProfile } from './profiles/language';
 import { playerCarColoursProfile } from './profiles/playerCarColours';
@@ -126,6 +128,16 @@ const ENTRIES: RegistryEntry[] = [
 		typeId: 0x2c,
 		key: 'hudMessage',
 		profiles: [hudMessageProfile],
+	},
+	{
+		typeId: 0x2e,
+		key: 'hudMessageSequence',
+		profiles: [hudMessageSequenceProfile],
+	},
+	{
+		typeId: 0x2f,
+		key: 'hudMessageSequenceDictionary',
+		profiles: [hudMessageSequenceDictionaryProfile],
 	},
 	{
 		typeId: 0x110,

--- a/src/lib/schema/resources/guiPopup.test.ts
+++ b/src/lib/schema/resources/guiPopup.test.ts
@@ -1,0 +1,198 @@
+// Schema coverage tests for guiPopupResourceSchema.
+//
+// Coverage fixture: example/POPUPS.PUP — the game-wide popup catalogue
+// (111 popups, every field shape the parser produces).
+//
+// Mirrors staticSoundMap.test.ts: parse the model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds. Adds coverage for this
+// schema's derive hook (mNameId from macName, miMessageParamsUsed from
+// maeMessageParams) and the char-buffer length validation.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseGuiPopup, type ParsedGuiPopup } from '../../core/guiPopup';
+import { encodeCgsId } from '../../core/cgsid';
+
+import { guiPopupResourceSchema } from './guiPopup';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema, SchemaContext } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/POPUPS.PUP');
+const GUI_POPUP_TYPE_ID = 0x1f;
+
+function loadModel(fixturePath: string): ParsedGuiPopup {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === GUI_POPUP_TYPE_ID);
+	if (!resource) throw new Error('fixture has no GuiPopup resource');
+	return parseGuiPopup(extractResourceRaw(buffer.buffer, bundle, resource), ctx.littleEndian);
+}
+
+const model = loadModel(BUNDLE_FIXTURE);
+
+describe('guiPopupResourceSchema coverage', () => {
+	it('fixture parses with non-trivial content', () => {
+		expect(model.popups.length).toBeGreaterThan(0);
+	});
+
+	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+		const missing: string[] = [];
+		for (const [recordName, rec] of Object.entries(guiPopupResourceSchema.registry)) {
+			for (const [fieldName, field] of Object.entries(rec.fields)) {
+				checkField(field, `${recordName}.${fieldName}`, missing);
+			}
+		}
+		if (missing.length > 0) {
+			throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+		}
+		function checkField(f: FieldSchema, where: string, out: string[]) {
+			if (f.kind === 'record') {
+				if (!guiPopupResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+				return;
+			}
+			if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+		}
+	});
+
+	it('walkResource visits every parsed field without throwing', () => {
+		let recordCount = 0;
+		let fieldCount = 0;
+		walkResource(guiPopupResourceSchema, model, (_p, _v, field, rec) => {
+			if (rec) recordCount++;
+			if (field) fieldCount++;
+		});
+		expect(recordCount).toBeGreaterThan(0);
+		expect(fieldCount).toBeGreaterThan(0);
+	});
+
+	it('no parsed record has fields absent from the schema', () => {
+		const missing: string[] = [];
+		walkResource(guiPopupResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const declared = new Set(Object.keys(rec.fields));
+			for (const key of Object.keys(value as Record<string, unknown>)) {
+				if (!declared.has(key)) {
+					missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+
+	it('every schema field is represented in the parsed data', () => {
+		const missing: string[] = [];
+		walkResource(guiPopupResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const obj = value as Record<string, unknown>;
+			for (const fieldName of Object.keys(rec.fields)) {
+				if (!(fieldName in obj)) {
+					missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+});
+
+describe('guiPopup path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(guiPopupResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedGuiPopup');
+	});
+
+	it('resolves popups[0] as a GuiPopup', () => {
+		const loc = resolveSchemaAtPath(guiPopupResourceSchema, ['popups', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('GuiPopup');
+	});
+
+	it('resolves popups[0].meStyle as a u32-backed enum', () => {
+		const loc = resolveSchemaAtPath(guiPopupResourceSchema, ['popups', 0, 'meStyle']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('enum');
+	});
+
+	it('resolves popups[0].mNameId as a hex bigint', () => {
+		const loc = resolveSchemaAtPath(guiPopupResourceSchema, ['popups', 0, 'mNameId']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('bigint');
+	});
+
+	it('resolves popups[0].maeMessageParams as a fixed list of enums', () => {
+		const loc = resolveSchemaAtPath(guiPopupResourceSchema, ['popups', 0, 'maeMessageParams']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('list');
+	});
+});
+
+describe('guiPopup derive hook', () => {
+	const rec = guiPopupResourceSchema.registry.GuiPopup;
+	const base = model.popups[0] as unknown as Record<string, unknown>;
+
+	it('re-derives mNameId when macName changes', () => {
+		const next = { ...base, macName: 'Renamed' };
+		const patch = rec.derive!(base, next);
+		expect(patch.mNameId).toBe(encodeCgsId('RENAMED'));
+	});
+
+	it('re-derives miMessageParamsUsed when params change', () => {
+		// popups[0] is the (1,0)/used=1 shape; switching slot 2 on makes it 2.
+		const next = { ...base, maeMessageParams: [1, 2] };
+		const patch = rec.derive!(base, next);
+		expect(patch.miMessageParamsUsed).toBe(2);
+	});
+
+	it('returns an empty patch when nothing derived changed', () => {
+		expect(rec.derive!(base, { ...base })).toEqual({});
+	});
+
+	it('skips the name id while the name is too long to encode', () => {
+		const next = { ...base, macName: 'WayTooLongPopupName' };
+		const patch = rec.derive!(base, next);
+		expect('mNameId' in patch).toBe(false);
+	});
+});
+
+describe('guiPopup validation', () => {
+	const rec = guiPopupResourceSchema.registry.GuiPopup;
+	const ctx: SchemaContext = { root: model, resource: guiPopupResourceSchema };
+	const base = model.popups[0] as unknown as Record<string, unknown>;
+
+	it('accepts every retail popup', () => {
+		for (const p of model.popups) {
+			expect(rec.validate!(p as unknown as Record<string, unknown>, ctx)).toEqual([]);
+		}
+	});
+
+	it('errors on a name that cannot fit char[13]', () => {
+		const results = rec.validate!({ ...base, macName: 'ThirteenChars' }, ctx);
+		expect(results.some((r) => r.severity === 'error' && r.field === 'macName')).toBe(true);
+	});
+
+	it('errors on a Language key that cannot fit char[32]', () => {
+		const results = rec.validate!({ ...base, macMessageId: 'X'.repeat(32) }, ctx);
+		expect(results.some((r) => r.severity === 'error' && r.field === 'macMessageId')).toBe(true);
+	});
+
+	it('warns on characters the CgsID encoding cannot round-trip', () => {
+		const results = rec.validate!({ ...base, macName: 'Bad.Name' }, ctx);
+		expect(results.some((r) => r.severity === 'warning' && r.field === 'macName')).toBe(true);
+	});
+});

--- a/src/lib/schema/resources/guiPopup.ts
+++ b/src/lib/schema/resources/guiPopup.ts
@@ -1,0 +1,264 @@
+// Hand-written schema for ParsedGuiPopup (resource type 0x1F).
+//
+// Mirrors the types in `src/lib/core/guiPopup.ts`. Keep these in lockstep
+// with the parser/writer — any field added to the parser needs a matching
+// entry here, or the schema walker reports it as drift.
+//
+// Domain: the game-wide popup catalogue (one resource, GUI/POPUPS.PUP). Game
+// code summons a popup by its CgsID (mNameId); the style picks the frame and
+// button bar; all visible text comes from the Language resource via char[32]
+// string KEYS, so editing macMessageId retargets the popup at a different
+// localised string rather than changing text directly.
+//
+// Two derived fields are kept in sync by the record's derive hook rather
+// than being hand-edited: mNameId (always encodeCgsId(macName.toUpperCase())
+// in retail — all 111 popups verified) and miMessageParamsUsed (the count of
+// leading non-Unused entries in maeMessageParams). Both are readOnly in the
+// inspector; edit macName / maeMessageParams instead.
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+	ValidationResult,
+} from '../types';
+import {
+	POPUP_STYLES,
+	POPUP_ICONS,
+	POPUP_PARAM_TYPES,
+	popupStyleLabel,
+	countMessageParamsUsed,
+	type GuiPopup as GuiPopupModel,
+} from '@/lib/core/guiPopup';
+import { encodeCgsId } from '@/lib/core/cgsid';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring propPhysics.ts)
+// ---------------------------------------------------------------------------
+
+const u8 = (): FieldSchema => ({ kind: 'u8' });
+const i32 = (): FieldSchema => ({ kind: 'i32' });
+const str = (): FieldSchema => ({ kind: 'string' });
+const boolField = (): FieldSchema => ({ kind: 'bool' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+const bigintId = (): FieldSchema => ({ kind: 'bigint', bytes: 8, hex: true });
+
+const fixedList = (item: FieldSchema, length: number): FieldSchema => ({
+	kind: 'list',
+	item,
+	minLength: length,
+	maxLength: length,
+	addable: false,
+	removable: false,
+});
+
+const styleEnum = (): FieldSchema => ({
+	kind: 'enum',
+	storage: 'u32',
+	values: POPUP_STYLES.map((s) => ({ value: s.value, label: s.label, description: s.description })),
+});
+const iconEnum = (): FieldSchema => ({
+	kind: 'enum',
+	storage: 'u32',
+	values: POPUP_ICONS.map((s) => ({ value: s.value, label: s.label, description: s.description })),
+});
+const paramTypeEnum = (): FieldSchema => ({
+	kind: 'enum',
+	storage: 'u32',
+	values: POPUP_PARAM_TYPES.map((s) => ({ value: s.value, label: s.label, description: s.description })),
+});
+
+// ---------------------------------------------------------------------------
+// Tree-label helper
+// ---------------------------------------------------------------------------
+
+function popupLabel(p: unknown, index: number): string {
+	try {
+		if (!p || typeof p !== 'object') return `#${index}`;
+		const e = p as { macName?: string; meStyle?: number; meIcon?: number };
+		const bits = [`#${index} · ${e.macName || '(unnamed)'}`];
+		if (e.meStyle != null) bits.push(popupStyleLabel(e.meStyle));
+		if (e.meIcon === 1) bits.push('⚠');
+		return bits.join(' · ');
+	} catch {
+		return `#${index}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+// Charset CgsID encoding can represent — anything else round-trips through
+// encode/decode as a different character, so the name field warns on it.
+const CGS_SAFE = /^[A-Za-z0-9 /_-]*$/;
+
+function validatePopup(value: Record<string, unknown>): ValidationResult[] {
+	const out: ValidationResult[] = [];
+	const p = value as Partial<GuiPopupModel>;
+	if (typeof p.macName === 'string') {
+		if (p.macName.length > 12) {
+			out.push({ severity: 'error', field: 'macName', message: `Name is ${p.macName.length} chars; char[13] fits at most 12.` });
+		}
+		if (!CGS_SAFE.test(p.macName)) {
+			out.push({ severity: 'warning', field: 'macName', message: 'Name has characters outside the CgsID charset (A–Z, 0–9, space, -, /, _); the derived name ID will not round-trip them.' });
+		}
+	}
+	for (const field of ['macTitleId', 'macMessageId', 'macButton1Id', 'macButton2Id'] as const) {
+		const v = p[field];
+		if (typeof v === 'string' && v.length > 31) {
+			out.push({ severity: 'error', field, message: `Key is ${v.length} chars; char[32] fits at most 31.` });
+		}
+	}
+	return out;
+}
+
+const GuiPopup: RecordSchema = {
+	name: 'GuiPopup',
+	description: 'One popup card. Game code summons it by name ID; the style picks the frame and button bar ("wait" styles have no buttons and are dismissed by code). All text fields are KEYS into the Language resource — empty key = no title / no button.',
+	fields: {
+		macName: str(),
+		mNameId: bigintId(),
+		meStyle: styleEnum(),
+		meIcon: iconEnum(),
+		macTitleId: str(),
+		macMessageId: str(),
+		maeMessageParams: fixedList(paramTypeEnum(), 2),
+		miMessageParamsUsed: i32(),
+		macButton1Id: str(),
+		meButton1Param: paramTypeEnum(),
+		mbButton1ParamUsed: boolField(),
+		macButton2Id: str(),
+		meButton2Param: paramTypeEnum(),
+		mbButton2ParamUsed: boolField(),
+		_pad15: fixedList(u8(), 3),
+		_padB1: fixedList(u8(), 3),
+		_padB9: fixedList(u8(), 7),
+	},
+	fieldMetadata: {
+		macName: {
+			label: 'Name',
+			description: 'Debug name, max 12 chars. Renaming re-derives the name ID, which is what game code uses to summon the popup — a renamed popup stops appearing unless the calling code knows the new name.',
+		},
+		mNameId: {
+			label: 'Name ID (CgsID)',
+			description: 'Base-40 packed macName.toUpperCase() — every retail popup follows that derivation, and the editor keeps it in sync when the name changes.',
+			readOnly: true,
+			derivedFrom: 'macName',
+		},
+		meStyle: {
+			label: 'Style',
+			description: 'Popup frame, placement, and button bar. CrashNav styles render in the front-end nav, In-game styles over gameplay; splash is the full-screen online mode card. Styles 14/15 are the v1.9+ Big Surf Island variants.',
+		},
+		meIcon: { label: 'Icon', description: 'Warning shows the hazard icon next to the message; Invisible shows none.' },
+		macTitleId: { label: 'Title key', description: 'Language string key for the heading. Empty = untitled card.' },
+		macMessageId: {
+			label: 'Message key',
+			description: 'Language string key for the body text. Some retail keys carry a \'~\' prefix (meaning unconfirmed) — keep it when retargeting.',
+		},
+		maeMessageParams: {
+			label: 'Message params',
+			description: 'How runtime fills the message string\'s two substitution slots: a raw string (e.g. a player name) or another Language string. Used slots must be leading — slot 2 can\'t be set while slot 1 is Unused.',
+		},
+		miMessageParamsUsed: {
+			label: 'Params used',
+			description: 'Count of leading non-Unused message params; re-derived automatically when the params change.',
+			readOnly: true,
+			derivedFrom: 'maeMessageParams',
+		},
+		macButton1Id: { label: 'Button 1 key', description: 'Language string key for the first button caption. Empty = no buttons ("wait" styles).' },
+		meButton1Param: { label: 'Button 1 param', description: 'Substitution slot for the button caption — Unused on every retail popup.' },
+		mbButton1ParamUsed: { label: 'Button 1 param used', description: 'False on every retail popup.' },
+		macButton2Id: { label: 'Button 2 key', description: 'Language string key for the second button caption (the Cancel/No slot). Empty = single-button popup.' },
+		meButton2Param: { label: 'Button 2 param', description: 'Substitution slot for the button caption — Unused on every retail popup.' },
+		mbButton2ParamUsed: { label: 'Button 2 param used', description: 'False on every retail popup.' },
+		_pad15: { label: 'pad +0x15', description: 'Record pad (zero in retail); preserved verbatim.', hidden: true },
+		_padB1: { label: 'pad +0xB1', description: 'Record pad — uninitialised build-machine garbage, identical in every retail record; preserved verbatim.', hidden: true },
+		_padB9: { label: 'pad +0xB9', description: 'Record pad — uninitialised build-machine garbage, identical in every retail record; preserved verbatim.', hidden: true },
+	},
+	propertyGroups: [
+		{ title: 'Identity', properties: ['macName', 'mNameId', 'meStyle', 'meIcon'] },
+		{ title: 'Text', properties: ['macTitleId', 'macMessageId', 'maeMessageParams', 'miMessageParamsUsed'] },
+		{ title: 'Buttons', properties: ['macButton1Id', 'meButton1Param', 'mbButton1ParamUsed', 'macButton2Id', 'meButton2Param', 'mbButton2ParamUsed'] },
+	],
+	label: (value, index) => popupLabel(value, index ?? 0),
+	validate: (value) => validatePopup(value),
+	derive: (prev, next) => {
+		const patch: Record<string, unknown> = {};
+		const name = next.macName;
+		// Length-guard: encodeCgsId throws past 12 chars; validation already
+		// flags that as an error, so derive just skips until the name fits.
+		if (name !== prev.macName && typeof name === 'string' && name.length <= 12) {
+			patch.mNameId = encodeCgsId(name.toUpperCase());
+		}
+		const params = next.maeMessageParams;
+		if (Array.isArray(params) && params.length === 2) {
+			const used = countMessageParamsUsed(params as [number, number]);
+			if (used !== next.miMessageParamsUsed) patch.miMessageParamsUsed = used;
+		}
+		return patch;
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+function makeEmptyPopup(): GuiPopupModel {
+	return {
+		mNameId: encodeCgsId('NEWPOPUP'),
+		macName: 'NewPopup',
+		meStyle: 7, // In-game — OK: the most common retail style
+		meIcon: 0,
+		macTitleId: '',
+		macMessageId: 'PLACEHOLDER_TEMP_STRING',
+		maeMessageParams: [0, 0],
+		miMessageParamsUsed: 0,
+		macButton1Id: 'GENERAL_OPTION_OK',
+		meButton1Param: 0,
+		mbButton1ParamUsed: false,
+		macButton2Id: '',
+		meButton2Param: 0,
+		mbButton2ParamUsed: false,
+		_pad15: [0, 0, 0],
+		_padB1: [0, 0, 0],
+		_padB9: [0, 0, 0, 0, 0, 0, 0],
+	};
+}
+
+const ParsedGuiPopup: RecordSchema = {
+	name: 'ParsedGuiPopup',
+	description: 'Root record for the GuiPopup resource (0x1F) — the game-wide popup catalogue (111 popups in retail POPUPS.PUP). The writer recomputes the whole layout from the list, so popups can be added or removed freely; the i16 size field caps the resource at ~165 popups.',
+	fields: {
+		popups: {
+			kind: 'list',
+			item: record('GuiPopup'),
+			addable: true,
+			removable: true,
+			makeEmpty: () => makeEmptyPopup(),
+			itemLabel: (item, index) => popupLabel(item, index),
+		},
+	},
+	fieldMetadata: {
+		popups: {
+			label: 'Popups',
+			description: 'Every popup card, in disk order. Code looks them up by name ID, not index, so order is cosmetic.',
+		},
+	},
+	propertyGroups: [
+		{ title: 'Catalogue', properties: ['popups'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedGuiPopup,
+	GuiPopup,
+};
+
+export const guiPopupResourceSchema: ResourceSchema = {
+	key: 'guiPopup',
+	name: 'GUI Popup',
+	rootType: 'ParsedGuiPopup',
+	registry,
+};

--- a/src/lib/schema/resources/hudMessage.test.ts
+++ b/src/lib/schema/resources/hudMessage.test.ts
@@ -1,0 +1,193 @@
+// Schema coverage tests for hudMessageResourceSchema.
+//
+// Coverage fixture: example/HUDMESSAGES.HM — the only retail HudMessage
+// resource (308 messages).
+//
+// Mirrors staticSoundMap.test.ts: parse the model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds. Also pins the derive hook
+// that keeps mMessageIdHash in sync with macMessageId.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseHudMessage, type ParsedHudMessage } from '../../core/hudMessage';
+import { encodeCgsId } from '../../core/cgsid';
+
+import { hudMessageResourceSchema, paramTypeName } from './hudMessage';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/HUDMESSAGES.HM');
+const HUD_MESSAGE_TYPE_ID = 0x2c;
+
+function loadModel(fixturePath: string): ParsedHudMessage {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === HUD_MESSAGE_TYPE_ID)!;
+	return parseHudMessage(extractResourceRaw(buffer.buffer, bundle, resource), ctx.littleEndian);
+}
+
+const model = loadModel(BUNDLE_FIXTURE);
+
+describe('hudMessageResourceSchema coverage', () => {
+	it('fixture parses with non-trivial content', () => {
+		expect(model.messages.length).toBeGreaterThan(0);
+		expect(model.messages[0].lines.length).toBe(3);
+	});
+
+	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+		const missing: string[] = [];
+		for (const [recordName, rec] of Object.entries(hudMessageResourceSchema.registry)) {
+			for (const [fieldName, field] of Object.entries(rec.fields)) {
+				checkField(field, `${recordName}.${fieldName}`, missing);
+			}
+		}
+		if (missing.length > 0) {
+			throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+		}
+		function checkField(f: FieldSchema, where: string, out: string[]) {
+			if (f.kind === 'record') {
+				if (!hudMessageResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+				return;
+			}
+			if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+		}
+	});
+
+	it('walkResource visits every parsed field without throwing', () => {
+		let recordCount = 0;
+		let fieldCount = 0;
+		walkResource(hudMessageResourceSchema, model, (_p, _v, field, rec) => {
+			if (rec) recordCount++;
+			if (field) fieldCount++;
+		});
+		expect(recordCount).toBeGreaterThan(0);
+		expect(fieldCount).toBeGreaterThan(0);
+	});
+
+	it('no parsed record has fields absent from the schema', () => {
+		const missing: string[] = [];
+		walkResource(hudMessageResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const declared = new Set(Object.keys(rec.fields));
+			for (const key of Object.keys(value as Record<string, unknown>)) {
+				if (!declared.has(key)) {
+					missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+
+	it('every schema field is represented in the parsed data', () => {
+		const missing: string[] = [];
+		walkResource(hudMessageResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const obj = value as Record<string, unknown>;
+			for (const fieldName of Object.keys(rec.fields)) {
+				if (!(fieldName in obj)) {
+					missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+});
+
+describe('hudMessage path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(hudMessageResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedHudMessage');
+	});
+
+	it('resolves messages[0] as a HudMessage', () => {
+		const loc = resolveSchemaAtPath(hudMessageResourceSchema, ['messages', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('HudMessage');
+	});
+
+	it('resolves messages[0].lines[0] as a HudMessageLine', () => {
+		const loc = resolveSchemaAtPath(hudMessageResourceSchema, ['messages', 0, 'lines', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('HudMessageLine');
+	});
+
+	it('resolves muAvailabilityBitSet as flags and meMessageGroup as enum', () => {
+		const flags = resolveSchemaAtPath(hudMessageResourceSchema, ['messages', 0, 'muAvailabilityBitSet']);
+		expect(flags!.field?.kind).toBe('flags');
+		const group = resolveSchemaAtPath(hudMessageResourceSchema, ['messages', 0, 'meMessageGroup']);
+		expect(group!.field?.kind).toBe('enum');
+	});
+
+	it('resolves mMessageIdHash as a hex bigint', () => {
+		const loc = resolveSchemaAtPath(hudMessageResourceSchema, ['messages', 0, 'mMessageIdHash']);
+		expect(loc!.field?.kind).toBe('bigint');
+	});
+});
+
+describe('hudMessage derive + labels', () => {
+	it('derive recomputes the CgsID when the message id changes', () => {
+		const rec = hudMessageResourceSchema.registry.HudMessage;
+		const prev = model.messages[0] as unknown as Record<string, unknown>;
+		const next = { ...prev, macMessageId: 'StewardTest' };
+		const patch = rec.derive!(prev, next);
+		expect(patch.mMessageIdHash).toBe(encodeCgsId('STEWARDTEST'));
+	});
+
+	it('derive leaves the hash alone when the id is untouched', () => {
+		const rec = hudMessageResourceSchema.registry.HudMessage;
+		const prev = model.messages[0] as unknown as Record<string, unknown>;
+		const next = { ...prev, mfDuration: 5 };
+		expect(rec.derive!(prev, next)).toEqual({});
+	});
+
+	it('message labels surface the id and first line', () => {
+		const rec = hudMessageResourceSchema.registry.HudMessage;
+		const ctx = { root: model, resource: hudMessageResourceSchema };
+		const label = rec.label!(model.messages[0] as unknown as Record<string, unknown>, 0, ctx);
+		expect(label).toContain('AggDrBstStrt');
+		expect(label).toContain('HUDMESSAGE_ONLINE_BOOST_STARTS');
+	});
+
+	it('line labels distinguish used and unused lanes', () => {
+		const rec = hudMessageResourceSchema.registry.HudMessageLine;
+		const ctx = { root: model, resource: hudMessageResourceSchema };
+		const used = rec.label!(model.messages[0].lines[0] as unknown as Record<string, unknown>, 0, ctx);
+		expect(used).toContain('HUDMESSAGE_ONLINE_BOOST_STARTS');
+		const unused = rec.label!(model.messages[0].lines[2] as unknown as Record<string, unknown>, 2, ctx);
+		expect(unused).toContain('(unused)');
+	});
+
+	it('paramTypeName names the retail param types', () => {
+		expect(paramTypeName(1)).toBe('String');
+		expect(paramTypeName(6)).toBe('StringId');
+		expect(paramTypeName(99)).toBe('?99');
+	});
+
+	it('line validation flags count/type drift the game would ignore', () => {
+		const rec = hudMessageResourceSchema.registry.HudMessageLine;
+		const ctx = { root: model, resource: hudMessageResourceSchema };
+		// Param beyond the declared count.
+		const drifted = { macStringId: 'X', miParamCount: 0, maeParamTypes: [1, 0, 0, 0] };
+		expect(rec.validate!(drifted, ctx).length).toBeGreaterThan(0);
+		// Retail line passes clean.
+		const retail = model.messages[0].lines[0] as unknown as Record<string, unknown>;
+		expect(rec.validate!(retail, ctx)).toEqual([]);
+	});
+});

--- a/src/lib/schema/resources/hudMessage.ts
+++ b/src/lib/schema/resources/hudMessage.ts
@@ -1,0 +1,311 @@
+// Hand-written schema for ParsedHudMessage (resource type 0x2C).
+//
+// Mirrors the types in `src/lib/core/hudMessage.ts`. Keep these in lockstep
+// with the parser/writer — any field added to the parser needs a matching
+// entry here, or the schema walker reports it as drift.
+//
+// Domain: the single retail HUD message catalogue (HUDMESSAGES.HM). Each
+// message has up to three lines; a line's string id is a SYMBOLIC reference
+// into the Language (0x27) string table ('HUDMESSAGE_GENERIC1' → the
+// translated text), so renaming an id here without a matching Language entry
+// silently blanks the line in game. mMessageIdHash is derived — it must
+// equal encodeCgsId(macMessageId.toUpperCase()) (verified across all 308
+// retail records) because the game fires messages by the hash; the derive
+// hook below keeps the pair in sync on rename.
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+	ValidationResult,
+} from '../types';
+import {
+	HUD_MESSAGE_AVAILABILITY_FLAGS,
+	HUD_MESSAGE_GROUPS,
+	HUD_MESSAGE_PARAM_TYPES,
+	HUD_MESSAGE_LINES,
+	HUD_MESSAGE_PARAMS_PER_LINE,
+	type HudMessage,
+	type HudMessageLine,
+} from '@/lib/core/hudMessage';
+import { encodeCgsId } from '@/lib/core/cgsid';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring staticSoundMap.ts / propPhysics.ts)
+// ---------------------------------------------------------------------------
+
+const f32 = (min?: number, max?: number): FieldSchema => ({ kind: 'f32', min, max });
+const i32 = (min?: number, max?: number): FieldSchema => ({ kind: 'i32', min, max });
+const u8 = (): FieldSchema => ({ kind: 'u8' });
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const str = (): FieldSchema => ({ kind: 'string' });
+const cgsId = (): FieldSchema => ({ kind: 'bigint', bytes: 8, hex: true });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+
+const groupEnum = (): FieldSchema => ({
+	kind: 'enum',
+	storage: 'i32',
+	values: HUD_MESSAGE_GROUPS.map((g) => ({ value: g.value, label: g.label })),
+});
+
+const availabilityFlags = (): FieldSchema => ({
+	kind: 'flags',
+	storage: 'u32',
+	bits: HUD_MESSAGE_AVAILABILITY_FLAGS.map((f) => ({ mask: f.mask, label: f.label, description: f.description })),
+});
+
+const paramTypesList = (): FieldSchema => ({
+	kind: 'list',
+	item: {
+		kind: 'enum',
+		storage: 'u32',
+		values: HUD_MESSAGE_PARAM_TYPES.map((p) => ({ value: p.value, label: p.label })),
+	},
+	addable: false,
+	removable: false,
+	minLength: HUD_MESSAGE_PARAMS_PER_LINE,
+	maxLength: HUD_MESSAGE_PARAMS_PER_LINE,
+	itemLabel: (item, index) => `slot ${index} · ${paramTypeName(item)}`,
+});
+
+const fixedList = (item: FieldSchema, n: number): FieldSchema => ({
+	kind: 'list',
+	item,
+	addable: false,
+	removable: false,
+	minLength: n,
+	maxLength: n,
+});
+
+// ---------------------------------------------------------------------------
+// Tree-label helpers
+// ---------------------------------------------------------------------------
+
+export function paramTypeName(value: unknown): string {
+	const entry = HUD_MESSAGE_PARAM_TYPES.find((p) => p.value === value);
+	return entry ? entry.label : `?${value}`;
+}
+
+function lineLabel(line: unknown, index: number): string {
+	try {
+		if (!line || typeof line !== 'object') return `#${index}`;
+		const l = line as Partial<HudMessageLine>;
+		if (!l.macStringId) return `#${index} · (unused)`;
+		const params = (l.miParamCount ?? 0) > 0 ? ` · ${l.miParamCount} param${l.miParamCount === 1 ? '' : 's'}` : '';
+		return `#${index} · ${l.macStringId}${params}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function messageLabel(msg: unknown, index: number): string {
+	try {
+		if (!msg || typeof msg !== 'object') return `#${index}`;
+		const m = msg as Partial<HudMessage>;
+		const id = m.macMessageId || '(no id)';
+		const firstLine = m.lines?.[0]?.macStringId;
+		return firstLine ? `#${index} · ${id} · ${firstLine}` : `#${index} · ${id}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function makeEmptyMessage(): HudMessage {
+	return {
+		lines: Array.from({ length: HUD_MESSAGE_LINES }, () => ({
+			macStringId: '',
+			miParamCount: 0,
+			maeParamTypes: Array.from({ length: HUD_MESSAGE_PARAMS_PER_LINE }, () => 0),
+		})),
+		macMessageStyle: 'NeutralMessage',
+		macDefaultIcon: 'invisible',
+		macMessageId: '',
+		mMessageIdHash: 0n,
+		muAvailabilityBitSet: 0x3f,
+		mfDuration: 2,
+		mfTimeToWait: 0,
+		miPriority: 50,
+		miForceRemoveThreshold: 0,
+		meMessageGroup: 3,
+		_padMessageId: [0, 0, 0],
+		_padTail: 0,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const HudMessageLineRecord: RecordSchema = {
+	name: 'HudMessageLine',
+	description: 'One text line of a HUD message. The string id is looked up in the Language (0x27) string table at runtime; param slots are printf-style substitutions the triggering game code fills in.',
+	fields: {
+		macStringId: str(),
+		miParamCount: i32(0, HUD_MESSAGE_PARAMS_PER_LINE),
+		maeParamTypes: paramTypesList(),
+	},
+	fieldMetadata: {
+		macStringId: {
+			label: 'String id',
+			description: 'Symbolic id into the Language (0x27) string table, e.g. HUDMESSAGE_GENERIC1. Empty = this line is unused. Max 63 chars. An id with no matching Language entry blanks the line in game.',
+		},
+		miParamCount: {
+			label: 'Param count',
+			description: 'Number of leading param slots this line consumes (0–4). Retail packs params as a prefix: non-Unused up to the count, Unused after.',
+		},
+		maeParamTypes: {
+			label: 'Param types',
+			description: 'Always 4 slots. The types the triggering code must supply, in order — retail only ever uses String, Int, Float, and StringId.',
+		},
+	},
+	label: (value, index) => lineLabel(value, index ?? 0),
+	validate: (value): ValidationResult[] => {
+		const results: ValidationResult[] = [];
+		const l = value as Partial<HudMessageLine>;
+		const count = l.miParamCount ?? 0;
+		if (count > 0 && !l.macStringId) {
+			results.push({ severity: 'warning', field: 'miParamCount', message: 'Params declared on a line with no string id — no retail message does this.' });
+		}
+		const types = l.maeParamTypes ?? [];
+		types.forEach((p, idx) => {
+			if (idx < count && p === 0) {
+				results.push({ severity: 'warning', field: 'maeParamTypes', message: `Slot ${idx} is Unused but sits inside the declared param count (${count}).` });
+			}
+			if (idx >= count && p !== 0) {
+				results.push({ severity: 'warning', field: 'maeParamTypes', message: `Slot ${idx} has a type but lies beyond the declared param count (${count}) — the game won't read it.` });
+			}
+		});
+		return results;
+	},
+};
+
+const HudMessageRecord: RecordSchema = {
+	name: 'HudMessage',
+	description: 'One HUD message: up to three Language-string lines plus display style, icon, timing, queue priority, and the event contexts it may appear in. The game fires it by the CgsID of its message id.',
+	fields: {
+		macMessageId: str(),
+		mMessageIdHash: cgsId(),
+		lines: fixedList(record('HudMessageLine'), HUD_MESSAGE_LINES),
+		macMessageStyle: str(),
+		macDefaultIcon: str(),
+		muAvailabilityBitSet: availabilityFlags(),
+		meMessageGroup: groupEnum(),
+		mfDuration: f32(0),
+		mfTimeToWait: f32(0),
+		miPriority: i32(0, 100),
+		miForceRemoveThreshold: i32(0, 100),
+		_padMessageId: fixedList(u8(), 3),
+		_padTail: u32(),
+	},
+	fieldMetadata: {
+		macMessageId: {
+			label: 'Message id',
+			description: 'Trigger id the game fires this message by, max 12 chars (e.g. AggDrBstStrt). Must be unique — renaming auto-updates the CgsID hash.',
+		},
+		mMessageIdHash: {
+			label: 'Message CgsID',
+			description: 'CgsID encoding of the uppercased message id — the actual lookup key at runtime. Derived from the message id; equal to encodeCgsId(id.toUpperCase()) in every retail record.',
+			readOnly: true,
+			derivedFrom: 'macMessageId',
+		},
+		lines: {
+			label: 'Lines',
+			description: 'The three on-disk text lanes. Retail: 163 of 308 messages use line 1, 18 use line 2.',
+		},
+		macMessageStyle: {
+			label: 'Style',
+			description: 'GUI style key controlling colour and placement, e.g. NeutralMessage, PosMessageBott01, NegMessage01. Retail uses 30 distinct styles. Max 31 chars.',
+		},
+		macDefaultIcon: {
+			label: 'Icon',
+			description: "Icon key shown beside the text — 'invisible' for none, 'EventSpecific' to follow the active event. Retail uses 22 distinct icons. Max 31 chars.",
+		},
+		muAvailabilityBitSet: {
+			label: 'Availability',
+			description: 'Event contexts the message may appear in. A message with no bits set can never display.',
+		},
+		meMessageGroup: {
+			label: 'Group',
+			description: 'Message queue group. Retail only uses Online live revenge (1), Online dirty tricks (2), and In-game messages (3).',
+		},
+		mfDuration: {
+			label: 'Duration',
+			description: 'Time the message stays on screen, in seconds. Retail range 0.7–10.',
+		},
+		mfTimeToWait: {
+			label: 'Delay',
+			description: 'Wait before displaying, in seconds. Retail range 0–30.',
+		},
+		miPriority: {
+			label: 'Priority',
+			description: 'Percent priority (0–100) for the message queue — higher displaces lower.',
+		},
+		miForceRemoveThreshold: {
+			label: 'Force-remove threshold',
+			description: 'Priority threshold (0–100) related to evicting queued messages; 0 for most retail messages.',
+		},
+		_padMessageId: {
+			label: 'pad +0x10D',
+			description: 'Build-tool heap garbage after the message id terminator (constant f9 1c 00 in retail). Preserved for byte-exact round-trip.',
+			hidden: true,
+		},
+		_padTail: {
+			label: 'pad +0x16C',
+			description: 'Build-tool heap garbage in the record tail (constant 0x001cf974 in retail). Preserved for byte-exact round-trip.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Identity', properties: ['macMessageId', 'mMessageIdHash'] },
+		{ title: 'Content', properties: ['lines', 'macMessageStyle', 'macDefaultIcon'] },
+		{ title: 'Behaviour', properties: ['muAvailabilityBitSet', 'meMessageGroup', 'mfDuration', 'mfTimeToWait', 'miPriority', 'miForceRemoveThreshold'] },
+	],
+	label: (value, index) => messageLabel(value, index ?? 0),
+	derive: (prev, next) => {
+		// The game fires messages by the CgsID, so it must follow id renames.
+		if (prev.macMessageId !== next.macMessageId) {
+			return { mMessageIdHash: encodeCgsId(String(next.macMessageId ?? '').toUpperCase()) };
+		}
+		return {};
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedHudMessage: RecordSchema = {
+	name: 'ParsedHudMessage',
+	description: 'Root record for the HudMessage resource (0x2C): the game-wide HUD message catalogue. Retail ships exactly one, in HUDMESSAGES.HM (308 messages).',
+	fields: {
+		messages: {
+			kind: 'list',
+			item: record('HudMessage'),
+			makeEmpty: () => makeEmptyMessage(),
+			itemLabel: (item, index) => messageLabel(item, index),
+		},
+	},
+	fieldMetadata: {
+		messages: {
+			label: 'Messages',
+			description: 'Every HUD message the game can display, in disk order. Order is not gameplay-significant (lookup is by CgsID), but keeping it stable minimises diffs.',
+		},
+	},
+	propertyGroups: [
+		{ title: 'Messages', properties: ['messages'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedHudMessage,
+	HudMessage: HudMessageRecord,
+	HudMessageLine: HudMessageLineRecord,
+};
+
+export const hudMessageResourceSchema: ResourceSchema = {
+	key: 'hudMessage',
+	name: 'HUD Message',
+	rootType: 'ParsedHudMessage',
+	registry,
+};

--- a/src/lib/schema/resources/hudMessageSequence.test.ts
+++ b/src/lib/schema/resources/hudMessageSequence.test.ts
@@ -1,0 +1,174 @@
+// Schema coverage tests for hudMessageSequenceResourceSchema.
+//
+// Coverage fixture: example/HUDMESSAGESEQUENCES.HMSC, which carries all SIX
+// retail sequences — the same schema must cover every one, so the suite
+// walks them all (they share one shape, but walking all six is cheap and
+// catches per-resource drift for free).
+//
+// Mirrors staticSoundMap.test.ts: parse each model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseHudMessageSequence, type ParsedHudMessageSequence } from '../../core/hudMessageSequences';
+import { encodeCgsId } from '../../core/cgsid';
+
+import { hudMessageSequenceResourceSchema } from './hudMessageSequence';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/HUDMESSAGESEQUENCES.HMSC');
+const SEQUENCE_TYPE_ID = 0x2e;
+
+function loadAllModels(fixturePath: string): ParsedHudMessageSequence[] {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	return bundle.resources
+		.filter((r) => r.resourceTypeId === SEQUENCE_TYPE_ID)
+		.map((r) => parseHudMessageSequence(extractResourceRaw(buffer.buffer, bundle, r), ctx.littleEndian));
+}
+
+const models = loadAllModels(BUNDLE_FIXTURE);
+
+describe('hudMessageSequence fixture inventory', () => {
+	it('loads all six sequences', () => {
+		expect(models.length).toBe(6);
+	});
+});
+
+for (const model of models) {
+	describe(`hudMessageSequenceResourceSchema coverage — ${model.macSequenceId}`, () => {
+		it('fixture parses with non-trivial content', () => {
+			expect(model.messages.length).toBeGreaterThan(0);
+			expect(model.macSequenceId.length).toBeGreaterThan(0);
+		});
+
+		it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+			const missing: string[] = [];
+			for (const [recordName, rec] of Object.entries(hudMessageSequenceResourceSchema.registry)) {
+				for (const [fieldName, field] of Object.entries(rec.fields)) {
+					checkField(field, `${recordName}.${fieldName}`, missing);
+				}
+			}
+			if (missing.length > 0) {
+				throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+			}
+			function checkField(f: FieldSchema, where: string, out: string[]) {
+				if (f.kind === 'record') {
+					if (!hudMessageSequenceResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+					return;
+				}
+				if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+			}
+		});
+
+		it('walkResource visits every parsed field without throwing', () => {
+			let recordCount = 0;
+			let fieldCount = 0;
+			walkResource(hudMessageSequenceResourceSchema, model, (_p, _v, field, rec) => {
+				if (rec) recordCount++;
+				if (field) fieldCount++;
+			});
+			expect(recordCount).toBeGreaterThan(0);
+			expect(fieldCount).toBeGreaterThan(0);
+		});
+
+		it('no parsed record has fields absent from the schema', () => {
+			const missing: string[] = [];
+			walkResource(hudMessageSequenceResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const declared = new Set(Object.keys(rec.fields));
+				for (const key of Object.keys(value as Record<string, unknown>)) {
+					if (!declared.has(key)) {
+						missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+
+		it('every schema field is represented in the parsed data', () => {
+			const missing: string[] = [];
+			walkResource(hudMessageSequenceResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const obj = value as Record<string, unknown>;
+				for (const fieldName of Object.keys(rec.fields)) {
+					if (!(fieldName in obj)) {
+						missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+	});
+}
+
+describe('hudMessageSequence path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(hudMessageSequenceResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedHudMessageSequence');
+	});
+
+	it('resolves messages[0] as a HudMessageSequenceMessage', () => {
+		const loc = resolveSchemaAtPath(hudMessageSequenceResourceSchema, ['messages', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('HudMessageSequenceMessage');
+	});
+
+	it('resolves messages[0].mMessageId as bigint', () => {
+		const loc = resolveSchemaAtPath(hudMessageSequenceResourceSchema, ['messages', 0, 'mMessageId']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('bigint');
+	});
+
+	it('resolves maeParams[0] as an enum', () => {
+		const loc = resolveSchemaAtPath(hudMessageSequenceResourceSchema, ['maeParams', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('enum');
+	});
+
+	it('resolves macSequenceId as string', () => {
+		const loc = resolveSchemaAtPath(hudMessageSequenceResourceSchema, ['macSequenceId']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('string');
+	});
+});
+
+describe('hudMessageSequence derive hook (name → hash)', () => {
+	const root = hudMessageSequenceResourceSchema.registry.ParsedHudMessageSequence;
+
+	it('recomputes the uppercase-folded hash when the name changes', () => {
+		const prev = { ...models[0] } as Record<string, unknown>;
+		const next = { ...models[0], macSequenceId: 'NewSeq' } as Record<string, unknown>;
+		expect(root.derive!(prev, next)).toEqual({ mSequenceIdHash: encodeCgsId('NEWSEQ') });
+	});
+
+	it('returns an empty patch when the name is untouched', () => {
+		const prev = { ...models[0] } as Record<string, unknown>;
+		const next = { ...models[0], miPriority: 2 } as Record<string, unknown>;
+		expect(root.derive!(prev, next)).toEqual({});
+	});
+
+	it('leaves the hash alone for an over-long name (the writer rejects it later)', () => {
+		const prev = { ...models[0] } as Record<string, unknown>;
+		const next = { ...models[0], macSequenceId: 'WayTooLongSequenceName' } as Record<string, unknown>;
+		expect(root.derive!(prev, next)).toEqual({});
+	});
+});

--- a/src/lib/schema/resources/hudMessageSequence.ts
+++ b/src/lib/schema/resources/hudMessageSequence.ts
@@ -1,0 +1,211 @@
+// Hand-written schema for ParsedHudMessageSequence (resource type 0x2E).
+//
+// Mirrors the types in `src/lib/core/hudMessageSequences.ts`. Keep these in
+// lockstep with the parser/writer — any field added to the parser needs a
+// matching entry here, or the schema walker reports it as drift.
+//
+// Domain: a sequence is an ordered set of HUD message CgsIDs displayed one
+// after another, each with its own duration. The on-disk struct has a FIXED
+// 8-slot message array; the parser only surfaces the active miMessageCount
+// slots, so this list caps at 8 and the writer regenerates the default
+// pattern for the rest. mSequenceIdHash is derived data — every retail hash
+// equals encodeCgsId(macSequenceId.toUpperCase()) — so it is read-only here
+// and a `derive` hook keeps it in sync when the name is edited.
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+} from '../types';
+import {
+	HUD_MESSAGE_PARAM_TYPES,
+	DEFAULT_MESSAGE_LENGTH_SECONDS,
+	MAX_NAME_CHARS,
+	SEQUENCE_MESSAGE_SLOTS,
+	SEQUENCE_PARAM_SLOTS,
+} from '@/lib/core/hudMessageSequences';
+import { decodeCgsId, encodeCgsId } from '@/lib/core/cgsid';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring staticSoundMap.ts)
+// ---------------------------------------------------------------------------
+
+const i32 = (): FieldSchema => ({ kind: 'i32' });
+const u8 = (): FieldSchema => ({ kind: 'u8' });
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const f32 = (): FieldSchema => ({ kind: 'f32' });
+const str = (): FieldSchema => ({ kind: 'string' });
+const cgsId = (): FieldSchema => ({ kind: 'bigint', bytes: 8, hex: true });
+
+const fixedList = (item: FieldSchema, length: number): FieldSchema => ({
+	kind: 'list',
+	item,
+	addable: false,
+	removable: false,
+	minLength: length,
+	maxLength: length,
+});
+
+const paramTypeEnum = (): FieldSchema => ({
+	kind: 'enum',
+	storage: 'i32',
+	values: HUD_MESSAGE_PARAM_TYPES.map((p) => ({ value: p.value, label: p.label })),
+});
+
+// ---------------------------------------------------------------------------
+// Tree-label helpers
+// ---------------------------------------------------------------------------
+
+function messageLabel(msg: unknown, index: number): string {
+	try {
+		if (!msg || typeof msg !== 'object') return `#${index}`;
+		const m = msg as { mMessageId?: bigint; mfMessageLength?: number };
+		const id = m.mMessageId != null ? decodeCgsId(m.mMessageId) : '';
+		const len = m.mfMessageLength != null ? `${m.mfMessageLength}s` : '?';
+		return `#${index} · ${id || '(no id)'} · ${len}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const HudMessageSequenceMessage: RecordSchema = {
+	name: 'HudMessageSequenceMessage',
+	description: 'One step of the sequence — a HUD message CgsID and how long it stays on screen. Retail never passes params: every id is -1.',
+	fields: {
+		mMessageId: cgsId(),
+		mfMessageLength: f32(),
+		maiParam1Ids: fixedList(i32(), 4),
+		maiParam2Ids: fixedList(i32(), 4),
+		_pad2C: u32(),
+	},
+	fieldMetadata: {
+		mMessageId: {
+			label: 'Message ID',
+			description: 'CgsID of the HUD Message to display — the uppercase-folded hash of the message name (e.g. DTARMING). Resolved against the HUD Message resources, not this bundle.',
+		},
+		mfMessageLength: {
+			label: 'Display time',
+			description: `Time to display the message in seconds. Retail always uses ${DEFAULT_MESSAGE_LENGTH_SECONDS}.`,
+		},
+		maiParam1Ids: {
+			label: 'Param IDs 1',
+			description: 'Parameter IDs 1 — always -1 (unused) in retail.',
+		},
+		maiParam2Ids: {
+			label: 'Param IDs 2',
+			description: 'Parameter IDs 2 — always -1 (unused) in retail.',
+		},
+		_pad2C: {
+			label: 'pad +0x2C',
+			description: 'Record pad (0 in retail); preserved verbatim.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Message', properties: ['mMessageId', 'mfMessageLength'] },
+		{ title: 'Parameters', properties: ['maiParam1Ids', 'maiParam2Ids'] },
+	],
+	label: (value, index) => messageLabel(value, index ?? 0),
+};
+
+const ParsedHudMessageSequence: RecordSchema = {
+	name: 'ParsedHudMessageSequence',
+	description: 'Root record for the HUD Message Sequence resource (0x2E): an ordered set of HUD message IDs shown back-to-back. A dev-era feature — the six retail sequences are all online Dirty Tricks arming flows.',
+	fields: {
+		mSequenceIdHash: cgsId(),
+		macSequenceId: str(),
+		miPriority: i32(),
+		miParamCount: i32(),
+		maeParams: fixedList(paramTypeEnum(), SEQUENCE_PARAM_SLOTS),
+		messages: {
+			kind: 'list',
+			item: { kind: 'record', type: 'HudMessageSequenceMessage' },
+			addable: true,
+			removable: true,
+			maxLength: SEQUENCE_MESSAGE_SLOTS,
+			makeEmpty: () => ({
+				mMessageId: 0n,
+				mfMessageLength: DEFAULT_MESSAGE_LENGTH_SECONDS,
+				maiParam1Ids: [-1, -1, -1, -1],
+				maiParam2Ids: [-1, -1, -1, -1],
+				_pad2C: 0,
+			}),
+			itemLabel: (item, index) => messageLabel(item, index),
+		},
+		_pad15: fixedList(u8(), 3),
+	},
+	fieldMetadata: {
+		mSequenceIdHash: {
+			label: 'Sequence ID hash',
+			description: 'CgsID of the sequence — derived: encodeCgsId(name.toUpperCase()) in every retail resource. Kept in sync automatically when the name is edited.',
+			readOnly: true,
+			derivedFrom: 'macSequenceId',
+		},
+		macSequenceId: {
+			label: 'Sequence name',
+			description: `Sequence name, max ${MAX_NAME_CHARS} chars (char[13] on disk). The dictionary (0x2F) references sequences by this exact string — renaming here without updating the dictionary orphans the sequence.`,
+		},
+		miPriority: {
+			label: 'Priority',
+			description: 'Sequence priority. Always 1 in retail.',
+		},
+		miParamCount: {
+			label: 'Param count',
+			description: 'Number of used maeParams slots. Always 0 in retail — sequences pass no parameters.',
+		},
+		maeParams: {
+			label: 'Param types',
+			description: 'HudMessageParamTypes[8] — fixed on-disk array. All Unused in retail.',
+		},
+		messages: {
+			label: 'Messages',
+			description: `The messages shown in order. The on-disk array is fixed at ${SEQUENCE_MESSAGE_SLOTS} slots — the writer fills unused slots with the default pattern (no id, ${DEFAULT_MESSAGE_LENGTH_SECONDS} s, params -1).`,
+		},
+		_pad15: {
+			label: 'pad +0x15',
+			description: 'Name-field alignment pad (0 in retail); preserved verbatim.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Identity', properties: ['macSequenceId', 'mSequenceIdHash', 'miPriority'] },
+		{ title: 'Messages', properties: ['messages'] },
+		{ title: 'Parameters', properties: ['miParamCount', 'maeParams'] },
+	],
+	label: (value) => {
+		const name = (value as { macSequenceId?: string }).macSequenceId;
+		return typeof name === 'string' && name.length > 0 ? name : 'HudMessageSequence';
+	},
+	derive: (prev, next) => {
+		if (prev.macSequenceId === next.macSequenceId) return {};
+		const name = typeof next.macSequenceId === 'string' ? next.macSequenceId : '';
+		// encodeCgsId throws beyond 12 chars; leave the hash alone then — the
+		// writer rejects the over-long name anyway, with a clearer message.
+		try {
+			return { mSequenceIdHash: encodeCgsId(name.toUpperCase()) };
+		} catch {
+			return {};
+		}
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Registry export
+// ---------------------------------------------------------------------------
+
+const registry: SchemaRegistry = {
+	ParsedHudMessageSequence,
+	HudMessageSequenceMessage,
+};
+
+export const hudMessageSequenceResourceSchema: ResourceSchema = {
+	key: 'hudMessageSequence',
+	name: 'HUD Message Sequence',
+	rootType: 'ParsedHudMessageSequence',
+	registry,
+};

--- a/src/lib/schema/resources/hudMessageSequenceDictionary.test.ts
+++ b/src/lib/schema/resources/hudMessageSequenceDictionary.test.ts
@@ -1,0 +1,137 @@
+// Schema coverage tests for hudMessageSequenceDictionaryResourceSchema.
+//
+// Coverage fixture: example/HUDMESSAGESEQUENCES.HMSC — the single retail
+// dictionary listing the six DT* sequences.
+//
+// Mirrors staticSoundMap.test.ts: parse the model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import {
+	parseHudMessageSequenceDictionary,
+	type ParsedHudMessageSequenceDictionary,
+} from '../../core/hudMessageSequences';
+
+import { hudMessageSequenceDictionaryResourceSchema } from './hudMessageSequenceDictionary';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/HUDMESSAGESEQUENCES.HMSC');
+const DICTIONARY_TYPE_ID = 0x2f;
+
+function loadModel(fixturePath: string): ParsedHudMessageSequenceDictionary {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === DICTIONARY_TYPE_ID);
+	if (!resource) throw new Error('No HudMessageSequenceDictionary resource in fixture');
+	return parseHudMessageSequenceDictionary(extractResourceRaw(buffer.buffer, bundle, resource), ctx.littleEndian);
+}
+
+const model = loadModel(BUNDLE_FIXTURE);
+
+describe('hudMessageSequenceDictionaryResourceSchema coverage', () => {
+	it('fixture parses with non-trivial content', () => {
+		expect(model.sequenceNames.length).toBeGreaterThan(0);
+	});
+
+	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+		const missing: string[] = [];
+		for (const [recordName, rec] of Object.entries(hudMessageSequenceDictionaryResourceSchema.registry)) {
+			for (const [fieldName, field] of Object.entries(rec.fields)) {
+				checkField(field, `${recordName}.${fieldName}`, missing);
+			}
+		}
+		if (missing.length > 0) {
+			throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+		}
+		function checkField(f: FieldSchema, where: string, out: string[]) {
+			if (f.kind === 'record') {
+				if (!hudMessageSequenceDictionaryResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+				return;
+			}
+			if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+		}
+	});
+
+	it('walkResource visits every parsed field without throwing', () => {
+		let recordCount = 0;
+		let fieldCount = 0;
+		walkResource(hudMessageSequenceDictionaryResourceSchema, model, (_p, _v, field, rec) => {
+			if (rec) recordCount++;
+			if (field) fieldCount++;
+		});
+		expect(recordCount).toBeGreaterThan(0);
+		expect(fieldCount).toBeGreaterThan(0);
+	});
+
+	it('no parsed record has fields absent from the schema', () => {
+		const missing: string[] = [];
+		walkResource(hudMessageSequenceDictionaryResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const declared = new Set(Object.keys(rec.fields));
+			for (const key of Object.keys(value as Record<string, unknown>)) {
+				if (!declared.has(key)) {
+					missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+
+	it('every schema field is represented in the parsed data', () => {
+		const missing: string[] = [];
+		walkResource(hudMessageSequenceDictionaryResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const obj = value as Record<string, unknown>;
+			for (const fieldName of Object.keys(rec.fields)) {
+				if (!(fieldName in obj)) {
+					missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+});
+
+describe('hudMessageSequenceDictionary path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(hudMessageSequenceDictionaryResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedHudMessageSequenceDictionary');
+	});
+
+	it('resolves sequenceNames as an addable/removable string list', () => {
+		const loc = resolveSchemaAtPath(hudMessageSequenceDictionaryResourceSchema, ['sequenceNames']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('list');
+	});
+
+	it('resolves sequenceNames[0] as string', () => {
+		const loc = resolveSchemaAtPath(hudMessageSequenceDictionaryResourceSchema, ['sequenceNames', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('string');
+	});
+
+	it('resolves _pad0C as u32', () => {
+		const loc = resolveSchemaAtPath(hudMessageSequenceDictionaryResourceSchema, ['_pad0C']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('u32');
+	});
+});

--- a/src/lib/schema/resources/hudMessageSequenceDictionary.ts
+++ b/src/lib/schema/resources/hudMessageSequenceDictionary.ts
@@ -1,0 +1,63 @@
+// Hand-written schema for ParsedHudMessageSequenceDictionary (resource type
+// 0x2F). Mirrors the types in `src/lib/core/hudMessageSequences.ts` — keep in
+// lockstep with the parser/writer or the schema walker reports drift.
+//
+// Domain: the dictionary is the game's index of HUD Message Sequences. Each
+// entry is the macSequenceId string of one 0x2E resource in the same bundle
+// (set equality holds in retail) — sequences are referenced BY NAME, so an
+// entry without a matching sequence (or vice versa) is orphaned at runtime.
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+} from '../types';
+import { MAX_NAME_CHARS } from '@/lib/core/hudMessageSequences';
+
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+
+function nameLabel(item: unknown, index: number): string {
+	return typeof item === 'string' && item.length > 0 ? `#${index} · ${item}` : `#${index} · (empty)`;
+}
+
+const ParsedHudMessageSequenceDictionary: RecordSchema = {
+	name: 'ParsedHudMessageSequenceDictionary',
+	description: 'Root record for the HUD Message Sequence Dictionary resource (0x2F): the name list enumerating every HUD Message Sequence (0x2E) in the bundle. Same on-disk shape as the HUD Message List.',
+	fields: {
+		sequenceNames: {
+			kind: 'list',
+			item: { kind: 'string' },
+			addable: true,
+			removable: true,
+			makeEmpty: () => 'NewSequence',
+			itemLabel: (item, index) => nameLabel(item, index),
+		},
+		_pad0C: u32(),
+	},
+	fieldMetadata: {
+		sequenceNames: {
+			label: 'Sequence names',
+			description: `Each entry must equal the macSequenceId of a sequence in the bundle — the game resolves sequences by this exact string. Max ${MAX_NAME_CHARS} chars (char[13] on disk).`,
+		},
+		_pad0C: {
+			label: 'pad +0x0C',
+			description: 'Undocumented header pad before the name-pointer array (0 in retail); preserved verbatim.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Sequences', properties: ['sequenceNames'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedHudMessageSequenceDictionary,
+};
+
+export const hudMessageSequenceDictionaryResourceSchema: ResourceSchema = {
+	key: 'hudMessageSequenceDictionary',
+	name: 'HUD Message Sequence Dictionary',
+	rootType: 'ParsedHudMessageSequenceDictionary',
+	registry,
+};

--- a/src/lib/schema/resources/index.ts
+++ b/src/lib/schema/resources/index.ts
@@ -11,6 +11,7 @@
 import type { ResourceSchema } from '../types';
 import { aiSectionsResourceSchema } from './aiSections';
 import { challengeListResourceSchema } from './challengeList';
+import { guiPopupResourceSchema } from './guiPopup';
 import { hudMessageResourceSchema } from './hudMessage';
 import { hudMessageSequenceResourceSchema } from './hudMessageSequence';
 import { hudMessageSequenceDictionaryResourceSchema } from './hudMessageSequenceDictionary';
@@ -34,6 +35,7 @@ import { zoneListResourceSchema } from './zoneList';
 const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	aiSections: aiSectionsResourceSchema,
 	challengeList: challengeListResourceSchema,
+	guiPopup: guiPopupResourceSchema,
 	hudMessage: hudMessageResourceSchema,
 	hudMessageSequence: hudMessageSequenceResourceSchema,
 	hudMessageSequenceDictionary: hudMessageSequenceDictionaryResourceSchema,

--- a/src/lib/schema/resources/index.ts
+++ b/src/lib/schema/resources/index.ts
@@ -12,6 +12,8 @@ import type { ResourceSchema } from '../types';
 import { aiSectionsResourceSchema } from './aiSections';
 import { challengeListResourceSchema } from './challengeList';
 import { hudMessageResourceSchema } from './hudMessage';
+import { hudMessageSequenceResourceSchema } from './hudMessageSequence';
+import { hudMessageSequenceDictionaryResourceSchema } from './hudMessageSequenceDictionary';
 import { iceTakeDictionaryResourceSchema } from './iceTakeDictionary';
 import { instanceListResourceSchema } from './instanceList';
 import { languageResourceSchema } from './language';
@@ -33,6 +35,8 @@ const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	aiSections: aiSectionsResourceSchema,
 	challengeList: challengeListResourceSchema,
 	hudMessage: hudMessageResourceSchema,
+	hudMessageSequence: hudMessageSequenceResourceSchema,
+	hudMessageSequenceDictionary: hudMessageSequenceDictionaryResourceSchema,
 	iceTakeDictionary: iceTakeDictionaryResourceSchema,
 	instanceList: instanceListResourceSchema,
 	language: languageResourceSchema,

--- a/src/lib/schema/resources/index.ts
+++ b/src/lib/schema/resources/index.ts
@@ -30,6 +30,7 @@ import { textureResourceSchema } from './texture';
 import { trafficDataResourceSchema } from './trafficData';
 import { triggerDataResourceSchema } from './triggerData';
 import { vehicleListResourceSchema } from './vehicleList';
+import { worldPainter2DResourceSchema } from './worldPainter2D';
 import { zoneListResourceSchema } from './zoneList';
 
 const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
@@ -54,6 +55,7 @@ const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	trafficData: trafficDataResourceSchema,
 	triggerData: triggerDataResourceSchema,
 	vehicleList: vehicleListResourceSchema,
+	worldPainter2D: worldPainter2DResourceSchema,
 	zoneList: zoneListResourceSchema,
 };
 

--- a/src/lib/schema/resources/index.ts
+++ b/src/lib/schema/resources/index.ts
@@ -13,6 +13,7 @@ import { aiSectionsResourceSchema } from './aiSections';
 import { challengeListResourceSchema } from './challengeList';
 import { iceTakeDictionaryResourceSchema } from './iceTakeDictionary';
 import { instanceListResourceSchema } from './instanceList';
+import { languageResourceSchema } from './language';
 import { playerCarColoursResourceSchema } from './playerCarColours';
 import { polygonSoupListResourceSchema } from './polygonSoupList';
 import { propGraphicsListResourceSchema } from './propGraphicsList';
@@ -32,6 +33,7 @@ const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	challengeList: challengeListResourceSchema,
 	iceTakeDictionary: iceTakeDictionaryResourceSchema,
 	instanceList: instanceListResourceSchema,
+	language: languageResourceSchema,
 	playerCarColours: playerCarColoursResourceSchema,
 	polygonSoupList: polygonSoupListResourceSchema,
 	propGraphicsList: propGraphicsListResourceSchema,

--- a/src/lib/schema/resources/index.ts
+++ b/src/lib/schema/resources/index.ts
@@ -11,6 +11,7 @@
 import type { ResourceSchema } from '../types';
 import { aiSectionsResourceSchema } from './aiSections';
 import { challengeListResourceSchema } from './challengeList';
+import { hudMessageResourceSchema } from './hudMessage';
 import { iceTakeDictionaryResourceSchema } from './iceTakeDictionary';
 import { instanceListResourceSchema } from './instanceList';
 import { languageResourceSchema } from './language';
@@ -31,6 +32,7 @@ import { zoneListResourceSchema } from './zoneList';
 const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	aiSections: aiSectionsResourceSchema,
 	challengeList: challengeListResourceSchema,
+	hudMessage: hudMessageResourceSchema,
 	iceTakeDictionary: iceTakeDictionaryResourceSchema,
 	instanceList: instanceListResourceSchema,
 	language: languageResourceSchema,

--- a/src/lib/schema/resources/language.test.ts
+++ b/src/lib/schema/resources/language.test.ts
@@ -1,0 +1,180 @@
+// Schema coverage tests for languageResourceSchema.
+//
+// Coverage fixture: example/LANGUAGE/0002.BUNDLE (retail English UK — carries
+// both padded entries and the trailing filler entry, so the walker sees every
+// model shape the parser can produce).
+//
+// Mirrors staticSoundMap.test.ts: parse the model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseLanguage, type ParsedLanguage } from '../../core/language';
+
+import { languageResourceSchema, formatHash } from './language';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/LANGUAGE/0002.BUNDLE');
+const LANGUAGE_TYPE_ID = 0x27;
+
+function loadModel(fixturePath: string): ParsedLanguage {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === LANGUAGE_TYPE_ID)!;
+	return parseLanguage(extractResourceRaw(buffer.buffer, bundle, resource), ctx.littleEndian);
+}
+
+const model = loadModel(BUNDLE_FIXTURE);
+
+describe('languageResourceSchema coverage', () => {
+	it('fixture parses with non-trivial content', () => {
+		expect(model.entries.length).toBeGreaterThan(0);
+	});
+
+	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+		const missing: string[] = [];
+		for (const [recordName, rec] of Object.entries(languageResourceSchema.registry)) {
+			for (const [fieldName, field] of Object.entries(rec.fields)) {
+				checkField(field, `${recordName}.${fieldName}`, missing);
+			}
+		}
+		if (missing.length > 0) {
+			throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+		}
+		function checkField(f: FieldSchema, where: string, out: string[]) {
+			if (f.kind === 'record') {
+				if (!languageResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+				return;
+			}
+			if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+		}
+	});
+
+	it('walkResource visits every parsed field without throwing', () => {
+		let recordCount = 0;
+		let fieldCount = 0;
+		walkResource(languageResourceSchema, model, (_p, _v, field, rec) => {
+			if (rec) recordCount++;
+			if (field) fieldCount++;
+		});
+		expect(recordCount).toBeGreaterThan(0);
+		expect(fieldCount).toBeGreaterThan(0);
+	});
+
+	it('no parsed record has fields absent from the schema', () => {
+		const missing: string[] = [];
+		walkResource(languageResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const declared = new Set(Object.keys(rec.fields));
+			for (const key of Object.keys(value as Record<string, unknown>)) {
+				if (!declared.has(key)) {
+					missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+
+	it('every schema field is represented in the parsed data', () => {
+		const missing: string[] = [];
+		walkResource(languageResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const obj = value as Record<string, unknown>;
+			for (const fieldName of Object.keys(rec.fields)) {
+				if (!(fieldName in obj)) {
+					missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+});
+
+describe('language path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(languageResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedLanguage');
+	});
+
+	it('resolves meLanguageID as an enum carrying every ELanguage value', () => {
+		const loc = resolveSchemaAtPath(languageResourceSchema, ['meLanguageID']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('enum');
+		if (loc!.field?.kind === 'enum') {
+			expect(loc!.field.values.length).toBe(25);
+			expect(loc!.field.values.find((v) => v.value === 8)?.label).toBe('English (UK)');
+		}
+	});
+
+	it('resolves entries[0] as a LanguageEntry', () => {
+		const loc = resolveSchemaAtPath(languageResourceSchema, ['entries', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('LanguageEntry');
+	});
+
+	it('resolves entries[0].text as an editable string', () => {
+		const loc = resolveSchemaAtPath(languageResourceSchema, ['entries', 0, 'text']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('string');
+	});
+
+	it('resolves entries[0].muHash as u32', () => {
+		const loc = resolveSchemaAtPath(languageResourceSchema, ['entries', 0, 'muHash']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('u32');
+	});
+});
+
+describe('language tree labels', () => {
+	const entrySchema = languageResourceSchema.registry.LanguageEntry;
+	const ctx = { root: model, resource: languageResourceSchema, path: ['entries', 0] };
+
+	it('shows hash and truncated text', () => {
+		const label = entrySchema.label!(
+			{ muHash: 0x7e1c1cc8, text: 'No motion blur.', _padAfter: 0 },
+			0,
+			ctx,
+		);
+		expect(label).toBe('#0 · 0x7E1C1CC8 · "No motion blur."');
+	});
+
+	it('truncates long strings so the tree stays readable', () => {
+		const label = entrySchema.label!(
+			{ muHash: 0x12345678, text: 'x'.repeat(100), _padAfter: 0 },
+			5,
+			ctx,
+		);
+		expect(label.length).toBeLessThan(60);
+		expect(label).toContain('…');
+	});
+
+	it('labels the retail filler entry instead of dumping 500k A characters', () => {
+		const filler = model.entries[model.entries.length - 1];
+		const label = entrySchema.label!(filler as unknown as Record<string, unknown>, model.entries.length - 1, ctx);
+		expect(label).toContain('filler');
+		expect(label.length).toBeLessThan(80);
+	});
+
+	it('formatHash pads to 8 hex digits', () => {
+		expect(formatHash(0x27)).toBe('0x00000027');
+		expect(formatHash(0xf12fd364)).toBe('0xF12FD364');
+	});
+});

--- a/src/lib/schema/resources/language.ts
+++ b/src/lib/schema/resources/language.ts
@@ -1,0 +1,140 @@
+// Hand-written schema for ParsedLanguage (resource type 0x27).
+//
+// Mirrors the types in `src/lib/core/language.ts`. Keep these in lockstep
+// with the parser/writer — any field added to the parser needs a matching
+// entry here, or the schema walker reports it as drift.
+//
+// Domain: one Language resource per language bundle maps a u32 hash of the
+// untranslated string ID to its UTF-8 translation. The hash is the
+// cross-language key — the SAME hash appears in all 14 bundles, so renaming a
+// hash here orphans the string in this language only. The last entry of every
+// retail bundle is a filler (hash 0, thousands of 'A's) sizing the resource
+// to exactly 0xD4800 bytes; if an edit grows the resource, shrinking the
+// filler text by the same number of UTF-8 bytes keeps the total size stable.
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+} from '../types';
+import { ELANGUAGE } from '@/lib/core/language';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring staticSoundMap.ts)
+// ---------------------------------------------------------------------------
+
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const string = (): FieldSchema => ({ kind: 'string' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+
+const languageEnum = (): FieldSchema => ({
+	kind: 'enum',
+	storage: 'u32',
+	values: ELANGUAGE.map((l) => ({ value: l.value, label: l.label })),
+});
+
+// ---------------------------------------------------------------------------
+// Tree-label helpers
+// ---------------------------------------------------------------------------
+
+export function formatHash(hash: number): string {
+	return `0x${(hash >>> 0).toString(16).toUpperCase().padStart(8, '0')}`;
+}
+
+const LABEL_TEXT_MAX = 32;
+
+function entryLabel(ent: unknown, index: number): string {
+	try {
+		if (!ent || typeof ent !== 'object') return `#${index}`;
+		const e = ent as { muHash?: number; text?: string };
+		if (e.muHash == null || e.text == null) return `#${index}`;
+		// The retail filler entry would otherwise label as 500k 'A's.
+		if (e.muHash === 0 && /^A+$/.test(e.text)) {
+			return `#${index} · filler (${e.text.length} bytes of size padding)`;
+		}
+		const text = e.text.length > LABEL_TEXT_MAX ? `${e.text.slice(0, LABEL_TEXT_MAX)}…` : e.text;
+		return `#${index} · ${formatHash(e.muHash)} · "${text}"`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const LanguageEntry: RecordSchema = {
+	name: 'LanguageEntry',
+	description: 'One localised string: the u32 hash of its untranslated string ID plus the UTF-8 translation. The hash is the lookup key the game uses, identical across all 14 language bundles.',
+	fields: {
+		muHash: u32(),
+		text: string(),
+		_padAfter: u32(),
+	},
+	fieldMetadata: {
+		muHash: {
+			label: 'String ID hash',
+			description: 'u32 hash of the untranslated string ID — the cross-language lookup key. Must stay unique within the resource (retail bundles have zero collisions); hash 0 is the trailing filler entry.',
+		},
+		text: {
+			label: 'Text',
+			description: 'The translated string, stored as NUL-terminated UTF-8. Any length is fine — the writer rebuilds every string offset — but it cannot contain an embedded NUL.',
+		},
+		_padAfter: {
+			label: 'Pad after terminator',
+			description: 'Extra zero bytes after this string\'s NUL terminator (0 or 3 in retail). Preserved for byte-exact round-trip.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'String', properties: ['muHash', 'text'] },
+	],
+	label: (value, index) => entryLabel(value, index ?? 0),
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedLanguage: RecordSchema = {
+	name: 'ParsedLanguage',
+	description: 'Root record for the Language resource (0x27): every localised string of one language. Retail sizes each resource to exactly 0xD4800 bytes via the trailing filler entry, so all 14 languages fit one fixed allocation.',
+	fields: {
+		meLanguageID: languageEnum(),
+		entries: {
+			kind: 'list',
+			item: record('LanguageEntry'),
+			addable: true,
+			removable: true,
+			itemLabel: entryLabel,
+			makeEmpty: () => ({ muHash: 0, text: '', _padAfter: 0 }),
+		},
+	},
+	fieldMetadata: {
+		meLanguageID: {
+			label: 'Language',
+			description: 'CgsLanguage::Sku::ELanguage id of this bundle. Note the wiki/retail mismatch: id 12 is named E_LANGUAGE_GREEK but retail bundle 0008 (the only user of 12) contains Russian strings.',
+		},
+		entries: {
+			label: 'Strings',
+			description: 'All strings in disk order (the table is ordered by blob offset, not by hash). New entries start with hash 0 — set a unique hash before shipping, since 0 is taken by the trailing filler entry.',
+		},
+	},
+	propertyGroups: [
+		{ title: 'Identity', properties: ['meLanguageID'] },
+		{ title: 'Strings', properties: ['entries'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedLanguage,
+	LanguageEntry,
+};
+
+export const languageResourceSchema: ResourceSchema = {
+	key: 'language',
+	name: 'Language',
+	rootType: 'ParsedLanguage',
+	registry,
+};

--- a/src/lib/schema/resources/worldPainter2D.test.ts
+++ b/src/lib/schema/resources/worldPainter2D.test.ts
@@ -1,0 +1,145 @@
+// Schema coverage tests for worldPainter2DResourceSchema.
+//
+// Coverage fixture: example/DISTRICTS.DAT (the single retail Districts map).
+//
+// Mirrors staticSoundMap.test.ts: parse the model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseWorldPainter2D, type ParsedWorldPainter2D } from '../../core/worldPainter2D';
+
+import { worldPainter2DResourceSchema, districtCellLabel } from './worldPainter2D';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/DISTRICTS.DAT');
+const WORLD_PAINTER_2D_TYPE_ID = 0x30;
+
+function loadModel(fixturePath: string): ParsedWorldPainter2D {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === WORLD_PAINTER_2D_TYPE_ID);
+	if (!resource) throw new Error('fixture has no WorldPainter2D resource');
+	return parseWorldPainter2D(extractResourceRaw(buffer.buffer, bundle, resource), ctx.littleEndian);
+}
+
+const model = loadModel(BUNDLE_FIXTURE);
+
+describe('worldPainter2DResourceSchema coverage', () => {
+	it('fixture parses with non-trivial content', () => {
+		expect(model.muWidth).toBeGreaterThan(0);
+		expect(model.muHeight).toBeGreaterThan(0);
+		expect(model.cells.length).toBe(model.muWidth * model.muHeight);
+	});
+
+	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+		const missing: string[] = [];
+		for (const [recordName, rec] of Object.entries(worldPainter2DResourceSchema.registry)) {
+			for (const [fieldName, field] of Object.entries(rec.fields)) {
+				checkField(field, `${recordName}.${fieldName}`, missing);
+			}
+		}
+		if (missing.length > 0) {
+			throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+		}
+		function checkField(f: FieldSchema, where: string, out: string[]) {
+			if (f.kind === 'record') {
+				if (!worldPainter2DResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+				return;
+			}
+			if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+		}
+	});
+
+	it('walkResource visits every parsed field without throwing', () => {
+		let recordCount = 0;
+		let fieldCount = 0;
+		walkResource(worldPainter2DResourceSchema, model, (_p, _v, field, rec) => {
+			if (rec) recordCount++;
+			if (field) fieldCount++;
+		});
+		expect(recordCount).toBeGreaterThan(0);
+		expect(fieldCount).toBeGreaterThan(0);
+	});
+
+	it('no parsed record has fields absent from the schema', () => {
+		const missing: string[] = [];
+		walkResource(worldPainter2DResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const declared = new Set(Object.keys(rec.fields));
+			for (const key of Object.keys(value as Record<string, unknown>)) {
+				if (!declared.has(key)) {
+					missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+
+	it('every schema field is represented in the parsed data', () => {
+		const missing: string[] = [];
+		walkResource(worldPainter2DResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const obj = value as Record<string, unknown>;
+			for (const fieldName of Object.keys(rec.fields)) {
+				if (!(fieldName in obj)) {
+					missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+});
+
+describe('worldPainter2D path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(worldPainter2DResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedWorldPainter2D');
+	});
+
+	it('resolves muWidth as read-only u16', () => {
+		const loc = resolveSchemaAtPath(worldPainter2DResourceSchema, ['muWidth']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('u16');
+	});
+
+	it('resolves cells as a custom leaf (the dense grid is not a schema list)', () => {
+		const loc = resolveSchemaAtPath(worldPainter2DResourceSchema, ['cells']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('custom');
+	});
+});
+
+describe('districtCellLabel', () => {
+	it('labels valid districts with their v1.9/Remastered name', () => {
+		expect(districtCellLabel(0)).toBe('0 Ocean View');
+		expect(districtCellLabel(14)).toBe('14 Downtown');
+		expect(districtCellLabel(22)).toBe("22 Perren's Point");
+	});
+
+	it('labels the 0xFF sentinel as unpainted', () => {
+		expect(districtCellLabel(255)).toBe('255 (unpainted)');
+	});
+
+	it('labels out-of-table values neutrally (Ambiences maps reuse the container)', () => {
+		expect(districtCellLabel(23)).toBe('23 (no district name)');
+	});
+});

--- a/src/lib/schema/resources/worldPainter2D.ts
+++ b/src/lib/schema/resources/worldPainter2D.ts
@@ -1,0 +1,98 @@
+// Hand-written schema for ParsedWorldPainter2D (resource type 0x30).
+//
+// Mirrors the types in `src/lib/core/worldPainter2D.ts`. Keep these in
+// lockstep with the parser/writer — any field added to the parser needs a
+// matching entry here, or the schema walker reports it as drift.
+//
+// Domain: a WorldPainter2D resource is a dense byte grid painted over the
+// world map — one district index per cell in DISTRICTS.DAT (BrnWorld::
+// EDistrict, 0xFF = nothing painted), one ambience index per cell in the
+// AMBIENCES variant. The runtime scales the grid over the world with
+// hardcoded origin/size values; nothing spatial is stored in the resource.
+//
+// The 98,304-cell payload is deliberately NOT exposed as a schema list — a
+// PrimListField with 98k u8 rows would hang the inspector, and individual
+// cell edits are meaningless without seeing the map. The grid waits for a
+// painter overlay (a coloured plane over the track geometry); until then the
+// `cells` field is hidden and the resource is effectively read-only in the
+// schema editor, with the grid dims visible for orientation.
+
+import type { FieldSchema, RecordSchema, ResourceSchema, SchemaRegistry } from '../types';
+import { DISTRICT_NAMES, INVALID_CELL } from '@/lib/core/worldPainter2D';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring staticSoundMap.ts)
+// ---------------------------------------------------------------------------
+
+const u16 = (): FieldSchema => ({ kind: 'u16' });
+const rawBytes = (): FieldSchema => ({ kind: 'custom', component: 'rawBytes' });
+
+// ---------------------------------------------------------------------------
+// Cell-label helper — exported for the future painter overlay's legend
+// ---------------------------------------------------------------------------
+
+/** Human reading of one cell byte. District names only apply to the
+ *  Districts resource — an Ambiences map reuses the values as ambience
+ *  indices, so out-of-table values are labelled neutrally, not as errors. */
+export function districtCellLabel(value: number): string {
+	if (value === INVALID_CELL) return '255 (unpainted)';
+	const name = value < DISTRICT_NAMES.length ? DISTRICT_NAMES[value] : null;
+	return name ? `${value} ${name}` : `${value} (no district name)`;
+}
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedWorldPainter2D: RecordSchema = {
+	name: 'ParsedWorldPainter2D',
+	description: 'Root record for the WorldPainter2D resource (0x30): a dense 2D byte grid mapping every world-map cell to a district (Districts) or ambience (Ambiences). Which palette applies lives only in the resource\'s debug name — the container is identical.',
+	fields: {
+		muWidth: u16(),
+		muHeight: u16(),
+		cells: rawBytes(),
+		_wrapperPad: rawBytes(),
+		_trailingPad: rawBytes(),
+	},
+	fieldMetadata: {
+		muWidth: {
+			label: 'Grid width',
+			description: 'Cells per row. Retail v1.4+ uses 384 (the Big Surf Island update widened the map); v1.0 used 256. Read-only: resizing requires repainting the whole grid.',
+			readOnly: true,
+		},
+		muHeight: {
+			label: 'Grid height',
+			description: 'Number of rows. Retail uses 256. Row 0 is the map\'s north edge.',
+			readOnly: true,
+		},
+		cells: {
+			label: 'Cell grid',
+			description: `Row-major width*height bytes, row 0 = north, x eastward. Each byte indexes BrnWorld::EDistrict (${DISTRICT_NAMES.length} valid districts in v1.9/Remastered) or an ambience table; 0xFF = nothing painted. Hidden until a painter overlay exists — 98k cells are uneditable as a flat list.`,
+			hidden: true,
+		},
+		_wrapperPad: {
+			label: 'Wrapper pad',
+			description: 'BinaryFile wrapper bytes 0x8..0xF (zero in retail). Preserved for byte-exact round-trip.',
+			hidden: true,
+		},
+		_trailingPad: {
+			label: 'Trailing pad',
+			description: 'Zero bytes padding the resource to 16-byte alignment, counted inside the wrapper\'s mu32DataSize. Re-emitted verbatim.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Grid', properties: ['muWidth', 'muHeight'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedWorldPainter2D,
+};
+
+export const worldPainter2DResourceSchema: ResourceSchema = {
+	key: 'worldPainter2D',
+	name: 'World Painter 2D',
+	rootType: 'ParsedWorldPainter2D',
+	registry,
+};


### PR DESCRIPTION
> **Stacked on #116** (which stacks on #115) — all three share handler-registration index files. GitHub retargets the base automatically as the chain merges.

## What

Six resource types implemented in one batch by five parallel workflow agents (one spec each), then registered and integrated serially by the conductor. One commit per spec; each is the full editing slice (parser/writer + handler with stress scenarios + gold tests + schema + coverage tests + editor profile), all validated against real game bytes before any parser code was written.

| Spec | Type | Fixture | Scale |
|---|---|---|---|
| Language | 0x27 | `LANGUAGE/*.BUNDLE` | byte-exact across **all 14** retail language bundles (7,584–8,291 strings each) |
| HudMessage | 0x2C | `HUDMESSAGES.HM` | 308 messages, byte-exact |
| HudMessageSequence | 0x2E | `HUDMESSAGESEQUENCES.HMSC` | 6 sequences (picker config), byte-exact |
| HudMessageSequenceDictionary | 0x2F | `HUDMESSAGESEQUENCES.HMSC` | byte-exact |
| GuiPopup | 0x1F | `POPUPS.PUP` | 111 popups, byte-exact |
| WorldPainter2D | 0x30 | `DISTRICTS.DAT` | 384×256 district grid, byte-exact |

## Data findings (all pinned in tests)

- **Language**: every bundle is sized to exactly 0xD4800 bytes via a trailing hash-0 filler entry of repeated `A`s; some entries carry exactly 3 extra zero bytes after their terminator (preserved verbatim); bundle 0008 stores the wiki's *Greek* language id but contains Russian strings.
- **HudMessage**: the wiki documents only 3 header fields — the real resource adds a pointer array and 128-byte section alignment; `mMessageIdHash == encodeCgsId(macMessageId)` in all 308 records, so the schema derives it on rename; record pads carry constant build-tool heap garbage, preserved verbatim.
- **Sequences**: `miResourceSize` excludes the alignment pad; unused message slots hold a default-initialised pattern (5 s, param ids −1) that the parser asserts and the writer regenerates — which is what makes add/remove edits byte-safe. The dictionary packs names at an unaligned 13-byte stride and references sequences by name (set equality pinned).
- **GuiPopup**: the size field is `int16_t`, capping the catalogue near 165 popups (writer guards 0x7FFF); `mNameId` is a derived CgsID; popup text references Language strings by char[32] ASCII key — a different mechanism from HudMessage's symbolic ids.
- **WorldPainter2D**: the wiki tables the grid dims at offset 0, ignoring the BinaryFile wrapper its own note mentions (real data at 0x10); all 23 v1.9 district ids are in use, 42.2% of cells unpainted (0xFF); full per-district histogram pinned.

## Tests

Full suite: **2,389 passing** (+303 from this batch). The registry fixture suite auto-enrolls all six handlers (parse, byte round-trip, describe, picker, 22 stress scenarios total). Verified in the workspace UI: the Language string table renders virtualized (7.6k entries, no jank) with labels like `#0 · 0x7E1C1CC8 · "No motion blur2"`, and HudMessage entries auto-derive their CgsID on rename.

Specs: https://burnout.wiki/wiki/Language · https://burnout.wiki/wiki/HUD_Message · https://burnout.wiki/wiki/HUD_Message_Sequence · https://burnout.wiki/wiki/GUI_Popup · https://burnout.wiki/wiki/World_Painter_2D

🤖 Generated with [Claude Code](https://claude.com/claude-code)