### PR TITLE
feat: batch 2 — seven resource types (environment trio, ColourCube, Font, MassiveLookupTable, Registry)

### DIFF
--- a/src/lib/core/__tests__/colourCube.test.ts
+++ b/src/lib/core/__tests__/colourCube.test.ts
@@ -1,0 +1,165 @@
+// Gold coverage for parseColourCube / writeColourCube (resource type 0x2B).
+//
+// Pins the byte-level facts established against all four retail DLC24HR
+// fixtures: 16-byte header (the wiki's struct table only documents 8 bytes,
+// but its file-size formula m_size^3*3+16 implies — and the bytes confirm —
+// the 16-byte header), m_pixels always 0x10, dense X-major RGB24 body, and
+// the surprising retail content: all four payloads are byte-identical and
+// hold the SAME separable "default RGB CLUT" (one shared per-channel S-curve
+// ramp), matching the wiki's note that the 1.6 update reverted the art-style
+// cubes to a default RGB CLUT.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+	parseColourCube,
+	writeColourCube,
+	colourCubeTexel,
+	setColourCubeTexel,
+	COLOURCUBE_HEADER_SIZE,
+} from '../colourCube';
+import { parseBundle } from '../bundle';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const COLOURCUBE_TYPE_ID = 0x2b;
+
+const FIXTURES = [
+	'example/ENVIRONMENTSETTINGS/COLOURCUBES/000_DLC24HR_FOG_A.BUNDLE',
+	'example/ENVIRONMENTSETTINGS/COLOURCUBES/000_DLC24HR_JUNKYARDT.BUNDLE',
+	'example/ENVIRONMENTSETTINGS/COLOURCUBES/000_DLC24HR_OC_A.BUNDLE',
+	'example/ENVIRONMENTSETTINGS/COLOURCUBES/000_DLC24HR_SUN_A.BUNDLE',
+];
+
+// Hand-verified shared per-channel tone ramp of the retail default CLUT —
+// texel(x,y,z) = (RAMP[x], RAMP[y], RAMP[z]) for every one of the 32^3 texels.
+const RETAIL_RAMP = [
+	0, 5, 10, 16, 22, 28, 35, 44, 51, 60, 69, 78, 89, 99, 110, 121,
+	134, 145, 156, 166, 177, 186, 195, 204, 211, 220, 227, 233, 239, 245, 250, 255,
+];
+
+function loadCube(bundleFile: string): Uint8Array {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const resources = bundle.resources.filter((r) => r.resourceTypeId === COLOURCUBE_TYPE_ID);
+	expect(resources.length).toBe(1);
+	return extractResourceRaw(buffer, bundle, resources[0]);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+describe('ColourCube gold values (example/ENVIRONMENTSETTINGS/COLOURCUBES)', () => {
+	const raws = FIXTURES.map(loadCube);
+
+	it('decodes the header: 32^3 cube, m_pixels offset 0x10, zero pads', () => {
+		const m = parseColourCube(raws[0]);
+		expect(m.mSize).toBe(32);
+		expect(m.pixels.byteLength).toBe(32 * 32 * 32 * 3);
+		expect(m._pad08).toBe(0);
+		expect(m._pad0C).toBe(0);
+		// The wiki size formula: m_size^3 * 3 + 16.
+		expect(raws[0].byteLength).toBe(32 ** 3 * 3 + COLOURCUBE_HEADER_SIZE);
+	});
+
+	it('all four DLC24HR payloads are byte-identical (the shared default RGB CLUT)', () => {
+		for (let i = 1; i < raws.length; i++) {
+			expect(bytesEqual(raws[i], raws[0]), FIXTURES[i]).toBe(true);
+		}
+	});
+
+	it('corner texels prove the axis mapping: x→R, y→G, z→B', () => {
+		const m = parseColourCube(raws[0]);
+		expect(colourCubeTexel(m, 0, 0, 0)).toEqual({ r: 0, g: 0, b: 0 });
+		expect(colourCubeTexel(m, 31, 0, 0)).toEqual({ r: 255, g: 0, b: 0 });
+		expect(colourCubeTexel(m, 0, 31, 0)).toEqual({ r: 0, g: 255, b: 0 });
+		expect(colourCubeTexel(m, 0, 0, 31)).toEqual({ r: 0, g: 0, b: 255 });
+		expect(colourCubeTexel(m, 31, 31, 31)).toEqual({ r: 255, g: 255, b: 255 });
+	});
+
+	it('the retail default CLUT is separable: texel(x,y,z) = (RAMP[x], RAMP[y], RAMP[z])', () => {
+		const m = parseColourCube(raws[0]);
+		for (let i = 0; i < 32; i++) {
+			expect(colourCubeTexel(m, i, 0, 0).r, `RAMP[${i}]`).toBe(RETAIL_RAMP[i]);
+		}
+		// Full-cube separability — the grade is a pure per-channel tone curve.
+		for (let z = 0; z < 32; z++) {
+			for (let y = 0; y < 32; y++) {
+				for (let x = 0; x < 32; x++) {
+					const t = colourCubeTexel(m, x, y, z);
+					if (t.r !== RETAIL_RAMP[x] || t.g !== RETAIL_RAMP[y] || t.b !== RETAIL_RAMP[z]) {
+						throw new Error(`texel (${x},${y},${z}) = (${t.r},${t.g},${t.b}), expected ramp (${RETAIL_RAMP[x]},${RETAIL_RAMP[y]},${RETAIL_RAMP[z]})`);
+					}
+				}
+			}
+		}
+	});
+
+	it('parsed pixels are a copy, not a view of the source bytes', () => {
+		const raw = loadCube(FIXTURES[0]);
+		const m = parseColourCube(raw);
+		setColourCubeTexel(m, 0, 0, 0, { r: 99, g: 99, b: 99 });
+		expect(raw[COLOURCUBE_HEADER_SIZE]).toBe(0);
+	});
+});
+
+describe('ColourCube round-trip', () => {
+	for (const fixture of FIXTURES) {
+		it(`round-trips ${path.basename(fixture)} byte-for-byte`, () => {
+			const raw = loadCube(fixture);
+			const rewritten = writeColourCube(parseColourCube(raw));
+			expect(rewritten.byteLength).toBe(raw.byteLength);
+			expect(bytesEqual(rewritten, raw)).toBe(true);
+		});
+	}
+
+	it('writer is idempotent', () => {
+		const raw = loadCube(FIXTURES[0]);
+		const once = writeColourCube(parseColourCube(raw));
+		const twice = writeColourCube(parseColourCube(once));
+		expect(bytesEqual(twice, once)).toBe(true);
+	});
+
+	it('an edited texel survives parse→write→parse', () => {
+		const m = parseColourCube(loadCube(FIXTURES[0]));
+		setColourCubeTexel(m, 5, 6, 7, { r: 1, g: 2, b: 3 });
+		const back = parseColourCube(writeColourCube(m));
+		expect(colourCubeTexel(back, 5, 6, 7)).toEqual({ r: 1, g: 2, b: 3 });
+	});
+});
+
+describe('ColourCube rigid-layout guards', () => {
+	it('parser rejects a resource whose size disagrees with m_size^3*3+16', () => {
+		const raw = loadCube(FIXTURES[0]);
+		expect(() => parseColourCube(raw.subarray(0, raw.byteLength - 1))).toThrow(/m_size/);
+	});
+
+	it('parser rejects a non-0x10 m_pixels offset', () => {
+		const raw = new Uint8Array(loadCube(FIXTURES[0]));
+		raw[4] = 0x20;
+		expect(() => parseColourCube(raw)).toThrow(/m_pixels/);
+	});
+
+	it('parser rejects a sub-header-sized resource', () => {
+		expect(() => parseColourCube(new Uint8Array(8))).toThrow(/header/);
+	});
+
+	it('writer rejects a pixel buffer inconsistent with mSize', () => {
+		const m = parseColourCube(loadCube(FIXTURES[0]));
+		const broken = { ...m, pixels: m.pixels.subarray(0, m.pixels.byteLength - 3) };
+		expect(() => writeColourCube(broken)).toThrow(/pixel bytes/);
+	});
+
+	it('texel accessors reject out-of-cube coordinates', () => {
+		const m = parseColourCube(loadCube(FIXTURES[0]));
+		expect(() => colourCubeTexel(m, 32, 0, 0)).toThrow(/outside/);
+		expect(() => colourCubeTexel(m, 0, -1, 0)).toThrow(/outside/);
+		expect(() => setColourCubeTexel(m, 0, 0, 32, { r: 0, g: 0, b: 0 })).toThrow(/outside/);
+	});
+});

--- a/src/lib/core/__tests__/environmentDictionary.test.ts
+++ b/src/lib/core/__tests__/environmentDictionary.test.ts
@@ -1,0 +1,209 @@
+// Gold coverage for parseEnvironmentDictionary / writeEnvironmentDictionary.
+//
+// DICTIONARY.BUNDLE carries exactly one ENV_DICTIONARY (0x10014) resource.
+// Beyond the byte-exact round-trip, this suite pins the cross-bundle contract
+// the dictionary exists for: each season's macBundle path resolves to a
+// sibling environment-settings bundle whose single EnvironmentTimeLine
+// (0x10013) resource has id crc32(lowercase(macResourceName)) and the same
+// debug name — Burnout resource ids are CRC32 of the lowercased debug name.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { crc32 } from 'node:zlib';
+
+import {
+	parseEnvironmentDictionary,
+	writeEnvironmentDictionary,
+} from '../environmentDictionary';
+import { parseBundle } from '../bundle';
+import { parseDebugDataFromXml, findDebugResourceById } from '../bundle/debugData';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const ENV_DICTIONARY_TYPE_ID = 0x10014;
+const ENV_TIMELINE_TYPE_ID = 0x10013;
+const DICTIONARY_BUNDLE = 'example/ENVIRONMENTSETTINGS/DICTIONARY.BUNDLE';
+
+function loadBundle(bundleFile: string) {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	return { buffer, bundle: parseBundle(buffer) };
+}
+
+function loadDictionaryRaw(): Uint8Array {
+	const { buffer, bundle } = loadBundle(DICTIONARY_BUNDLE);
+	const resources = bundle.resources.filter((r) => r.resourceTypeId === ENV_DICTIONARY_TYPE_ID);
+	expect(resources.length).toBe(1);
+	return extractResourceRaw(buffer, bundle, resources[0]);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+/** Resolve a game-relative path ("EnvironmentSettings\X.bundle") against the
+ *  fixture tree case-insensitively (retail stores mixed case, the fixtures
+ *  are uppercase). */
+function resolveGamePath(gamePath: string): string {
+	let dir = path.resolve(REPO_ROOT, 'example');
+	const segments = gamePath.split('\\');
+	for (const segment of segments) {
+		const match = fs.readdirSync(dir).find((e) => e.toLowerCase() === segment.toLowerCase());
+		expect(match, `${segment} (from ${gamePath}) in ${dir}`).toBeDefined();
+		dir = path.join(dir, match!);
+	}
+	return dir;
+}
+
+describe('EnvironmentDictionary gold values (example/ENVIRONMENTSETTINGS/DICTIONARY.BUNDLE)', () => {
+	const raw = loadDictionaryRaw();
+	const m = parseEnvironmentDictionary(raw);
+
+	it('decodes the header: version 2, 4 seasons, 1 location, zero header pad', () => {
+		expect(m.muVersion).toBe(2);
+		expect(m.seasons.length).toBe(4);
+		expect(m.locations.length).toBe(1);
+		expect(m._headerPad.byteLength).toBe(12);
+		expect(m._headerPad.every((b) => b === 0)).toBe(true);
+		// Header 0x20 + 4*0x100 seasons + 1*0x40 location = 0x460, tiled exactly.
+		expect(raw.byteLength).toBe(0x460);
+	});
+
+	it('decodes the four seasons in disk order: SUN, OC, FOG, JunkyardT', () => {
+		expect(m.seasons.map((s) => s.macResourceName)).toEqual([
+			'ENV_TL_000_DLC24hr_SUN_A',
+			'ENV_TL_000_DLC24hr_OC_A',
+			'ENV_TL_000_DLC24hr_FOG_A',
+			'ENV_TL_000_DLC24hr_JunkyardT',
+		]);
+		expect(m.seasons[0].macBundle).toBe('EnvironmentSettings\\000_DLC24hr_SUN_A.bundle');
+		expect(m.seasons[0].macColourCubesBundle).toBe('EnvironmentSettings\\ColourCubes\\000_DLC24hr_SUN_A.bundle');
+		expect(m.seasons[3].macBundle).toBe('EnvironmentSettings\\000_DLC24hr_JunkyardT.bundle');
+		expect(m.seasons[3].macColourCubesBundle).toBe('EnvironmentSettings\\ColourCubes\\000_DLC24hr_JunkyardT.bundle');
+	});
+
+	it('decodes the single location "city"', () => {
+		expect(m.locations).toEqual([{ macName: 'city' }]);
+	});
+
+	it('the dictionary resource id itself is crc32("env_dictionary")', () => {
+		const { bundle } = loadBundle(DICTIONARY_BUNDLE);
+		const res = bundle.resources.find((r) => r.resourceTypeId === ENV_DICTIONARY_TYPE_ID)!;
+		expect(res.resourceId.low >>> 0).toBe(crc32(Buffer.from('env_dictionary')) >>> 0);
+		expect(res.resourceId.high).toBe(0);
+	});
+});
+
+describe('EnvironmentDictionary cross-bundle contract', () => {
+	const m = parseEnvironmentDictionary(loadDictionaryRaw());
+
+	it('every macBundle / macColourCubesBundle path resolves to a fixture bundle', () => {
+		for (const s of m.seasons) {
+			expect(fs.existsSync(resolveGamePath(s.macBundle)), s.macBundle).toBe(true);
+			expect(fs.existsSync(resolveGamePath(s.macColourCubesBundle)), s.macColourCubesBundle).toBe(true);
+		}
+	});
+
+	it('each season bundle has exactly one timeline (0x10013) whose id and debug name derive from macResourceName', () => {
+		for (const s of m.seasons) {
+			const sibPath = resolveGamePath(s.macBundle);
+			const buf = fs.readFileSync(sibPath);
+			const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+			const bundle = parseBundle(buffer);
+			const timelines = bundle.resources.filter((r) => r.resourceTypeId === ENV_TIMELINE_TYPE_ID);
+			expect(timelines.length, s.macBundle).toBe(1);
+			// Resource ids are CRC32 of the lowercased debug name — this is how
+			// the game finds the timeline named by the dictionary entry.
+			const expectedId = crc32(Buffer.from(s.macResourceName.toLowerCase())) >>> 0;
+			expect(timelines[0].resourceId.low >>> 0, s.macResourceName).toBe(expectedId);
+			const debugResources = typeof bundle.debugData === 'string'
+				? parseDebugDataFromXml(bundle.debugData)
+				: [];
+			const debugEntry = findDebugResourceById(debugResources, timelines[0].resourceId.low.toString(16));
+			expect(debugEntry?.name, s.macBundle).toBe(s.macResourceName);
+		}
+	});
+
+	it('the location name appears in every season bundle\'s keyframe names (ENV_KF_<season>_<location>_<time>)', () => {
+		const location = m.locations[0].macName;
+		for (const s of m.seasons) {
+			const buf = fs.readFileSync(resolveGamePath(s.macBundle));
+			const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+			const bundle = parseBundle(buffer);
+			const debugResources = typeof bundle.debugData === 'string'
+				? parseDebugDataFromXml(bundle.debugData)
+				: [];
+			const keyframeNames = debugResources
+				.filter((d) => d.name.startsWith('ENV_KF_'))
+				.map((d) => d.name);
+			expect(keyframeNames.length, s.macBundle).toBeGreaterThan(0);
+			for (const name of keyframeNames) {
+				expect(name, s.macBundle).toContain(`_${location}_`);
+			}
+		}
+	});
+});
+
+describe('EnvironmentDictionary round-trip', () => {
+	const raw = loadDictionaryRaw();
+
+	it('round-trips byte-for-byte and the writer is idempotent', () => {
+		const write1 = writeEnvironmentDictionary(parseEnvironmentDictionary(raw));
+		expect(write1.byteLength).toBe(raw.byteLength);
+		expect(bytesEqual(write1, raw)).toBe(true);
+		const write2 = writeEnvironmentDictionary(parseEnvironmentDictionary(write1));
+		expect(bytesEqual(write2, write1)).toBe(true);
+	});
+
+	it('recomputes mpLocationDatii when a season is removed', () => {
+		const m = parseEnvironmentDictionary(raw);
+		const out = writeEnvironmentDictionary({ ...m, seasons: m.seasons.slice(0, 2) });
+		expect(out.byteLength).toBe(0x20 + 2 * 0x100 + 0x40);
+		const dv = new DataView(out.buffer, out.byteOffset, out.byteLength);
+		expect(dv.getUint32(0x10, true)).toBe(0x20 + 2 * 0x100);
+		const back = parseEnvironmentDictionary(out);
+		expect(back.seasons.map((s) => s.macResourceName)).toEqual([
+			'ENV_TL_000_DLC24hr_SUN_A',
+			'ENV_TL_000_DLC24hr_OC_A',
+		]);
+		expect(back.locations).toEqual([{ macName: 'city' }]);
+	});
+});
+
+describe('EnvironmentDictionary rigid-layout guards', () => {
+	const raw = loadDictionaryRaw();
+
+	it('parser rejects an unknown version', () => {
+		const mutated = new Uint8Array(raw); // copy — raw may be a Buffer view
+		mutated[0] = 3;
+		expect(() => parseEnvironmentDictionary(mutated)).toThrow(/muVersion 3/);
+	});
+
+	it('parser rejects a season count inconsistent with mpLocationDatii', () => {
+		const mutated = new Uint8Array(raw);
+		mutated[0x4] = 5; // muSeasonCnt 4 -> 5 without moving mpLocationDatii
+		expect(() => parseEnvironmentDictionary(mutated)).toThrow(/mpLocationDatii/);
+	});
+
+	it('parser rejects garbage after a string NUL (zero-fill write could not reproduce it)', () => {
+		const mutated = new Uint8Array(raw);
+		mutated[0x9f] = 0xab; // last byte of season[0].macResourceName's zero tail
+		expect(() => parseEnvironmentDictionary(mutated)).toThrow(/non-zero byte/);
+	});
+
+	it('parser rejects a string with no NUL terminator', () => {
+		const mutated = new Uint8Array(raw);
+		mutated.fill(0x41, 0x420, 0x460); // location[0].macName all 'A'
+		expect(() => parseEnvironmentDictionary(mutated)).toThrow(/no NUL terminator/);
+	});
+
+	it('writer rejects a string that overflows its fixed field', () => {
+		const m = parseEnvironmentDictionary(raw);
+		const seasons = m.seasons.slice();
+		seasons[0] = { ...seasons[0], macBundle: 'x'.repeat(0x40) };
+		expect(() => writeEnvironmentDictionary({ ...m, seasons })).toThrow(/max 63/);
+	});
+});

--- a/src/lib/core/__tests__/environmentSettings.test.ts
+++ b/src/lib/core/__tests__/environmentSettings.test.ts
@@ -1,0 +1,292 @@
+// Gold coverage for parseEnvironmentKeyframe / writeEnvironmentKeyframe and
+// parseEnvironmentTimeLine / writeEnvironmentTimeLine.
+//
+// A season bundle carries MANY keyframes (8–17 across the four fixtures) but
+// the auto-generated registry fixture suite only exercises the first resource
+// of a type per bundle — so this suite walks ALL of them (all 17 in SUN_A),
+// pins hand-verified decoded values from FOG_A's city_1800 keyframe, and pins
+// the timeline↔keyframe import relationship: every timeline entry's id is a
+// keyframe in the same bundle, the set covers the bundle exactly once, and
+// the ascending times match the keyframes' _HHMM debug-name suffixes.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+	parseEnvironmentKeyframe,
+	writeEnvironmentKeyframe,
+	parseEnvironmentTimeLine,
+	writeEnvironmentTimeLine,
+	formatTimeOfDay,
+} from '../environmentSettings';
+import { parseBundle } from '../bundle';
+import { parseDebugDataFromXml, findDebugResourceById } from '../bundle/debugData';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const KEYFRAME_TYPE_ID = 0x10012;
+const TIME_LINE_TYPE_ID = 0x10013;
+
+const FIXTURES = [
+	{ bundle: 'example/ENVIRONMENTSETTINGS/000_DLC24HR_FOG_A.BUNDLE', keyframes: 11 },
+	{ bundle: 'example/ENVIRONMENTSETTINGS/000_DLC24HR_JUNKYARDT.BUNDLE', keyframes: 12 },
+	{ bundle: 'example/ENVIRONMENTSETTINGS/000_DLC24HR_OC_A.BUNDLE', keyframes: 8 },
+	{ bundle: 'example/ENVIRONMENTSETTINGS/000_DLC24HR_SUN_A.BUNDLE', keyframes: 17 },
+] as const;
+
+type Extracted = { name: string; id: bigint; raw: Uint8Array };
+type LoadedBundle = { keyframes: Extracted[]; timelines: Extracted[] };
+
+function loadEnvBundle(bundleFile: string): LoadedBundle {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const debugResources = typeof bundle.debugData === 'string' ? parseDebugDataFromXml(bundle.debugData) : [];
+	const extract = (typeId: number): Extracted[] =>
+		bundle.resources
+			.filter((r) => r.resourceTypeId === typeId)
+			.map((r) => ({
+				name: findDebugResourceById(debugResources, r.resourceId.low.toString(16))?.name ?? '?',
+				id: (BigInt(r.resourceId.high) << 32n) | BigInt(r.resourceId.low >>> 0),
+				raw: extractResourceRaw(buffer, bundle, r),
+			}));
+	return { keyframes: extract(KEYFRAME_TYPE_ID), timelines: extract(TIME_LINE_TYPE_ID) };
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+/** ENV_KF names end in _HHMM — the clock time the keyframe is authored for. */
+function secondsFromName(name: string): number {
+	const m = name.match(/_(\d{2})(\d{2})$/);
+	expect(m, `keyframe name "${name}" should end in _HHMM`).not.toBeNull();
+	return parseInt(m![1], 10) * 3600 + parseInt(m![2], 10) * 60;
+}
+
+describe('EnvironmentKeyframe gold values (FOG_A city_1800)', () => {
+	const { keyframes } = loadEnvBundle(FIXTURES[0].bundle);
+	const gold = keyframes.find((k) => k.name === 'ENV_KF_000_DLC24hr_FOG_A_city_1800')!;
+	const m = parseEnvironmentKeyframe(gold.raw);
+
+	it('decodes the header and bloom block', () => {
+		expect(m.muVersion).toBe(8);
+		expect(m.mBloomData.mfLuminance).toBeCloseTo(1.55667, 4);
+		expect(m.mBloomData.mfThreshold).toBeCloseTo(1 / 3, 5);
+		expect(m.mBloomData.mv4Scale.x).toBeCloseTo(0.824813, 5);
+		expect(m.mBloomData.mv4Scale.y).toBeCloseTo(0.694311, 5);
+		expect(m.mBloomData.mv4Scale.z).toBeCloseTo(0.522678, 5);
+		expect(m.mBloomData.mv4Scale.w).toBe(1);
+	});
+
+	it('decodes the vignette block', () => {
+		expect(m.mVignetteData.mfAngle).toBe(0);
+		expect(m.mVignetteData.mfSharpness).toBeCloseTo(0.26, 5);
+		expect(m.mVignetteData.mv2Amount.x).toBeCloseTo(1 / 3, 5);
+		expect(m.mVignetteData.mv2Amount.y).toBeCloseTo(0.746667, 5);
+		expect(m.mVignetteData.mv2Centre.x).toBe(0.5);
+		expect(m.mVignetteData.mv2Centre.y).toBeCloseTo(0.463333, 5);
+		expect(m.mVignetteData.mv4InnerColour).toEqual({ x: 1, y: 1, z: 1, w: 0 });
+		expect(m.mVignetteData.mv4OuterColour.x).toBeCloseTo(0.603083, 5);
+		expect(m.mVignetteData.mv4OuterColour.w).toBe(1);
+	});
+
+	it('surfaces the ColourCube import id (TintData pointer is 0 on disk)', () => {
+		expect(m.mColourCubeId).toBe(0x7e36af9dn);
+	});
+
+	it('decodes the scattering block', () => {
+		expect(m.mScatteringData.mv3SkyTopColour.x).toBeCloseTo(0.610964, 5);
+		expect(m.mScatteringData.mv3SkyTopColour.y).toBeCloseTo(0.641494, 5);
+		expect(m.mScatteringData.mv3SkyTopColour.z).toBeCloseTo(0.675464, 5);
+		expect(m.mScatteringData.mfSkyHorPow).toBeCloseTo(1.83333, 4);
+		expect(m.mScatteringData.mfSkySunPow).toBe(50);
+		expect(m.mScatteringData.mfSkyDrk).toBe(0);
+		expect(m.mScatteringData.mfSkyHorBleedScl).toBeCloseTo(17.87, 4);
+		expect(m.mScatteringData.mv3ScattTopColour.x).toBe(0);
+		expect(m.mScatteringData.mv3ScattTopColour.y).toBeCloseTo(0.1, 5);
+		expect(m.mScatteringData.mv3ScattTopColour.z).toBeCloseTo(0.3, 5);
+		expect(m.mScatteringData.mv3ScattSunColour).toEqual({ x: 1, y: 1, z: 1 });
+		expect(m.mScatteringData.mafScattDist.length).toBe(2);
+		expect(m.mScatteringData.mafScattDist[0]).toBeCloseTo(2.33333, 4);
+		expect(m.mScatteringData.mafScattDist[1]).toBe(200);
+		expect(m.mScatteringData.mfScattPow).toBeCloseTo(0.566667, 5);
+		expect(m.mScatteringData.mfScattCap).toBeCloseTo(0.93, 5);
+	});
+
+	it('decodes the lighting rig — fills go HDR-overbright (>1)', () => {
+		expect(m.mLightingData.mv3KeyLightColour.x).toBeCloseTo(0.6409, 5);
+		expect(m.mLightingData.mv3KeyLightColour.y).toBeCloseTo(0.538089, 5);
+		expect(m.mLightingData.mv3KeyLightColour.z).toBeCloseTo(0.446052, 5);
+		// Down-fill is the proof that these are NOT 0–1-clamped colours.
+		expect(m.mLightingData.mv3DownFillColour.x).toBeCloseTo(3.2032, 4);
+		expect(m.mLightingData.mv3DownFillColour.y).toBeCloseTo(3.14302, 4);
+		expect(m.mLightingData.mv3DownFillColour.z).toBeCloseTo(2.93973, 4);
+		expect(m.mLightingData.mfAmbientIrradianceScale).toBeCloseTo(0.2, 5);
+	});
+
+	it('decodes the cloud layers', () => {
+		expect(m.mCloudsData.mav3LayerLiteColour.length).toBe(2);
+		expect(m.mCloudsData.mav3LayerLiteColour[0].x).toBeCloseTo(0.20385, 5);
+		expect(m.mCloudsData.mav3LayerLiteColour[1]).toEqual({ x: 0, y: 0, z: 0 });
+		expect(m.mCloudsData.mav3LayerDarkColour[0].x).toBeCloseTo(0.0886667, 5);
+		expect(m.mCloudsData.mafLayerDensity).toEqual([0, 0]);
+		expect(m.mCloudsData.mafLayerFeathering[0]).toBeCloseTo(1.1, 5);
+		expect(m.mCloudsData.mafLayerOpacity[0]).toBe(0.5);
+		expect(m.mCloudsData.mafLayerSpeed).toEqual([3, 6]);
+		expect(m.mCloudsData.mafLayerScale[1]).toBeCloseTo(3891.11, 2);
+		expect(m.mCloudsData.mfDirectionAngle).toBeCloseTo(66.6667, 3);
+	});
+});
+
+describe('EnvironmentKeyframe walks all 17 resources (SUN_A)', () => {
+	const { keyframes } = loadEnvBundle(FIXTURES[3].bundle);
+
+	it('finds exactly 17 keyframes with distinct _HHMM authoring times', () => {
+		expect(keyframes.length).toBe(17);
+		const times = keyframes.map((k) => secondsFromName(k.name));
+		expect(new Set(times).size).toBe(17);
+	});
+
+	it('parses and byte-round-trips every keyframe, each importing a ColourCube', () => {
+		for (const kf of keyframes) {
+			const model = parseEnvironmentKeyframe(kf.raw);
+			expect(model.muVersion, kf.name).toBe(8);
+			expect(model.mColourCubeId, kf.name).not.toBe(0n);
+			const rewritten = writeEnvironmentKeyframe(model);
+			expect(bytesEqual(rewritten, kf.raw), kf.name).toBe(true);
+		}
+	});
+});
+
+describe('EnvironmentTimeLine gold values (FOG_A)', () => {
+	const { keyframes, timelines } = loadEnvBundle(FIXTURES[0].bundle);
+	const m = parseEnvironmentTimeLine(timelines[0].raw);
+
+	it('has one location with 11 keyframes and the pinned time schedule', () => {
+		expect(m.muVersion).toBe(1);
+		expect(m.locations.length).toBe(1);
+		expect(m.locations[0].keyframes.map((k) => k.mfTimeOfDay)).toEqual([
+			0, 14400, 21600, 32400, 39600, 43200, 46800, 54000, 64800, 75600, 82800,
+		]);
+	});
+
+	it('entry 0 references the midnight keyframe by resource id', () => {
+		const midnight = keyframes.find((k) => k.name === 'ENV_KF_000_DLC24hr_FOG_A_city_0000')!;
+		expect(m.locations[0].keyframes[0].mKeyframeId).toBe(midnight.id);
+		expect(m.locations[0].keyframes[0].mKeyframeId).toBe(0xb78c4bc1n);
+	});
+});
+
+for (const fixture of FIXTURES) {
+	describe(`Environment settings relationship + round-trip (${path.basename(fixture.bundle)})`, () => {
+		const { keyframes, timelines } = loadEnvBundle(fixture.bundle);
+
+		it(`has ${fixture.keyframes} keyframes and exactly one timeline`, () => {
+			expect(keyframes.length).toBe(fixture.keyframes);
+			expect(timelines.length).toBe(1);
+		});
+
+		it('the timeline covers every keyframe in the bundle exactly once, ascending from 00:00', () => {
+			const m = parseEnvironmentTimeLine(timelines[0].raw);
+			expect(m.locations.length).toBe(1);
+			const entries = m.locations[0].keyframes;
+			expect(entries.length).toBe(keyframes.length);
+			expect(new Set(entries.map((e) => e.mKeyframeId)).size).toBe(entries.length);
+			const bundleIds = new Set(keyframes.map((k) => k.id));
+			for (const e of entries) expect(bundleIds.has(e.mKeyframeId)).toBe(true);
+			expect(entries[0].mfTimeOfDay).toBe(0);
+			for (let i = 1; i < entries.length; i++) {
+				expect(entries[i].mfTimeOfDay).toBeGreaterThan(entries[i - 1].mfTimeOfDay);
+			}
+		});
+
+		it("each entry's time matches its keyframe's _HHMM debug-name suffix", () => {
+			const byId = new Map(keyframes.map((k) => [k.id, k.name]));
+			const m = parseEnvironmentTimeLine(timelines[0].raw);
+			for (const e of m.locations[0].keyframes) {
+				expect(secondsFromName(byId.get(e.mKeyframeId)!)).toBe(e.mfTimeOfDay);
+			}
+		});
+
+		it('round-trips every keyframe and the timeline byte-for-byte, idempotently', () => {
+			for (const kf of keyframes) {
+				const write1 = writeEnvironmentKeyframe(parseEnvironmentKeyframe(kf.raw));
+				expect(bytesEqual(write1, kf.raw), kf.name).toBe(true);
+				const write2 = writeEnvironmentKeyframe(parseEnvironmentKeyframe(write1));
+				expect(bytesEqual(write2, write1), `${kf.name} idempotence`).toBe(true);
+			}
+			const tl1 = writeEnvironmentTimeLine(parseEnvironmentTimeLine(timelines[0].raw));
+			expect(bytesEqual(tl1, timelines[0].raw)).toBe(true);
+			const tl2 = writeEnvironmentTimeLine(parseEnvironmentTimeLine(tl1));
+			expect(bytesEqual(tl2, tl1)).toBe(true);
+		});
+	});
+}
+
+describe('Environment settings rigid-layout rejections', () => {
+	const { keyframes, timelines } = loadEnvBundle(FIXTURES[0].bundle);
+
+	it('keyframe parser rejects a truncated resource', () => {
+		expect(() => parseEnvironmentKeyframe(keyframes[0].raw.slice(0, 0x240))).toThrow(/0x240 bytes, expected 0x250/);
+	});
+
+	it('keyframe parser rejects an unknown version', () => {
+		// extractResourceRaw can hand back a Buffer view — copy before mutating.
+		const bytes = new Uint8Array(keyframes[0].raw);
+		bytes[0] = 9;
+		expect(() => parseEnvironmentKeyframe(bytes)).toThrow(/muVersion 9/);
+	});
+
+	it('keyframe parser rejects a non-zero pad word', () => {
+		const bytes = new Uint8Array(keyframes[0].raw);
+		bytes[0x84] = 1; // tint pad
+		expect(() => parseEnvironmentKeyframe(bytes)).toThrow(/non-zero pad/);
+	});
+
+	it('keyframe parser rejects an import not patching mpColourCube', () => {
+		const bytes = new Uint8Array(keyframes[0].raw);
+		bytes[0x248] = 0x84; // patch offset 0x80 → 0x84
+		expect(() => parseEnvironmentKeyframe(bytes)).toThrow(/import patch offset/);
+	});
+
+	it('keyframe writer rejects a cloud array that is not exactly 2 entries', () => {
+		const m = parseEnvironmentKeyframe(keyframes[0].raw);
+		const broken = { ...m, mCloudsData: { ...m.mCloudsData, mafLayerSpeed: [3, 6, 9] } };
+		expect(() => writeEnvironmentKeyframe(broken)).toThrow(/mafLayerSpeed/);
+	});
+
+	it('timeline parser rejects a non-canonical location pointer', () => {
+		const bytes = new Uint8Array(timelines[0].raw);
+		bytes[0x18] = 0x24; // mppKeyframes 0x20 → 0x24
+		expect(() => parseEnvironmentTimeLine(bytes)).toThrow(/mppKeyframes/);
+	});
+
+	it('timeline parser rejects an on-disk pointer slot that is not 0', () => {
+		const bytes = new Uint8Array(timelines[0].raw);
+		bytes[0x20] = 1;
+		expect(() => parseEnvironmentTimeLine(bytes)).toThrow(/pointer slots/);
+	});
+
+	it('timeline parser rejects a size inconsistent with the keyframe count', () => {
+		const bytes = new Uint8Array(timelines[0].raw);
+		bytes[0x10] = 12; // muKeyframeCnt 11 → 12 without growing the resource
+		expect(() => parseEnvironmentTimeLine(bytes)).toThrow(/expected 0x/);
+	});
+});
+
+describe('formatTimeOfDay', () => {
+	it('formats whole-minute clock times', () => {
+		expect(formatTimeOfDay(0)).toBe('00:00');
+		expect(formatTimeOfDay(14400)).toBe('04:00');
+		expect(formatTimeOfDay(82800)).toBe('23:00');
+		expect(formatTimeOfDay(86340)).toBe('23:59');
+	});
+
+	it('only appends seconds when non-zero', () => {
+		expect(formatTimeOfDay(45)).toBe('00:00:45');
+	});
+});

--- a/src/lib/core/__tests__/font.test.ts
+++ b/src/lib/core/__tests__/font.test.ts
@@ -1,0 +1,281 @@
+// Gold coverage for parseFont / writeFont (resource type 0x21).
+//
+// The handler declares three fixtures; this suite sweeps ALL 26 retail .FONT
+// bundles in example/FONTS/ for byte-exact round-trip + writer idempotence,
+// pins hand-verified decoded values, and pins the data findings the wiki does
+// not document: the on-disk element order, the derivable hash table, the
+// universal 3-space non-renderable set, and the 2-page fonts whose second
+// atlas page imports a Texture from ANOTHER bundle while its pointer slot
+// carries build-time garbage.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseFont, writeFont, computeHashOffsets, FONT_TYPE_ID } from '../font';
+import { parseBundle } from '../bundle';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const FONTS_DIR = path.resolve(REPO_ROOT, 'example/FONTS');
+const TEXTURE_TYPE_ID = 0x0;
+
+type ExtractedFont = {
+	raw: Uint8Array;
+	/** The bundled atlas Texture's resource id (every .FONT carries exactly one). */
+	textureId: bigint;
+	importCount: number;
+};
+
+function loadFont(fontFile: string): ExtractedFont {
+	const buf = fs.readFileSync(path.resolve(FONTS_DIR, fontFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const fontRes = bundle.resources.filter((r) => r.resourceTypeId === FONT_TYPE_ID);
+	const texRes = bundle.resources.filter((r) => r.resourceTypeId === TEXTURE_TYPE_ID);
+	expect(fontRes.length, fontFile).toBe(1);
+	expect(texRes.length, fontFile).toBe(1);
+	return {
+		raw: extractResourceRaw(buffer, bundle, fontRes[0]),
+		textureId: (BigInt(texRes[0].resourceId.high) << 32n) | BigInt(texRes[0].resourceId.low),
+		importCount: fontRes[0].importCount,
+	};
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+const ALL_FONTS = fs.readdirSync(FONTS_DIR).filter((f) => f.endsWith('.FONT')).sort();
+
+describe('Font gold values (example/FONTS/CHINESE_SIMPLIFIED.FONT)', () => {
+	const { raw, textureId } = loadFont('CHINESE_SIMPLIFIED.FONT');
+	const m = parseFont(raw);
+
+	it('decodes the hand-verified header', () => {
+		expect(m.muVersionId).toBe(10);
+		expect(m.mScaleUV.x).toBeCloseTo(25.6, 4);
+		expect(m.mScaleUV.y).toBeCloseTo(51.2, 4);
+		// scaleUV * fontHeight = 2048 x 4096 — the atlas pixel dimensions.
+		expect(m.muFontHeightInPixels).toBe(80);
+		expect(m.mfLowerCaseScale).toBe(0);
+		expect(m.mfBaseLine).toBeCloseTo(0.76992, 4);
+		expect(m.mfXHeight).toBeCloseTo(0.75742, 4);
+		expect(m.macTypefaceFamilyName).toBe('B5HelveticaBold');
+		expect(m.macTypefaceStyleName).toBe('B5EAConDisS');
+		expect(m.chars.length).toBe(1633);
+	});
+
+	it('decodes hand-verified glyphs', () => {
+		// chars[0] is U+3000 ideographic space — non-renderable, UV sentinel.
+		expect(m.chars[0].charId).toBe(0x3000);
+		expect(m.chars[0].mbIsRenderable).toBe(false);
+		expect(m.chars[0].mTopLeftUV).toEqual({ x: -1, y: -1 });
+		// chars[1] is U+4E00 一 — a real glyph on page 0.
+		expect(m.chars[1].charId).toBe(0x4e00);
+		expect(String.fromCharCode(m.chars[1].charId)).toBe('一');
+		expect(m.chars[1].mbIsRenderable).toBe(true);
+		expect(m.chars[1].mTopLeftUV.x).toBeCloseTo(0.0332, 3);
+		expect(m.chars[1].mTopLeftUV.y).toBeCloseTo(0.8577, 3);
+		expect(m.chars[1].mfAdvance).toBeCloseTo(0.0352, 3);
+		expect(m.chars[1].mu16TexturePageId).toBe(0);
+	});
+
+	it('binds its single atlas page to the bundled Texture resource', () => {
+		expect(m.texturePages.length).toBe(1);
+		expect(m.texturePages[0].textureId).toBe(textureId);
+		expect(m.texturePages[0].textureId).toBe(0xba9aacb7n);
+		expect(m.texturePages[0]._ptrSlot).toBe(0);
+	});
+});
+
+describe('Font gold values (example/FONTS/B5BODY_THAI_35.FONT)', () => {
+	const { raw, textureId } = loadFont('B5BODY_THAI_35.FONT');
+	const m = parseFont(raw);
+
+	it('decodes the hand-verified header', () => {
+		expect(m.chars.length).toBe(263);
+		expect(m.muFontHeightInPixels).toBe(140);
+		// Unlike the CJK/Western fonts, 13.157 * 140 is no power of two — the
+		// scaleUV-equals-atlas-dims pattern is NOT universal.
+		expect(m.mScaleUV.x).toBeCloseTo(13.1572, 3);
+		expect(m.mScaleUV.y).toBeCloseTo(13.1572, 3);
+		expect(m.macTypefaceFamilyName).toBe('B5HelveticaBold');
+		expect(m.macTypefaceStyleName).toBe('Bold');
+	});
+
+	it('decodes a Thai glyph', () => {
+		expect(m.chars[2].charId).toBe(0x0e01);
+		expect(String.fromCharCode(m.chars[2].charId)).toBe('ก');
+		expect(m.chars[2].mbIsRenderable).toBe(true);
+		expect(m.chars[2].mu16TexturePageId).toBe(0);
+	});
+
+	it('binds its single atlas page to the bundled Texture resource', () => {
+		expect(m.texturePages.length).toBe(1);
+		expect(m.texturePages[0].textureId).toBe(textureId);
+	});
+});
+
+describe('Font 2-page shape (the LIMITED Chinese fonts)', () => {
+	// The only retail fonts with >1 texture page. Page 0 binds the bundled
+	// Texture; page 1 imports a Texture that lives in a DIFFERENT bundle, and
+	// its on-disk pointer slot carries build-time garbage instead of 0.
+	const cases = [
+		{ file: 'CHINESE_SIMPLIFIED_LIMITED.FONT', page1Id: 0xfe06d33bn, page1Slot: 0xc75dfdd1 },
+		{ file: 'CHINESE_TRADITIONAL_LIMITED.FONT', page1Id: 0x4576d81en, page1Slot: 0xc7124dd1 },
+	];
+
+	for (const { file, page1Id, page1Slot } of cases) {
+		it(`${file}: page 0 in-bundle, page 1 external with garbage ptr slot`, () => {
+			const { raw, textureId, importCount } = loadFont(file);
+			const m = parseFont(raw);
+			expect(m.texturePages.length).toBe(2);
+			expect(importCount).toBe(2);
+			expect(m.texturePages[0].textureId).toBe(textureId);
+			expect(m.texturePages[0]._ptrSlot).toBe(0);
+			expect(m.texturePages[1].textureId).toBe(page1Id);
+			expect(m.texturePages[1]._ptrSlot).toBe(page1Slot);
+			// Both pages are actually used by glyphs.
+			const pagesUsed = new Set(m.chars.map((c) => c.mu16TexturePageId));
+			expect([...pagesUsed].sort()).toEqual([0, 1]);
+		});
+	}
+});
+
+describe('Font data findings (all 26 retail fonts)', () => {
+	for (const file of ALL_FONTS) {
+		it(`${file}: invariants the editor relies on`, () => {
+			const { raw, textureId, importCount } = loadFont(file);
+			const m = parseFont(raw);
+
+			expect(m.muVersionId).toBe(10);
+			expect(m.mfLowerCaseScale).toBe(0);
+			expect(m.chars.some((c) => c.mbIsLowerCaseScale)).toBe(false);
+
+			// Exactly three non-renderable chars in every font — the three space
+			// variants — and the (-1,-1) UV sentinel is equivalent to the flag.
+			const nonRenderable = m.chars.filter((c) => !c.mbIsRenderable);
+			expect(nonRenderable.map((c) => c.charId).sort((a, b) => a - b)).toEqual([0x20, 0xa0, 0x3000]);
+			for (const c of m.chars) {
+				if (c.mbIsRenderable) {
+					expect(c.mTopLeftUV.x).toBeGreaterThanOrEqual(0);
+					expect(c.mTopLeftUV.y).toBeGreaterThanOrEqual(0);
+				} else {
+					expect(c.mTopLeftUV).toEqual({ x: -1, y: -1 });
+				}
+			}
+
+			// No duplicate char ids.
+			expect(new Set(m.chars.map((c) => c.charId)).size).toBe(m.chars.length);
+
+			// One import entry per texture page; single-page fonts always bind
+			// the Texture that ships in the same bundle.
+			expect(importCount).toBe(m.texturePages.length);
+			if (m.texturePages.length === 1) {
+				expect(m.texturePages[0].textureId).toBe(textureId);
+			}
+		});
+	}
+});
+
+describe('Font round-trip (all 26 retail fonts)', () => {
+	for (const file of ALL_FONTS) {
+		it(`${file}: byte-exact and idempotent`, () => {
+			const { raw } = loadFont(file);
+			const rewritten = writeFont(parseFont(raw));
+			expect(rewritten.byteLength).toBe(raw.byteLength);
+			expect(bytesEqual(rewritten, raw)).toBe(true);
+			const second = writeFont(parseFont(rewritten));
+			expect(bytesEqual(second, rewritten)).toBe(true);
+		});
+	}
+});
+
+describe('Font rigid-layout guards', () => {
+	const { raw } = loadFont('DEFAULT.FONT');
+
+	it('parser rejects a corrupted hash table', () => {
+		const corrupted = new Uint8Array(raw); // copy — never mutate the extracted view
+		corrupted[0x2a] ^= 0xff; // mauHashOffsets[1]
+		expect(() => parseFont(corrupted)).toThrow(/mauHashOffsets/);
+	});
+
+	it('parser rejects a non-retail version id', () => {
+		const corrupted = new Uint8Array(raw);
+		corrupted[0] = 1; // dev-era muVersionId
+		expect(() => parseFont(corrupted)).toThrow(/muVersionId/);
+	});
+
+	it('writer rejects chars that break hash-bucket grouping', () => {
+		const m = parseFont(raw);
+		const chars = m.chars.slice().reverse();
+		expect(() => writeFont({ ...m, chars })).toThrow(/bucket/);
+	});
+
+	it('writer rejects a glyph referencing a missing texture page', () => {
+		const m = parseFont(raw);
+		const chars = m.chars.slice();
+		chars[0] = { ...chars[0], mu16TexturePageId: 5 };
+		expect(() => writeFont({ ...m, chars })).toThrow(/texture page/);
+	});
+
+	it('writer rejects an over-long typeface name instead of truncating it', () => {
+		const m = parseFont(raw);
+		expect(() => writeFont({ ...m, macTypefaceFamilyName: 'x'.repeat(128) })).toThrow(/char\[128\]/);
+	});
+
+	it('writer rejects a font with no texture pages', () => {
+		const m = parseFont(raw);
+		expect(() => writeFont({ ...m, texturePages: [] })).toThrow(/texture page/);
+	});
+
+	it('hash offsets recompute matches the game layout for a hand-built case', () => {
+		const glyph = (charId: number) => ({
+			charId,
+			mTopLeftUV: { x: 0, y: 0 },
+			mDimensionsUV: { x: 0, y: 0 },
+			mStart: { x: 0, y: 0 },
+			mfAdvance: 0,
+			mu16TexturePageId: 0,
+			mbIsLowerCaseScale: false,
+			mbIsRenderable: true,
+		});
+		// Buckets: 0x3000→0, 0x20→32, 0xA0→32, 0x41→65.
+		const h = computeHashOffsets([glyph(0x3000), glyph(0x20), glyph(0xa0), glyph(0x41)]);
+		expect(h[0]).toBe(0);
+		expect(h[1]).toBe(1); // bucket 0 holds one char
+		expect(h[32]).toBe(1);
+		expect(h[33]).toBe(3); // bucket 32 holds two chars
+		expect(h[65]).toBe(3);
+		expect(h[66]).toBe(4);
+		expect(h[128]).toBe(4);
+	});
+});
+
+describe('Font char add/remove (parser/writer level)', () => {
+	it('round-trips a model with an appended glyph through write→parse', () => {
+		const { raw } = loadFont('DEFAULT.FONT');
+		const m = parseFont(raw);
+		// Bucket of the last char must be >= the previous last to keep grouping;
+		// append into bucket 127 (0x7F), which is >= every existing bucket.
+		const chars = m.chars.concat([{
+			charId: 0xff,
+			mTopLeftUV: { x: 0.5, y: 0.5 },
+			mDimensionsUV: { x: 0.05, y: 0.05 },
+			mStart: { x: 0, y: 0 },
+			mfAdvance: 0.05,
+			mu16TexturePageId: 0,
+			mbIsLowerCaseScale: false,
+			mbIsRenderable: true,
+		}]);
+		const reparsed = parseFont(writeFont({ ...m, chars }));
+		expect(reparsed.chars.length).toBe(m.chars.length + 1);
+		expect(reparsed.chars[reparsed.chars.length - 1].charId).toBe(0xff);
+		// NOTE: payload-level only. Growing the char array moves the inline
+		// import table, so the bundle-level importOffset must be recomputed by
+		// the bundle writer — which is why the schema keeps the list fixed.
+	});
+});

--- a/src/lib/core/__tests__/massiveLookupTable.test.ts
+++ b/src/lib/core/__tests__/massiveLookupTable.test.ts
@@ -1,0 +1,130 @@
+// Gold coverage for parseMassiveLookupTable / writeMassiveLookupTable.
+//
+// One retail resource exists (example/MASSIVETABLE.BIN → MassiveTable): the
+// 20 ad placements of the Massive Incorporated in-game ad service. Values
+// pinned here were hand-decoded from the raw bytes before the parser existed.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+	parseMassiveLookupTable,
+	writeMassiveLookupTable,
+	makeEmptyMassiveItem,
+} from '../massiveLookupTable';
+import { parseBundle } from '../bundle';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const MASSIVE_LOOKUP_TABLE_TYPE_ID = 0x1001a;
+
+function loadRaw(): Uint8Array {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, 'example/MASSIVETABLE.BIN'));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const resources = bundle.resources.filter((r) => r.resourceTypeId === MASSIVE_LOOKUP_TABLE_TYPE_ID);
+	expect(resources.length).toBe(1);
+	return extractResourceRaw(buffer, bundle, resources[0]);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+const raw = loadRaw();
+
+describe('MassiveLookupTable gold values (example/MASSIVETABLE.BIN)', () => {
+	const m = parseMassiveLookupTable(raw);
+
+	it('decompresses to 0x510 bytes and decodes 20 ad placements', () => {
+		expect(raw.byteLength).toBe(0x510);
+		expect(m.items.length).toBe(20);
+	});
+
+	it('decodes item 0 — flat billboard quad in scene 0x891F7C15', () => {
+		const item = m.items[0];
+		expect(item.mBoundingBoxMin.x).toBeCloseTo(-8.006, 3);
+		expect(item.mBoundingBoxMin.y).toBe(0);
+		expect(item.mBoundingBoxMin.z).toBe(0);
+		expect(item.mBoundingBoxMax.x).toBeCloseTo(8.003, 3);
+		expect(item.mBoundingBoxMax.y).toBeCloseTo(7.9944, 3);
+		expect(item.mBoundingBoxMax.z).toBe(0);
+		expect(item.mSceneId).toBe(0x891f7c15n);
+		expect(item.miIEIndex).toBe(2);
+		expect(item.muRenderableIndex).toBe(0);
+	});
+
+	it('decodes item 19 — the one non-flat box, scene 0x670B0927', () => {
+		const item = m.items[19];
+		expect(item.mBoundingBoxMin.x).toBeCloseTo(-15.566, 3);
+		expect(item.mBoundingBoxMin.y).toBeCloseTo(-3.2386, 3);
+		expect(item.mBoundingBoxMin.z).toBeCloseTo(-0.0145, 3);
+		expect(item.mBoundingBoxMax.x).toBeCloseTo(15.863, 3);
+		expect(item.mSceneId).toBe(0x670b0927n);
+		expect(item.miIEIndex).toBe(-1);
+		expect(item.muRenderableIndex).toBe(19);
+	});
+
+	it('renderable indexes run 0..19 in disk order', () => {
+		expect(m.items.map((i) => i.muRenderableIndex)).toEqual(
+			Array.from({ length: 20 }, (_, i) => i),
+		);
+	});
+
+	it('IE indexes: items 0-9 carry slots 0..8 (item 4 skipped), 10-19 are -1', () => {
+		expect(m.items.map((i) => i.miIEIndex)).toEqual([
+			2, 0, 1, 3, -1, 4, 5, 6, 7, 8,
+			-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+		]);
+	});
+
+	it('runtime/unused lanes are zero in retail', () => {
+		expect(Array.from(m._pad08)).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+		for (const item of m.items) {
+			expect(item._minW).toBe(0);
+			expect(item._maxW).toBe(0);
+			expect(item._mpSubscriber).toBe(0);
+			expect(item._pad31.every((b) => b === 0)).toBe(true);
+		}
+	});
+});
+
+describe('MassiveLookupTable round-trip', () => {
+	it('round-trips byte-for-byte and the writer is idempotent', () => {
+		const first = writeMassiveLookupTable(parseMassiveLookupTable(raw));
+		expect(bytesEqual(first, raw)).toBe(true);
+		const second = writeMassiveLookupTable(parseMassiveLookupTable(first));
+		expect(bytesEqual(second, first)).toBe(true);
+	});
+
+	it('appending an item survives a model round-trip with counts re-derived', () => {
+		const m = parseMassiveLookupTable(raw);
+		const added = { ...makeEmptyMassiveItem(), mSceneId: 0xdeadbeefn, miIEIndex: 9 };
+		const reparsed = parseMassiveLookupTable(
+			writeMassiveLookupTable({ ...m, items: [...m.items, added] }),
+		);
+		expect(reparsed.items.length).toBe(21);
+		expect(reparsed.items[20].mSceneId).toBe(0xdeadbeefn);
+		expect(reparsed.items[20].miIEIndex).toBe(9);
+	});
+
+	it('parser rejects a truncated resource (items must tile exactly)', () => {
+		expect(() => parseMassiveLookupTable(raw.slice(0, raw.byteLength - 0x10))).toThrow(/resource is/);
+	});
+
+	it('parser rejects a relocated item array', () => {
+		const broken = new Uint8Array(raw);
+		broken[4] = 0x20; // mpItems 0x10 → 0x20
+		expect(() => parseMassiveLookupTable(broken)).toThrow(/mpItems/);
+	});
+
+	it('writer rejects malformed verbatim pads', () => {
+		const m = parseMassiveLookupTable(raw);
+		expect(() => writeMassiveLookupTable({ ...m, _pad08: new Uint8Array(4) })).toThrow(/_pad08/);
+		const badItem = { ...m.items[0], _pad31: new Uint8Array(3) };
+		expect(() => writeMassiveLookupTable({ ...m, items: [badItem, ...m.items.slice(1)] })).toThrow(/_pad31/);
+	});
+});

--- a/src/lib/core/__tests__/soundRegistry.test.ts
+++ b/src/lib/core/__tests__/soundRegistry.test.ts
@@ -1,0 +1,317 @@
+// Gold coverage for parseRegistry / writeRegistry (resource type 0xA000).
+//
+// Two retail fixtures with deliberately different shapes:
+//  - PLAYBACKREGISTRY.BUNDLE: 27 entities across FIVE payload kinds
+//    (ContentClass / ContentType / SlotSchema / ParameterSchema /
+//    FeatureSchema) — the playback graph vocabulary.
+//  - RWACFEATUREREGISTRY.BUNDLE: 21 entities of ONE kind, the wiki-
+//    undocumented ~GenericRwacFeatureImplementation~ — concrete DSP features
+//    with uninitialised 0xCDCD pads that must survive verbatim.
+// The two cross-reference each other (GinsuPlayer's FeatureSchema parameter
+// list matches its RWAC implementation's bindings), pinned below.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+	parseRegistry,
+	writeRegistry,
+	soundHash,
+	registrySlotOf,
+	makeEmptyRegistryEntity,
+	REGISTRY_TYPE_HASHES,
+	type ParsedRegistry,
+	type RegistryEntity,
+} from '../soundRegistry';
+import { parseBundle } from '../bundle';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const REGISTRY_TYPE_ID = 0xa000;
+
+function loadRaw(bundleFile: string): Uint8Array {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const resources = bundle.resources.filter((r) => r.resourceTypeId === REGISTRY_TYPE_ID);
+	expect(resources.length).toBe(1);
+	return extractResourceRaw(buffer, bundle, resources[0]);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+function byName(m: ParsedRegistry, name: string): RegistryEntity {
+	const h = soundHash(name);
+	const e = m.entities.find((x) => x.mName === h);
+	expect(e, name).toBeDefined();
+	return e!;
+}
+
+const playbackRaw = loadRaw('example/PLAYBACKREGISTRY.BUNDLE');
+const rwacRaw = loadRaw('example/RWACFEATUREREGISTRY.BUNDLE');
+
+describe('soundHash (CgsSound::Playback::Name::MakeHash)', () => {
+	it('reproduces the wiki-documented type-name hashes', () => {
+		expect(soundHash('~ParameterSchema~')).toBe(0x8d2c6829);
+		expect(soundHash('~ContentSpec~')).toBe(0x511a448b);
+		expect(soundHash('~FeatureSchema~')).toBe(0xcb8b64c5);
+		expect(soundHash('~VoiceSchema~')).toBe(0xc7382281);
+		expect(soundHash('~SlotSchema~')).toBe(0xeb396d83);
+		expect(soundHash('~VoiceSpec~')).toBe(0x3597ad9b);
+	});
+
+	it('reproduces the wiki-UNdocumented type-name hashes seen in retail', () => {
+		expect(soundHash('~ContentClass~')).toBe(REGISTRY_TYPE_HASHES.CONTENT_CLASS);
+		expect(soundHash('~ContentType~')).toBe(REGISTRY_TYPE_HASHES.CONTENT_TYPE);
+		expect(soundHash('~GenericRwacFeatureImplementation~')).toBe(REGISTRY_TYPE_HASHES.RWAC_FEATURE);
+	});
+
+	it('is NOT case-folded (unlike CgsID)', () => {
+		expect(soundHash('GinsuPlayer')).toBe(0x720b821b);
+		expect(soundHash('GINSUPLAYER')).not.toBe(0x720b821b);
+	});
+});
+
+describe('Registry gold values — PLAYBACKREGISTRY.BUNDLE', () => {
+	const m = parseRegistry(playbackRaw);
+
+	it('decodes the header shape: 0x800-slot table, mask 0x7FF', () => {
+		expect(playbackRaw.byteLength).toBe(0x2580);
+		expect(m.mu32EntityCapacity).toBe(0x800);
+		expect(m.muNameHashMask).toBe(0x7ff);
+		expect(m.entities.length).toBe(27);
+		expect(m.strings.length).toBe(35);
+	});
+
+	it('carries five payload kinds: 5 classes, 5 types, 4 slots, 9 params, 4 features', () => {
+		const count = (pred: (e: RegistryEntity) => boolean) => m.entities.filter(pred).length;
+		expect(count((e) => e.mTypeName === REGISTRY_TYPE_HASHES.CONTENT_CLASS)).toBe(5);
+		expect(count((e) => e.mTypeName === REGISTRY_TYPE_HASHES.CONTENT_TYPE)).toBe(5);
+		expect(count((e) => e.mTypeName === REGISTRY_TYPE_HASHES.SLOT_SCHEMA)).toBe(4);
+		expect(count((e) => e.parameterSchema != null)).toBe(9);
+		expect(count((e) => e.featureSchema != null)).toBe(4);
+		expect(count((e) => e.rwacFeature != null)).toBe(0);
+		expect(count((e) => e._unknownPayload != null)).toBe(0);
+	});
+
+	it('every entity name hash resolves to a string in the pool', () => {
+		const pool = new Set(m.strings.map(soundHash));
+		for (const e of m.entities) {
+			expect(pool.has(e.mName), `0x${e.mName.toString(16)}`).toBe(true);
+			expect(pool.has(e.mTypeName)).toBe(true);
+		}
+	});
+
+	it('the pool also registers type names never instantiated here', () => {
+		expect(m.strings).toContain('~ContentSpec~');
+		expect(m.strings).toContain('~VoiceSchema~');
+		expect(m.strings).toContain('~VoiceSpec~');
+	});
+
+	it('entity 0 is the wave-data ContentClass (no payload)', () => {
+		expect(m.entities[0].mName).toBe(soundHash('~Content::SK_WAVE_DATA_CLASS~'));
+		expect(m.entities[0].mTypeName).toBe(REGISTRY_TYPE_HASHES.CONTENT_CLASS);
+		expect(m.entities[0].mpContentClass).toBeNull();
+		expect(m.entities[0].parameterSchema).toBeNull();
+	});
+
+	it('ContentType / SlotSchema payloads reference ContentClass entities by name hash', () => {
+		// The wiki lists 0x7CCDA2E7 as a "ContentClass class value" — it is
+		// actually the NAME of this ContentType entity.
+		const waveType = byName(m, '~GenericRwacWaveContent::SK_WAVE_DATA_CONTENT_TYPE~');
+		expect(waveType.mTypeName).toBe(REGISTRY_TYPE_HASHES.CONTENT_TYPE);
+		expect(waveType.mpContentClass).toBe(soundHash('~Content::SK_WAVE_DATA_CLASS~'));
+
+		const playerSlot = byName(m, '~PlayerVoice::SK_PLAYER_SLOT_NAME~');
+		expect(playerSlot.mTypeName).toBe(REGISTRY_TYPE_HASHES.SLOT_SCHEMA);
+		expect(playerSlot.mpContentClass).toBe(soundHash('~Content::SK_WAVE_DATA_CLASS~'));
+	});
+
+	it('decodes ParameterSchema ranges and directions', () => {
+		const pitch = byName(m, '~GenericRwacPlayerVoice::SK_PLAYER_PARAMETER_PITCH~').parameterSchema!;
+		expect(pitch.mf32Minimum).toBe(0.125);
+		expect(pitch.mf32Maximum).toBe(8);
+		expect(pitch.mu32Direction).toBe(0);
+
+		const freq = byName(m, 'GinsuFrequency').parameterSchema!;
+		expect(freq.mf32Maximum).toBe(20000);
+
+		// "Get*" parameters are outputs — the only direction=1 in retail.
+		const getPitch = byName(m, 'GinsuGetCurrentPitch').parameterSchema!;
+		expect(getPitch.mu32Direction).toBe(1);
+		expect(m.entities.filter((e) => e.parameterSchema?.mu32Direction === 1).length).toBe(1);
+	});
+
+	it('decodes the GinsuPlayer FeatureSchema: 5 params then 1 slot, outCount 0', () => {
+		const ginsu = byName(m, 'GinsuPlayer').featureSchema!;
+		expect(ginsu.parameterHashes).toEqual([
+			soundHash('GinsuFrequency'),
+			soundHash('GinsuGetCurrentPitch'),
+			soundHash('GinsuSetPitch'),
+			soundHash('GinsuSetShuffleWidth'),
+			soundHash('GinsuPause'),
+		]);
+		expect(ginsu.slotHashes).toEqual([soundHash('GinsuSlot')]);
+		expect(ginsu.mu32OutputParamCount).toBe(0);
+	});
+
+	it('hash table: slot = (hash >> 1) & mask with linear probing on collision', () => {
+		// GinsuSetPitch and GinsuSetShuffleWidth share home slot 1473; the
+		// later-inserted (disk-order) entity was probed to 1474. The parser
+		// asserts the rebuilt table matches, so parse succeeding proves the
+		// rule — this just pins the collision so the fixture stays honest.
+		expect(registrySlotOf(soundHash('GinsuSetPitch'), m.muNameHashMask)).toBe(1473);
+		expect(registrySlotOf(soundHash('GinsuSetShuffleWidth'), m.muNameHashMask)).toBe(1473);
+		const pitchIdx = m.entities.findIndex((e) => e.mName === soundHash('GinsuSetPitch'));
+		const widthIdx = m.entities.findIndex((e) => e.mName === soundHash('GinsuSetShuffleWidth'));
+		expect(pitchIdx).toBeLessThan(widthIdx);
+	});
+});
+
+describe('Registry gold values — RWACFEATUREREGISTRY.BUNDLE', () => {
+	const m = parseRegistry(rwacRaw);
+
+	it('decodes 21 entities, all GenericRwacFeatureImplementation', () => {
+		expect(rwacRaw.byteLength).toBe(0x29e0);
+		expect(m.entities.length).toBe(21);
+		expect(m.strings.length).toBe(80);
+		for (const e of m.entities) {
+			expect(e.mTypeName).toBe(REGISTRY_TYPE_HASHES.RWAC_FEATURE);
+			expect(e.rwacFeature).not.toBeNull();
+			// Uninitialised allocator fill, preserved verbatim.
+			expect(e.rwacFeature!._uninit08).toBe(0xcdcdcdcd);
+		}
+	});
+
+	it('decodes Panning: one Pn21 block exposing 7 parameters, no slots', () => {
+		const panning = byName(m, 'Panning').rwacFeature!;
+		expect(panning.blocks).toEqual([{ code: 'Pn21', mUnknown04: 0, mUnknown08: 6 }]);
+		expect(panning.params.length).toBe(7);
+		expect(panning.slots.length).toBe(0);
+		expect(panning.params[0]).toEqual({
+			mParamName: soundHash('PanningAngle'),
+			mu16BlockIndex: 0,
+			mu16ParamIndex: 0,
+		});
+		expect(panning.params[6].mParamName).toBe(soundHash('PanningLfeLevel'));
+	});
+
+	it('SimplePanning reuses the Pn21 block with a sparse parameter subset', () => {
+		const simple = byName(m, 'SimplePanning').rwacFeature!;
+		expect(simple.blocks[0].code).toBe('Pn21');
+		expect(simple.params.map((p) => p.mu16ParamIndex)).toEqual([0, 1, 4, 5, 6]);
+		expect(simple.params[4].mParamName).toBe(soundHash('SimplePanningLfeLevel'));
+	});
+
+	it('decodes GinsuPlayer: three DSP blocks with cross-block param bindings', () => {
+		const ginsu = byName(m, 'GinsuPlayer').rwacFeature!;
+		expect(ginsu.blocks.map((b) => b.code)).toEqual(['Gns0', 'Rsp0', 'Pau0']);
+		const binding = (name: string) => ginsu.params.find((p) => p.mParamName === soundHash(name))!;
+		// Semantically coherent routing: SetPitch drives the resampler block,
+		// Pause drives the pause block, the rest live on the Ginsu block.
+		expect(binding('GinsuSetPitch')).toMatchObject({ mu16BlockIndex: 1, mu16ParamIndex: 0 });
+		expect(binding('GinsuPause')).toMatchObject({ mu16BlockIndex: 2, mu16ParamIndex: 0 });
+		expect(binding('GinsuGetCurrentPitch')).toMatchObject({ mu16BlockIndex: 0, mu16ParamIndex: 2 });
+		expect(ginsu.slots).toEqual([{
+			mSlotName: soundHash('GinsuSlot'),
+			mSlotClass: soundHash('~GinsuSlot~'),
+			mu16Index: 0,
+			_pad0A: 0xcdcd,
+		}]);
+	});
+
+	it('StreamingPlayer streams through JStr → Rch0 → Rsp0', () => {
+		const streaming = byName(m, 'StreamingPlayer').rwacFeature!;
+		expect(streaming.blocks.map((b) => b.code)).toEqual(['JStr', 'Rch0', 'Rsp0']);
+		expect(streaming.slots[0].mSlotClass).toBe(soundHash('~GenericRwacContentSlot~'));
+	});
+});
+
+describe('Registry cross-fixture relationships', () => {
+	it('GinsuPlayer schema (playback) and implementation (rwac) agree on the parameter list', () => {
+		const schema = byName(parseRegistry(playbackRaw), 'GinsuPlayer').featureSchema!;
+		const impl = byName(parseRegistry(rwacRaw), 'GinsuPlayer').rwacFeature!;
+		expect(impl.params.map((p) => p.mParamName)).toEqual(schema.parameterHashes);
+		expect(impl.slots.map((s) => s.mSlotName)).toEqual(schema.slotHashes);
+	});
+
+	it('SK_PLAYER_FEATURE exists in both registries under the same name hash', () => {
+		const name = soundHash('~GenericRwacPlayerVoice::SK_PLAYER_FEATURE~');
+		expect(byName(parseRegistry(playbackRaw), '~GenericRwacPlayerVoice::SK_PLAYER_FEATURE~').mName).toBe(name);
+		const impl = byName(parseRegistry(rwacRaw), '~GenericRwacPlayerVoice::SK_PLAYER_FEATURE~');
+		expect(impl.rwacFeature!.blocks.map((b) => b.code)).toEqual(['SnP1', 'Rch0', 'Rsp0']);
+	});
+});
+
+describe('Registry round-trip', () => {
+	for (const [label, raw] of [
+		['PLAYBACKREGISTRY', playbackRaw],
+		['RWACFEATUREREGISTRY', rwacRaw],
+	] as const) {
+		it(`round-trips ${label} byte-for-byte and the writer is idempotent`, () => {
+			const first = writeRegistry(parseRegistry(raw));
+			expect(bytesEqual(first, raw)).toBe(true);
+			const second = writeRegistry(parseRegistry(first));
+			expect(bytesEqual(second, first)).toBe(true);
+		});
+	}
+
+	it('an undecoded entity type round-trips its payload verbatim', () => {
+		const m = parseRegistry(playbackRaw);
+		const added: RegistryEntity = {
+			...makeEmptyRegistryEntity(),
+			mName: soundHash('StewardSynthetic'),
+			mTypeName: REGISTRY_TYPE_HASHES.CONTENT_SPEC,
+			_unknownPayload: new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0x01]),
+		};
+		const reparsed = parseRegistry(writeRegistry({ ...m, entities: [...m.entities, added] }));
+		const back = reparsed.entities[reparsed.entities.length - 1];
+		expect(back.mName).toBe(soundHash('StewardSynthetic'));
+		expect(Array.from(back._unknownPayload!)).toEqual([0xde, 0xad, 0xbe, 0xef, 0x01]);
+	});
+
+	it('appending a string re-derives sizes and the 16-byte trailing pad', () => {
+		const m = parseRegistry(playbackRaw);
+		const written = writeRegistry({ ...m, strings: [...m.strings, 'StewardProbe'] });
+		expect(written.byteLength % 16).toBe(0);
+		const reparsed = parseRegistry(written);
+		expect(reparsed.strings[reparsed.strings.length - 1]).toBe('StewardProbe');
+	});
+
+	it('writer rejects a mask that is not capacity-1', () => {
+		const m = parseRegistry(playbackRaw);
+		expect(() => writeRegistry({ ...m, muNameHashMask: 0x7fe })).toThrow(/muNameHashMask/);
+	});
+
+	it('writer rejects a DSP block code that is not 4 chars', () => {
+		const m = parseRegistry(rwacRaw);
+		const feature = m.entities[0].rwacFeature!;
+		const broken = {
+			...m.entities[0],
+			rwacFeature: { ...feature, blocks: [{ ...feature.blocks[0], code: 'Pn215' }] },
+		};
+		expect(() => writeRegistry({ ...m, entities: [broken, ...m.entities.slice(1)] })).toThrow(/4 characters/);
+	});
+
+	it('parser rejects a corrupted hash-table slot', () => {
+		const broken = new Uint8Array(playbackRaw);
+		// Move the first occupied slot's pointer to an empty neighbour — the
+		// rebuilt table no longer matches.
+		const dv = new DataView(broken.buffer);
+		for (let slot = 0; slot < 0x800; slot++) {
+			const at = 0x1c + slot * 4;
+			const v = dv.getUint32(at, true);
+			if (v !== 0) {
+				dv.setUint32(at, 0, true);
+				dv.setUint32(at + 4, v, true);
+				break;
+			}
+		}
+		expect(() => parseRegistry(broken)).toThrow();
+	});
+});

--- a/src/lib/core/colourCube.ts
+++ b/src/lib/core/colourCube.ts
@@ -1,0 +1,139 @@
+// ColourCube parser and writer (resource type 0x2B, rw::graphics::postfx::ColourCube).
+//
+// A ColourCube is a 3D CLUT (colour look-up table) used by EnvironmentSettings
+// and PostFX to grade and tone-map the whole frame: the renderer feeds each
+// output pixel's RGB through the cube, with input Red indexing the X axis,
+// Green the Y axis, and Blue the Z axis (verified on retail bytes — the
+// (max,0,0) corner texel is pure red, (0,max,0) pure green, (0,0,max) pure
+// blue, so a neutral cube maps every colour to itself).
+//
+// On-disk layout (32-bit PC, little-endian):
+//   0x00  u32  m_size    — texels per axis (retail: 32)
+//   0x04  u32  m_pixels  — file-relative offset of the texel data, fixed up
+//                          to a pointer at load. Always 0x10.
+//   0x08  u32×2          — header pad to 16 bytes (0 in retail)
+//   0x10  u8[m_size³ × 3] — dense RGB24 body, X-major:
+//                          texel(x,y,z) at (m_size²·z + m_size·y + x) × 3
+//
+// The wiki's 32-bit struct only documents the first 8 bytes, but its own
+// file-size formula (m_size³ × 3 + 16) implies the 16-byte header — confirmed
+// against every fixture (m_size 32 → 98 320 bytes exactly).
+//
+// All four retail DLC24HR fixtures carry the SAME payload: a "default RGB
+// CLUT" (the 1.6 update reverted the art-style cubes to one, per the wiki).
+// That default is perfectly separable — texel(x,y,z) = (ramp[x], ramp[y],
+// ramp[z]) for a single shared 32-entry S-curve ramp — i.e. just a per-channel
+// tone curve, no cross-channel grading.
+//
+// Round-trip strategy: the body is opaque bytes preserved verbatim; m_pixels
+// is recomputed (always 0x10) and asserted on read; the header pad words are
+// preserved verbatim in _-prefixed fields. Byte-exact by construction.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type ParsedColourCube = {
+	/** Texels per axis — the cube holds mSize³ RGB24 texels. Retail: 32. */
+	mSize: number;
+	/** Dense RGB24 body, mSize³ × 3 bytes, X-major (see file header). */
+	pixels: Uint8Array;
+	/** Header pad words at 0x8 / 0xC (0 in retail) — preserved verbatim. */
+	_pad08: number;
+	_pad0C: number;
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+export const COLOURCUBE_HEADER_SIZE = 0x10;
+const BYTES_PER_TEXEL = 3;
+
+// =============================================================================
+// Texel access — shared by the preview path, stress scenarios, and tests.
+// =============================================================================
+
+function texelByteOffset(model: ParsedColourCube, x: number, y: number, z: number): number {
+	const s = model.mSize;
+	if (!Number.isInteger(x) || !Number.isInteger(y) || !Number.isInteger(z)
+		|| x < 0 || y < 0 || z < 0 || x >= s || y >= s || z >= s) {
+		throw new Error(`ColourCube: texel (${x},${y},${z}) outside the ${s}^3 cube`);
+	}
+	return (s * s * z + s * y + x) * BYTES_PER_TEXEL;
+}
+
+/** Output colour for LUT coordinate (x,y,z) — input R selects x, G y, B z. */
+export function colourCubeTexel(
+	model: ParsedColourCube, x: number, y: number, z: number,
+): { r: number; g: number; b: number } {
+	const off = texelByteOffset(model, x, y, z);
+	return { r: model.pixels[off], g: model.pixels[off + 1], b: model.pixels[off + 2] };
+}
+
+/** Overwrite one texel in place (callers own cloning; stress runners pass clones). */
+export function setColourCubeTexel(
+	model: ParsedColourCube, x: number, y: number, z: number,
+	rgb: { r: number; g: number; b: number },
+): void {
+	const off = texelByteOffset(model, x, y, z);
+	model.pixels[off] = rgb.r & 0xff;
+	model.pixels[off + 1] = rgb.g & 0xff;
+	model.pixels[off + 2] = rgb.b & 0xff;
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+export function parseColourCube(raw: Uint8Array, littleEndian = true): ParsedColourCube {
+	if (raw.byteLength < COLOURCUBE_HEADER_SIZE) {
+		throw new Error(`ColourCube: ${raw.byteLength} bytes is smaller than the 0x10 header`);
+	}
+	const r = new BinReader(raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength), littleEndian);
+	const mSize = r.readU32();
+	const mPixels = r.readU32();
+	const _pad08 = r.readU32();
+	const _pad0C = r.readU32();
+
+	// The layout is rigid; bail loudly on violations rather than silently
+	// producing a model that won't round-trip.
+	if (mPixels !== COLOURCUBE_HEADER_SIZE) {
+		throw new Error(`ColourCube: m_pixels is 0x${mPixels.toString(16)}, expected 0x10 (rigid layout)`);
+	}
+	const expectedSize = COLOURCUBE_HEADER_SIZE + mSize * mSize * mSize * BYTES_PER_TEXEL;
+	if (raw.byteLength !== expectedSize) {
+		throw new Error(`ColourCube: resource is ${raw.byteLength} bytes, expected ${expectedSize} for m_size ${mSize} (m_size^3*3+16)`);
+	}
+
+	// Copy, never view: extractResourceRaw can hand back a Node Buffer whose
+	// .slice/.subarray alias the bundle bytes — a view would let texel edits
+	// corrupt the source buffer.
+	const pixels = new Uint8Array(raw.subarray(COLOURCUBE_HEADER_SIZE, expectedSize));
+
+	return { mSize, pixels, _pad08, _pad0C };
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+export function writeColourCube(model: ParsedColourCube, littleEndian = true): Uint8Array {
+	const expectedPixelBytes = model.mSize * model.mSize * model.mSize * BYTES_PER_TEXEL;
+	if (model.pixels.byteLength !== expectedPixelBytes) {
+		throw new Error(`ColourCube writer: ${model.pixels.byteLength} pixel bytes != m_size ${model.mSize} cube (${expectedPixelBytes})`);
+	}
+
+	const w = new BinWriter(COLOURCUBE_HEADER_SIZE + expectedPixelBytes, littleEndian);
+	w.writeU32(model.mSize);
+	w.writeU32(COLOURCUBE_HEADER_SIZE); // m_pixels — recomputed, never stored
+	w.writeU32(model._pad08);
+	w.writeU32(model._pad0C);
+	if (w.offset !== COLOURCUBE_HEADER_SIZE) {
+		throw new Error(`ColourCube writer: header offset mismatch ${w.offset} vs ${COLOURCUBE_HEADER_SIZE}`);
+	}
+	w.writeBytes(model.pixels);
+	return w.bytes;
+}

--- a/src/lib/core/environmentDictionary.ts
+++ b/src/lib/core/environmentDictionary.ts
@@ -1,0 +1,217 @@
+// EnvironmentDictionary parser and writer (resource type 0x10014).
+//
+// The single ENV_DICTIONARY resource (ENVIRONMENTSETTINGS/DICTIONARY.BUNDLE)
+// is the game's catalogue of environment-settings "seasons" — weather/time-of-
+// day looks like SUN, OC (overcast), FOG — plus the list of locations the
+// per-season keyframes are authored for. Each SeasonData row names:
+//   - macResourceName: the debug name of the EnvironmentTimeLine (0x10013)
+//     resource inside the season's bundle (ENV_TL_<season>). Resource IDs in
+//     Burnout Paradise are CRC32 of the lowercased debug name, so
+//     crc32(lower(macResourceName)) is the timeline's resource id — that is
+//     how the game finds the timeline after loading the bundle.
+//   - macBundle: game-relative path (backslash separators, e.g.
+//     "EnvironmentSettings\000_DLC24hr_SUN_A.bundle") of the bundle carrying
+//     the timeline (0x10013) + its keyframes (0x10012).
+//   - macColourCubesBundle: game-relative path of the matching colour-cube
+//     (post-process tint) texture bundle under EnvironmentSettings\ColourCubes.
+// LocationData rows are bare names ("city") matching the location segment of
+// keyframe debug names (ENV_KF_<season>_<location>_<time>).
+//
+// On-disk layout (32-bit PC, little-endian; wiki muVersion 2):
+//   0x00 u32 muVersion          — always 2
+//   0x04 u32 muSeasonCnt
+//   0x08 u32 mpSeasonDatii      — file-relative offset, always 0x20 (the 0x14
+//                                 header padded to 16-byte alignment)
+//   0x0C u32 muLocationCnt
+//   0x10 u32 mpLocationDatii    — 0x20 + muSeasonCnt * 0x100
+//   0x14 12B pad to 0x20        — zeros in retail; preserved verbatim
+//   SeasonData[muSeasonCnt]     — 0x100 each: char[128] macResourceName,
+//                                 char[64] macBundle, char[64] macColourCubesBundle
+//   LocationData[muLocationCnt] — 0x40 each: char[64] macName
+// The records tile the resource exactly; record sizes are all multiples of 16
+// so no trailing pad exists.
+//
+// Round-trip strategy: offsets/counts are recomputed from the arrays on write.
+// Fixed char arrays are NUL-terminated with all-zero tails in the fixture; the
+// parser THROWS on a non-zero tail (or a missing NUL) rather than silently
+// dropping bytes the writer's zero-fill could not reproduce.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type EnvironmentDictionarySeason = {
+	/** Debug name of the season's EnvironmentTimeLine (0x10013); crc32(lowercase) = its resource id. Max 127 chars. */
+	macResourceName: string;
+	/** Game-relative path of the season's settings bundle (backslash separators). Max 63 chars. */
+	macBundle: string;
+	/** Game-relative path of the season's colour-cube bundle. Max 63 chars. */
+	macColourCubesBundle: string;
+};
+
+export type EnvironmentDictionaryLocation = {
+	/** Location name matched against the keyframe debug names (ENV_KF_<season>_<location>_<time>). Max 63 chars. */
+	macName: string;
+};
+
+export type ParsedEnvironmentDictionary = {
+	/** Format version — 2 in retail; the parser rejects anything else. */
+	muVersion: number;
+	seasons: EnvironmentDictionarySeason[];
+	locations: EnvironmentDictionaryLocation[];
+	/** 12 header-alignment bytes at 0x14 (zeros in retail) — preserved verbatim. */
+	_headerPad: Uint8Array;
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const SUPPORTED_VERSION = 2;
+const HEADER_FIELDS_SIZE = 0x14;
+// SeasonData always starts at the 16-byte-aligned end of the header, even for
+// the (unobserved) zero-season shape — keeps the writer deterministic.
+const SEASONS_OFFSET = 0x20;
+const HEADER_PAD_SIZE = SEASONS_OFFSET - HEADER_FIELDS_SIZE;
+const SEASON_RECORD_SIZE = 0x100;
+const LOCATION_RECORD_SIZE = 0x40;
+export const SEASON_RESOURCE_NAME_CAP = 0x80;
+export const SEASON_BUNDLE_PATH_CAP = 0x40;
+export const LOCATION_NAME_CAP = 0x40;
+
+// =============================================================================
+// Fixed C-string helpers
+// =============================================================================
+
+function readFixedCString(bytes: Uint8Array, start: number, cap: number, what: string): string {
+	let end = start;
+	while (end < start + cap && bytes[end] !== 0) end++;
+	if (end === start + cap) {
+		throw new Error(`EnvironmentDictionary: ${what} has no NUL terminator within its ${cap}-byte field`);
+	}
+	for (let i = end; i < start + cap; i++) {
+		if (bytes[i] !== 0) {
+			throw new Error(
+				`EnvironmentDictionary: non-zero byte 0x${bytes[i].toString(16)} after the NUL of ${what} ` +
+				`(at +0x${(i - start).toString(16)}) — zero-fill write would not round-trip`,
+			);
+		}
+	}
+	return new TextDecoder().decode(bytes.subarray(start, end));
+}
+
+function writeFixedCString(w: BinWriter, value: string, cap: number, what: string): void {
+	const encoded = new TextEncoder().encode(value);
+	if (encoded.length > cap - 1) {
+		throw new Error(`EnvironmentDictionary writer: ${what} is ${encoded.length} bytes, max ${cap - 1} (+ NUL)`);
+	}
+	w.writeBytes(encoded);
+	w.writeZeroes(cap - encoded.length);
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+export function parseEnvironmentDictionary(raw: Uint8Array, littleEndian = true): ParsedEnvironmentDictionary {
+	// Copy up front: raw may be a Node Buffer whose .slice is a view.
+	const bytes = new Uint8Array(raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength));
+	const r = new BinReader(bytes.buffer, littleEndian);
+
+	const muVersion = r.readU32();
+	if (muVersion !== SUPPORTED_VERSION) {
+		throw new Error(`EnvironmentDictionary: unsupported muVersion ${muVersion} (expected ${SUPPORTED_VERSION})`);
+	}
+	const muSeasonCnt = r.readU32();
+	const mpSeasonDatii = r.readU32();
+	const muLocationCnt = r.readU32();
+	const mpLocationDatii = r.readU32();
+
+	// Rigid layout — bail loudly on violations rather than silently mis-parsing.
+	const locationsOffset = SEASONS_OFFSET + muSeasonCnt * SEASON_RECORD_SIZE;
+	const totalSize = locationsOffset + muLocationCnt * LOCATION_RECORD_SIZE;
+	if (mpSeasonDatii !== SEASONS_OFFSET) {
+		throw new Error(`EnvironmentDictionary: mpSeasonDatii is 0x${mpSeasonDatii.toString(16)}, expected 0x${SEASONS_OFFSET.toString(16)}`);
+	}
+	if (mpLocationDatii !== locationsOffset) {
+		throw new Error(
+			`EnvironmentDictionary: mpLocationDatii is 0x${mpLocationDatii.toString(16)}, ` +
+			`expected 0x${locationsOffset.toString(16)} for ${muSeasonCnt} seasons`,
+		);
+	}
+	if (totalSize !== bytes.byteLength) {
+		throw new Error(`EnvironmentDictionary: records end at 0x${totalSize.toString(16)}, resource is 0x${bytes.byteLength.toString(16)} bytes`);
+	}
+
+	const _headerPad = bytes.slice(HEADER_FIELDS_SIZE, SEASONS_OFFSET);
+
+	const seasons: EnvironmentDictionarySeason[] = [];
+	for (let i = 0; i < muSeasonCnt; i++) {
+		const base = SEASONS_OFFSET + i * SEASON_RECORD_SIZE;
+		seasons.push({
+			macResourceName: readFixedCString(bytes, base, SEASON_RESOURCE_NAME_CAP, `season[${i}].macResourceName`),
+			macBundle: readFixedCString(bytes, base + SEASON_RESOURCE_NAME_CAP, SEASON_BUNDLE_PATH_CAP, `season[${i}].macBundle`),
+			macColourCubesBundle: readFixedCString(
+				bytes,
+				base + SEASON_RESOURCE_NAME_CAP + SEASON_BUNDLE_PATH_CAP,
+				SEASON_BUNDLE_PATH_CAP,
+				`season[${i}].macColourCubesBundle`,
+			),
+		});
+	}
+
+	const locations: EnvironmentDictionaryLocation[] = [];
+	for (let i = 0; i < muLocationCnt; i++) {
+		const base = locationsOffset + i * LOCATION_RECORD_SIZE;
+		locations.push({
+			macName: readFixedCString(bytes, base, LOCATION_NAME_CAP, `location[${i}].macName`),
+		});
+	}
+
+	return { muVersion, seasons, locations, _headerPad };
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+export function writeEnvironmentDictionary(model: ParsedEnvironmentDictionary, littleEndian = true): Uint8Array {
+	const { seasons, locations } = model;
+	if (model._headerPad.byteLength !== HEADER_PAD_SIZE) {
+		throw new Error(`EnvironmentDictionary writer: _headerPad is ${model._headerPad.byteLength} bytes, expected ${HEADER_PAD_SIZE}`);
+	}
+
+	const locationsOffset = SEASONS_OFFSET + seasons.length * SEASON_RECORD_SIZE;
+	const totalSize = locationsOffset + locations.length * LOCATION_RECORD_SIZE;
+	const w = new BinWriter(totalSize, littleEndian);
+
+	w.writeU32(model.muVersion);
+	w.writeU32(seasons.length);
+	w.writeU32(SEASONS_OFFSET); // mpSeasonDatii
+	w.writeU32(locations.length);
+	w.writeU32(locationsOffset); // mpLocationDatii
+	w.writeBytes(model._headerPad);
+	if (w.offset !== SEASONS_OFFSET) {
+		throw new Error(`EnvironmentDictionary writer: header offset mismatch ${w.offset} vs ${SEASONS_OFFSET}`);
+	}
+
+	seasons.forEach((s, i) => {
+		writeFixedCString(w, s.macResourceName, SEASON_RESOURCE_NAME_CAP, `season[${i}].macResourceName`);
+		writeFixedCString(w, s.macBundle, SEASON_BUNDLE_PATH_CAP, `season[${i}].macBundle`);
+		writeFixedCString(w, s.macColourCubesBundle, SEASON_BUNDLE_PATH_CAP, `season[${i}].macColourCubesBundle`);
+	});
+	if (w.offset !== locationsOffset) {
+		throw new Error(`EnvironmentDictionary writer: locations offset mismatch ${w.offset} vs ${locationsOffset}`);
+	}
+
+	locations.forEach((l, i) => {
+		writeFixedCString(w, l.macName, LOCATION_NAME_CAP, `location[${i}].macName`);
+	});
+	if (w.offset !== totalSize) {
+		throw new Error(`EnvironmentDictionary writer: wrote ${w.offset} bytes, expected ${totalSize}`);
+	}
+
+	return w.bytes;
+}

--- a/src/lib/core/environmentSettings.ts
+++ b/src/lib/core/environmentSettings.ts
@@ -1,0 +1,626 @@
+// EnvironmentKeyframe (0x10012) + EnvironmentTimeLine (0x10013) parsers and
+// writers — the BrnWorld::EnvironmentSettings family (with EnvironmentDictionary
+// / 0x10014, see environmentDictionary.ts).
+//
+// A "season" bundle (ENVIRONMENTSETTINGS/000_*.BUNDLE) carries one TimeLine
+// plus its Keyframes. A Keyframe is a full snapshot of the environment look at
+// one time of day: bloom, vignette, post-process tint (a ColourCube texture),
+// atmospheric scattering (sky + in-scattering colour ramps), the eight-direction
+// fill-light rig, and the two cloud layers. The TimeLine is the schedule: per
+// location, an ascending list of (time-of-day seconds, keyframe) pairs the game
+// interpolates between as the clock advances. Fixture sweep (4 DLC24HR bundles,
+// 48 keyframes + 4 timelines): keyframe counts vary per season (8/11/12/17) and
+// every timeline has exactly ONE location ("city" — see the dictionary's
+// LocationData), whose entries cover all of that bundle's keyframes.
+//
+// Colour values are linear float RGB. Nominal range is 0–1 but fills and sky
+// colours go HDR-overbright (observed max ≈ 3.5 on lighting fills, ≈ 2.19 on
+// sky colours) — do not clamp to 1.
+//
+// Cross-resource references ride the BND2 INLINE import table at the tail of
+// each resource's own payload (entries: u64 resourceId, u32 ptrOffset, u32 pad;
+// the pointer-to-patch is 0 on disk):
+//   - Keyframe: exactly one import — the ColourCube (0x50) patched into
+//     TintData::mpColourCube at 0x80. Surfaced as mColourCubeId.
+//   - TimeLine: one import per keyframe, patched into the mppKeyframes pointer
+//     slots IN ORDER — so import i pairs with mpfKeyframeTimes[i]. Surfaced as
+//     keyframes[i].mKeyframeId (resource ids are crc32(lowercase debug name)).
+// The import table is part of the payload these writers emit, but the bundle
+// envelope's ResourceEntry.importOffset/importCount are separate metadata —
+// adding/removing timeline keyframes changes both, which the envelope writer
+// does not currently recompute. Field edits (times, colours, retargeting an
+// existing slot's id) are safe; count-changing edits need envelope support.
+//
+// Scope: 32-bit PC, little-endian, matching the rest of src/lib/core.
+//
+// Round-trip strategy: both layouts are rigid and fully derivable, so NOTHING
+// is preserved verbatim — every pad, unused vector lane, pointer slot, and
+// import patch-offset is asserted on parse (throwing on violations instead of
+// silently mis-parsing) and regenerated on write. Byte-exactness was verified
+// across every resource in all four fixture bundles.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type Vec2 = { x: number; y: number };
+export type Vec3 = { x: number; y: number; z: number };
+export type Vec4 = { x: number; y: number; z: number; w: number };
+
+export type EnvironmentBloomData = {
+	mfLuminance: number;
+	mfThreshold: number;
+	/** Per-channel bloom scale (RGB in xyz; w observed 0–1). */
+	mv4Scale: Vec4;
+};
+
+export type EnvironmentVignetteData = {
+	mfAngle: number;
+	mfSharpness: number;
+	mv2Amount: Vec2;
+	mv2Centre: Vec2;
+	/** Linear RGBA colour at the vignette centre. */
+	mv4InnerColour: Vec4;
+	/** Linear RGBA colour at the screen edges. */
+	mv4OuterColour: Vec4;
+};
+
+export type EnvironmentScatteringData = {
+	mv3SkyTopColour: Vec3;
+	mv3SkyHorColour: Vec3;
+	mv3SkySunColour: Vec3;
+	mfSkyHorPow: number;
+	mfSkySunPow: number;
+	mfSkyDrk: number;
+	mfSkyHorBleedScl: number;
+	mfSkyHorBleedPow: number;
+	mfSkySunBleedPow: number;
+	mv3ScattTopColour: Vec3;
+	mv3ScattHorColour: Vec3;
+	mv3ScattSunColour: Vec3;
+	mfScattHorPow: number;
+	mfScattSunPow: number;
+	mfScattDrk: number;
+	mfScattHorBleedScl: number;
+	mfScattHorBleedPow: number;
+	mfScattSunBleedPow: number;
+	/** Near/far in-scattering distances (world units; retail 1–2000). */
+	mafScattDist: number[]; // f32[2]
+	mfScattPow: number;
+	mfScattCap: number;
+};
+
+export type EnvironmentLightingData = {
+	mv3KeyLightColour: Vec3;
+	mv3SpecularColour: Vec3;
+	mv3KeyFillColour: Vec3;
+	mv3ShadowFillColour: Vec3;
+	mv3RightFillColour: Vec3;
+	mv3LeftFillColour: Vec3;
+	mv3UpFillColour: Vec3;
+	mv3DownFillColour: Vec3;
+	mfAmbientIrradianceScale: number;
+};
+
+export type EnvironmentCloudsData = {
+	/** Sun-lit colour per cloud layer. */
+	mav3LayerLiteColour: Vec3[]; // [2]
+	/** Shadowed colour per cloud layer. */
+	mav3LayerDarkColour: Vec3[]; // [2]
+	mafLayerDensity: number[]; // f32[2]
+	mafLayerFeathering: number[]; // f32[2]
+	mafLayerOpacity: number[]; // f32[2]
+	mafLayerSpeed: number[]; // f32[2]
+	mafLayerScale: number[]; // f32[2]
+	/** Cloud drift direction in degrees (retail 0–100). */
+	mfDirectionAngle: number;
+};
+
+export type ParsedEnvironmentKeyframe = {
+	/** Format version — 8 in retail; the parser rejects anything else. */
+	muVersion: number;
+	mBloomData: EnvironmentBloomData;
+	mVignetteData: EnvironmentVignetteData;
+	/** ColourCube (0x50) resource id from the inline import patching TintData::mpColourCube. */
+	mColourCubeId: bigint;
+	mScatteringData: EnvironmentScatteringData;
+	mLightingData: EnvironmentLightingData;
+	mCloudsData: EnvironmentCloudsData;
+};
+
+export type EnvironmentTimeLineKeyframe = {
+	/** Time of day in seconds (0–86400; 4:00 AM = 14400). */
+	mfTimeOfDay: number;
+	/** EnvironmentKeyframe (0x10012) resource id — crc32(lowercase debug name). */
+	mKeyframeId: bigint;
+};
+
+export type EnvironmentTimeLineLocation = {
+	/** Ascending schedule the game interpolates through as the clock advances. */
+	keyframes: EnvironmentTimeLineKeyframe[];
+};
+
+export type ParsedEnvironmentTimeLine = {
+	/** Format version — 1 in retail; the parser rejects anything else. */
+	muVersion: number;
+	/** Every retail timeline has exactly one location ("city"). */
+	locations: EnvironmentTimeLineLocation[];
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+export const ENVIRONMENT_KEYFRAME_TYPE_ID = 0x10012;
+export const ENVIRONMENT_TIME_LINE_TYPE_ID = 0x10013;
+
+export const ENVIRONMENT_KEYFRAME_VERSION = 8;
+export const ENVIRONMENT_TIME_LINE_VERSION = 1;
+
+const KEYFRAME_STRUCT_SIZE = 0x240;
+const IMPORT_ENTRY_SIZE = 0x10;
+const KEYFRAME_RAW_SIZE = KEYFRAME_STRUCT_SIZE + IMPORT_ENTRY_SIZE; // 0x250
+/** TintData::mpColourCube — the field the keyframe's single import patches. */
+const TINT_COLOUR_CUBE_OFFSET = 0x80;
+
+const TIMELINE_HEADER_SIZE = 0x10;
+const TIMELINE_LOCATION_SIZE = 0x0c;
+
+const align16 = (n: number) => (n + 15) & ~15;
+
+/** Seconds → "HH:MM" (clock time of day; appends ":SS" only when non-zero). */
+export function formatTimeOfDay(seconds: number): string {
+	const total = Math.round(seconds);
+	const h = Math.floor(total / 3600) % 24;
+	const m = Math.floor((total % 3600) / 60);
+	const s = ((total % 60) + 60) % 60;
+	const hm = `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+	return s !== 0 ? `${hm}:${s.toString().padStart(2, '0')}` : hm;
+}
+
+// =============================================================================
+// Shared helpers
+// =============================================================================
+
+// Zero checks read raw u32 bit patterns (not floats) so a -0.0 or NaN-payload
+// byte in a "pad" lane can't slip past the assert and break byte-exactness.
+function assertZeroWords(r: BinReader, words: number, what: string, type: string) {
+	for (let i = 0; i < words; i++) {
+		const v = r.readU32();
+		if (v !== 0) {
+			throw new Error(`${type}: ${what} has non-zero pad word 0x${v.toString(16)} — layout not as expected`);
+		}
+	}
+}
+
+// Vector3 occupies a full 0x10 vpu register on disk; the w lane is unused and
+// 0 in all 48 retail keyframes, so it is asserted instead of preserved.
+function readVec3(r: BinReader, what: string, type: string): Vec3 {
+	const x = r.readF32();
+	const y = r.readF32();
+	const z = r.readF32();
+	assertZeroWords(r, 1, `${what}.w`, type);
+	return { x, y, z };
+}
+
+function readVec4(r: BinReader): Vec4 {
+	return { x: r.readF32(), y: r.readF32(), z: r.readF32(), w: r.readF32() };
+}
+
+// Vector2 also occupies a full 0x10 register; lanes 2–3 unused, asserted 0.
+function readVec2(r: BinReader, what: string, type: string): Vec2 {
+	const x = r.readF32();
+	const y = r.readF32();
+	assertZeroWords(r, 2, `${what}.zw`, type);
+	return { x, y };
+}
+
+function writeVec3(w: BinWriter, v: Vec3) {
+	w.writeF32(v.x);
+	w.writeF32(v.y);
+	w.writeF32(v.z);
+	w.writeU32(0);
+}
+
+function writeVec4(w: BinWriter, v: Vec4) {
+	w.writeF32(v.x);
+	w.writeF32(v.y);
+	w.writeF32(v.z);
+	w.writeF32(v.w);
+}
+
+function writeVec2(w: BinWriter, v: Vec2) {
+	w.writeF32(v.x);
+	w.writeF32(v.y);
+	w.writeU32(0);
+	w.writeU32(0);
+}
+
+function readF32Pair(r: BinReader): number[] {
+	return [r.readF32(), r.readF32()];
+}
+
+function assertPair(arr: number[], what: string, type: string) {
+	if (arr.length !== 2) {
+		throw new Error(`${type} writer: ${what} has ${arr.length} entries, the on-disk array is fixed at 2`);
+	}
+}
+
+function checkOffset(actual: number, expected: number, what: string, type: string) {
+	if (actual !== expected) {
+		throw new Error(`${type}: ${what} at 0x${actual.toString(16)}, expected 0x${expected.toString(16)}`);
+	}
+}
+
+// =============================================================================
+// EnvironmentKeyframe (0x10012)
+// =============================================================================
+
+export function parseEnvironmentKeyframe(raw: Uint8Array, littleEndian = true): ParsedEnvironmentKeyframe {
+	const T = 'EnvironmentKeyframe';
+	if (raw.byteLength !== KEYFRAME_RAW_SIZE) {
+		throw new Error(`${T}: resource is 0x${raw.byteLength.toString(16)} bytes, expected 0x${KEYFRAME_RAW_SIZE.toString(16)} (fixed struct + one import entry)`);
+	}
+	const r = new BinReader(raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength), littleEndian);
+
+	const muVersion = r.readU32();
+	if (muVersion !== ENVIRONMENT_KEYFRAME_VERSION) {
+		throw new Error(`${T}: muVersion ${muVersion}, only version ${ENVIRONMENT_KEYFRAME_VERSION} is supported`);
+	}
+	assertZeroWords(r, 3, 'header pad', T);
+
+	// --- BloomData (0x10) ---
+	const mfLuminance = r.readF32();
+	const mfThreshold = r.readF32();
+	assertZeroWords(r, 2, 'bloom pad', T);
+	const mv4Scale = readVec4(r);
+
+	// --- VignetteData (0x30) ---
+	const mfAngle = r.readF32();
+	const mfSharpness = r.readF32();
+	assertZeroWords(r, 2, 'vignette pad', T);
+	const mv2Amount = readVec2(r, 'mv2Amount', T);
+	const mv2Centre = readVec2(r, 'mv2Centre', T);
+	const mv4InnerColour = readVec4(r);
+	const mv4OuterColour = readVec4(r);
+
+	// --- TintData (0x80) — mpColourCube is 0 on disk, patched by the import ---
+	checkOffset(r.position, TINT_COLOUR_CUBE_OFFSET, 'TintData', T);
+	assertZeroWords(r, 1, 'mpColourCube on-disk pointer', T);
+	assertZeroWords(r, 3, 'tint pad', T);
+
+	// --- ScatteringData (0x90) ---
+	const mv3SkyTopColour = readVec3(r, 'mv3SkyTopColour', T);
+	const mv3SkyHorColour = readVec3(r, 'mv3SkyHorColour', T);
+	const mv3SkySunColour = readVec3(r, 'mv3SkySunColour', T);
+	const mfSkyHorPow = r.readF32();
+	const mfSkySunPow = r.readF32();
+	const mfSkyDrk = r.readF32();
+	const mfSkyHorBleedScl = r.readF32();
+	const mfSkyHorBleedPow = r.readF32();
+	const mfSkySunBleedPow = r.readF32();
+	assertZeroWords(r, 2, 'scattering sky pad', T);
+	const mv3ScattTopColour = readVec3(r, 'mv3ScattTopColour', T);
+	const mv3ScattHorColour = readVec3(r, 'mv3ScattHorColour', T);
+	const mv3ScattSunColour = readVec3(r, 'mv3ScattSunColour', T);
+	const mfScattHorPow = r.readF32();
+	const mfScattSunPow = r.readF32();
+	const mfScattDrk = r.readF32();
+	const mfScattHorBleedScl = r.readF32();
+	const mfScattHorBleedPow = r.readF32();
+	const mfScattSunBleedPow = r.readF32();
+	const mafScattDist = readF32Pair(r);
+	const mfScattPow = r.readF32();
+	const mfScattCap = r.readF32();
+	assertZeroWords(r, 2, 'scattering tail pad', T);
+
+	// --- LightingData (0x140) ---
+	checkOffset(r.position, 0x140, 'LightingData', T);
+	const mv3KeyLightColour = readVec3(r, 'mv3KeyLightColour', T);
+	const mv3SpecularColour = readVec3(r, 'mv3SpecularColour', T);
+	const mv3KeyFillColour = readVec3(r, 'mv3KeyFillColour', T);
+	const mv3ShadowFillColour = readVec3(r, 'mv3ShadowFillColour', T);
+	const mv3RightFillColour = readVec3(r, 'mv3RightFillColour', T);
+	const mv3LeftFillColour = readVec3(r, 'mv3LeftFillColour', T);
+	const mv3UpFillColour = readVec3(r, 'mv3UpFillColour', T);
+	const mv3DownFillColour = readVec3(r, 'mv3DownFillColour', T);
+	const mfAmbientIrradianceScale = r.readF32();
+	assertZeroWords(r, 3, 'lighting pad', T);
+
+	// --- CloudsData (0x1D0) ---
+	checkOffset(r.position, 0x1d0, 'CloudsData', T);
+	const mav3LayerLiteColour = [readVec3(r, 'mav3LayerLiteColour[0]', T), readVec3(r, 'mav3LayerLiteColour[1]', T)];
+	const mav3LayerDarkColour = [readVec3(r, 'mav3LayerDarkColour[0]', T), readVec3(r, 'mav3LayerDarkColour[1]', T)];
+	const mafLayerDensity = readF32Pair(r);
+	const mafLayerFeathering = readF32Pair(r);
+	const mafLayerOpacity = readF32Pair(r);
+	const mafLayerSpeed = readF32Pair(r);
+	const mafLayerScale = readF32Pair(r);
+	const mfDirectionAngle = r.readF32();
+	assertZeroWords(r, 1, 'clouds pad', T);
+
+	// --- Inline import table: exactly one ColourCube entry ---
+	checkOffset(r.position, KEYFRAME_STRUCT_SIZE, 'import table', T);
+	const mColourCubeId = r.readU64();
+	const patchOffset = r.readU32();
+	if (patchOffset !== TINT_COLOUR_CUBE_OFFSET) {
+		throw new Error(`${T}: import patch offset 0x${patchOffset.toString(16)}, expected 0x${TINT_COLOUR_CUBE_OFFSET.toString(16)} (mpColourCube)`);
+	}
+	assertZeroWords(r, 1, 'import entry pad', T);
+
+	return {
+		muVersion,
+		mBloomData: { mfLuminance, mfThreshold, mv4Scale },
+		mVignetteData: { mfAngle, mfSharpness, mv2Amount, mv2Centre, mv4InnerColour, mv4OuterColour },
+		mColourCubeId,
+		mScatteringData: {
+			mv3SkyTopColour, mv3SkyHorColour, mv3SkySunColour,
+			mfSkyHorPow, mfSkySunPow, mfSkyDrk, mfSkyHorBleedScl, mfSkyHorBleedPow, mfSkySunBleedPow,
+			mv3ScattTopColour, mv3ScattHorColour, mv3ScattSunColour,
+			mfScattHorPow, mfScattSunPow, mfScattDrk, mfScattHorBleedScl, mfScattHorBleedPow, mfScattSunBleedPow,
+			mafScattDist, mfScattPow, mfScattCap,
+		},
+		mLightingData: {
+			mv3KeyLightColour, mv3SpecularColour, mv3KeyFillColour, mv3ShadowFillColour,
+			mv3RightFillColour, mv3LeftFillColour, mv3UpFillColour, mv3DownFillColour,
+			mfAmbientIrradianceScale,
+		},
+		mCloudsData: {
+			mav3LayerLiteColour, mav3LayerDarkColour,
+			mafLayerDensity, mafLayerFeathering, mafLayerOpacity, mafLayerSpeed, mafLayerScale,
+			mfDirectionAngle,
+		},
+	};
+}
+
+export function writeEnvironmentKeyframe(model: ParsedEnvironmentKeyframe, littleEndian = true): Uint8Array {
+	const T = 'EnvironmentKeyframe';
+	if (model.muVersion !== ENVIRONMENT_KEYFRAME_VERSION) {
+		throw new Error(`${T} writer: muVersion ${model.muVersion}, only version ${ENVIRONMENT_KEYFRAME_VERSION} is supported`);
+	}
+	const { mBloomData: b, mVignetteData: v, mScatteringData: s, mLightingData: l, mCloudsData: c } = model;
+	assertPair(s.mafScattDist, 'mafScattDist', T);
+	for (const [name, arr] of [
+		['mav3LayerLiteColour', c.mav3LayerLiteColour],
+		['mav3LayerDarkColour', c.mav3LayerDarkColour],
+		['mafLayerDensity', c.mafLayerDensity],
+		['mafLayerFeathering', c.mafLayerFeathering],
+		['mafLayerOpacity', c.mafLayerOpacity],
+		['mafLayerSpeed', c.mafLayerSpeed],
+		['mafLayerScale', c.mafLayerScale],
+	] as const) {
+		assertPair(arr as number[], name, T);
+	}
+
+	const w = new BinWriter(KEYFRAME_RAW_SIZE, littleEndian);
+	w.writeU32(ENVIRONMENT_KEYFRAME_VERSION);
+	w.writeZeroes(0xc);
+
+	w.writeF32(b.mfLuminance);
+	w.writeF32(b.mfThreshold);
+	w.writeZeroes(8);
+	writeVec4(w, b.mv4Scale);
+
+	w.writeF32(v.mfAngle);
+	w.writeF32(v.mfSharpness);
+	w.writeZeroes(8);
+	writeVec2(w, v.mv2Amount);
+	writeVec2(w, v.mv2Centre);
+	writeVec4(w, v.mv4InnerColour);
+	writeVec4(w, v.mv4OuterColour);
+
+	checkOffset(w.offset, TINT_COLOUR_CUBE_OFFSET, 'writer TintData', T);
+	w.writeU32(0); // mpColourCube — patched at load from the import entry below
+	w.writeZeroes(0xc);
+
+	writeVec3(w, s.mv3SkyTopColour);
+	writeVec3(w, s.mv3SkyHorColour);
+	writeVec3(w, s.mv3SkySunColour);
+	w.writeF32(s.mfSkyHorPow);
+	w.writeF32(s.mfSkySunPow);
+	w.writeF32(s.mfSkyDrk);
+	w.writeF32(s.mfSkyHorBleedScl);
+	w.writeF32(s.mfSkyHorBleedPow);
+	w.writeF32(s.mfSkySunBleedPow);
+	w.writeZeroes(8);
+	writeVec3(w, s.mv3ScattTopColour);
+	writeVec3(w, s.mv3ScattHorColour);
+	writeVec3(w, s.mv3ScattSunColour);
+	w.writeF32(s.mfScattHorPow);
+	w.writeF32(s.mfScattSunPow);
+	w.writeF32(s.mfScattDrk);
+	w.writeF32(s.mfScattHorBleedScl);
+	w.writeF32(s.mfScattHorBleedPow);
+	w.writeF32(s.mfScattSunBleedPow);
+	w.writeF32(s.mafScattDist[0]);
+	w.writeF32(s.mafScattDist[1]);
+	w.writeF32(s.mfScattPow);
+	w.writeF32(s.mfScattCap);
+	w.writeZeroes(8);
+
+	checkOffset(w.offset, 0x140, 'writer LightingData', T);
+	writeVec3(w, l.mv3KeyLightColour);
+	writeVec3(w, l.mv3SpecularColour);
+	writeVec3(w, l.mv3KeyFillColour);
+	writeVec3(w, l.mv3ShadowFillColour);
+	writeVec3(w, l.mv3RightFillColour);
+	writeVec3(w, l.mv3LeftFillColour);
+	writeVec3(w, l.mv3UpFillColour);
+	writeVec3(w, l.mv3DownFillColour);
+	w.writeF32(l.mfAmbientIrradianceScale);
+	w.writeZeroes(0xc);
+
+	checkOffset(w.offset, 0x1d0, 'writer CloudsData', T);
+	writeVec3(w, c.mav3LayerLiteColour[0]);
+	writeVec3(w, c.mav3LayerLiteColour[1]);
+	writeVec3(w, c.mav3LayerDarkColour[0]);
+	writeVec3(w, c.mav3LayerDarkColour[1]);
+	for (const arr of [c.mafLayerDensity, c.mafLayerFeathering, c.mafLayerOpacity, c.mafLayerSpeed, c.mafLayerScale]) {
+		w.writeF32(arr[0]);
+		w.writeF32(arr[1]);
+	}
+	w.writeF32(c.mfDirectionAngle);
+	w.writeU32(0);
+
+	checkOffset(w.offset, KEYFRAME_STRUCT_SIZE, 'writer import table', T);
+	w.writeU64(model.mColourCubeId);
+	w.writeU32(TINT_COLOUR_CUBE_OFFSET);
+	w.writeU32(0);
+
+	checkOffset(w.offset, KEYFRAME_RAW_SIZE, 'writer end', T);
+	return w.bytes;
+}
+
+// =============================================================================
+// EnvironmentTimeLine (0x10013)
+// =============================================================================
+
+// Canonical layout (every fixture matches; the parser THROWS on any other):
+//   header(0x10: version, locationCnt, mpLocationDatii=0x10, pad) →
+//   LocationData[N] (0xC each: cnt, mpfKeyframeTimes, mppKeyframes, packed) →
+//   per location, each segment align16 with zero gaps:
+//     mppKeyframes slots (u32[cnt], 0 on disk — patched from imports) →
+//     mpfKeyframeTimes (f32[cnt]) →
+//   import table (cnt entries per location, patching the pointer slots in
+//   order — which is what pins keyframes[i] to times[i]).
+// With N=1 the bytes cannot distinguish "0xC-packed locations + align16" from
+// a 0x10 location stride; the asserts below would catch a multi-location
+// resource that disagrees with this reading.
+
+type TimeLineLayout = {
+	locationHeaders: { cnt: number; timesPtr: number; kfPtr: number }[];
+	importOffset: number;
+	totalKeyframes: number;
+};
+
+function timeLineCanonicalLayout(counts: number[]): TimeLineLayout {
+	let cursor = align16(TIMELINE_HEADER_SIZE + TIMELINE_LOCATION_SIZE * counts.length);
+	const locationHeaders = counts.map((cnt) => {
+		const kfPtr = cursor;
+		cursor = align16(kfPtr + 4 * cnt);
+		const timesPtr = cursor;
+		cursor = align16(timesPtr + 4 * cnt);
+		return { cnt, timesPtr, kfPtr };
+	});
+	return {
+		locationHeaders,
+		importOffset: cursor,
+		totalKeyframes: counts.reduce((a, b) => a + b, 0),
+	};
+}
+
+export function parseEnvironmentTimeLine(raw: Uint8Array, littleEndian = true): ParsedEnvironmentTimeLine {
+	const T = 'EnvironmentTimeLine';
+	if (raw.byteLength < TIMELINE_HEADER_SIZE) {
+		throw new Error(`${T}: resource is ${raw.byteLength} bytes, smaller than the 0x10 header`);
+	}
+	const r = new BinReader(raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength), littleEndian);
+
+	const muVersion = r.readU32();
+	if (muVersion !== ENVIRONMENT_TIME_LINE_VERSION) {
+		throw new Error(`${T}: muVersion ${muVersion}, only version ${ENVIRONMENT_TIME_LINE_VERSION} is supported`);
+	}
+	const locationCnt = r.readU32();
+	const mpLocationDatii = r.readU32();
+	checkOffset(mpLocationDatii, TIMELINE_HEADER_SIZE, 'mpLocationDatii', T);
+	assertZeroWords(r, 1, 'header pad', T);
+
+	const stored: { cnt: number; timesPtr: number; kfPtr: number }[] = [];
+	for (let i = 0; i < locationCnt; i++) {
+		const cnt = r.readU32();
+		const timesPtr = r.readU32();
+		const kfPtr = r.readU32();
+		stored.push({ cnt, timesPtr, kfPtr });
+	}
+
+	const layout = timeLineCanonicalLayout(stored.map((h) => h.cnt));
+	if (raw.byteLength !== layout.importOffset + layout.totalKeyframes * IMPORT_ENTRY_SIZE) {
+		throw new Error(`${T}: resource is 0x${raw.byteLength.toString(16)} bytes, expected 0x${(layout.importOffset + layout.totalKeyframes * IMPORT_ENTRY_SIZE).toString(16)} for ${layout.totalKeyframes} keyframes`);
+	}
+	for (let i = 0; i < locationCnt; i++) {
+		checkOffset(stored[i].kfPtr, layout.locationHeaders[i].kfPtr, `locations[${i}].mppKeyframes`, T);
+		checkOffset(stored[i].timesPtr, layout.locationHeaders[i].timesPtr, `locations[${i}].mpfKeyframeTimes`, T);
+	}
+
+	// Align gaps and pointer slots are regenerated as zero on write — assert
+	// every word between the location headers and the import table that is not
+	// a time value, including the slots themselves (0 on disk; the runtime
+	// patches them from the imports).
+	const times: number[][] = [];
+	for (let i = 0; i < locationCnt; i++) {
+		const h = layout.locationHeaders[i];
+		const segStart = i === 0 ? TIMELINE_HEADER_SIZE + TIMELINE_LOCATION_SIZE * locationCnt : align16(layout.locationHeaders[i - 1].timesPtr + 4 * layout.locationHeaders[i - 1].cnt);
+		r.position = segStart;
+		assertZeroWords(r, (h.kfPtr - segStart) / 4, `pad before locations[${i}] pointer slots`, T);
+		assertZeroWords(r, h.cnt, `locations[${i}] on-disk pointer slots`, T);
+		assertZeroWords(r, (h.timesPtr - (h.kfPtr + 4 * h.cnt)) / 4, `pad before locations[${i}] times`, T);
+		const t: number[] = [];
+		for (let j = 0; j < h.cnt; j++) t.push(r.readF32());
+		times.push(t);
+	}
+	const lastEnd = locationCnt > 0
+		? layout.locationHeaders[locationCnt - 1].timesPtr + 4 * layout.locationHeaders[locationCnt - 1].cnt
+		: TIMELINE_HEADER_SIZE;
+	r.position = lastEnd;
+	assertZeroWords(r, (layout.importOffset - lastEnd) / 4, 'pad before import table', T);
+
+	// --- Inline import table: one keyframe id per pointer slot, in order ---
+	const locations: EnvironmentTimeLineLocation[] = [];
+	r.position = layout.importOffset;
+	for (let i = 0; i < locationCnt; i++) {
+		const h = layout.locationHeaders[i];
+		const keyframes: EnvironmentTimeLineKeyframe[] = [];
+		for (let j = 0; j < h.cnt; j++) {
+			const mKeyframeId = r.readU64();
+			const patchOffset = r.readU32();
+			checkOffset(patchOffset, h.kfPtr + 4 * j, `import patch offset for locations[${i}].keyframes[${j}]`, T);
+			assertZeroWords(r, 1, 'import entry pad', T);
+			keyframes.push({ mfTimeOfDay: times[i][j], mKeyframeId });
+		}
+		locations.push({ keyframes });
+	}
+
+	return { muVersion, locations };
+}
+
+export function writeEnvironmentTimeLine(model: ParsedEnvironmentTimeLine, littleEndian = true): Uint8Array {
+	const T = 'EnvironmentTimeLine';
+	if (model.muVersion !== ENVIRONMENT_TIME_LINE_VERSION) {
+		throw new Error(`${T} writer: muVersion ${model.muVersion}, only version ${ENVIRONMENT_TIME_LINE_VERSION} is supported`);
+	}
+	const layout = timeLineCanonicalLayout(model.locations.map((l) => l.keyframes.length));
+	const totalSize = layout.importOffset + layout.totalKeyframes * IMPORT_ENTRY_SIZE;
+	const w = new BinWriter(totalSize, littleEndian);
+
+	w.writeU32(ENVIRONMENT_TIME_LINE_VERSION);
+	w.writeU32(model.locations.length);
+	w.writeU32(TIMELINE_HEADER_SIZE); // mpLocationDatii
+	w.writeU32(0);
+	for (const h of layout.locationHeaders) {
+		w.writeU32(h.cnt);
+		w.writeU32(h.timesPtr);
+		w.writeU32(h.kfPtr);
+	}
+	for (let i = 0; i < model.locations.length; i++) {
+		const h = layout.locationHeaders[i];
+		while (w.offset < h.kfPtr) w.writeU8(0);
+		w.writeZeroes(4 * h.cnt); // mppKeyframes slots — patched at load from imports
+		while (w.offset < h.timesPtr) w.writeU8(0);
+		for (const kf of model.locations[i].keyframes) w.writeF32(kf.mfTimeOfDay);
+	}
+	while (w.offset < layout.importOffset) w.writeU8(0);
+
+	for (let i = 0; i < model.locations.length; i++) {
+		const h = layout.locationHeaders[i];
+		model.locations[i].keyframes.forEach((kf, j) => {
+			w.writeU64(kf.mKeyframeId);
+			w.writeU32(h.kfPtr + 4 * j);
+			w.writeU32(0);
+		});
+	}
+
+	checkOffset(w.offset, totalSize, 'writer end', T);
+	return w.bytes;
+}

--- a/src/lib/core/font.ts
+++ b/src/lib/core/font.ts
@@ -1,0 +1,378 @@
+// Font parser and writer (resource type 0x21, CgsResource::Font).
+//
+// A Font links UTF-16 code units to glyph rectangles on one or more texture
+// atlas pages so text consumers (Apt UI scripts, debug text) can lay out and
+// render strings. Each retail .FONT bundle carries exactly one Font plus one
+// Texture (the first atlas page); fonts with a second page import that page's
+// Texture from ANOTHER bundle by resource id.
+//
+// Glyph → atlas mapping: mTopLeftUV / mDimensionsUV are normalized [0..1]
+// texture coordinates on the page mu16TexturePageId — multiply by the bound
+// texture's pixel dimensions to recover the glyph's atlas rect. Non-renderable
+// chars (spaces) store the (-1,-1) UV sentinel and only contribute mfAdvance.
+// mStart is the render offset of the glyph quad from the pen position and
+// mfAdvance the pen advance, both in the same UV-scaled units (mScaleUV
+// converts them to glyph space; for most fonts mScaleUV * muFontHeightInPixels
+// equals the atlas pixel dimensions exactly, but not for the Thai pair).
+//
+// Char lookup is a 128-bucket hash: bucket = charId & 0x7F. The char array is
+// stored grouped by ascending bucket and mauHashOffsets[129] holds the bucket
+// boundaries (h[b]..h[b+1]) with h[128] == numChars. The table is fully
+// derivable from the char order — the parser validates it and the writer
+// recomputes it, throwing if the array is no longer bucket-grouped.
+//
+// On-disk element order (NOT documented on the wiki, grounded by sweeping all
+// 26 retail FONT bundles):
+//   header(0x24C) → pad4 → texture ptr slots @0x250 (u32 × numPages) →
+//   charIds @align16 (u16 × numChars) → FontChars @align32 (0x20 each) →
+//   inline BND2 import table @mSizeOfFont (16 bytes per page).
+// The import table binds each texture ptr slot (keyed by the slot's byte
+// offset) to a Texture resource id. Slot 0 is always 0 on disk, but the
+// second slot of the two 2-page fonts carries build-time pointer garbage —
+// preserved verbatim per page in _ptrSlot.
+//
+// Scope: 32-bit PC, little-endian, retail layout only (muVersionId 10). The
+// dev-era variant (wiki Font/Development) used vpu vectors and a different
+// FontChar shape; it is out of scope like every other dev-only layout.
+//
+// Round-trip strategy: every pointer, count, size, and the hash table are
+// recomputed from the chars/texturePages arrays on write; all pad regions and
+// the TextureState block are asserted zero on parse and regenerated. Only
+// _ptrSlot is preserved verbatim. Byte-exact on all 26 retail fonts.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type FontChar = {
+	/** UTF-16 code unit (CgsUtf16) this glyph renders — from the parallel mpaFontCharIds array. */
+	charId: number; // u16
+	/** Normalized top-left atlas coordinate; (-1,-1) sentinel when not renderable. */
+	mTopLeftUV: { x: number; y: number };
+	/** Normalized glyph width/height on the atlas page. */
+	mDimensionsUV: { x: number; y: number };
+	/** Quad offset from the pen position, in UV-scaled glyph units. */
+	mStart: { x: number; y: number };
+	/** Pen advance after this glyph, in UV-scaled glyph units. */
+	mfAdvance: number;
+	/** Index into the texture page list. */
+	mu16TexturePageId: number; // u16
+	mbIsLowerCaseScale: boolean; // bool8
+	mbIsRenderable: boolean; // bool8
+};
+
+export type FontTexturePage = {
+	/** Texture resource id this page binds — the import-table entry for the page's pointer slot. */
+	textureId: bigint; // u64
+	// On-disk value of the page's pointer slot. 0 for slot 0 everywhere, but
+	// the second slot of the 2-page fonts carries build-time pointer garbage
+	// the import patcher overwrites at load — preserved verbatim.
+	_ptrSlot: number; // u32
+};
+
+export type ParsedFont = {
+	/** Layout version — 10 in every retail font; the parser rejects anything else. */
+	muVersionId: number;
+	/** Converts UV-space metrics to glyph space (mScaleUV * muFontHeightInPixels equals the atlas pixel dims for most fonts). */
+	mScaleUV: { x: number; y: number };
+	/** Extra scale applied to glyphs flagged mbIsLowerCaseScale (0 in every retail font — the flag is never set). */
+	mfLowerCaseScale: number;
+	/** Baseline height as a fraction of the line cell. */
+	mfBaseLine: number;
+	/** x-height as a fraction of the line cell. */
+	mfXHeight: number;
+	/** Source rasterization size in pixels (35–288 across retail). */
+	muFontHeightInPixels: number;
+	/** Typeface family, e.g. "B5HelveticaBold" (char[128], NUL-terminated). */
+	macTypefaceFamilyName: string;
+	/** Typeface style, e.g. "Bold" (char[128], NUL-terminated). */
+	macTypefaceStyleName: string;
+	/** Glyphs in disk order — grouped by ascending hash bucket (charId & 0x7F); the writer re-derives the lookup table from this order. */
+	chars: FontChar[];
+	/** Atlas pages, each bound to a Texture resource via the inline import table. */
+	texturePages: FontTexturePage[];
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Resource type ID for CgsResource::Font. */
+export const FONT_TYPE_ID = 0x21;
+
+const HEADER_SIZE = 0x24c;
+// Texture ptr slots start at align16(header end); constant because the header
+// size is fixed.
+const TEXTURE_PTRS_OFFSET = 0x250;
+const FONT_CHAR_RECORD_SIZE = 0x20;
+const IMPORT_ENTRY_SIZE = 0x10;
+const HASH_TABLE_ENTRIES = 129; // 128 bucket starts + total-count sentinel
+const NAME_FIELD_SIZE = 0x80;
+
+const align16 = (x: number): number => (x + 15) & ~15;
+const align32 = (x: number): number => (x + 31) & ~31;
+
+// =============================================================================
+// Hash table
+// =============================================================================
+
+/**
+ * Recompute mauHashOffsets[129] from char order. The game looks chars up by
+ * bucket = charId & 0x7F, scanning [h[b], h[b+1]) — so the char array MUST
+ * stay grouped by ascending bucket. Throws when it isn't, because a silently
+ * wrong table would make glyphs unfindable at runtime.
+ */
+export function computeHashOffsets(chars: FontChar[]): number[] {
+	const counts = new Array<number>(128).fill(0);
+	let prevBucket = 0;
+	for (let i = 0; i < chars.length; i++) {
+		const bucket = chars[i].charId & 0x7f;
+		if (bucket < prevBucket) {
+			throw new Error(`Font: chars[${i}] (charId 0x${chars[i].charId.toString(16)}) breaks hash-bucket grouping — bucket ${bucket} after ${prevBucket}`);
+		}
+		prevBucket = bucket;
+		counts[bucket]++;
+	}
+	const offsets = new Array<number>(HASH_TABLE_ENTRIES);
+	offsets[0] = 0;
+	for (let b = 0; b < 128; b++) offsets[b + 1] = offsets[b] + counts[b];
+	return offsets;
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+function assertZero(raw: Uint8Array, start: number, end: number, what: string): void {
+	for (let i = start; i < end; i++) {
+		if (raw[i] !== 0) throw new Error(`Font: non-zero ${what} byte at 0x${i.toString(16)} — layout not as expected`);
+	}
+}
+
+function readName(raw: Uint8Array, base: number, what: string): string {
+	const seg = raw.slice(base, base + NAME_FIELD_SIZE);
+	const nul = seg.indexOf(0);
+	if (nul < 0) throw new Error(`Font: ${what} is not NUL-terminated`);
+	assertZero(seg, nul, NAME_FIELD_SIZE, `${what} tail`);
+	return new TextDecoder().decode(seg.slice(0, nul));
+}
+
+export function parseFont(raw: Uint8Array, littleEndian = true): ParsedFont {
+	const r = new BinReader(raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength), littleEndian);
+
+	// --- Header (0x24C bytes) ---
+	const muVersionId = r.readU32();
+	const mSizeOfFont = r.readU32();
+	const mScaleUV = { x: r.readF32(), y: r.readF32() };
+	const mfLowerCaseScale = r.readF32();
+	const mfBaseLine = r.readF32();
+	const mfXHeight = r.readF32();
+	const muNumChars = r.readU32();
+	const mpaFontChars = r.readU32();
+	const mpaFontCharIds = r.readU32();
+	const storedHash = new Array<number>(HASH_TABLE_ENTRIES);
+	for (let i = 0; i < HASH_TABLE_ENTRIES; i++) storedHash[i] = r.readU16();
+	const pad12A = r.readU16();
+	const muNumTexturePages = r.readU32();
+	const mpapTextures = r.readU32();
+	// mpTextureState + mTextureStateResource (rw::Resource, 4 ptrs on PC) —
+	// 0x134..0x148, zero in every retail font; asserted below.
+	r.position = 0x148;
+	const muFontHeightInPixels = r.readU32();
+
+	if (muVersionId !== 10) {
+		throw new Error(`Font: muVersionId is ${muVersionId}, only retail version 10 is supported`);
+	}
+
+	// The layout is rigid; bail loudly on violations rather than silently
+	// mis-parsing.
+	const idsOffset = align16(TEXTURE_PTRS_OFFSET + muNumTexturePages * 4);
+	const charsOffset = align32(idsOffset + muNumChars * 2);
+	const charsEnd = charsOffset + muNumChars * FONT_CHAR_RECORD_SIZE;
+	if (mpapTextures !== TEXTURE_PTRS_OFFSET) {
+		throw new Error(`Font: mpapTextures is 0x${mpapTextures.toString(16)}, expected 0x${TEXTURE_PTRS_OFFSET.toString(16)} (rigid layout)`);
+	}
+	if (mpaFontCharIds !== idsOffset) {
+		throw new Error(`Font: mpaFontCharIds is 0x${mpaFontCharIds.toString(16)}, expected 0x${idsOffset.toString(16)} for ${muNumTexturePages} pages`);
+	}
+	if (mpaFontChars !== charsOffset) {
+		throw new Error(`Font: mpaFontChars is 0x${mpaFontChars.toString(16)}, expected 0x${charsOffset.toString(16)} for ${muNumChars} chars`);
+	}
+	if (mSizeOfFont !== charsEnd) {
+		throw new Error(`Font: mSizeOfFont 0x${mSizeOfFont.toString(16)} != char-array end 0x${charsEnd.toString(16)}`);
+	}
+	if (raw.byteLength !== charsEnd + muNumTexturePages * IMPORT_ENTRY_SIZE) {
+		throw new Error(`Font: payload is ${raw.byteLength} bytes, expected 0x${charsEnd.toString(16)} + ${muNumTexturePages} import entries`);
+	}
+	if (pad12A !== 0) throw new Error(`Font: pad at 0x12A is ${pad12A}, expected 0`);
+	// All pad regions and the TextureState block are regenerated as zero by the
+	// writer — a non-zero byte would silently break the byte-exact round-trip,
+	// so fail loud instead (zero in all 26 retail fonts).
+	assertZero(raw, 0x134, 0x148, 'TextureState block');
+	assertZero(raw, HEADER_SIZE, TEXTURE_PTRS_OFFSET, 'header pad');
+	assertZero(raw, TEXTURE_PTRS_OFFSET + muNumTexturePages * 4, idsOffset, 'texture→ids pad');
+	assertZero(raw, idsOffset + muNumChars * 2, charsOffset, 'ids→chars pad');
+
+	const macTypefaceFamilyName = readName(raw, 0x14c, 'family name');
+	const macTypefaceStyleName = readName(raw, 0x1cc, 'style name');
+
+	// --- Char ids (u16 each) + FontChars (0x20 each), merged into one record ---
+	const chars: FontChar[] = [];
+	for (let i = 0; i < muNumChars; i++) {
+		r.position = idsOffset + i * 2;
+		const charId = r.readU16();
+		r.position = charsOffset + i * FONT_CHAR_RECORD_SIZE;
+		const mTopLeftUV = { x: r.readF32(), y: r.readF32() };
+		const mDimensionsUV = { x: r.readF32(), y: r.readF32() };
+		const mStart = { x: r.readF32(), y: r.readF32() };
+		const mfAdvance = r.readF32();
+		const mu16TexturePageId = r.readU16();
+		const lcs = r.readU8();
+		const renderable = r.readU8();
+		if (lcs > 1 || renderable > 1) {
+			throw new Error(`Font: chars[${i}] bool bytes ${lcs}/${renderable} are not 0/1 — layout not as expected`);
+		}
+		if (mu16TexturePageId >= muNumTexturePages) {
+			throw new Error(`Font: chars[${i}] references texture page ${mu16TexturePageId} of ${muNumTexturePages}`);
+		}
+		chars.push({
+			charId,
+			mTopLeftUV,
+			mDimensionsUV,
+			mStart,
+			mfAdvance,
+			mu16TexturePageId,
+			mbIsLowerCaseScale: lcs === 1,
+			mbIsRenderable: renderable === 1,
+		});
+	}
+
+	// The stored hash table must match what the writer will regenerate from
+	// char order — this also proves the array is bucket-grouped.
+	const recomputed = computeHashOffsets(chars);
+	for (let i = 0; i < HASH_TABLE_ENTRIES; i++) {
+		if (storedHash[i] !== recomputed[i]) {
+			throw new Error(`Font: mauHashOffsets[${i}] is ${storedHash[i]}, recomputed ${recomputed[i]} — table not derivable from char order`);
+		}
+	}
+
+	// --- Texture pages: ptr slot (verbatim) + inline import-table entry ---
+	const texturePages: FontTexturePage[] = [];
+	for (let i = 0; i < muNumTexturePages; i++) {
+		r.position = TEXTURE_PTRS_OFFSET + i * 4;
+		const _ptrSlot = r.readU32();
+		r.position = charsEnd + i * IMPORT_ENTRY_SIZE;
+		const textureId = r.readU64();
+		const ptrOffset = r.readU32();
+		const importPad = r.readU32();
+		if (ptrOffset !== TEXTURE_PTRS_OFFSET + i * 4) {
+			throw new Error(`Font: import[${i}] patches 0x${ptrOffset.toString(16)}, expected texture slot 0x${(TEXTURE_PTRS_OFFSET + i * 4).toString(16)}`);
+		}
+		if (importPad !== 0) throw new Error(`Font: import[${i}] pad is ${importPad}, expected 0`);
+		texturePages.push({ textureId, _ptrSlot });
+	}
+
+	return {
+		muVersionId,
+		mScaleUV,
+		mfLowerCaseScale,
+		mfBaseLine,
+		mfXHeight,
+		muFontHeightInPixels,
+		macTypefaceFamilyName,
+		macTypefaceStyleName,
+		chars,
+		texturePages,
+	};
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+export function writeFont(model: ParsedFont, littleEndian = true): Uint8Array {
+	const { chars, texturePages } = model;
+	if (model.muVersionId !== 10) {
+		throw new Error(`Font writer: muVersionId ${model.muVersionId} — only retail version 10 is supported`);
+	}
+	if (texturePages.length === 0) {
+		throw new Error('Font writer: a font needs at least one texture page');
+	}
+	for (const name of [model.macTypefaceFamilyName, model.macTypefaceStyleName]) {
+		if (new TextEncoder().encode(name).byteLength >= NAME_FIELD_SIZE) {
+			throw new Error(`Font writer: typeface name "${name}" exceeds the ${NAME_FIELD_SIZE - 1}-byte char[128] field`);
+		}
+	}
+	for (let i = 0; i < chars.length; i++) {
+		if (chars[i].mu16TexturePageId >= texturePages.length) {
+			throw new Error(`Font writer: chars[${i}] references texture page ${chars[i].mu16TexturePageId} of ${texturePages.length}`);
+		}
+	}
+	// Throws when chars are no longer grouped by ascending bucket.
+	const hashOffsets = computeHashOffsets(chars);
+
+	// Layout offsets recomputed from the array lengths, never stored.
+	const idsOffset = align16(TEXTURE_PTRS_OFFSET + texturePages.length * 4);
+	const charsOffset = align32(idsOffset + chars.length * 2);
+	const sizeOfFont = charsOffset + chars.length * FONT_CHAR_RECORD_SIZE;
+	const totalSize = sizeOfFont + texturePages.length * IMPORT_ENTRY_SIZE;
+
+	const w = new BinWriter(totalSize, littleEndian);
+
+	// --- Header (0x24C bytes) ---
+	w.writeU32(model.muVersionId);
+	w.writeU32(sizeOfFont);
+	w.writeF32(model.mScaleUV.x);
+	w.writeF32(model.mScaleUV.y);
+	w.writeF32(model.mfLowerCaseScale);
+	w.writeF32(model.mfBaseLine);
+	w.writeF32(model.mfXHeight);
+	w.writeU32(chars.length);
+	w.writeU32(charsOffset); // mpaFontChars
+	w.writeU32(idsOffset);   // mpaFontCharIds
+	for (const h of hashOffsets) w.writeU16(h);
+	w.writeU16(0); // pad 0x12A
+	w.writeU32(texturePages.length);
+	w.writeU32(TEXTURE_PTRS_OFFSET); // mpapTextures
+	w.writeU32(0); // mpTextureState
+	w.writeZeroes(0x10); // mTextureStateResource (rw::Resource, 4 null ptrs)
+	w.writeU32(model.muFontHeightInPixels);
+	w.writeFixedString(model.macTypefaceFamilyName, NAME_FIELD_SIZE);
+	w.writeFixedString(model.macTypefaceStyleName, NAME_FIELD_SIZE);
+	if (w.offset !== HEADER_SIZE) throw new Error(`Font writer: header offset mismatch ${w.offset} vs ${HEADER_SIZE}`);
+
+	// --- Texture ptr slots (verbatim) ---
+	w.writeZeroes(TEXTURE_PTRS_OFFSET - HEADER_SIZE);
+	for (const page of texturePages) w.writeU32(page._ptrSlot);
+
+	// --- Char ids ---
+	w.writeZeroes(idsOffset - w.offset);
+	for (const c of chars) w.writeU16(c.charId);
+
+	// --- FontChars ---
+	w.writeZeroes(charsOffset - w.offset);
+	for (const c of chars) {
+		w.writeF32(c.mTopLeftUV.x);
+		w.writeF32(c.mTopLeftUV.y);
+		w.writeF32(c.mDimensionsUV.x);
+		w.writeF32(c.mDimensionsUV.y);
+		w.writeF32(c.mStart.x);
+		w.writeF32(c.mStart.y);
+		w.writeF32(c.mfAdvance);
+		w.writeU16(c.mu16TexturePageId);
+		w.writeU8(c.mbIsLowerCaseScale ? 1 : 0);
+		w.writeU8(c.mbIsRenderable ? 1 : 0);
+	}
+	if (w.offset !== sizeOfFont) throw new Error(`Font writer: import-table offset mismatch ${w.offset} vs ${sizeOfFont}`);
+
+	// --- Inline import table (one entry per texture page) ---
+	for (let i = 0; i < texturePages.length; i++) {
+		w.writeU64(texturePages[i].textureId);
+		w.writeU32(TEXTURE_PTRS_OFFSET + i * 4);
+		w.writeU32(0);
+	}
+
+	return w.bytes;
+}

--- a/src/lib/core/massiveLookupTable.ts
+++ b/src/lib/core/massiveLookupTable.ts
@@ -1,0 +1,180 @@
+// MassiveLookupTable parser and writer (resource type 0x1001A).
+//
+// The lookup table the game used to choose where to display in-game ads
+// served by the (now defunct) Massive Incorporated ad network. One retail
+// resource exists (MASSIVETABLE.BIN, debug name MassiveTable): 20 items, one
+// per ad placement. Each item is a local-space bounding box for the ad quad,
+// the ID of the Scene resource the ad lives in, an "IE index" (ad-rotation /
+// inventory slot; -1 for placements with no index), and the index of the
+// Renderable whose texture the ad replaces. Massive was mostly removed from
+// Remastered, though the assets survive in some versions.
+//
+// On-disk layout (32-bit PC, little-endian):
+//   0x00 i32  miNumberItems
+//   0x04 u32  mpItems — file-relative offset fixed up to a pointer at load;
+//             always 0x10 (the 8-byte header is padded to 16-byte alignment)
+//   0x08      8 pad bytes (0 in retail, preserved verbatim)
+//   0x10      items, 0x40 each, tiling exactly to the end of the resource:
+//     +0x00 Vector3 mBoundingBoxMin (4 f32 lanes; lane 3 unused, 0 in retail)
+//     +0x10 Vector3 mBoundingBoxMax (same)
+//     +0x20 u64 mSceneID (resource ID of the placement's Scene)
+//     +0x28 u32 mpSubscriber (runtime pointer, 0 on disk)
+//     +0x2C i32 miIEIndex
+//     +0x30 u8  muRenderableIndex
+//     +0x31      15 pad bytes (0 in retail, preserved verbatim)
+//
+// Round-trip strategy: count and mpItems are recomputed from the item array
+// on write; the parser asserts the rigid layout (mpItems == 0x10, items tile
+// the resource exactly) and throws on violations instead of mis-parsing.
+// Unused vector lanes and pad bytes are preserved verbatim in _-prefixed
+// fields so the round-trip is byte-exact even if some build stores junk.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type MassiveLookupTableItem = {
+	/** Local-space AABB min of the ad quad (metres, relative to the scene). */
+	mBoundingBoxMin: { x: number; y: number; z: number };
+	/** Local-space AABB max of the ad quad. */
+	mBoundingBoxMax: { x: number; y: number; z: number };
+	/** Resource ID of the Scene this placement belongs to. */
+	mSceneId: bigint;
+	/** Ad inventory slot index; -1 for placements without one. */
+	miIEIndex: number;
+	/** Index of the Renderable whose texture the served ad replaces. */
+	muRenderableIndex: number;
+	/** Unused 4th vpu lane of mBoundingBoxMin (0 in retail) — preserved verbatim. */
+	_minW: number;
+	/** Unused 4th vpu lane of mBoundingBoxMax (0 in retail) — preserved verbatim. */
+	_maxW: number;
+	/** Runtime BrnMassiveSubscriber pointer (0 on disk) — preserved verbatim. */
+	_mpSubscriber: number;
+	/** Item pad at +0x31, 15 bytes (0 in retail) — preserved verbatim. */
+	_pad31: Uint8Array;
+};
+
+export type ParsedMassiveLookupTable = {
+	items: MassiveLookupTableItem[];
+	/** Header pad at 0x08, 8 bytes (0 in retail) — preserved verbatim. */
+	_pad08: Uint8Array;
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const ITEMS_OFFSET = 0x10;
+const ITEM_RECORD_SIZE = 0x40;
+const HEADER_PAD_SIZE = ITEMS_OFFSET - 0x8;
+const ITEM_PAD_SIZE = 0x40 - 0x31;
+
+export function makeEmptyMassiveItem(): MassiveLookupTableItem {
+	return {
+		mBoundingBoxMin: { x: 0, y: 0, z: 0 },
+		mBoundingBoxMax: { x: 0, y: 0, z: 0 },
+		mSceneId: 0n,
+		miIEIndex: -1,
+		muRenderableIndex: 0,
+		_minW: 0,
+		_maxW: 0,
+		_mpSubscriber: 0,
+		_pad31: new Uint8Array(ITEM_PAD_SIZE),
+	};
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+export function parseMassiveLookupTable(raw: Uint8Array, littleEndian = true): ParsedMassiveLookupTable {
+	// Copy up front — extractResourceRaw may hand back a Buffer view, and the
+	// verbatim pad fields below must not alias the caller's bytes.
+	const bytes = new Uint8Array(raw);
+	const r = new BinReader(bytes.buffer, littleEndian);
+
+	const miNumberItems = r.readI32();
+	const mpItems = r.readU32();
+	if (mpItems !== ITEMS_OFFSET) {
+		throw new Error(`MassiveLookupTable: mpItems is 0x${mpItems.toString(16)}, expected 0x10 (rigid layout)`);
+	}
+	if (miNumberItems < 0) {
+		throw new Error(`MassiveLookupTable: negative item count ${miNumberItems}`);
+	}
+	const itemsEnd = ITEMS_OFFSET + miNumberItems * ITEM_RECORD_SIZE;
+	if (itemsEnd !== bytes.byteLength) {
+		throw new Error(`MassiveLookupTable: ${miNumberItems} items end at 0x${itemsEnd.toString(16)} but the resource is 0x${bytes.byteLength.toString(16)} bytes`);
+	}
+	const _pad08 = bytes.slice(0x8, ITEMS_OFFSET);
+
+	const items: MassiveLookupTableItem[] = [];
+	r.position = ITEMS_OFFSET;
+	for (let i = 0; i < miNumberItems; i++) {
+		const base = ITEMS_OFFSET + i * ITEM_RECORD_SIZE;
+		const mBoundingBoxMin = { x: r.readF32(), y: r.readF32(), z: r.readF32() };
+		const _minW = r.readF32();
+		const mBoundingBoxMax = { x: r.readF32(), y: r.readF32(), z: r.readF32() };
+		const _maxW = r.readF32();
+		const mSceneId = r.readU64();
+		const _mpSubscriber = r.readU32();
+		const miIEIndex = r.readI32();
+		const muRenderableIndex = r.readU8();
+		const _pad31 = bytes.slice(base + 0x31, base + ITEM_RECORD_SIZE);
+		r.position = base + ITEM_RECORD_SIZE;
+		items.push({
+			mBoundingBoxMin,
+			mBoundingBoxMax,
+			mSceneId,
+			miIEIndex,
+			muRenderableIndex,
+			_minW,
+			_maxW,
+			_mpSubscriber,
+			_pad31,
+		});
+	}
+
+	return { items, _pad08 };
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+export function writeMassiveLookupTable(model: ParsedMassiveLookupTable, littleEndian = true): Uint8Array {
+	if (model._pad08.byteLength !== HEADER_PAD_SIZE) {
+		throw new Error(`MassiveLookupTable writer: _pad08 is ${model._pad08.byteLength} bytes, expected ${HEADER_PAD_SIZE}`);
+	}
+	const totalSize = ITEMS_OFFSET + model.items.length * ITEM_RECORD_SIZE;
+	const w = new BinWriter(totalSize, littleEndian);
+
+	w.writeI32(model.items.length);
+	w.writeU32(ITEMS_OFFSET); // mpItems — recomputed, never stored
+	w.writeBytes(model._pad08);
+
+	for (const item of model.items) {
+		if (item._pad31.byteLength !== ITEM_PAD_SIZE) {
+			throw new Error(`MassiveLookupTable writer: item _pad31 is ${item._pad31.byteLength} bytes, expected ${ITEM_PAD_SIZE}`);
+		}
+		w.writeF32(item.mBoundingBoxMin.x);
+		w.writeF32(item.mBoundingBoxMin.y);
+		w.writeF32(item.mBoundingBoxMin.z);
+		w.writeF32(item._minW);
+		w.writeF32(item.mBoundingBoxMax.x);
+		w.writeF32(item.mBoundingBoxMax.y);
+		w.writeF32(item.mBoundingBoxMax.z);
+		w.writeF32(item._maxW);
+		w.writeU64(item.mSceneId);
+		w.writeU32(item._mpSubscriber);
+		w.writeI32(item.miIEIndex);
+		w.writeU8(item.muRenderableIndex);
+		w.writeBytes(item._pad31);
+	}
+
+	if (w.offset !== totalSize) {
+		throw new Error(`MassiveLookupTable writer: wrote ${w.offset} bytes, expected ${totalSize}`);
+	}
+	return w.bytes;
+}

--- a/src/lib/core/registry/handlers/colourCube.ts
+++ b/src/lib/core/registry/handlers/colourCube.ts
@@ -1,0 +1,141 @@
+// ColourCube registry handler — thin wrapper around parseColourCube /
+// writeColourCube in src/lib/core/colourCube.ts.
+//
+// Every ENVIRONMENTSETTINGS/COLOURCUBES bundle carries exactly one 0x2B
+// resource, so no picker config. All four retail DLC24HR fixtures hold the
+// SAME byte-identical payload (the 1.6-update "default RGB CLUT") — the
+// stress scenarios below are therefore the only thing exercising non-default
+// cube contents until a graded fixture shows up.
+
+import {
+	parseColourCube,
+	writeColourCube,
+	colourCubeTexel,
+	setColourCubeTexel,
+	type ParsedColourCube,
+} from '../../colourCube';
+import type { ResourceHandler } from '../handler';
+
+// A texel value no retail ramp produces (the default CLUT is separable, so
+// any cross-channel value proves the mutation actually landed).
+const STRESS_RGB = { r: 12, g: 200, b: 34 };
+
+export const colourCubeHandler: ResourceHandler<ParsedColourCube> = {
+	typeId: 0x2b,
+	key: 'colourCube',
+	name: 'Colour Cube',
+	description: 'A 3D colour look-up table (CLUT) that grades and tone-maps the whole frame — EnvironmentSettings / PostFX feed each rendered pixel\'s RGB through it (R indexes X, G indexes Y, B indexes Z); 32×32×32 RGB24 texels in retail',
+	category: 'Graphics',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Colour_Cube',
+
+	parseRaw(raw, ctx) {
+		return parseColourCube(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeColourCube(model, ctx.littleEndian);
+	},
+	describe(model) {
+		return `${model.mSize}x${model.mSize}x${model.mSize} RGB24 CLUT, ${model.pixels.byteLength} texel bytes`;
+	},
+
+	fixtures: [
+		// All four payloads are byte-identical (verified by sha256 in the gold
+		// suite) — kept anyway so a regression in any one bundle's container
+		// (compression, debug data) still surfaces per-file.
+		{ bundle: 'example/ENVIRONMENTSETTINGS/COLOURCUBES/000_DLC24HR_FOG_A.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/ENVIRONMENTSETTINGS/COLOURCUBES/000_DLC24HR_JUNKYARDT.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/ENVIRONMENTSETTINGS/COLOURCUBES/000_DLC24HR_OC_A.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/ENVIRONMENTSETTINGS/COLOURCUBES/000_DLC24HR_SUN_A.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.mSize !== before.mSize) problems.push(`mSize ${after.mSize} != ${before.mSize}`);
+				if (after.pixels.byteLength !== before.pixels.byteLength) {
+					problems.push(`pixel bytes ${after.pixels.byteLength} != ${before.pixels.byteLength}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-texel',
+			description: 'recolour one interior texel and verify it survives round-trip without disturbing a far corner',
+			mutate: (m) => {
+				setColourCubeTexel(m, 1, 2, 3, STRESS_RGB);
+				return m;
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const got = colourCubeTexel(afterReparse, 1, 2, 3);
+				if (got.r !== STRESS_RGB.r || got.g !== STRESS_RGB.g || got.b !== STRESS_RGB.b) {
+					problems.push(`texel (1,2,3) = (${got.r},${got.g},${got.b}), expected (${STRESS_RGB.r},${STRESS_RGB.g},${STRESS_RGB.b})`);
+				}
+				const s = afterMutate.mSize - 1;
+				const far = colourCubeTexel(afterReparse, s, s, s);
+				const farBefore = colourCubeTexel(afterMutate, s, s, s);
+				if (far.r !== farBefore.r || far.g !== farBefore.g || far.b !== farBefore.b) {
+					problems.push(`far corner texel changed to (${far.r},${far.g},${far.b})`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'invert-red-channel',
+			description: 'invert every texel\'s red output (a real-world grading edit) and verify a sample texel',
+			mutate: (m) => {
+				for (let i = 0; i < m.pixels.byteLength; i += 3) m.pixels[i] = 255 - m.pixels[i];
+				return m;
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const s = afterReparse.mSize - 1;
+				for (const [x, y, z] of [[0, 0, 0], [s, 0, 0], [s, s, s]] as const) {
+					const want = colourCubeTexel(afterMutate, x, y, z);
+					const got = colourCubeTexel(afterReparse, x, y, z);
+					if (got.r !== want.r || got.g !== want.g || got.b !== want.b) {
+						problems.push(`texel (${x},${y},${z}) = (${got.r},${got.g},${got.b}), expected (${want.r},${want.g},${want.b})`);
+					}
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'neutralize-to-linear-identity',
+			description: 'overwrite the cube with a linear identity CLUT (texel = linearly scaled coordinate) and verify the corners come back pure',
+			mutate: (m) => {
+				const s = m.mSize;
+				const ramp = (i: number) => Math.round((i * 255) / (s - 1));
+				for (let z = 0; z < s; z++) {
+					for (let y = 0; y < s; y++) {
+						for (let x = 0; x < s; x++) {
+							setColourCubeTexel(m, x, y, z, { r: ramp(x), g: ramp(y), b: ramp(z) });
+						}
+					}
+				}
+				return m;
+			},
+			verify: (_afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const s = afterReparse.mSize - 1;
+				const expectCorner = (x: number, y: number, z: number, want: [number, number, number]) => {
+					const got = colourCubeTexel(afterReparse, x, y, z);
+					if (got.r !== want[0] || got.g !== want[1] || got.b !== want[2]) {
+						problems.push(`corner (${x},${y},${z}) = (${got.r},${got.g},${got.b}), expected (${want.join(',')})`);
+					}
+				};
+				expectCorner(0, 0, 0, [0, 0, 0]);
+				expectCorner(s, 0, 0, [255, 0, 0]);
+				expectCorner(0, s, 0, [0, 255, 0]);
+				expectCorner(0, 0, s, [0, 0, 255]);
+				expectCorner(s, s, s, [255, 255, 255]);
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/environmentDictionary.ts
+++ b/src/lib/core/registry/handlers/environmentDictionary.ts
@@ -1,0 +1,145 @@
+// EnvironmentDictionary registry handler — thin wrapper around
+// parseEnvironmentDictionary / writeEnvironmentDictionary in
+// src/lib/core/environmentDictionary.ts.
+//
+// One ENV_DICTIONARY resource per game install (DICTIONARY.BUNDLE carries
+// exactly one), so no picker config. Adding a season here only matters if the
+// referenced bundle paths exist on disk — the game loads macBundle /
+// macColourCubesBundle by these literal game-relative paths and resolves the
+// timeline inside by crc32(lowercase(macResourceName)).
+
+import {
+	parseEnvironmentDictionary,
+	writeEnvironmentDictionary,
+	type ParsedEnvironmentDictionary,
+} from '../../environmentDictionary';
+import type { ResourceHandler } from '../handler';
+
+export const environmentDictionaryHandler: ResourceHandler<ParsedEnvironmentDictionary> = {
+	typeId: 0x10014,
+	key: 'environmentDictionary',
+	name: 'Environment Dictionary',
+	description: 'Catalogue of environment-settings bundles — one entry per weather/time-of-day "season" naming its timeline resource, settings bundle, and colour-cube bundle, plus the location names its keyframes are authored for',
+	category: 'Data',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Environment_Dictionary',
+
+	parseRaw(raw, ctx) {
+		return parseEnvironmentDictionary(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeEnvironmentDictionary(model, ctx.littleEndian);
+	},
+	describe(model) {
+		const locations = model.locations.map((l) => l.macName).join(', ');
+		return `seasons ${model.seasons.length}, locations ${model.locations.length}${locations ? ` (${locations})` : ''}`;
+	},
+
+	fixtures: [
+		{ bundle: 'example/ENVIRONMENTSETTINGS/DICTIONARY.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.seasons.length !== before.seasons.length) {
+					problems.push(`season count ${after.seasons.length} != ${before.seasons.length}`);
+				}
+				if (after.locations.length !== before.locations.length) {
+					problems.push(`location count ${after.locations.length} != ${before.locations.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'rename-season-timeline',
+			description: 'rename seasons[0].macResourceName and verify it survives with the bundle paths untouched',
+			mutate: (m) => {
+				const seasons = m.seasons.slice();
+				seasons[0] = { ...seasons[0], macResourceName: 'ENV_TL_STRESS_RENAME' };
+				return { ...m, seasons };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.seasons[0].macResourceName !== 'ENV_TL_STRESS_RENAME') {
+					problems.push(`macResourceName = "${afterReparse.seasons[0].macResourceName}", expected "ENV_TL_STRESS_RENAME"`);
+				}
+				if (afterReparse.seasons[0].macBundle !== afterMutate.seasons[0].macBundle) {
+					problems.push(`macBundle changed to "${afterReparse.seasons[0].macBundle}"`);
+				}
+				if (afterReparse.seasons[0].macColourCubesBundle !== afterMutate.seasons[0].macColourCubesBundle) {
+					problems.push(`macColourCubesBundle changed to "${afterReparse.seasons[0].macColourCubesBundle}"`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'retarget-bundle-path',
+			description: 'point seasons[0].macBundle at a different bundle path and verify the exact string survives',
+			mutate: (m) => {
+				const seasons = m.seasons.slice();
+				seasons[0] = { ...seasons[0], macBundle: 'EnvironmentSettings\\stress_retarget.bundle' };
+				return { ...m, seasons };
+			},
+			verify: (_afterMutate, afterReparse) => {
+				const got = afterReparse.seasons[0].macBundle;
+				return got === 'EnvironmentSettings\\stress_retarget.bundle'
+					? []
+					: [`macBundle = "${got}"`];
+			},
+		},
+		{
+			name: 'add-season',
+			description: 'append a new season entry; verify the count, the new strings, and the shifted location array all survive',
+			mutate: (m) => ({
+				...m,
+				seasons: [
+					...m.seasons,
+					{
+						macResourceName: 'ENV_TL_STRESS_NEW',
+						macBundle: 'EnvironmentSettings\\stress_new.bundle',
+						macColourCubesBundle: 'EnvironmentSettings\\ColourCubes\\stress_new.bundle',
+					},
+				],
+			}),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.seasons.length !== afterMutate.seasons.length) {
+					problems.push(`season count ${afterReparse.seasons.length} != ${afterMutate.seasons.length}`);
+				}
+				const added = afterReparse.seasons[afterReparse.seasons.length - 1];
+				if (added?.macResourceName !== 'ENV_TL_STRESS_NEW') {
+					problems.push(`appended macResourceName = "${added?.macResourceName}"`);
+				}
+				// mpLocationDatii moves by 0x100 — the locations must still parse.
+				if (afterReparse.locations.length !== afterMutate.locations.length) {
+					problems.push(`location count ${afterReparse.locations.length} != ${afterMutate.locations.length}`);
+				}
+				if (afterReparse.locations[0]?.macName !== afterMutate.locations[0]?.macName) {
+					problems.push(`location[0] = "${afterReparse.locations[0]?.macName}"`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'add-location',
+			description: 'append a new location name and verify both locations survive',
+			mutate: (m) => ({ ...m, locations: [...m.locations, { macName: 'stress_location' }] }),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.locations.length !== afterMutate.locations.length) {
+					problems.push(`location count ${afterReparse.locations.length} != ${afterMutate.locations.length}`);
+				}
+				const added = afterReparse.locations[afterReparse.locations.length - 1];
+				if (added?.macName !== 'stress_location') {
+					problems.push(`appended macName = "${added?.macName}"`);
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/environmentKeyframe.ts
+++ b/src/lib/core/registry/handlers/environmentKeyframe.ts
@@ -1,0 +1,169 @@
+// EnvironmentKeyframe registry handler — thin wrapper around
+// parseEnvironmentKeyframe / writeEnvironmentKeyframe in
+// src/lib/core/environmentSettings.ts.
+//
+// A season bundle carries MANY keyframes (8–17 across the fixture bundles),
+// so the handler ships a picker config. The time of day each keyframe is
+// authored for lives only in the debug name's _HHMM suffix
+// (ENV_KF_<season>_<location>_<HHMM>) — the resource itself stores no time;
+// the EnvironmentTimeLine (0x10013) in the same bundle owns the schedule.
+
+import {
+	parseEnvironmentKeyframe,
+	writeEnvironmentKeyframe,
+	formatTimeOfDay,
+	type ParsedEnvironmentKeyframe,
+} from '../../environmentSettings';
+import type { ResourceHandler, PickerEntry } from '../handler';
+
+/** Seconds of day from the debug name's _HHMM suffix, or null without one. */
+function timeOfDayFromName(name: string): number | null {
+	const m = name.match(/_(\d{2})(\d{2})$/);
+	if (!m) return null;
+	return parseInt(m[1], 10) * 3600 + parseInt(m[2], 10) * 60;
+}
+
+function compareByName(a: PickerEntry<ParsedEnvironmentKeyframe>, b: PickerEntry<ParsedEnvironmentKeyframe>): number {
+	return a.ctx.name.localeCompare(b.ctx.name, undefined, { numeric: true });
+}
+
+function fmt3(v: { x: number; y: number; z: number }): string {
+	return `(${v.x.toFixed(2)}, ${v.y.toFixed(2)}, ${v.z.toFixed(2)})`;
+}
+
+export const environmentKeyframeHandler: ResourceHandler<ParsedEnvironmentKeyframe> = {
+	typeId: 0x10012,
+	key: 'environmentKeyframe',
+	name: 'Environment Keyframe',
+	description: 'Snapshot of the environment look at one time of day — bloom, vignette, ColourCube tint, sky/in-scattering colour ramps, the eight-direction fill-light rig, and the two cloud layers; the EnvironmentTimeLine in the same bundle schedules them',
+	category: 'Graphics',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Environment_Keyframe',
+	notes: 'Colours are linear float RGB and go HDR-overbright (lighting fills up to ~3.5 in retail) — values above 1 are intentional, not corruption.',
+
+	parseRaw(raw, ctx) {
+		return parseEnvironmentKeyframe(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeEnvironmentKeyframe(model, ctx.littleEndian);
+	},
+	describe(model) {
+		return `key light ${fmt3(model.mLightingData.mv3KeyLightColour)}, bloom ${model.mBloomData.mfLuminance.toFixed(2)}/${model.mBloomData.mfThreshold.toFixed(2)}, colour cube 0x${model.mColourCubeId.toString(16).toUpperCase()}`;
+	},
+
+	picker: {
+		labelOf(model, { name }) {
+			if (model == null) {
+				return {
+					primary: name,
+					secondary: 'parse failed',
+					badges: [{ label: 'parse failed', tone: 'warn' }],
+				};
+			}
+			const secs = timeOfDayFromName(name);
+			return {
+				primary: name,
+				secondary: `key ${fmt3(model.mLightingData.mv3KeyLightColour)} · bloom ${model.mBloomData.mfLuminance.toFixed(2)}`,
+				badges: secs != null ? [{ label: formatTimeOfDay(secs), tone: 'accent' as const }] : undefined,
+			};
+		},
+		sortKeys: [
+			{
+				id: 'time',
+				// Names embed the authored time as _HHMM, so name order IS time
+				// order within one season — but this key survives renames and mixed
+				// prefixes by parsing the suffix numerically.
+				label: 'Time of day',
+				compare: (a, b) => (timeOfDayFromName(a.ctx.name) ?? Infinity) - (timeOfDayFromName(b.ctx.name) ?? Infinity),
+			},
+			{ id: 'name', label: 'Name (A→Z)', compare: compareByName },
+			{ id: 'index', label: 'Bundle order', compare: (a, b) => a.ctx.index - b.ctx.index },
+		],
+		defaultSort: 'time',
+	},
+
+	fixtures: [
+		// The auto suite only exercises the first keyframe in bundle order; all
+		// 17 of SUN_A (plus the timeline↔keyframe import relationship) are
+		// covered in __tests__/environmentSettings.test.ts.
+		{ bundle: 'example/ENVIRONMENTSETTINGS/000_DLC24HR_FOG_A.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/ENVIRONMENTSETTINGS/000_DLC24HR_JUNKYARDT.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/ENVIRONMENTSETTINGS/000_DLC24HR_OC_A.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/ENVIRONMENTSETTINGS/000_DLC24HR_SUN_A.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.mColourCubeId !== before.mColourCubeId) {
+					problems.push(`mColourCubeId 0x${after.mColourCubeId.toString(16)} != 0x${before.mColourCubeId.toString(16)}`);
+				}
+				if (after.mBloomData.mfLuminance !== before.mBloomData.mfLuminance) {
+					problems.push(`mfLuminance ${after.mBloomData.mfLuminance} != ${before.mBloomData.mfLuminance}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-key-light',
+			// 1.5/0.25/0.125 are exact f32 values, so equality (not closeTo) holds
+			// after the round-trip — and 1.5 also proves HDR >1 values survive.
+			description: 'recolour the key light (including an HDR >1 channel) and verify it survives round-trip',
+			mutate: (m) => ({
+				...m,
+				mLightingData: { ...m.mLightingData, mv3KeyLightColour: { x: 1.5, y: 0.25, z: 0.125 } },
+			}),
+			verify: (_before, after) => {
+				const got = after.mLightingData.mv3KeyLightColour;
+				return got.x === 1.5 && got.y === 0.25 && got.z === 0.125
+					? []
+					: [`mv3KeyLightColour (${got.x}, ${got.y}, ${got.z}), expected (1.5, 0.25, 0.125)`];
+			},
+		},
+		{
+			name: 'edit-bloom',
+			description: 'change bloom luminance/threshold and verify the untouched scale vector is not perturbed',
+			mutate: (m) => ({
+				...m,
+				mBloomData: { ...m.mBloomData, mfLuminance: 2.5, mfThreshold: 0.5 },
+			}),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.mBloomData.mfLuminance !== 2.5) problems.push(`mfLuminance ${afterReparse.mBloomData.mfLuminance} != 2.5`);
+				if (afterReparse.mBloomData.mfThreshold !== 0.5) problems.push(`mfThreshold ${afterReparse.mBloomData.mfThreshold} != 0.5`);
+				if (afterReparse.mBloomData.mv4Scale.x !== afterMutate.mBloomData.mv4Scale.x) {
+					problems.push(`mv4Scale.x drifted to ${afterReparse.mBloomData.mv4Scale.x}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'swap-colour-cube',
+			description: 'retarget the ColourCube import id and verify it lands back in the inline import entry',
+			mutate: (m) => ({ ...m, mColourCubeId: 0xdeadbeefn }),
+			verify: (_before, after) =>
+				after.mColourCubeId === 0xdeadbeefn ? [] : [`mColourCubeId 0x${after.mColourCubeId.toString(16)}, expected 0xdeadbeef`],
+		},
+		{
+			name: 'edit-cloud-layers',
+			description: 'change both cloud layer speeds and the drift angle; the fixed-2 arrays must survive intact',
+			mutate: (m) => ({
+				...m,
+				mCloudsData: { ...m.mCloudsData, mafLayerSpeed: [4, 8], mfDirectionAngle: 90 },
+			}),
+			verify: (_before, after) => {
+				const problems: string[] = [];
+				const { mafLayerSpeed, mfDirectionAngle } = after.mCloudsData;
+				if (mafLayerSpeed.length !== 2 || mafLayerSpeed[0] !== 4 || mafLayerSpeed[1] !== 8) {
+					problems.push(`mafLayerSpeed [${mafLayerSpeed.join(', ')}], expected [4, 8]`);
+				}
+				if (mfDirectionAngle !== 90) problems.push(`mfDirectionAngle ${mfDirectionAngle} != 90`);
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/environmentKeyframe.ts
+++ b/src/lib/core/registry/handlers/environmentKeyframe.ts
@@ -72,9 +72,19 @@ export const environmentKeyframeHandler: ResourceHandler<ParsedEnvironmentKeyfra
 				id: 'time',
 				// Names embed the authored time as _HHMM, so name order IS time
 				// order within one season — but this key survives renames and mixed
-				// prefixes by parsing the suffix numerically.
+				// prefixes by parsing the suffix numerically. Suffix-less names sort
+				// after timed ones, by name among themselves — the naive
+				// (a ?? Infinity) - (b ?? Infinity) form yields NaN for two untimed
+				// entries, which the picker contract forbids.
 				label: 'Time of day',
-				compare: (a, b) => (timeOfDayFromName(a.ctx.name) ?? Infinity) - (timeOfDayFromName(b.ctx.name) ?? Infinity),
+				compare: (a, b) => {
+					const ta = timeOfDayFromName(a.ctx.name);
+					const tb = timeOfDayFromName(b.ctx.name);
+					if (ta != null && tb != null) return ta - tb;
+					if (ta != null) return -1;
+					if (tb != null) return 1;
+					return compareByName(a, b);
+				},
 			},
 			{ id: 'name', label: 'Name (A→Z)', compare: compareByName },
 			{ id: 'index', label: 'Bundle order', compare: (a, b) => a.ctx.index - b.ctx.index },

--- a/src/lib/core/registry/handlers/environmentTimeLine.ts
+++ b/src/lib/core/registry/handlers/environmentTimeLine.ts
@@ -1,0 +1,142 @@
+// EnvironmentTimeLine registry handler — thin wrapper around
+// parseEnvironmentTimeLine / writeEnvironmentTimeLine in
+// src/lib/core/environmentSettings.ts.
+//
+// One timeline per season bundle (no picker needed). Its keyframe references
+// are BND2 imports resolved by resource id against the EnvironmentKeyframe
+// (0x10012) resources in the SAME bundle — every fixture timeline covers all
+// of its bundle's keyframes exactly once, in ascending time order.
+
+import {
+	parseEnvironmentTimeLine,
+	writeEnvironmentTimeLine,
+	formatTimeOfDay,
+	type ParsedEnvironmentTimeLine,
+} from '../../environmentSettings';
+import type { ResourceHandler } from '../handler';
+
+export const environmentTimeLineHandler: ResourceHandler<ParsedEnvironmentTimeLine> = {
+	typeId: 0x10013,
+	key: 'environmentTimeLine',
+	name: 'Environment Timeline',
+	description: 'Time-of-day schedule for a season — per location, an ascending list of (clock time, EnvironmentKeyframe) pairs the game interpolates between as the in-game clock advances',
+	category: 'Graphics',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Environment_Timeline',
+	notes: 'Keyframe references live in the resource\'s inline import table. Editing times or retargeting existing entries is safe; adding/removing entries also changes the import table size, which the bundle envelope\'s import metadata does not track yet.',
+
+	parseRaw(raw, ctx) {
+		return parseEnvironmentTimeLine(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeEnvironmentTimeLine(model, ctx.littleEndian);
+	},
+	describe(model) {
+		const total = model.locations.reduce((n, l) => n + l.keyframes.length, 0);
+		const first = model.locations[0]?.keyframes[0];
+		const lastLoc = model.locations[model.locations.length - 1];
+		const last = lastLoc?.keyframes[lastLoc.keyframes.length - 1];
+		const span = first && last ? `, ${formatTimeOfDay(first.mfTimeOfDay)} → ${formatTimeOfDay(last.mfTimeOfDay)}` : '';
+		return `${model.locations.length} location${model.locations.length === 1 ? '' : 's'}, ${total} keyframe${total === 1 ? '' : 's'}${span}`;
+	},
+
+	fixtures: [
+		// Timeline↔keyframe set equality and the import-order ↔ time-order
+		// relationship are pinned in __tests__/environmentSettings.test.ts.
+		{ bundle: 'example/ENVIRONMENTSETTINGS/000_DLC24HR_FOG_A.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/ENVIRONMENTSETTINGS/000_DLC24HR_JUNKYARDT.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/ENVIRONMENTSETTINGS/000_DLC24HR_OC_A.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/ENVIRONMENTSETTINGS/000_DLC24HR_SUN_A.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.locations.length !== before.locations.length) {
+					problems.push(`location count ${after.locations.length} != ${before.locations.length}`);
+				}
+				const a = after.locations[0]?.keyframes.length ?? -1;
+				const b = before.locations[0]?.keyframes.length ?? -1;
+				if (a !== b) problems.push(`keyframe count ${a} != ${b}`);
+				return problems;
+			},
+		},
+		{
+			name: 'shift-time',
+			description: 'move the first keyframe 5 minutes later (stays below entry [1]) and verify the time survives',
+			mutate: (m) => {
+				const keyframes = m.locations[0].keyframes.slice();
+				keyframes[0] = { ...keyframes[0], mfTimeOfDay: keyframes[0].mfTimeOfDay + 300 };
+				return { ...m, locations: [{ keyframes }, ...m.locations.slice(1)] };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const want = afterMutate.locations[0].keyframes[0].mfTimeOfDay;
+				const got = afterReparse.locations[0].keyframes[0].mfTimeOfDay;
+				return got === want ? [] : [`mfTimeOfDay ${got}, expected ${want}`];
+			},
+		},
+		{
+			name: 'retarget-keyframe',
+			description: 'point the first entry at a different keyframe id; the import entry must carry it while its time stays put',
+			mutate: (m) => {
+				const keyframes = m.locations[0].keyframes.slice();
+				keyframes[0] = { ...keyframes[0], mKeyframeId: 0x12345678n };
+				return { ...m, locations: [{ keyframes }, ...m.locations.slice(1)] };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const got = afterReparse.locations[0].keyframes[0];
+				if (got.mKeyframeId !== 0x12345678n) problems.push(`mKeyframeId 0x${got.mKeyframeId.toString(16)}, expected 0x12345678`);
+				if (got.mfTimeOfDay !== afterMutate.locations[0].keyframes[0].mfTimeOfDay) {
+					problems.push(`mfTimeOfDay drifted to ${got.mfTimeOfDay}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'append-keyframe',
+			// Counts, pointers, and import patch-offsets are all recomputed from
+			// the arrays — appending grows the resource by 4+4+16 bytes (slot,
+			// time, import entry) plus alignment. Payload-level only: the bundle
+			// envelope's importCount is not this writer's to update.
+			description: 'append a 23:59 entry and verify counts, the new entry, and the grown import table reparse correctly',
+			mutate: (m) => ({
+				...m,
+				locations: [
+					{ keyframes: [...m.locations[0].keyframes, { mfTimeOfDay: 86340, mKeyframeId: 0xabcdef01n }] },
+					...m.locations.slice(1),
+				],
+			}),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const want = afterMutate.locations[0].keyframes.length;
+				const got = afterReparse.locations[0].keyframes;
+				if (got.length !== want) problems.push(`keyframe count ${got.length} != ${want}`);
+				const last = got[got.length - 1];
+				if (last.mfTimeOfDay !== 86340) problems.push(`appended time ${last.mfTimeOfDay} != 86340`);
+				if (last.mKeyframeId !== 0xabcdef01n) problems.push(`appended id 0x${last.mKeyframeId.toString(16)} != 0xabcdef01`);
+				return problems;
+			},
+		},
+		{
+			name: 'remove-last-keyframe',
+			description: 'drop the final entry; the layout (and import table) must shrink consistently',
+			mutate: (m) => ({
+				...m,
+				locations: [
+					{ keyframes: m.locations[0].keyframes.slice(0, -1) },
+					...m.locations.slice(1),
+				],
+			}),
+			verify: (afterMutate, afterReparse) => {
+				const want = afterMutate.locations[0].keyframes.length;
+				const got = afterReparse.locations[0].keyframes.length;
+				return got === want ? [] : [`keyframe count ${got} != ${want}`];
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/font.ts
+++ b/src/lib/core/registry/handlers/font.ts
@@ -1,0 +1,136 @@
+// Font registry handler — thin wrapper around parseFont / writeFont in
+// src/lib/core/font.ts.
+//
+// Every retail .FONT bundle carries exactly one Font resource (plus the
+// Texture it imports), so no picker is needed. The three declared fixtures
+// cover the largest CJK font, the second CJK glyph set, and the Thai layout
+// whose mScaleUV breaks the scale*height == atlas-dims pattern; the remaining
+// 23 retail fonts are swept in __tests__/font.test.ts.
+
+import { parseFont, writeFont, type ParsedFont } from '../../font';
+import type { ResourceHandler } from '../handler';
+
+// 0x3080 keeps chars[0]'s hash bucket (charId & 0x7F) so the writer's
+// bucket-grouping invariant holds, while provably changing the stored id
+// (chars[0] is U+3000 ideographic space in every retail font).
+const STRESS_CHAR_ID = 0x3080;
+const STRESS_TEXTURE_ID = 0x00000000deadbeefn;
+
+export const fontHandler: ResourceHandler<ParsedFont> = {
+	typeId: 0x21,
+	key: 'font',
+	name: 'Font',
+	description: 'Links UTF-16 characters to glyph rectangles on texture atlas pages for text rendering (Apt UI, debug text) — per-glyph UV rects, advances, and a 128-bucket char-lookup hash',
+	category: 'Graphics',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Font',
+
+	parseRaw(raw, ctx) {
+		return parseFont(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeFont(model, ctx.littleEndian);
+	},
+	describe(model) {
+		return `${model.macTypefaceFamilyName} ${model.macTypefaceStyleName}, ${model.chars.length} chars, ${model.texturePages.length} page${model.texturePages.length === 1 ? '' : 's'}, ${model.muFontHeightInPixels}px`;
+	},
+
+	fixtures: [
+		{ bundle: 'example/FONTS/CHINESE_SIMPLIFIED.FONT', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/FONTS/CHINESE_TRADITIONAL.FONT', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/FONTS/B5BODY_THAI_35.FONT', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.chars.length !== before.chars.length) {
+					problems.push(`char count ${after.chars.length} != ${before.chars.length}`);
+				}
+				if (after.texturePages.length !== before.texturePages.length) {
+					problems.push(`page count ${after.texturePages.length} != ${before.texturePages.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-glyph-metrics',
+			description: 'nudge chars[0]\'s advance and start offset and verify the new metrics survive round-trip',
+			mutate: (m) => {
+				const chars = m.chars.slice();
+				chars[0] = {
+					...chars[0],
+					mfAdvance: chars[0].mfAdvance + 0.015625, // exactly representable in f32
+					mStart: { x: chars[0].mStart.x + 0.25, y: chars[0].mStart.y + 0.5 },
+				};
+				return { ...m, chars };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const a = afterMutate.chars[0];
+				const b = afterReparse.chars[0];
+				if (Math.abs(a.mfAdvance - b.mfAdvance) > 1e-6) problems.push(`mfAdvance = ${b.mfAdvance}, expected ${a.mfAdvance}`);
+				if (Math.abs(a.mStart.x - b.mStart.x) > 1e-6) problems.push(`mStart.x = ${b.mStart.x}, expected ${a.mStart.x}`);
+				if (Math.abs(a.mStart.y - b.mStart.y) > 1e-6) problems.push(`mStart.y = ${b.mStart.y}, expected ${a.mStart.y}`);
+				return problems;
+			},
+		},
+		{
+			name: 'remap-char-id',
+			description: 'change chars[0].charId within its hash bucket and verify it survives alongside a recomputed lookup table',
+			mutate: (m) => {
+				const chars = m.chars.slice();
+				chars[0] = { ...chars[0], charId: STRESS_CHAR_ID };
+				return { ...m, chars };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.chars[0].charId !== STRESS_CHAR_ID) {
+					problems.push(`charId = 0x${afterReparse.chars[0].charId.toString(16)}, expected 0x${STRESS_CHAR_ID.toString(16)}`);
+				}
+				// charId shares its 0x20-byte record with the UV rect — editing the
+				// id must not perturb the glyph metrics.
+				if (afterReparse.chars[0].mfAdvance !== afterMutate.chars[0].mfAdvance) {
+					problems.push(`mfAdvance changed to ${afterReparse.chars[0].mfAdvance}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'toggle-renderable',
+			description: 'flip chars[0].mbIsRenderable (a space in every retail font) and verify the bool byte round-trips',
+			mutate: (m) => {
+				const chars = m.chars.slice();
+				chars[0] = { ...chars[0], mbIsRenderable: !chars[0].mbIsRenderable };
+				return { ...m, chars };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.chars[0].mbIsRenderable !== afterMutate.chars[0].mbIsRenderable) {
+					problems.push(`mbIsRenderable = ${afterReparse.chars[0].mbIsRenderable}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'retarget-texture-page',
+			description: 'point texturePages[0] at a different Texture resource id and verify the regenerated import table carries it',
+			mutate: (m) => {
+				const texturePages = m.texturePages.slice();
+				texturePages[0] = { ...texturePages[0], textureId: STRESS_TEXTURE_ID };
+				return { ...m, texturePages };
+			},
+			verify: (_afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.texturePages[0].textureId !== STRESS_TEXTURE_ID) {
+					problems.push(`textureId = 0x${afterReparse.texturePages[0].textureId.toString(16)}, expected 0x${STRESS_TEXTURE_ID.toString(16)}`);
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/massiveLookupTable.ts
+++ b/src/lib/core/registry/handlers/massiveLookupTable.ts
@@ -1,0 +1,126 @@
+// MassiveLookupTable registry handler — thin wrapper around
+// parseMassiveLookupTable / writeMassiveLookupTable in
+// src/lib/core/massiveLookupTable.ts.
+//
+// One resource in the whole game (MASSIVETABLE.BIN → MassiveTable): the 20 ad
+// placements the defunct Massive Incorporated service filled with served ads.
+
+import {
+	parseMassiveLookupTable,
+	writeMassiveLookupTable,
+	makeEmptyMassiveItem,
+	type ParsedMassiveLookupTable,
+} from '../../massiveLookupTable';
+import type { ResourceHandler } from '../handler';
+
+export const massiveLookupTableHandler: ResourceHandler<ParsedMassiveLookupTable> = {
+	typeId: 0x1001a,
+	key: 'massiveLookupTable',
+	name: 'Massive Lookup Table',
+	description: 'In-game ad placement lookup for the defunct Massive Incorporated ad service — per placement: the ad quad\'s bounding box, owning Scene ID, inventory slot, and the Renderable whose texture the served ad replaced',
+	category: 'Data',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Massive_Lookup_Table',
+	notes: 'The ad service shut down with Massive Incorporated; the table is inert in retail but still parsed by the game where the asset survives.',
+
+	parseRaw(raw, ctx) {
+		return parseMassiveLookupTable(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeMassiveLookupTable(model, ctx.littleEndian);
+	},
+	describe(model) {
+		const indexed = model.items.filter((i) => i.miIEIndex >= 0).length;
+		return `${model.items.length} ad placement${model.items.length === 1 ? '' : 's'}, ${indexed} with inventory slots`;
+	},
+
+	fixtures: [
+		{ bundle: 'example/MASSIVETABLE.BIN', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.items.length !== before.items.length) {
+					problems.push(`item count ${after.items.length} != ${before.items.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'move-bounding-box',
+			description: 'translate items[0]\'s AABB and verify the new bounds survive round-trip',
+			mutate: (m) => {
+				const items = m.items.slice();
+				const it = items[0];
+				items[0] = {
+					...it,
+					mBoundingBoxMin: { x: it.mBoundingBoxMin.x + 1, y: it.mBoundingBoxMin.y + 2, z: it.mBoundingBoxMin.z + 3 },
+					mBoundingBoxMax: { x: it.mBoundingBoxMax.x + 1, y: it.mBoundingBoxMax.y + 2, z: it.mBoundingBoxMax.z + 3 },
+				};
+				return { ...m, items };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				for (const axis of ['x', 'y', 'z'] as const) {
+					if (Math.abs(afterMutate.items[0].mBoundingBoxMin[axis] - afterReparse.items[0].mBoundingBoxMin[axis]) > 1e-3) {
+						problems.push(`min.${axis} = ${afterReparse.items[0].mBoundingBoxMin[axis]}`);
+					}
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'change-ie-index',
+			description: 'assign items[0] a new inventory slot, leaving its scene/renderable untouched',
+			mutate: (m) => {
+				const items = m.items.slice();
+				items[0] = { ...items[0], miIEIndex: 42 };
+				return { ...m, items };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.items[0].miIEIndex !== 42) {
+					problems.push(`miIEIndex = ${afterReparse.items[0].miIEIndex}, expected 42`);
+				}
+				if (afterReparse.items[0].mSceneId !== afterMutate.items[0].mSceneId) {
+					problems.push('mSceneId changed');
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'add-item',
+			description: 'append a placement — count and mpItems are re-derived from the array',
+			mutate: (m) => ({
+				...m,
+				items: [...m.items, { ...makeEmptyMassiveItem(), mSceneId: 0x1234n, muRenderableIndex: 20 }],
+			}),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.items.length !== afterMutate.items.length) {
+					problems.push(`item count ${afterReparse.items.length} != ${afterMutate.items.length}`);
+				}
+				const last = afterReparse.items[afterReparse.items.length - 1];
+				if (last.mSceneId !== 0x1234n) problems.push(`appended sceneId ${last.mSceneId}`);
+				return problems;
+			},
+		},
+		{
+			name: 'remove-last-item',
+			description: 'drop the final placement — the shrunken table must reparse cleanly',
+			mutate: (m) => ({ ...m, items: m.items.slice(0, -1) }),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.items.length !== afterMutate.items.length) {
+					problems.push(`item count ${afterReparse.items.length} != ${afterMutate.items.length}`);
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/registry.ts
+++ b/src/lib/core/registry/handlers/registry.ts
@@ -1,0 +1,181 @@
+// Registry (0xA000) handler — thin wrapper around parseRegistry /
+// writeRegistry in src/lib/core/soundRegistry.ts. (The core file avoids the
+// name registry.ts because `src/lib/core/registry` is this folder; the
+// handler key stays 'registry', matching the wiki type name.)
+//
+// Our fixtures carry one Registry each, but retail bundles can carry many
+// (SOUND/AEMS/CSIS.BUNDLE packs nine: *CsisEntityReg / *CsisVoiceReg /
+// *CsisFactoryReg per surface type), so a picker config is included.
+
+import {
+	parseRegistry,
+	writeRegistry,
+	soundHash,
+	REGISTRY_TYPE_HASHES,
+	REGISTRY_TYPE_LABELS,
+	type ParsedRegistry,
+	type RegistryEntity,
+} from '../../soundRegistry';
+import type { PickerEntry, ResourceHandler } from '../handler';
+
+function kindHistogram(entities: RegistryEntity[]): string {
+	const counts = new Map<string, number>();
+	for (const e of entities) {
+		const label = REGISTRY_TYPE_LABELS[e.mTypeName] ?? `0x${e.mTypeName.toString(16)}`;
+		counts.set(label, (counts.get(label) ?? 0) + 1);
+	}
+	return [...counts.entries()].map(([k, n]) => `${n} ${k}`).join(', ');
+}
+
+function compareByName(a: PickerEntry<ParsedRegistry>, b: PickerEntry<ParsedRegistry>): number {
+	return a.ctx.name.localeCompare(b.ctx.name, undefined, { numeric: true });
+}
+
+export const registryHandler: ResourceHandler<ParsedRegistry> = {
+	typeId: 0xa000,
+	key: 'registry',
+	name: 'Registry',
+	description: 'Sound entity registry (CgsSound::Playback::Registry) — a name-hash table mapping sound entities to content classes/types, voice slots, parameter/feature schemas, and RWAC DSP feature implementations',
+	category: 'Audio',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Registry',
+	notes: 'Entity payloads validated against PLAYBACKREGISTRY + RWACFEATUREREGISTRY; type names absent from those fixtures (ContentSpec, VoiceSchema, VoiceSpec) round-trip as verbatim payload blobs.',
+
+	parseRaw(raw, ctx) {
+		return parseRegistry(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeRegistry(model, ctx.littleEndian);
+	},
+	describe(model) {
+		return `${model.entities.length} entities (${kindHistogram(model.entities)}), ${model.strings.length} strings`;
+	},
+
+	picker: {
+		labelOf(model, { name }) {
+			if (model == null) {
+				return {
+					primary: name,
+					secondary: 'parse failed',
+					badges: [{ label: 'parse failed', tone: 'warn' }],
+				};
+			}
+			if (model.entities.length === 0) {
+				return { primary: name, secondary: 'no entities', badges: [{ label: 'empty', tone: 'muted' }] };
+			}
+			return {
+				primary: name,
+				secondary: `${model.entities.length} entit${model.entities.length === 1 ? 'y' : 'ies'} · ${model.strings.length} strings`,
+			};
+		},
+		sortKeys: [
+			{ id: 'name', label: 'Name (A→Z)', compare: compareByName },
+			{ id: 'index', label: 'Bundle order', compare: (a, b) => a.ctx.index - b.ctx.index },
+			{
+				id: 'entities-desc',
+				label: 'Entity count (high→low)',
+				compare: (a, b) => (b.model?.entities.length ?? -1) - (a.model?.entities.length ?? -1),
+			},
+		],
+		defaultSort: 'name',
+	},
+
+	fixtures: [
+		// Deliberately different shapes: PLAYBACK mixes five payload kinds;
+		// RWAC is all GenericRwacFeatureImplementation with 0xCD uninitialised
+		// fills that must survive verbatim. Per-kind payload edits live in
+		// __tests__/soundRegistry.test.ts — the scenarios below only mutate
+		// shapes both fixtures share (names, entity list, string pool).
+		{ bundle: 'example/PLAYBACKREGISTRY.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/RWACFEATUREREGISTRY.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.entities.length !== before.entities.length) {
+					problems.push(`entity count ${after.entities.length} != ${before.entities.length}`);
+				}
+				if (after.strings.length !== before.strings.length) {
+					problems.push(`string count ${after.strings.length} != ${before.strings.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'rename-first-entity',
+			description: 'change entities[0].mName — the hash table must be rebuilt around the new home slot',
+			mutate: (m) => {
+				const entities = m.entities.slice();
+				entities[0] = { ...entities[0], mName: soundHash('StewardStressName') };
+				return { ...m, entities };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.entities[0]?.mName !== soundHash('StewardStressName')) {
+					problems.push(`entities[0].mName = 0x${afterReparse.entities[0]?.mName.toString(16)}`);
+				}
+				if (afterReparse.entities.length !== afterMutate.entities.length) {
+					problems.push(`entity count ${afterReparse.entities.length} != ${afterMutate.entities.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'add-content-class',
+			description: 'append a payload-less ContentClass entity — counts, sizes, and the slot table are re-derived',
+			mutate: (m) => ({
+				...m,
+				entities: [...m.entities, {
+					mName: soundHash('StewardStressClass'),
+					mTypeName: REGISTRY_TYPE_HASHES.CONTENT_CLASS,
+					mpContentClass: null,
+					parameterSchema: null,
+					featureSchema: null,
+					rwacFeature: null,
+					_unknownPayload: null,
+				}],
+				strings: [...m.strings, 'StewardStressClass'],
+			}),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const last = afterReparse.entities[afterReparse.entities.length - 1];
+				if (last?.mName !== soundHash('StewardStressClass')) {
+					problems.push('appended entity did not survive round-trip');
+				}
+				if (afterReparse.strings[afterReparse.strings.length - 1] !== 'StewardStressClass') {
+					problems.push('appended string did not survive round-trip');
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'remove-last-entity',
+			description: 'drop the final entity — data size, table, and pointers must all re-derive cleanly',
+			mutate: (m) => ({ ...m, entities: m.entities.slice(0, -1) }),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.entities.length !== afterMutate.entities.length) {
+					problems.push(`entity count ${afterReparse.entities.length} != ${afterMutate.entities.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'add-string',
+			description: 'append a debug string — string-table size and the 16-byte trailing pad are re-derived',
+			mutate: (m) => ({ ...m, strings: [...m.strings, 'StewardStressString'] }),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.strings[afterReparse.strings.length - 1] !== 'StewardStressString') {
+					problems.push('appended string did not survive round-trip');
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/index.ts
+++ b/src/lib/core/registry/index.ts
@@ -44,6 +44,9 @@ import { environmentKeyframeHandler } from './handlers/environmentKeyframe';
 import { environmentTimeLineHandler } from './handlers/environmentTimeLine';
 import { environmentDictionaryHandler } from './handlers/environmentDictionary';
 import { colourCubeHandler } from './handlers/colourCube';
+import { fontHandler } from './handlers/font';
+import { massiveLookupTableHandler } from './handlers/massiveLookupTable';
+import { registryHandler } from './handlers/registry';
 import { textFileHandler } from './handlers/textFile';
 
 export const registry: ResourceHandler[] = [
@@ -84,6 +87,9 @@ export const registry: ResourceHandler[] = [
 	environmentTimeLineHandler,
 	environmentDictionaryHandler,
 	colourCubeHandler,
+	fontHandler,
+	massiveLookupTableHandler,
+	registryHandler,
 	textFileHandler,
 ];
 

--- a/src/lib/core/registry/index.ts
+++ b/src/lib/core/registry/index.ts
@@ -40,6 +40,8 @@ import { hudMessageSequenceHandler } from './handlers/hudMessageSequence';
 import { hudMessageSequenceDictionaryHandler } from './handlers/hudMessageSequenceDictionary';
 import { guiPopupHandler } from './handlers/guiPopup';
 import { worldPainter2DHandler } from './handlers/worldPainter2D';
+import { environmentKeyframeHandler } from './handlers/environmentKeyframe';
+import { environmentTimeLineHandler } from './handlers/environmentTimeLine';
 import { textFileHandler } from './handlers/textFile';
 
 export const registry: ResourceHandler[] = [
@@ -76,6 +78,8 @@ export const registry: ResourceHandler[] = [
 	hudMessageSequenceDictionaryHandler,
 	guiPopupHandler,
 	worldPainter2DHandler,
+	environmentKeyframeHandler,
+	environmentTimeLineHandler,
 	textFileHandler,
 ];
 

--- a/src/lib/core/registry/index.ts
+++ b/src/lib/core/registry/index.ts
@@ -42,6 +42,8 @@ import { guiPopupHandler } from './handlers/guiPopup';
 import { worldPainter2DHandler } from './handlers/worldPainter2D';
 import { environmentKeyframeHandler } from './handlers/environmentKeyframe';
 import { environmentTimeLineHandler } from './handlers/environmentTimeLine';
+import { environmentDictionaryHandler } from './handlers/environmentDictionary';
+import { colourCubeHandler } from './handlers/colourCube';
 import { textFileHandler } from './handlers/textFile';
 
 export const registry: ResourceHandler[] = [
@@ -80,6 +82,8 @@ export const registry: ResourceHandler[] = [
 	worldPainter2DHandler,
 	environmentKeyframeHandler,
 	environmentTimeLineHandler,
+	environmentDictionaryHandler,
+	colourCubeHandler,
 	textFileHandler,
 ];
 

--- a/src/lib/core/soundRegistry.ts
+++ b/src/lib/core/soundRegistry.ts
@@ -1,0 +1,563 @@
+// Registry parser and writer (resource type 0xA000, CgsSound::Playback::Registry).
+//
+// (File is named soundRegistry.ts only because src/lib/core/registry/ is the
+// handler-registry folder — `./registry` already resolves there. The handler
+// key is 'registry', matching the wiki type name.)
+//
+// A Registry maps sound "entities" (name hash → typed payload) so the engine
+// can find sounds and DSP features by name. PLAYBACKREGISTRY.BUNDLE describes
+// the playback graph vocabulary (content classes/types, voice slots, feature
+// schemas with their parameters); RWACFEATUREREGISTRY.BUNDLE describes the
+// concrete RWAC DSP feature implementations (panning, filters, reverb, the
+// Ginsu music player, …) those schemas bind to.
+//
+// On-disk layout (32-bit PC, little-endian):
+//   0x00 u32 mu32EntityCount
+//   0x04 u32 mu32EntityCapacity   — hash-table slots (0x800 in retail)
+//   0x08 u32 muDataSize           — entity-data byte size
+//   0x0C u32 mpu8Data             — entity-data END offset (fixed up at load)
+//   0x10 u32 muStringTableSize
+//   0x14 u32 mpcStringTable       — string-table END offset (= content end)
+//   0x18 u32 muNameHashMask       — capacity - 1 (asserted)
+//   0x1C     hash table: capacity u32 slots, 0 = empty, else file-relative
+//            offset of one entity. Slot = (soundHash(name) >> 1) & mask with
+//            forward linear probing on collision; insertion order is entity
+//            disk order, so the parser rebuilds the table from the entities
+//            and asserts it matches — the writer regenerates it the same way.
+//            (Verified: GinsuSetPitch/GinsuSetShuffleWidth share home slot
+//            1473 in PLAYBACKREGISTRY; the later-inserted one sits at 1474.)
+//   then     entity data (entities packed back to back in insertion order)
+//   then     string table: NUL-terminated strings, the plain-text names of
+//            every hash the registry uses (a debug reverse-lookup pool —
+//            order is arbitrary and strings need not match any entity)
+//   then     zero pad to 16-byte alignment.
+//
+// Every entity starts with (mName u32, mTypeName u32) sound hashes; mTypeName
+// selects the payload shape. Decoded payloads (validated against both retail
+// fixtures):
+//   ~ContentClass~      1F4F9B6F  no payload
+//   ~ContentType~       9E25A791  u32 ContentClass name hash
+//   ~SlotSchema~        EB396D83  u32 ContentClass name hash
+//   ~ParameterSchema~   8D2C6829  f32 min, f32 max, u32 direction (0 in/1 out)
+//   ~FeatureSchema~     CB8B64C5  u32 paramCount, u32 slotCount, u32
+//                                 outputParamCount, then paramCount+slotCount
+//                                 name hashes (params first, then slots)
+//   ~GenericRwacFeatureImplementation~ B8083A05 (absent from the wiki):
+//       u32 uninitialised (0xCDCDCDCD), u32 blockCount, u32 paramCount,
+//       u32 slotCount, then blockCount × { u32 reversed-fourCC DSP block code
+//       ('Pn21', 'Gns0', 'Rsp0', …), u32, u32 }, paramCount × { u32 param
+//       name hash, u16 block index, u16 param index within block }, slotCount
+//       × { u32 slot name hash, u32 slot class hash, u16 index, u16
+//       uninitialised pad (0xCDCD) }.
+// Any other type (~ContentSpec~, ~VoiceSchema~, ~VoiceSpec~ are known to
+// exist in other retail registries but not in these fixtures) is preserved as
+// a verbatim payload blob so unknown registries still round-trip byte-exact.
+//
+// Wiki divergences found against real bytes (burnout.wiki/wiki/Registry):
+//  - ~ContentType~ / ~ContentClass~ type hashes and the entire
+//    GenericRwacFeatureImplementation entity type are undocumented.
+//  - The wiki's "ContentClass possible class values" hashes are actually the
+//    NAMES of ContentType entities: 84D7FBE7 = ~SplicerContent::
+//    SK_CONTENT_TYPE~, 7CCDA2E7 = ~GenericRwacWaveContent::
+//    SK_WAVE_DATA_CONTENT_TYPE~.
+//  - The hash-table slot function and probe order are undocumented ("randomly
+//    placed").
+//  - The wiki's VoiceSchema offsets (0x8/0x10/0x11/0x12 for four u32s) are
+//    self-overlapping and cannot be the real layout.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Sound hash
+// =============================================================================
+
+/**
+ * CgsSound::Playback::Name::MakeHash — the custom hash behind every Name in
+ * sound resources (from the 2007-10-31 review-build debug symbols, via the
+ * wiki's SoundHash gadget). NOT case-folded, unlike CgsID. Empty string has
+ * no hash (the game returns -1); callers should treat '' as unhashable.
+ */
+export function soundHash(name: string): number {
+	if (name.length === 0) return -1;
+	let result = 0x09b66e03;
+	let temp = 0;
+	for (let i = 0; i < name.length; i++) {
+		temp = Math.imul(result + (name.charCodeAt(i) & 0xff), 0x09b66c41);
+		result = temp ^ 0x1de13c89;
+	}
+	if ((result & 1) === 0) result = temp ^ 0x9de13c88;
+	return result >>> 0;
+}
+
+// =============================================================================
+// Entity type-name hashes
+// =============================================================================
+
+export const REGISTRY_TYPE_HASHES = {
+	CONTENT_CLASS: 0x1f4f9b6f, // soundHash('~ContentClass~')
+	CONTENT_TYPE: 0x9e25a791, // soundHash('~ContentType~')
+	SLOT_SCHEMA: 0xeb396d83, // soundHash('~SlotSchema~')
+	PARAMETER_SCHEMA: 0x8d2c6829, // soundHash('~ParameterSchema~')
+	FEATURE_SCHEMA: 0xcb8b64c5, // soundHash('~FeatureSchema~')
+	RWAC_FEATURE: 0xb8083a05, // soundHash('~GenericRwacFeatureImplementation~')
+	// Known from the wiki / string tables but not present in our fixtures —
+	// parsed as verbatim payload blobs:
+	CONTENT_SPEC: 0x511a448b, // soundHash('~ContentSpec~')
+	VOICE_SCHEMA: 0xc7382281, // soundHash('~VoiceSchema~')
+	VOICE_SPEC: 0x3597ad9b, // soundHash('~VoiceSpec~')
+} as const;
+
+export const REGISTRY_TYPE_LABELS: Record<number, string> = {
+	[REGISTRY_TYPE_HASHES.CONTENT_CLASS]: 'ContentClass',
+	[REGISTRY_TYPE_HASHES.CONTENT_TYPE]: 'ContentType',
+	[REGISTRY_TYPE_HASHES.SLOT_SCHEMA]: 'SlotSchema',
+	[REGISTRY_TYPE_HASHES.PARAMETER_SCHEMA]: 'ParameterSchema',
+	[REGISTRY_TYPE_HASHES.FEATURE_SCHEMA]: 'FeatureSchema',
+	[REGISTRY_TYPE_HASHES.RWAC_FEATURE]: 'RwacFeature',
+	[REGISTRY_TYPE_HASHES.CONTENT_SPEC]: 'ContentSpec',
+	[REGISTRY_TYPE_HASHES.VOICE_SCHEMA]: 'VoiceSchema',
+	[REGISTRY_TYPE_HASHES.VOICE_SPEC]: 'VoiceSpec',
+};
+
+export const PARAMETER_DIRECTIONS = [
+	{ value: 0, label: 'Input' },
+	{ value: 1, label: 'Output' },
+] as const;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type RegistryParameterSchema = {
+	mf32Minimum: number;
+	mf32Maximum: number;
+	/** EParameterDirection — 0 input, 1 output ("Get*" params are outputs). */
+	mu32Direction: number;
+};
+
+export type RegistryFeatureSchema = {
+	/** Always 0 in retail; meaning unverified (no fixture uses it). */
+	mu32OutputParamCount: number;
+	/** Name hashes of the feature's ParameterSchema entities. */
+	parameterHashes: number[];
+	/** Name hashes of the feature's SlotSchema entities. */
+	slotHashes: number[];
+};
+
+export type RwacDspBlock = {
+	/** 4-char DSP block code, human (reversed-byte) order: 'Pn21', 'Gns0', 'Rsp0', … */
+	code: string;
+	mUnknown04: number;
+	mUnknown08: number;
+};
+
+export type RwacParamBinding = {
+	/** Sound hash of the parameter name (matches a ParameterSchema in the playback registry). */
+	mParamName: number;
+	/** Which DSP block of this feature owns the parameter. */
+	mu16BlockIndex: number;
+	/** Parameter index within that block. */
+	mu16ParamIndex: number;
+};
+
+export type RwacSlotBinding = {
+	/** Sound hash of the slot name (matches a SlotSchema in the playback registry). */
+	mSlotName: number;
+	/** Sound hash of the slot implementation class (e.g. ~GenericRwacContentSlot~). */
+	mSlotClass: number;
+	mu16Index: number;
+	/** Uninitialised tail pad (0xCDCD in retail) — preserved verbatim. */
+	_pad0A: number;
+};
+
+export type RegistryRwacFeature = {
+	/** Uninitialised u32 at payload start (0xCDCDCDCD in retail) — preserved verbatim. */
+	_uninit08: number;
+	blocks: RwacDspBlock[];
+	params: RwacParamBinding[];
+	slots: RwacSlotBinding[];
+};
+
+// Exactly one payload field is non-null, selected by mTypeName — except
+// ContentClass entities (no payload), where all five are null. ContentType
+// and SlotSchema share mpContentClass.
+export type RegistryEntity = {
+	/** Sound hash of the entity name (plain text usually in `strings`). */
+	mName: number;
+	/** Sound hash of the type name — selects the payload shape. */
+	mTypeName: number;
+	/** ContentType / SlotSchema payload: name hash of a ContentClass entity. */
+	mpContentClass: number | null;
+	parameterSchema: RegistryParameterSchema | null;
+	featureSchema: RegistryFeatureSchema | null;
+	rwacFeature: RegistryRwacFeature | null;
+	/** Verbatim payload for type names this parser doesn't decode. */
+	_unknownPayload: Uint8Array | null;
+};
+
+export type ParsedRegistry = {
+	/** Hash-table slot count. 0x800 in retail; must stay a power of two. */
+	mu32EntityCapacity: number;
+	/** Always capacity - 1 (asserted on parse). */
+	muNameHashMask: number;
+	/** Entities in disk (= hash-table insertion) order. */
+	entities: RegistryEntity[];
+	/** Debug string pool — plain-text names of the hashes used above. */
+	strings: string[];
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const HEADER_SIZE = 0x1c;
+const align16 = (n: number) => (n + 15) & ~15;
+
+export function makeEmptyRegistryEntity(): RegistryEntity {
+	return {
+		mName: 0,
+		mTypeName: REGISTRY_TYPE_HASHES.CONTENT_CLASS,
+		mpContentClass: null,
+		parameterSchema: null,
+		featureSchema: null,
+		rwacFeature: null,
+		_unknownPayload: null,
+	};
+}
+
+function entityPayloadSize(e: RegistryEntity): number {
+	if (e.mpContentClass != null) return 4;
+	if (e.parameterSchema != null) return 12;
+	if (e.featureSchema != null) {
+		return 12 + 4 * (e.featureSchema.parameterHashes.length + e.featureSchema.slotHashes.length);
+	}
+	if (e.rwacFeature != null) {
+		const f = e.rwacFeature;
+		return 16 + f.blocks.length * 12 + f.params.length * 8 + f.slots.length * 12;
+	}
+	if (e._unknownPayload != null) return e._unknownPayload.byteLength;
+	return 0;
+}
+
+/** Home slot of a name hash in the registry's open-addressed table. */
+export function registrySlotOf(nameHash: number, mask: number): number {
+	return (nameHash >>> 1) & mask;
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+export function parseRegistry(raw: Uint8Array, littleEndian = true): ParsedRegistry {
+	// Copy up front — extractResourceRaw may hand back a Buffer view, and the
+	// verbatim payload fields below must not alias the caller's bytes.
+	const bytes = new Uint8Array(raw);
+	const r = new BinReader(bytes.buffer, littleEndian);
+
+	const entityCount = r.readU32();
+	const capacity = r.readU32();
+	const dataSize = r.readU32();
+	const dataEnd = r.readU32();
+	const stringTableSize = r.readU32();
+	const stringTableEnd = r.readU32();
+	const mask = r.readU32();
+
+	// The layout is rigid; bail loudly on violations rather than silently
+	// producing a model that won't round-trip.
+	if (mask !== capacity - 1 || (capacity & mask) !== 0) {
+		throw new Error(`Registry: muNameHashMask 0x${mask.toString(16)} != capacity-1 (capacity 0x${capacity.toString(16)})`);
+	}
+	const dataStart = HEADER_SIZE + capacity * 4;
+	if (dataEnd !== dataStart + dataSize) {
+		throw new Error(`Registry: mpu8Data 0x${dataEnd.toString(16)} != table end 0x${dataStart.toString(16)} + muDataSize 0x${dataSize.toString(16)}`);
+	}
+	if (stringTableEnd !== dataEnd + stringTableSize) {
+		throw new Error(`Registry: mpcStringTable 0x${stringTableEnd.toString(16)} != data end + muStringTableSize`);
+	}
+	if (bytes.byteLength !== align16(stringTableEnd)) {
+		throw new Error(`Registry: resource is 0x${bytes.byteLength.toString(16)} bytes, expected string-table end 0x${stringTableEnd.toString(16)} padded to 16`);
+	}
+	for (let i = stringTableEnd; i < bytes.byteLength; i++) {
+		if (bytes[i] !== 0) throw new Error(`Registry: non-zero trailing pad byte at 0x${i.toString(16)}`);
+	}
+
+	// --- Hash table → entity offsets ---
+	const slotByOffset = new Map<number, number>();
+	for (let slot = 0; slot < capacity; slot++) {
+		r.position = HEADER_SIZE + slot * 4;
+		const ptr = r.readU32();
+		if (ptr === 0) continue;
+		if (ptr < dataStart || ptr >= dataEnd) {
+			throw new Error(`Registry: slot ${slot} points at 0x${ptr.toString(16)}, outside entity data [0x${dataStart.toString(16)}, 0x${dataEnd.toString(16)})`);
+		}
+		slotByOffset.set(ptr, slot);
+	}
+	if (slotByOffset.size !== entityCount) {
+		throw new Error(`Registry: ${slotByOffset.size} occupied slots != mu32EntityCount ${entityCount}`);
+	}
+	const offsets = [...slotByOffset.keys()].sort((a, b) => a - b);
+	if (entityCount > 0 && offsets[0] !== dataStart) {
+		throw new Error(`Registry: first entity at 0x${offsets[0].toString(16)}, expected data start 0x${dataStart.toString(16)}`);
+	}
+	if (entityCount === 0 && dataSize !== 0) {
+		throw new Error(`Registry: empty table but muDataSize is 0x${dataSize.toString(16)}`);
+	}
+
+	// --- Entities (packed back to back; the next offset bounds each one) ---
+	const entities: RegistryEntity[] = [];
+	for (let i = 0; i < offsets.length; i++) {
+		const start = offsets[i];
+		const end = i + 1 < offsets.length ? offsets[i + 1] : dataEnd;
+		entities.push(parseEntity(r, bytes, start, end));
+	}
+
+	// --- Rebuilt hash table must reproduce the stored slots exactly, or the
+	// writer's regeneration would not be byte-exact. ---
+	const rebuilt = buildHashTable(entities, capacity, mask, offsets);
+	for (const [ptr, slot] of slotByOffset) {
+		if (rebuilt.get(ptr) !== slot) {
+			throw new Error(`Registry: entity at 0x${ptr.toString(16)} stored in slot ${slot} but (hash>>1)&mask + linear probing derives ${rebuilt.get(ptr)} — insertion order assumption violated`);
+		}
+	}
+
+	// --- String table: NUL-terminated, latin1 so arbitrary bytes round-trip ---
+	const strings: string[] = [];
+	let cur = dataEnd;
+	while (cur < stringTableEnd) {
+		let end = cur;
+		while (end < stringTableEnd && bytes[end] !== 0) end++;
+		if (end === stringTableEnd) {
+			throw new Error(`Registry: unterminated string at 0x${cur.toString(16)}`);
+		}
+		let s = '';
+		for (let j = cur; j < end; j++) s += String.fromCharCode(bytes[j]);
+		strings.push(s);
+		cur = end + 1;
+	}
+
+	return { mu32EntityCapacity: capacity, muNameHashMask: mask, entities, strings };
+}
+
+function parseEntity(r: BinReader, bytes: Uint8Array, start: number, end: number): RegistryEntity {
+	r.position = start;
+	const mName = r.readU32();
+	const mTypeName = r.readU32();
+	const entity = { ...makeEmptyRegistryEntity(), mName, mTypeName };
+	const avail = end - start - 8;
+	const sized = (need: number) => {
+		if (avail !== need) {
+			throw new Error(`Registry: ${REGISTRY_TYPE_LABELS[mTypeName]} entity 0x${mName.toString(16)} has ${avail} payload bytes, expected ${need}`);
+		}
+	};
+
+	switch (mTypeName) {
+		case REGISTRY_TYPE_HASHES.CONTENT_CLASS:
+			sized(0);
+			break;
+		case REGISTRY_TYPE_HASHES.CONTENT_TYPE:
+		case REGISTRY_TYPE_HASHES.SLOT_SCHEMA:
+			sized(4);
+			entity.mpContentClass = r.readU32();
+			break;
+		case REGISTRY_TYPE_HASHES.PARAMETER_SCHEMA:
+			sized(12);
+			entity.parameterSchema = {
+				mf32Minimum: r.readF32(),
+				mf32Maximum: r.readF32(),
+				mu32Direction: r.readU32(),
+			};
+			break;
+		case REGISTRY_TYPE_HASHES.FEATURE_SCHEMA: {
+			const paramCount = r.readU32();
+			const slotCount = r.readU32();
+			const mu32OutputParamCount = r.readU32();
+			sized(12 + 4 * (paramCount + slotCount));
+			const parameterHashes: number[] = [];
+			for (let i = 0; i < paramCount; i++) parameterHashes.push(r.readU32());
+			const slotHashes: number[] = [];
+			for (let i = 0; i < slotCount; i++) slotHashes.push(r.readU32());
+			entity.featureSchema = { mu32OutputParamCount, parameterHashes, slotHashes };
+			break;
+		}
+		case REGISTRY_TYPE_HASHES.RWAC_FEATURE: {
+			const _uninit08 = r.readU32();
+			const blockCount = r.readU32();
+			const paramCount = r.readU32();
+			const slotCount = r.readU32();
+			sized(16 + blockCount * 12 + paramCount * 8 + slotCount * 12);
+			const blocks: RwacDspBlock[] = [];
+			for (let i = 0; i < blockCount; i++) {
+				const code = readBlockCode(bytes, r.position);
+				r.position += 4;
+				blocks.push({ code, mUnknown04: r.readU32(), mUnknown08: r.readU32() });
+			}
+			const params: RwacParamBinding[] = [];
+			for (let i = 0; i < paramCount; i++) {
+				params.push({ mParamName: r.readU32(), mu16BlockIndex: r.readU16(), mu16ParamIndex: r.readU16() });
+			}
+			const slots: RwacSlotBinding[] = [];
+			for (let i = 0; i < slotCount; i++) {
+				slots.push({ mSlotName: r.readU32(), mSlotClass: r.readU32(), mu16Index: r.readU16(), _pad0A: r.readU16() });
+			}
+			entity.rwacFeature = { _uninit08, blocks, params, slots };
+			break;
+		}
+		default:
+			entity._unknownPayload = bytes.slice(start + 8, end);
+			break;
+	}
+	return entity;
+}
+
+// The block code is a u32 multi-char constant — byte-reversing gives the
+// human-readable tag ('Pn21', 'Gns0', …). Non-printable bytes would make the
+// reversal ambiguous to re-encode, so they fail loudly.
+function readBlockCode(bytes: Uint8Array, at: number): string {
+	let code = '';
+	for (let i = 3; i >= 0; i--) {
+		const b = bytes[at + i];
+		if (b < 0x20 || b > 0x7e) {
+			throw new Error(`Registry: non-printable DSP block code byte 0x${b.toString(16)} at 0x${(at + i).toString(16)}`);
+		}
+		code += String.fromCharCode(b);
+	}
+	return code;
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+function buildHashTable(
+	entities: RegistryEntity[],
+	capacity: number,
+	mask: number,
+	offsets: number[],
+): Map<number, number> {
+	const used = new Set<number>();
+	const slotByOffset = new Map<number, number>();
+	for (let i = 0; i < entities.length; i++) {
+		let slot = registrySlotOf(entities[i].mName, mask);
+		let hops = 0;
+		while (used.has(slot)) {
+			slot = (slot + 1) & mask;
+			if (++hops > capacity) throw new Error('Registry: hash table full');
+		}
+		used.add(slot);
+		slotByOffset.set(offsets[i], slot);
+	}
+	return slotByOffset;
+}
+
+export function writeRegistry(model: ParsedRegistry, littleEndian = true): Uint8Array {
+	const capacity = model.mu32EntityCapacity;
+	const mask = model.muNameHashMask;
+	if (mask !== capacity - 1 || (capacity & mask) !== 0) {
+		throw new Error(`Registry writer: muNameHashMask 0x${mask.toString(16)} != capacity-1 (capacity 0x${capacity.toString(16)})`);
+	}
+	if (model.entities.length > capacity) {
+		throw new Error(`Registry writer: ${model.entities.length} entities exceed table capacity ${capacity}`);
+	}
+
+	// File-relative offsets recomputed from the entity shapes, never stored.
+	const dataStart = HEADER_SIZE + capacity * 4;
+	const offsets: number[] = [];
+	let cursor = dataStart;
+	for (const e of model.entities) {
+		offsets.push(cursor);
+		cursor += 8 + entityPayloadSize(e);
+	}
+	const dataEnd = cursor;
+	let stringTableSize = 0;
+	for (const s of model.strings) stringTableSize += s.length + 1;
+	const stringTableEnd = dataEnd + stringTableSize;
+	const totalSize = align16(stringTableEnd);
+
+	const w = new BinWriter(totalSize, littleEndian);
+	w.writeU32(model.entities.length);
+	w.writeU32(capacity);
+	w.writeU32(dataEnd - dataStart);
+	w.writeU32(dataEnd);
+	w.writeU32(stringTableSize);
+	w.writeU32(stringTableEnd);
+	w.writeU32(mask);
+
+	// --- Hash table (insertion order = entity order) ---
+	w.writeZeroes(capacity * 4);
+	for (const [offset, slot] of buildHashTable(model.entities, capacity, mask, offsets)) {
+		w.setU32(HEADER_SIZE + slot * 4, offset);
+	}
+
+	// --- Entity data ---
+	for (let i = 0; i < model.entities.length; i++) {
+		if (w.offset !== offsets[i]) {
+			throw new Error(`Registry writer: entity ${i} at 0x${w.offset.toString(16)}, expected 0x${offsets[i].toString(16)}`);
+		}
+		writeEntity(w, model.entities[i]);
+	}
+	if (w.offset !== dataEnd) {
+		throw new Error(`Registry writer: entity data ends at 0x${w.offset.toString(16)}, expected 0x${dataEnd.toString(16)}`);
+	}
+
+	// --- String table (latin1) + zero pad to 16 ---
+	for (const s of model.strings) {
+		for (let i = 0; i < s.length; i++) {
+			const c = s.charCodeAt(i);
+			if (c === 0 || c > 0xff) {
+				throw new Error(`Registry writer: string "${s}" has a byte-unrepresentable character`);
+			}
+			w.writeU8(c);
+		}
+		w.writeU8(0);
+	}
+	if (w.offset !== stringTableEnd) {
+		throw new Error(`Registry writer: string table ends at 0x${w.offset.toString(16)}, expected 0x${stringTableEnd.toString(16)}`);
+	}
+	w.writeZeroes(totalSize - stringTableEnd);
+	return w.bytes;
+}
+
+function writeEntity(w: BinWriter, e: RegistryEntity) {
+	w.writeU32(e.mName);
+	w.writeU32(e.mTypeName);
+	if (e.mpContentClass != null) {
+		w.writeU32(e.mpContentClass);
+	} else if (e.parameterSchema != null) {
+		w.writeF32(e.parameterSchema.mf32Minimum);
+		w.writeF32(e.parameterSchema.mf32Maximum);
+		w.writeU32(e.parameterSchema.mu32Direction);
+	} else if (e.featureSchema != null) {
+		w.writeU32(e.featureSchema.parameterHashes.length);
+		w.writeU32(e.featureSchema.slotHashes.length);
+		w.writeU32(e.featureSchema.mu32OutputParamCount);
+		for (const h of e.featureSchema.parameterHashes) w.writeU32(h);
+		for (const h of e.featureSchema.slotHashes) w.writeU32(h);
+	} else if (e.rwacFeature != null) {
+		const f = e.rwacFeature;
+		w.writeU32(f._uninit08);
+		w.writeU32(f.blocks.length);
+		w.writeU32(f.params.length);
+		w.writeU32(f.slots.length);
+		for (const b of f.blocks) {
+			if (b.code.length !== 4) {
+				throw new Error(`Registry writer: DSP block code "${b.code}" must be exactly 4 characters`);
+			}
+			for (let i = 3; i >= 0; i--) w.writeU8(b.code.charCodeAt(i));
+			w.writeU32(b.mUnknown04);
+			w.writeU32(b.mUnknown08);
+		}
+		for (const p of f.params) {
+			w.writeU32(p.mParamName);
+			w.writeU16(p.mu16BlockIndex);
+			w.writeU16(p.mu16ParamIndex);
+		}
+		for (const s of f.slots) {
+			w.writeU32(s.mSlotName);
+			w.writeU32(s.mSlotClass);
+			w.writeU16(s.mu16Index);
+			w.writeU16(s._pad0A);
+		}
+	} else if (e._unknownPayload != null) {
+		w.writeBytes(e._unknownPayload);
+	}
+}

--- a/src/lib/editor/profiles/colourCube.ts
+++ b/src/lib/editor/profiles/colourCube.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedColourCube } from '@/lib/core/colourCube';
+import { colourCubeResourceSchema } from '@/lib/schema/resources/colourCube';
+
+export const colourCubeProfile = defineProfile<ParsedColourCube>({
+	kind: 'default',
+	displayName: 'Colour Cube',
+	schema: colourCubeResourceSchema,
+});

--- a/src/lib/editor/profiles/environmentDictionary.ts
+++ b/src/lib/editor/profiles/environmentDictionary.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedEnvironmentDictionary } from '@/lib/core/environmentDictionary';
+import { environmentDictionaryResourceSchema } from '@/lib/schema/resources/environmentDictionary';
+
+export const environmentDictionaryProfile = defineProfile<ParsedEnvironmentDictionary>({
+	kind: 'default',
+	displayName: 'Environment Dictionary',
+	schema: environmentDictionaryResourceSchema,
+});

--- a/src/lib/editor/profiles/environmentKeyframe.ts
+++ b/src/lib/editor/profiles/environmentKeyframe.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedEnvironmentKeyframe } from '@/lib/core/environmentSettings';
+import { environmentKeyframeResourceSchema } from '@/lib/schema/resources/environmentKeyframe';
+
+export const environmentKeyframeProfile = defineProfile<ParsedEnvironmentKeyframe>({
+	kind: 'default',
+	displayName: 'Environment Keyframe',
+	schema: environmentKeyframeResourceSchema,
+});

--- a/src/lib/editor/profiles/environmentTimeLine.ts
+++ b/src/lib/editor/profiles/environmentTimeLine.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedEnvironmentTimeLine } from '@/lib/core/environmentSettings';
+import { environmentTimeLineResourceSchema } from '@/lib/schema/resources/environmentTimeLine';
+
+export const environmentTimeLineProfile = defineProfile<ParsedEnvironmentTimeLine>({
+	kind: 'default',
+	displayName: 'Environment Timeline',
+	schema: environmentTimeLineResourceSchema,
+});

--- a/src/lib/editor/profiles/font.ts
+++ b/src/lib/editor/profiles/font.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedFont } from '@/lib/core/font';
+import { fontResourceSchema } from '@/lib/schema/resources/font';
+
+export const fontProfile = defineProfile<ParsedFont>({
+	kind: 'default',
+	displayName: 'Font',
+	schema: fontResourceSchema,
+});

--- a/src/lib/editor/profiles/massiveLookupTable.ts
+++ b/src/lib/editor/profiles/massiveLookupTable.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedMassiveLookupTable } from '@/lib/core/massiveLookupTable';
+import { massiveLookupTableResourceSchema } from '@/lib/schema/resources/massiveLookupTable';
+
+export const massiveLookupTableProfile = defineProfile<ParsedMassiveLookupTable>({
+	kind: 'default',
+	displayName: 'Massive Lookup Table',
+	schema: massiveLookupTableResourceSchema,
+});

--- a/src/lib/editor/profiles/registry.ts
+++ b/src/lib/editor/profiles/registry.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedRegistry } from '@/lib/core/soundRegistry';
+import { registryResourceSchema } from '@/lib/schema/resources/registry';
+
+export const registryProfile = defineProfile<ParsedRegistry>({
+	kind: 'default',
+	displayName: 'Registry',
+	schema: registryResourceSchema,
+});

--- a/src/lib/editor/registry.ts
+++ b/src/lib/editor/registry.ts
@@ -15,6 +15,8 @@
 
 import { aiSectionsV12Profile, aiSectionsV4Profile, aiSectionsV6Profile } from './profiles/aiSections';
 import { challengeListProfile } from './profiles/challengeList';
+import { colourCubeProfile } from './profiles/colourCube';
+import { environmentDictionaryProfile } from './profiles/environmentDictionary';
 import { environmentKeyframeProfile } from './profiles/environmentKeyframe';
 import { environmentTimeLineProfile } from './profiles/environmentTimeLine';
 import { guiPopupProfile } from './profiles/guiPopup';
@@ -162,6 +164,16 @@ const ENTRIES: RegistryEntry[] = [
 		typeId: 0x10013,
 		key: 'environmentTimeLine',
 		profiles: [environmentTimeLineProfile],
+	},
+	{
+		typeId: 0x10014,
+		key: 'environmentDictionary',
+		profiles: [environmentDictionaryProfile],
+	},
+	{
+		typeId: 0x2b,
+		key: 'colourCube',
+		profiles: [colourCubeProfile],
 	},
 	{
 		typeId: 0x110,

--- a/src/lib/editor/registry.ts
+++ b/src/lib/editor/registry.ts
@@ -15,6 +15,8 @@
 
 import { aiSectionsV12Profile, aiSectionsV4Profile, aiSectionsV6Profile } from './profiles/aiSections';
 import { challengeListProfile } from './profiles/challengeList';
+import { environmentKeyframeProfile } from './profiles/environmentKeyframe';
+import { environmentTimeLineProfile } from './profiles/environmentTimeLine';
 import { guiPopupProfile } from './profiles/guiPopup';
 import { hudMessageProfile } from './profiles/hudMessage';
 import { hudMessageSequenceProfile } from './profiles/hudMessageSequence';
@@ -150,6 +152,16 @@ const ENTRIES: RegistryEntry[] = [
 		typeId: 0x30,
 		key: 'worldPainter2D',
 		profiles: [worldPainter2DProfile],
+	},
+	{
+		typeId: 0x10012,
+		key: 'environmentKeyframe',
+		profiles: [environmentKeyframeProfile],
+	},
+	{
+		typeId: 0x10013,
+		key: 'environmentTimeLine',
+		profiles: [environmentTimeLineProfile],
 	},
 	{
 		typeId: 0x110,

--- a/src/lib/editor/registry.ts
+++ b/src/lib/editor/registry.ts
@@ -19,13 +19,16 @@ import { colourCubeProfile } from './profiles/colourCube';
 import { environmentDictionaryProfile } from './profiles/environmentDictionary';
 import { environmentKeyframeProfile } from './profiles/environmentKeyframe';
 import { environmentTimeLineProfile } from './profiles/environmentTimeLine';
+import { fontProfile } from './profiles/font';
 import { guiPopupProfile } from './profiles/guiPopup';
 import { hudMessageProfile } from './profiles/hudMessage';
 import { hudMessageSequenceProfile } from './profiles/hudMessageSequence';
 import { hudMessageSequenceDictionaryProfile } from './profiles/hudMessageSequenceDictionary';
 import { iceTakeDictionaryProfile } from './profiles/iceTakeDictionary';
 import { languageProfile } from './profiles/language';
+import { massiveLookupTableProfile } from './profiles/massiveLookupTable';
 import { playerCarColoursProfile } from './profiles/playerCarColours';
+import { registryProfile } from './profiles/registry';
 import { polygonSoupListProfile } from './profiles/polygonSoupList';
 import { propInstanceDataProfile } from './profiles/propInstanceData';
 import { propGraphicsListProfile } from './profiles/propGraphicsList';
@@ -174,6 +177,21 @@ const ENTRIES: RegistryEntry[] = [
 		typeId: 0x2b,
 		key: 'colourCube',
 		profiles: [colourCubeProfile],
+	},
+	{
+		typeId: 0x21,
+		key: 'font',
+		profiles: [fontProfile],
+	},
+	{
+		typeId: 0x1001a,
+		key: 'massiveLookupTable',
+		profiles: [massiveLookupTableProfile],
+	},
+	{
+		typeId: 0xa000,
+		key: 'registry',
+		profiles: [registryProfile],
 	},
 	{
 		typeId: 0x110,

--- a/src/lib/schema/resources/colourCube.test.ts
+++ b/src/lib/schema/resources/colourCube.test.ts
@@ -1,0 +1,130 @@
+// Schema coverage tests for colourCubeResourceSchema.
+//
+// Coverage fixture: example/ENVIRONMENTSETTINGS/COLOURCUBES/000_DLC24HR_FOG_A.BUNDLE
+// (all four retail cubes carry byte-identical payloads, so one fixture covers
+// the only retail shape).
+//
+// Mirrors staticSoundMap.test.ts: parse the model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseColourCube, type ParsedColourCube } from '../../core/colourCube';
+
+import { colourCubeResourceSchema } from './colourCube';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/ENVIRONMENTSETTINGS/COLOURCUBES/000_DLC24HR_FOG_A.BUNDLE');
+const COLOURCUBE_TYPE_ID = 0x2b;
+
+function loadModel(fixturePath: string): ParsedColourCube {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === COLOURCUBE_TYPE_ID);
+	if (!resource) throw new Error('No ColourCube resource in fixture');
+	return parseColourCube(extractResourceRaw(buffer.buffer, bundle, resource), ctx.littleEndian);
+}
+
+const model = loadModel(BUNDLE_FIXTURE);
+
+describe('colourCubeResourceSchema coverage', () => {
+	it('fixture parses with non-trivial content', () => {
+		expect(model.mSize).toBe(32);
+		expect(model.pixels.byteLength).toBeGreaterThan(0);
+	});
+
+	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+		const missing: string[] = [];
+		for (const [recordName, rec] of Object.entries(colourCubeResourceSchema.registry)) {
+			for (const [fieldName, field] of Object.entries(rec.fields)) {
+				checkField(field, `${recordName}.${fieldName}`, missing);
+			}
+		}
+		if (missing.length > 0) {
+			throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+		}
+		function checkField(f: FieldSchema, where: string, out: string[]) {
+			if (f.kind === 'record') {
+				if (!colourCubeResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+				return;
+			}
+			if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+		}
+	});
+
+	it('walkResource visits every parsed field without throwing', () => {
+		let recordCount = 0;
+		let fieldCount = 0;
+		walkResource(colourCubeResourceSchema, model, (_p, _v, field, rec) => {
+			if (rec) recordCount++;
+			if (field) fieldCount++;
+		});
+		expect(recordCount).toBeGreaterThan(0);
+		expect(fieldCount).toBeGreaterThan(0);
+	});
+
+	it('no parsed record has fields absent from the schema', () => {
+		const missing: string[] = [];
+		walkResource(colourCubeResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const declared = new Set(Object.keys(rec.fields));
+			for (const key of Object.keys(value as Record<string, unknown>)) {
+				if (!declared.has(key)) {
+					missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+
+	it('every schema field is represented in the parsed data', () => {
+		const missing: string[] = [];
+		walkResource(colourCubeResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const obj = value as Record<string, unknown>;
+			for (const fieldName of Object.keys(rec.fields)) {
+				if (!(fieldName in obj)) {
+					missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+});
+
+describe('colourCube path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(colourCubeResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedColourCube');
+	});
+
+	it('resolves mSize as a read-only u32', () => {
+		const loc = resolveSchemaAtPath(colourCubeResourceSchema, ['mSize']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('u32');
+	});
+
+	it('resolves pixels as the rawBytes custom renderer', () => {
+		const loc = resolveSchemaAtPath(colourCubeResourceSchema, ['pixels']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('custom');
+	});
+});

--- a/src/lib/schema/resources/colourCube.ts
+++ b/src/lib/schema/resources/colourCube.ts
@@ -1,0 +1,65 @@
+// Hand-written schema for ParsedColourCube (resource type 0x2B).
+//
+// Mirrors the types in `src/lib/core/colourCube.ts`. Keep these in lockstep
+// with the parser/writer — any field added to the parser needs a matching
+// entry here, or the schema walker reports it as drift.
+//
+// Domain: a ColourCube is the 3D CLUT EnvironmentSettings / PostFX feed every
+// rendered pixel through to grade and tone-map the frame. The body is mSize³
+// RGB24 texels (98 304 bytes for the retail 32-cube) — individually
+// meaningless in a tree UI, so it stays a hidden raw blob; meaningful editing
+// belongs to a future swatch/preview extension that samples texels via
+// colourCubeTexel (X-major layout: input R indexes X, G indexes Y, B
+// indexes Z).
+
+import type { FieldSchema, RecordSchema, ResourceSchema, SchemaRegistry } from '../types';
+
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const rawBytes = (): FieldSchema => ({ kind: 'custom', component: 'rawBytes' });
+
+const ParsedColourCube: RecordSchema = {
+	name: 'ParsedColourCube',
+	description: 'Root record for the ColourCube resource (0x2B): a 3D colour look-up table that grades the whole frame. All four retail DLC24HR cubes carry the same byte-identical "default RGB CLUT" — a per-channel tone curve with no cross-channel grading.',
+	fields: {
+		mSize: u32(),
+		pixels: rawBytes(),
+		_pad08: u32(),
+		_pad0C: u32(),
+	},
+	fieldMetadata: {
+		mSize: {
+			label: 'Cube size',
+			description: 'Texels per axis — the body holds mSize³ RGB24 texels (retail: 32, i.e. 32 768 texels / 96 KiB). Read-only: resizing requires regenerating the entire texel payload, which the writer enforces (it rejects a pixel buffer that is not exactly mSize³ × 3 bytes).',
+			readOnly: true,
+		},
+		pixels: {
+			label: 'Texel data',
+			description: 'Dense RGB24 LUT body, X-major: texel (x,y,z) lives at (mSize²·z + mSize·y + x) × 3. Input Red indexes X, Green Y, Blue Z; each texel is the output colour. Preserved verbatim — edit via a preview extension, not byte-by-byte.',
+			hidden: true,
+		},
+		_pad08: {
+			label: 'pad +0x8',
+			description: 'Header pad word (0 in retail); preserved verbatim for byte-exact round-trip.',
+			hidden: true,
+		},
+		_pad0C: {
+			label: 'pad +0xC',
+			description: 'Header pad word (0 in retail); preserved verbatim for byte-exact round-trip.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Cube', properties: ['mSize'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedColourCube,
+};
+
+export const colourCubeResourceSchema: ResourceSchema = {
+	key: 'colourCube',
+	name: 'Colour Cube',
+	rootType: 'ParsedColourCube',
+	registry,
+};

--- a/src/lib/schema/resources/environmentDictionary.test.ts
+++ b/src/lib/schema/resources/environmentDictionary.test.ts
@@ -1,0 +1,171 @@
+// Schema coverage tests for environmentDictionaryResourceSchema.
+//
+// Coverage fixture: example/ENVIRONMENTSETTINGS/DICTIONARY.BUNDLE — the single
+// ENV_DICTIONARY (0x10014) resource, 4 seasons + 1 location.
+//
+// Mirrors staticSoundMap.test.ts: parse the model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import {
+	parseEnvironmentDictionary,
+	type ParsedEnvironmentDictionary,
+} from '../../core/environmentDictionary';
+
+import { environmentDictionaryResourceSchema } from './environmentDictionary';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/ENVIRONMENTSETTINGS/DICTIONARY.BUNDLE');
+const ENV_DICTIONARY_TYPE_ID = 0x10014;
+
+function loadModel(fixturePath: string): ParsedEnvironmentDictionary {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === ENV_DICTIONARY_TYPE_ID);
+	expect(resource).toBeDefined();
+	return parseEnvironmentDictionary(extractResourceRaw(buffer.buffer, bundle, resource!), ctx.littleEndian);
+}
+
+const model = loadModel(BUNDLE_FIXTURE);
+
+describe('environmentDictionaryResourceSchema coverage', () => {
+	it('fixture parses with non-trivial content', () => {
+		expect(model.seasons.length).toBeGreaterThan(0);
+		expect(model.locations.length).toBeGreaterThan(0);
+	});
+
+	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+		const missing: string[] = [];
+		for (const [recordName, rec] of Object.entries(environmentDictionaryResourceSchema.registry)) {
+			for (const [fieldName, field] of Object.entries(rec.fields)) {
+				checkField(field, `${recordName}.${fieldName}`, missing);
+			}
+		}
+		if (missing.length > 0) {
+			throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+		}
+		function checkField(f: FieldSchema, where: string, out: string[]) {
+			if (f.kind === 'record') {
+				if (!environmentDictionaryResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+				return;
+			}
+			if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+		}
+	});
+
+	it('walkResource visits every parsed field without throwing', () => {
+		let recordCount = 0;
+		let fieldCount = 0;
+		walkResource(environmentDictionaryResourceSchema, model, (_p, _v, field, rec) => {
+			if (rec) recordCount++;
+			if (field) fieldCount++;
+		});
+		expect(recordCount).toBeGreaterThan(0);
+		expect(fieldCount).toBeGreaterThan(0);
+	});
+
+	it('no parsed record has fields absent from the schema', () => {
+		const missing: string[] = [];
+		walkResource(environmentDictionaryResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const declared = new Set(Object.keys(rec.fields));
+			for (const key of Object.keys(value as Record<string, unknown>)) {
+				if (!declared.has(key)) {
+					missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+
+	it('every schema field is represented in the parsed data', () => {
+		const missing: string[] = [];
+		walkResource(environmentDictionaryResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const obj = value as Record<string, unknown>;
+			for (const fieldName of Object.keys(rec.fields)) {
+				if (!(fieldName in obj)) {
+					missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+});
+
+describe('environmentDictionary path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(environmentDictionaryResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedEnvironmentDictionary');
+	});
+
+	it('resolves seasons[0] as an EnvironmentDictionarySeason', () => {
+		const loc = resolveSchemaAtPath(environmentDictionaryResourceSchema, ['seasons', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('EnvironmentDictionarySeason');
+	});
+
+	it('resolves seasons[0].macBundle as a string', () => {
+		const loc = resolveSchemaAtPath(environmentDictionaryResourceSchema, ['seasons', 0, 'macBundle']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('string');
+	});
+
+	it('resolves locations[0].macName as a string', () => {
+		const loc = resolveSchemaAtPath(environmentDictionaryResourceSchema, ['locations', 0, 'macName']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('string');
+	});
+});
+
+describe('environmentDictionary labels and validation', () => {
+	const seasonRec = environmentDictionaryResourceSchema.registry.EnvironmentDictionarySeason;
+	const locationRec = environmentDictionaryResourceSchema.registry.EnvironmentDictionaryLocation;
+	const ctx = { root: model, resource: environmentDictionaryResourceSchema };
+
+	it('season labels strip the redundant ENV_TL_ prefix', () => {
+		const label = seasonRec.label!(model.seasons[0] as unknown as Record<string, unknown>, 0, ctx);
+		expect(label).toBe('#0 · 000_DLC24hr_SUN_A');
+	});
+
+	it('location labels show the name', () => {
+		const label = locationRec.label!(model.locations[0] as unknown as Record<string, unknown>, 0, ctx);
+		expect(label).toBe('#0 · city');
+	});
+
+	it('validate flags a bundle path that overflows its 64-byte field', () => {
+		const overlong = { ...model.seasons[0], macBundle: 'x'.repeat(64) };
+		const results = seasonRec.validate!(overlong as unknown as Record<string, unknown>, ctx);
+		expect(results).toEqual([
+			expect.objectContaining({ severity: 'error', field: 'macBundle' }),
+		]);
+	});
+
+	it('validate passes every retail entry', () => {
+		for (const s of model.seasons) {
+			expect(seasonRec.validate!(s as unknown as Record<string, unknown>, ctx)).toEqual([]);
+		}
+		for (const l of model.locations) {
+			expect(locationRec.validate!(l as unknown as Record<string, unknown>, ctx)).toEqual([]);
+		}
+	});
+});

--- a/src/lib/schema/resources/environmentDictionary.ts
+++ b/src/lib/schema/resources/environmentDictionary.ts
@@ -1,0 +1,188 @@
+// Hand-written schema for ParsedEnvironmentDictionary (resource type 0x10014).
+//
+// Mirrors the types in `src/lib/core/environmentDictionary.ts`. Keep these in
+// lockstep with the parser/writer — any field added to the parser needs a
+// matching entry here, or the schema walker reports it as drift.
+//
+// Domain: the dictionary is the game's catalogue of environment-settings
+// "seasons" (weather/time-of-day looks). Each entry names the season's
+// EnvironmentTimeLine resource, the bundle file carrying that timeline + its
+// keyframes, and the colour-cube (post-process tint) bundle. The game loads
+// the bundle by macBundle's literal game-relative path and finds the timeline
+// inside via crc32(lowercase(macResourceName)) — so renaming an entry without
+// renaming the resource in the target bundle orphans the season. Location
+// names pair with seasons to select keyframe sets
+// (ENV_KF_<season>_<location>_<time>).
+
+import {
+	SEASON_RESOURCE_NAME_CAP,
+	SEASON_BUNDLE_PATH_CAP,
+	LOCATION_NAME_CAP,
+} from '@/lib/core/environmentDictionary';
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+	ValidationResult,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring staticSoundMap.ts)
+// ---------------------------------------------------------------------------
+
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const str = (): FieldSchema => ({ kind: 'string' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+const rawBytes = (): FieldSchema => ({ kind: 'custom', component: 'rawBytes' });
+
+// The writer needs every string to fit its fixed char array (capacity − 1
+// chars + NUL); validate at edit time so the failure isn't a write-time throw.
+function fixedStringOverflow(
+	value: Record<string, unknown>,
+	field: string,
+	cap: number,
+): ValidationResult[] {
+	const text = value[field];
+	if (typeof text !== 'string') return [];
+	const byteLength = new TextEncoder().encode(text).length;
+	if (byteLength <= cap - 1) return [];
+	return [{
+		severity: 'error',
+		message: `${field} is ${byteLength} bytes; the on-disk field holds at most ${cap - 1} (+ NUL terminator)`,
+		field,
+	}];
+}
+
+// ---------------------------------------------------------------------------
+// Tree-label helpers
+// ---------------------------------------------------------------------------
+
+function seasonLabel(season: unknown, index: number): string {
+	if (!season || typeof season !== 'object') return `#${index}`;
+	const name = (season as { macResourceName?: string }).macResourceName;
+	if (!name) return `#${index}`;
+	// "ENV_TL_000_DLC24hr_SUN_A" → "000_DLC24hr_SUN_A": every retail timeline
+	// name carries the ENV_TL_ prefix, which adds no information in the tree.
+	return `#${index} · ${name.startsWith('ENV_TL_') ? name.slice('ENV_TL_'.length) : name}`;
+}
+
+function locationLabel(location: unknown, index: number): string {
+	if (!location || typeof location !== 'object') return `#${index}`;
+	const name = (location as { macName?: string }).macName;
+	return name ? `#${index} · ${name}` : `#${index}`;
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const EnvironmentDictionarySeason: RecordSchema = {
+	name: 'EnvironmentDictionarySeason',
+	description: 'One environment-settings "season" (weather/time-of-day look): the timeline resource it provides, the bundle carrying it, and the matching colour-cube bundle.',
+	fields: {
+		macResourceName: str(),
+		macBundle: str(),
+		macColourCubesBundle: str(),
+	},
+	fieldMetadata: {
+		macResourceName: {
+			label: 'Timeline resource name',
+			description: `Debug name of the EnvironmentTimeLine (0x10013) inside the season's bundle, e.g. ENV_TL_000_DLC24hr_SUN_A. The game resolves it by crc32(lowercase(name)), so it must match the resource in the target bundle exactly (case-insensitively). Max ${SEASON_RESOURCE_NAME_CAP - 1} chars.`,
+		},
+		macBundle: {
+			label: 'Settings bundle path',
+			description: `Game-relative path of the bundle carrying the timeline + keyframes, backslash separators, e.g. EnvironmentSettings\\000_DLC24hr_SUN_A.bundle. Loaded literally — a wrong path is a missing season at runtime. Max ${SEASON_BUNDLE_PATH_CAP - 1} chars.`,
+		},
+		macColourCubesBundle: {
+			label: 'Colour-cubes bundle path',
+			description: `Game-relative path of the season's colour-cube (post-process tint) texture bundle, e.g. EnvironmentSettings\\ColourCubes\\000_DLC24hr_SUN_A.bundle. Max ${SEASON_BUNDLE_PATH_CAP - 1} chars.`,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Season', properties: ['macResourceName', 'macBundle', 'macColourCubesBundle'] },
+	],
+	label: (value, index) => seasonLabel(value, index ?? 0),
+	validate: (value) => [
+		...fixedStringOverflow(value, 'macResourceName', SEASON_RESOURCE_NAME_CAP),
+		...fixedStringOverflow(value, 'macBundle', SEASON_BUNDLE_PATH_CAP),
+		...fixedStringOverflow(value, 'macColourCubesBundle', SEASON_BUNDLE_PATH_CAP),
+	],
+};
+
+const EnvironmentDictionaryLocation: RecordSchema = {
+	name: 'EnvironmentDictionaryLocation',
+	description: 'A location the environment keyframes are authored for — pairs with a season to select a keyframe set (ENV_KF_<season>_<location>_<time>). Retail uses a single "city".',
+	fields: {
+		macName: str(),
+	},
+	fieldMetadata: {
+		macName: {
+			label: 'Name',
+			description: `Location name matched against the keyframe debug names in the season bundles. Max ${LOCATION_NAME_CAP - 1} chars.`,
+		},
+	},
+	label: (value, index) => locationLabel(value, index ?? 0),
+	validate: (value) => fixedStringOverflow(value, 'macName', LOCATION_NAME_CAP),
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedEnvironmentDictionary: RecordSchema = {
+	name: 'ParsedEnvironmentDictionary',
+	description: 'Root record for the EnvironmentDictionary resource (0x10014): the catalogue of every environment-settings bundle the game can load, plus the location names their keyframes cover.',
+	fields: {
+		muVersion: u32(),
+		seasons: {
+			kind: 'list',
+			item: record('EnvironmentDictionarySeason'),
+			itemLabel: (item, index) => seasonLabel(item, index),
+			makeEmpty: () => ({ macResourceName: '', macBundle: '', macColourCubesBundle: '' }),
+		},
+		locations: {
+			kind: 'list',
+			item: record('EnvironmentDictionaryLocation'),
+			itemLabel: (item, index) => locationLabel(item, index),
+			makeEmpty: () => ({ macName: '' }),
+		},
+		_headerPad: rawBytes(),
+	},
+	fieldMetadata: {
+		muVersion: {
+			label: 'Version',
+			description: 'Dictionary format version — 2 in every retail build; the parser rejects anything else.',
+			readOnly: true,
+		},
+		seasons: {
+			label: 'Seasons',
+			description: 'One entry per environment-settings bundle. An entry only works if its bundle paths exist on disk and the named timeline resource lives inside.',
+		},
+		locations: {
+			label: 'Locations',
+			description: 'Location names the per-season keyframes are authored for. Retail uses a single "city".',
+		},
+		_headerPad: {
+			label: 'Header pad',
+			description: '12 alignment bytes between the 0x14-byte header and the season table (zeros in retail). Preserved verbatim for byte-exact round-trip.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Dictionary', properties: ['muVersion', 'seasons', 'locations'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedEnvironmentDictionary,
+	EnvironmentDictionarySeason,
+	EnvironmentDictionaryLocation,
+};
+
+export const environmentDictionaryResourceSchema: ResourceSchema = {
+	key: 'environmentDictionary',
+	name: 'Environment Dictionary',
+	rootType: 'ParsedEnvironmentDictionary',
+	registry,
+};

--- a/src/lib/schema/resources/environmentKeyframe.test.ts
+++ b/src/lib/schema/resources/environmentKeyframe.test.ts
@@ -1,0 +1,160 @@
+// Schema coverage tests for environmentKeyframeResourceSchema.
+//
+// Coverage fixture: example/ENVIRONMENTSETTINGS/000_DLC24HR_FOG_A.BUNDLE —
+// the first keyframe in bundle order plus a second one, since all 48 retail
+// keyframes share one rigid shape and the schema must drift against none.
+//
+// Mirrors staticSoundMap.test.ts: parse each model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseEnvironmentKeyframe, type ParsedEnvironmentKeyframe } from '../../core/environmentSettings';
+
+import { environmentKeyframeResourceSchema } from './environmentKeyframe';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/ENVIRONMENTSETTINGS/000_DLC24HR_FOG_A.BUNDLE');
+const KEYFRAME_TYPE_ID = 0x10012;
+
+function loadModels(fixturePath: string, count: number): ParsedEnvironmentKeyframe[] {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	return bundle.resources
+		.filter((r) => r.resourceTypeId === KEYFRAME_TYPE_ID)
+		.slice(0, count)
+		.map((r) => parseEnvironmentKeyframe(extractResourceRaw(buffer.buffer, bundle, r), ctx.littleEndian));
+}
+
+const models = loadModels(BUNDLE_FIXTURE, 2);
+
+for (const [label, model] of [
+	['keyframe (resource 0)', models[0]],
+	['keyframe (resource 1)', models[1]],
+] as const) {
+	describe(`environmentKeyframeResourceSchema coverage — ${label}`, () => {
+		it('fixture parses with non-trivial content', () => {
+			expect(model.muVersion).toBe(8);
+			expect(model.mColourCubeId).not.toBe(0n);
+		});
+
+		it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+			const missing: string[] = [];
+			for (const [recordName, rec] of Object.entries(environmentKeyframeResourceSchema.registry)) {
+				for (const [fieldName, field] of Object.entries(rec.fields)) {
+					checkField(field, `${recordName}.${fieldName}`, missing);
+				}
+			}
+			if (missing.length > 0) {
+				throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+			}
+			function checkField(f: FieldSchema, where: string, out: string[]) {
+				if (f.kind === 'record') {
+					if (!environmentKeyframeResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+					return;
+				}
+				if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+			}
+		});
+
+		it('walkResource visits every parsed field without throwing', () => {
+			let recordCount = 0;
+			let fieldCount = 0;
+			walkResource(environmentKeyframeResourceSchema, model, (_p, _v, field, rec) => {
+				if (rec) recordCount++;
+				if (field) fieldCount++;
+			});
+			expect(recordCount).toBeGreaterThan(0);
+			expect(fieldCount).toBeGreaterThan(0);
+		});
+
+		it('no parsed record has fields absent from the schema', () => {
+			const missing: string[] = [];
+			walkResource(environmentKeyframeResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const declared = new Set(Object.keys(rec.fields));
+				for (const key of Object.keys(value as Record<string, unknown>)) {
+					if (!declared.has(key)) {
+						missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+
+		it('every schema field is represented in the parsed data', () => {
+			const missing: string[] = [];
+			walkResource(environmentKeyframeResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const obj = value as Record<string, unknown>;
+				for (const fieldName of Object.keys(rec.fields)) {
+					if (!(fieldName in obj)) {
+						missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+	});
+}
+
+describe('environmentKeyframe path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(environmentKeyframeResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedEnvironmentKeyframe');
+	});
+
+	it('resolves mBloomData as an EnvironmentBloomData record', () => {
+		const loc = resolveSchemaAtPath(environmentKeyframeResourceSchema, ['mBloomData']);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('EnvironmentBloomData');
+	});
+
+	it('resolves mLightingData.mv3KeyLightColour as vec3', () => {
+		const loc = resolveSchemaAtPath(environmentKeyframeResourceSchema, ['mLightingData', 'mv3KeyLightColour']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('vec3');
+	});
+
+	it('resolves mVignetteData.mv4InnerColour as vec4', () => {
+		const loc = resolveSchemaAtPath(environmentKeyframeResourceSchema, ['mVignetteData', 'mv4InnerColour']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('vec4');
+	});
+
+	it('resolves mCloudsData.mav3LayerLiteColour[1] as vec3', () => {
+		const loc = resolveSchemaAtPath(environmentKeyframeResourceSchema, ['mCloudsData', 'mav3LayerLiteColour', 1]);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('vec3');
+	});
+
+	it('resolves mScatteringData.mafScattDist[0] as f32', () => {
+		const loc = resolveSchemaAtPath(environmentKeyframeResourceSchema, ['mScatteringData', 'mafScattDist', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('f32');
+	});
+
+	it('resolves mColourCubeId as a hex bigint', () => {
+		const loc = resolveSchemaAtPath(environmentKeyframeResourceSchema, ['mColourCubeId']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('bigint');
+	});
+});

--- a/src/lib/schema/resources/environmentKeyframe.ts
+++ b/src/lib/schema/resources/environmentKeyframe.ts
@@ -1,0 +1,288 @@
+// Hand-written schema for ParsedEnvironmentKeyframe (resource type 0x10012).
+//
+// Mirrors the types in `src/lib/core/environmentSettings.ts`. Keep these in
+// lockstep with the parser/writer — any field added to the parser needs a
+// matching entry here, or the schema walker reports it as drift.
+//
+// Domain: a keyframe is a full snapshot of the environment look at one time
+// of day (the time lives in the debug name's _HHMM suffix and in the
+// EnvironmentTimeLine's schedule, not in this resource). All colour fields
+// are LINEAR FLOAT RGB: nominal range 0–1, but sky colours and the lighting
+// fills go HDR-overbright in retail (observed max ≈ 3.5 on the down fill) —
+// values above 1 are intentional, never clamp them. The post-process tint is
+// not stored here either: mColourCubeId references a ColourCube (0x50)
+// texture via the resource's inline import table.
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring staticSoundMap.ts)
+// ---------------------------------------------------------------------------
+
+const f32 = (): FieldSchema => ({ kind: 'f32' });
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const vec2 = (): FieldSchema => ({ kind: 'vec2' });
+const vec3 = (): FieldSchema => ({ kind: 'vec3' });
+const vec4 = (): FieldSchema => ({ kind: 'vec4' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+const resourceId = (): FieldSchema => ({ kind: 'bigint', bytes: 8, hex: true });
+
+const fixedF32Pair = (): FieldSchema => ({
+	kind: 'list',
+	item: f32(),
+	addable: false,
+	removable: false,
+	minLength: 2,
+	maxLength: 2,
+});
+
+const cloudLayerColours = (): FieldSchema => ({
+	kind: 'list',
+	item: vec3(),
+	addable: false,
+	removable: false,
+	minLength: 2,
+	maxLength: 2,
+	itemLabel: (_item, index) => `layer ${index}`,
+});
+
+const RGB_NOTE = 'Linear float RGB — nominal 0–1, HDR values above 1 are valid (do not clamp).';
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const EnvironmentBloomData: RecordSchema = {
+	name: 'EnvironmentBloomData',
+	description: 'HDR bloom (glow around bright areas) for this time of day.',
+	fields: {
+		mfLuminance: f32(),
+		mfThreshold: f32(),
+		mv4Scale: vec4(),
+	},
+	fieldMetadata: {
+		mfLuminance: {
+			label: 'Luminance',
+			description: 'Scene luminance the bloom adapts around (retail 0.71–3.36).',
+		},
+		mfThreshold: {
+			label: 'Threshold',
+			description: 'Brightness above which pixels start blooming (retail 0.05–0.84).',
+		},
+		mv4Scale: {
+			label: 'Bloom scale (RGB + w)',
+			description: `Per-channel bloom colour scale, RGB in x/y/z. ${RGB_NOTE} Retail keeps every lane in 0.001–1.`,
+		},
+	},
+};
+
+const EnvironmentVignetteData: RecordSchema = {
+	name: 'EnvironmentVignetteData',
+	description: 'Screen-edge vignette tint for this time of day.',
+	fields: {
+		mfAngle: f32(),
+		mfSharpness: f32(),
+		mv2Amount: vec2(),
+		mv2Centre: vec2(),
+		mv4InnerColour: vec4(),
+		mv4OuterColour: vec4(),
+	},
+	fieldMetadata: {
+		mfAngle: {
+			label: 'Angle',
+			description: 'Vignette rotation. 0 in every retail keyframe.',
+		},
+		mfSharpness: {
+			label: 'Sharpness',
+			description: 'Falloff sharpness from centre to edge (retail 0.24–0.39).',
+		},
+		mv2Amount: {
+			label: 'Amount',
+			description: 'Vignette strength (x/y; retail 0.3–1.01).',
+		},
+		mv2Centre: {
+			label: 'Centre',
+			description: 'Vignette centre in normalized screen space (retail 0.2–0.7).',
+		},
+		mv4InnerColour: {
+			label: 'Inner colour (RGBA)',
+			description: `Colour at the vignette centre. ${RGB_NOTE}`,
+		},
+		mv4OuterColour: {
+			label: 'Outer colour (RGBA)',
+			description: `Colour at the screen edges. ${RGB_NOTE}`,
+		},
+	},
+};
+
+const EnvironmentScatteringData: RecordSchema = {
+	name: 'EnvironmentScatteringData',
+	description: 'Atmospheric model: the sky dome colour ramp (Sky*) and the in-scattering / distance-haze ramp applied to geometry (Scatt*). Each ramp blends a zenith, horizon, and sun-direction colour.',
+	fields: {
+		mv3SkyTopColour: vec3(),
+		mv3SkyHorColour: vec3(),
+		mv3SkySunColour: vec3(),
+		mfSkyHorPow: f32(),
+		mfSkySunPow: f32(),
+		mfSkyDrk: f32(),
+		mfSkyHorBleedScl: f32(),
+		mfSkyHorBleedPow: f32(),
+		mfSkySunBleedPow: f32(),
+		mv3ScattTopColour: vec3(),
+		mv3ScattHorColour: vec3(),
+		mv3ScattSunColour: vec3(),
+		mfScattHorPow: f32(),
+		mfScattSunPow: f32(),
+		mfScattDrk: f32(),
+		mfScattHorBleedScl: f32(),
+		mfScattHorBleedPow: f32(),
+		mfScattSunBleedPow: f32(),
+		mafScattDist: fixedF32Pair(),
+		mfScattPow: f32(),
+		mfScattCap: f32(),
+	},
+	fieldMetadata: {
+		mv3SkyTopColour: { label: 'Sky zenith colour (RGB)', description: `Sky colour straight up. ${RGB_NOTE}` },
+		mv3SkyHorColour: { label: 'Sky horizon colour (RGB)', description: `Sky colour at the horizon. ${RGB_NOTE} Retail sky colours reach ≈2.19.` },
+		mv3SkySunColour: { label: 'Sky sun colour (RGB)', description: `Sky colour around the sun disc. ${RGB_NOTE}` },
+		mfSkyHorPow: { label: 'Sky horizon power', description: 'Zenith→horizon blend exponent (retail 0.2–10).' },
+		mfSkySunPow: { label: 'Sky sun power', description: 'Sun-glow concentration exponent — higher = tighter glow (retail 1.8–50).' },
+		mfSkyDrk: { label: 'Sky darkening', description: 'Sky darkening factor.' },
+		mfSkyHorBleedScl: { label: 'Sky horizon bleed scale', description: 'How far the horizon colour bleeds up the dome.' },
+		mfSkyHorBleedPow: { label: 'Sky horizon bleed power', description: 'Bleed falloff exponent.' },
+		mfSkySunBleedPow: { label: 'Sky sun bleed power', description: 'Sun-colour bleed falloff exponent.' },
+		mv3ScattTopColour: { label: 'Scattering zenith colour (RGB)', description: `In-scattering colour for upward view. ${RGB_NOTE}` },
+		mv3ScattHorColour: { label: 'Scattering horizon colour (RGB)', description: `In-scattering (haze) colour toward the horizon. ${RGB_NOTE}` },
+		mv3ScattSunColour: { label: 'Scattering sun colour (RGB)', description: `In-scattering colour toward the sun. ${RGB_NOTE}` },
+		mfScattHorPow: { label: 'Scattering horizon power', description: 'Scattering ramp blend exponent.' },
+		mfScattSunPow: { label: 'Scattering sun power', description: 'Sun-direction scattering exponent.' },
+		mfScattDrk: { label: 'Scattering darkening', description: 'Scattering darkening factor.' },
+		mfScattHorBleedScl: { label: 'Scattering horizon bleed scale', description: 'Horizon-colour bleed distance for the scattering ramp.' },
+		mfScattHorBleedPow: { label: 'Scattering horizon bleed power', description: 'Bleed falloff exponent.' },
+		mfScattSunBleedPow: { label: 'Scattering sun bleed power', description: 'Sun-colour bleed falloff exponent.' },
+		mafScattDist: { label: 'Scattering distances', description: 'Near/far in-scattering fog distances in world units/metres (retail 1–2000).' },
+		mfScattPow: { label: 'Scattering power', description: 'Overall distance-fog curve exponent.' },
+		mfScattCap: { label: 'Scattering cap', description: 'Maximum scattering opacity, 0–1 (retail ≤ 0.93) — keeps distant geometry from fogging out completely.' },
+	},
+	propertyGroups: [
+		{ title: 'Sky dome', properties: ['mv3SkyTopColour', 'mv3SkyHorColour', 'mv3SkySunColour', 'mfSkyHorPow', 'mfSkySunPow', 'mfSkyDrk', 'mfSkyHorBleedScl', 'mfSkyHorBleedPow', 'mfSkySunBleedPow'] },
+		{ title: 'In-scattering', properties: ['mv3ScattTopColour', 'mv3ScattHorColour', 'mv3ScattSunColour', 'mfScattHorPow', 'mfScattSunPow', 'mfScattDrk', 'mfScattHorBleedScl', 'mfScattHorBleedPow', 'mfScattSunBleedPow', 'mafScattDist', 'mfScattPow', 'mfScattCap'] },
+	],
+};
+
+const EnvironmentLightingData: RecordSchema = {
+	name: 'EnvironmentLightingData',
+	description: 'The world light rig: key light + specular plus a six-direction ambient fill cube (right/left/up/down and key/shadow side). This is what makes noon look different from dusk on geometry.',
+	fields: {
+		mv3KeyLightColour: vec3(),
+		mv3SpecularColour: vec3(),
+		mv3KeyFillColour: vec3(),
+		mv3ShadowFillColour: vec3(),
+		mv3RightFillColour: vec3(),
+		mv3LeftFillColour: vec3(),
+		mv3UpFillColour: vec3(),
+		mv3DownFillColour: vec3(),
+		mfAmbientIrradianceScale: f32(),
+	},
+	fieldMetadata: {
+		mv3KeyLightColour: { label: 'Key light colour (RGB)', description: `Directional sun/moon light colour. ${RGB_NOTE}` },
+		mv3SpecularColour: { label: 'Specular colour (RGB)', description: `Specular highlight tint. ${RGB_NOTE}` },
+		mv3KeyFillColour: { label: 'Key-side fill (RGB)', description: `Ambient fill from the key-light direction. ${RGB_NOTE} Retail fills reach ≈3.5.` },
+		mv3ShadowFillColour: { label: 'Shadow-side fill (RGB)', description: `Ambient fill opposite the key light. ${RGB_NOTE}` },
+		mv3RightFillColour: { label: 'Right fill (RGB)', description: `Ambient fill from +X. ${RGB_NOTE}` },
+		mv3LeftFillColour: { label: 'Left fill (RGB)', description: `Ambient fill from -X. ${RGB_NOTE}` },
+		mv3UpFillColour: { label: 'Up fill (RGB)', description: `Ambient fill from above (sky bounce). ${RGB_NOTE}` },
+		mv3DownFillColour: { label: 'Down fill (RGB)', description: `Ambient fill from below (ground bounce — the brightest fill in retail, up to ≈3.5). ${RGB_NOTE}` },
+		mfAmbientIrradianceScale: { label: 'Ambient irradiance scale', description: 'Master scale on the fill cube (retail 0.11–0.58).' },
+	},
+	propertyGroups: [
+		{ title: 'Direct light', properties: ['mv3KeyLightColour', 'mv3SpecularColour'] },
+		{ title: 'Ambient fill cube', properties: ['mv3KeyFillColour', 'mv3ShadowFillColour', 'mv3RightFillColour', 'mv3LeftFillColour', 'mv3UpFillColour', 'mv3DownFillColour', 'mfAmbientIrradianceScale'] },
+	],
+};
+
+const EnvironmentCloudsData: RecordSchema = {
+	name: 'EnvironmentCloudsData',
+	description: 'Two scrolling cloud layers. Every array here is fixed at 2 entries — index 0 is layer 0, index 1 is layer 1 (a season can disable a layer by zeroing its opacity/colours).',
+	fields: {
+		mav3LayerLiteColour: cloudLayerColours(),
+		mav3LayerDarkColour: cloudLayerColours(),
+		mafLayerDensity: fixedF32Pair(),
+		mafLayerFeathering: fixedF32Pair(),
+		mafLayerOpacity: fixedF32Pair(),
+		mafLayerSpeed: fixedF32Pair(),
+		mafLayerScale: fixedF32Pair(),
+		mfDirectionAngle: f32(),
+	},
+	fieldMetadata: {
+		mav3LayerLiteColour: { label: 'Lit colour per layer (RGB)', description: `Sun-facing cloud colour for layers 0/1. ${RGB_NOTE}` },
+		mav3LayerDarkColour: { label: 'Dark colour per layer (RGB)', description: `Shadowed cloud colour for layers 0/1. ${RGB_NOTE}` },
+		mafLayerDensity: { label: 'Density per layer', description: 'Cloud coverage 0–1 per layer.' },
+		mafLayerFeathering: { label: 'Feathering per layer', description: 'Edge softness per layer (retail 0.1–1.1).' },
+		mafLayerOpacity: { label: 'Opacity per layer', description: 'Layer opacity 0–1; 0 disables the layer.' },
+		mafLayerSpeed: { label: 'Speed per layer', description: 'Scroll speed per layer (retail 3–30).' },
+		mafLayerScale: { label: 'Scale per layer', description: 'Texture scale per layer (retail 1–7000).' },
+		mfDirectionAngle: { label: 'Drift direction', description: 'Cloud drift direction in degrees (retail 0–100).' },
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedEnvironmentKeyframe: RecordSchema = {
+	name: 'ParsedEnvironmentKeyframe',
+	description: 'Root record for the Environment Keyframe resource (0x10012): the complete environment look at one time of day. The EnvironmentTimeLine (0x10013) in the same bundle schedules and interpolates between these.',
+	fields: {
+		muVersion: u32(),
+		mColourCubeId: resourceId(),
+		mBloomData: record('EnvironmentBloomData'),
+		mVignetteData: record('EnvironmentVignetteData'),
+		mScatteringData: record('EnvironmentScatteringData'),
+		mLightingData: record('EnvironmentLightingData'),
+		mCloudsData: record('EnvironmentCloudsData'),
+	},
+	fieldMetadata: {
+		muVersion: {
+			label: 'Version',
+			description: 'Format version — 8 in every retail resource; the writer rejects anything else.',
+			readOnly: true,
+		},
+		mColourCubeId: {
+			label: 'Colour cube',
+			description: 'Resource id of the ColourCube (0x50) post-process tint texture, referenced via the inline import table (the on-disk TintData pointer is 0 until load). Ids are crc32 of the lowercased debug name; the cube lives in the season\'s ColourCubes bundle, not this one.',
+		},
+		mBloomData: { label: 'Bloom' },
+		mVignetteData: { label: 'Vignette' },
+		mScatteringData: { label: 'Sky & scattering' },
+		mLightingData: { label: 'Lighting rig' },
+		mCloudsData: { label: 'Cloud layers' },
+	},
+	propertyGroups: [
+		{ title: 'Post-processing', properties: ['mBloomData', 'mVignetteData', 'mColourCubeId'] },
+		{ title: 'Atmosphere', properties: ['mScatteringData', 'mCloudsData'] },
+		{ title: 'Lighting', properties: ['mLightingData'] },
+		{ title: 'Format', properties: ['muVersion'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedEnvironmentKeyframe,
+	EnvironmentBloomData,
+	EnvironmentVignetteData,
+	EnvironmentScatteringData,
+	EnvironmentLightingData,
+	EnvironmentCloudsData,
+};
+
+export const environmentKeyframeResourceSchema: ResourceSchema = {
+	key: 'environmentKeyframe',
+	name: 'Environment Keyframe',
+	rootType: 'ParsedEnvironmentKeyframe',
+	registry,
+};

--- a/src/lib/schema/resources/environmentTimeLine.test.ts
+++ b/src/lib/schema/resources/environmentTimeLine.test.ts
@@ -1,0 +1,163 @@
+// Schema coverage tests for environmentTimeLineResourceSchema.
+//
+// Coverage fixture: example/ENVIRONMENTSETTINGS/000_DLC24HR_FOG_A.BUNDLE —
+// its single timeline (one location, 11 keyframe entries).
+//
+// Mirrors staticSoundMap.test.ts: parse the model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds. Also pins the location-level
+// ascending-times validation hook.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseEnvironmentTimeLine, type ParsedEnvironmentTimeLine } from '../../core/environmentSettings';
+
+import { environmentTimeLineResourceSchema } from './environmentTimeLine';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema, SchemaContext } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/ENVIRONMENTSETTINGS/000_DLC24HR_FOG_A.BUNDLE');
+const TIME_LINE_TYPE_ID = 0x10013;
+
+function loadModel(fixturePath: string): ParsedEnvironmentTimeLine {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === TIME_LINE_TYPE_ID)!;
+	return parseEnvironmentTimeLine(extractResourceRaw(buffer.buffer, bundle, resource), ctx.littleEndian);
+}
+
+const model = loadModel(BUNDLE_FIXTURE);
+
+describe('environmentTimeLineResourceSchema coverage', () => {
+	it('fixture parses with non-trivial content', () => {
+		expect(model.locations.length).toBe(1);
+		expect(model.locations[0].keyframes.length).toBeGreaterThan(0);
+	});
+
+	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+		const missing: string[] = [];
+		for (const [recordName, rec] of Object.entries(environmentTimeLineResourceSchema.registry)) {
+			for (const [fieldName, field] of Object.entries(rec.fields)) {
+				checkField(field, `${recordName}.${fieldName}`, missing);
+			}
+		}
+		if (missing.length > 0) {
+			throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+		}
+		function checkField(f: FieldSchema, where: string, out: string[]) {
+			if (f.kind === 'record') {
+				if (!environmentTimeLineResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+				return;
+			}
+			if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+		}
+	});
+
+	it('walkResource visits every parsed field without throwing', () => {
+		let recordCount = 0;
+		let fieldCount = 0;
+		walkResource(environmentTimeLineResourceSchema, model, (_p, _v, field, rec) => {
+			if (rec) recordCount++;
+			if (field) fieldCount++;
+		});
+		expect(recordCount).toBeGreaterThan(0);
+		expect(fieldCount).toBeGreaterThan(0);
+	});
+
+	it('no parsed record has fields absent from the schema', () => {
+		const missing: string[] = [];
+		walkResource(environmentTimeLineResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const declared = new Set(Object.keys(rec.fields));
+			for (const key of Object.keys(value as Record<string, unknown>)) {
+				if (!declared.has(key)) {
+					missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+
+	it('every schema field is represented in the parsed data', () => {
+		const missing: string[] = [];
+		walkResource(environmentTimeLineResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const obj = value as Record<string, unknown>;
+			for (const fieldName of Object.keys(rec.fields)) {
+				if (!(fieldName in obj)) {
+					missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+});
+
+describe('environmentTimeLine path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(environmentTimeLineResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedEnvironmentTimeLine');
+	});
+
+	it('resolves locations[0] as an EnvironmentTimeLineLocation', () => {
+		const loc = resolveSchemaAtPath(environmentTimeLineResourceSchema, ['locations', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('EnvironmentTimeLineLocation');
+	});
+
+	it('resolves locations[0].keyframes[0] as an EnvironmentTimeLineKeyframe', () => {
+		const loc = resolveSchemaAtPath(environmentTimeLineResourceSchema, ['locations', 0, 'keyframes', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('EnvironmentTimeLineKeyframe');
+	});
+
+	it('resolves locations[0].keyframes[0].mfTimeOfDay as f32', () => {
+		const loc = resolveSchemaAtPath(environmentTimeLineResourceSchema, ['locations', 0, 'keyframes', 0, 'mfTimeOfDay']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('f32');
+	});
+
+	it('resolves locations[0].keyframes[0].mKeyframeId as a hex bigint', () => {
+		const loc = resolveSchemaAtPath(environmentTimeLineResourceSchema, ['locations', 0, 'keyframes', 0, 'mKeyframeId']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('bigint');
+	});
+});
+
+describe('environmentTimeLine location validation', () => {
+	const locationSchema = environmentTimeLineResourceSchema.registry.EnvironmentTimeLineLocation;
+	const ctx: SchemaContext = { root: model, resource: environmentTimeLineResourceSchema };
+
+	it('accepts the retail ascending schedule', () => {
+		expect(locationSchema.validate!(model.locations[0] as never, ctx)).toEqual([]);
+	});
+
+	it('warns when schedule times do not ascend', () => {
+		const broken = {
+			keyframes: [
+				{ mfTimeOfDay: 14400, mKeyframeId: 1n },
+				{ mfTimeOfDay: 0, mKeyframeId: 2n },
+			],
+		};
+		const results = locationSchema.validate!(broken as never, ctx);
+		expect(results.length).toBe(1);
+		expect(results[0].severity).toBe('warning');
+		expect(results[0].message).toMatch(/ascend/);
+	});
+});

--- a/src/lib/schema/resources/environmentTimeLine.ts
+++ b/src/lib/schema/resources/environmentTimeLine.ts
@@ -1,0 +1,172 @@
+// Hand-written schema for ParsedEnvironmentTimeLine (resource type 0x10013).
+//
+// Mirrors the types in `src/lib/core/environmentSettings.ts`. Keep these in
+// lockstep with the parser/writer — any field added to the parser needs a
+// matching entry here, or the schema walker reports it as drift.
+//
+// Domain: the timeline is a season's time-of-day schedule. Per location
+// (every retail timeline has exactly one — "city"), an ascending list of
+// (clock-time seconds, EnvironmentKeyframe id) pairs the game interpolates
+// between as the in-game clock advances. The keyframe references are BND2
+// imports resolved against the 0x10012 resources in the SAME bundle; retail
+// timelines cover every keyframe in their bundle exactly once. Editing times
+// or retargeting an entry is safe; adding/removing entries also resizes the
+// resource's inline import table, which the bundle envelope's import metadata
+// (importCount/importOffset) does not track yet — hence the warning below.
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+	ValidationResult,
+} from '../types';
+import { formatTimeOfDay } from '@/lib/core/environmentSettings';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring staticSoundMap.ts)
+// ---------------------------------------------------------------------------
+
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const resourceId = (): FieldSchema => ({ kind: 'bigint', bytes: 8, hex: true });
+
+// ---------------------------------------------------------------------------
+// Tree-label helpers
+// ---------------------------------------------------------------------------
+
+function keyframeEntryLabel(item: unknown, index: number): string {
+	try {
+		if (!item || typeof item !== 'object') return `#${index}`;
+		const e = item as { mfTimeOfDay?: number; mKeyframeId?: bigint };
+		const time = e.mfTimeOfDay != null ? formatTimeOfDay(e.mfTimeOfDay) : '?';
+		const id = e.mKeyframeId != null ? `0x${e.mKeyframeId.toString(16).toUpperCase()}` : '?';
+		return `#${index} · ${time} · ${id}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function locationLabel(value: unknown, index: number): string {
+	try {
+		if (!value || typeof value !== 'object') return `#${index}`;
+		const loc = value as { keyframes?: unknown[] };
+		const n = loc.keyframes?.length ?? 0;
+		return `#${index} · ${n} keyframe${n === 1 ? '' : 's'}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const EnvironmentTimeLineKeyframe: RecordSchema = {
+	name: 'EnvironmentTimeLineKeyframe',
+	description: 'One schedule entry: at this clock time, the environment look is exactly the referenced keyframe; between entries the game interpolates.',
+	fields: {
+		mfTimeOfDay: { kind: 'f32', min: 0, max: 86400 },
+		mKeyframeId: resourceId(),
+	},
+	fieldMetadata: {
+		mfTimeOfDay: {
+			label: 'Time of day',
+			description: 'Clock time in seconds since midnight (0–86400; 4:00 AM = 14400). Entries must stay in ascending order.',
+		},
+		mKeyframeId: {
+			label: 'Keyframe',
+			description: 'Resource id of the EnvironmentKeyframe (0x10012) in the same bundle (crc32 of the lowercased debug name), referenced via the inline import table — the on-disk pointer slot is 0 until load.',
+		},
+	},
+	label: (value, index) => keyframeEntryLabel(value, index ?? 0),
+};
+
+const EnvironmentTimeLineLocation: RecordSchema = {
+	name: 'EnvironmentTimeLineLocation',
+	description: 'The schedule for one named location. Location names live in the EnvironmentDictionary (0x10014), matched by index — retail defines a single "city" location.',
+	fields: {
+		keyframes: {
+			kind: 'list',
+			item: { kind: 'record', type: 'EnvironmentTimeLineKeyframe' },
+			addable: true,
+			removable: true,
+			makeEmpty: () => ({ mfTimeOfDay: 0, mKeyframeId: 0n }),
+			itemLabel: (item, index) => keyframeEntryLabel(item, index),
+		},
+	},
+	fieldMetadata: {
+		keyframes: {
+			label: 'Schedule',
+			description: 'Ascending (time, keyframe) pairs. Retail timelines start at 00:00 and cover every keyframe in the bundle exactly once.',
+			warning: 'Adding or removing entries resizes the resource\'s inline import table; the bundle envelope\'s import metadata is not recomputed yet — prefer editing times / retargeting existing entries.',
+		},
+	},
+	label: (value, index) => locationLabel(value, index ?? 0),
+	validate: (value): ValidationResult[] => {
+		const keyframes = (value as { keyframes?: { mfTimeOfDay?: number }[] }).keyframes ?? [];
+		const results: ValidationResult[] = [];
+		for (let i = 1; i < keyframes.length; i++) {
+			const prev = keyframes[i - 1]?.mfTimeOfDay ?? 0;
+			const cur = keyframes[i]?.mfTimeOfDay ?? 0;
+			if (cur <= prev) {
+				results.push({
+					severity: 'warning',
+					message: `Schedule times must ascend: entry #${i} (${formatTimeOfDay(cur)}) is not after #${i - 1} (${formatTimeOfDay(prev)})`,
+					field: 'keyframes',
+				});
+			}
+		}
+		return results;
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedEnvironmentTimeLine: RecordSchema = {
+	name: 'ParsedEnvironmentTimeLine',
+	description: 'Root record for the Environment Timeline resource (0x10013): the per-location time-of-day schedule of EnvironmentKeyframes for one season. One timeline per season bundle.',
+	fields: {
+		muVersion: u32(),
+		locations: {
+			kind: 'list',
+			item: { kind: 'record', type: 'EnvironmentTimeLineLocation' },
+			// Every retail timeline has exactly one location, and the on-disk
+			// layout for >1 is unverified (the parser would reject a multi-
+			// location resource that disagrees with its canonical reading) —
+			// so the list shape is locked.
+			addable: false,
+			removable: false,
+			itemLabel: (item, index) => locationLabel(item, index),
+		},
+	},
+	fieldMetadata: {
+		muVersion: {
+			label: 'Version',
+			description: 'Format version — 1 in every retail resource; the writer rejects anything else.',
+			readOnly: true,
+		},
+		locations: {
+			label: 'Locations',
+			description: 'One schedule per location, matched by index against the EnvironmentDictionary\'s location list ("city" in retail).',
+		},
+	},
+	propertyGroups: [
+		{ title: 'Schedule', properties: ['locations'] },
+		{ title: 'Format', properties: ['muVersion'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedEnvironmentTimeLine,
+	EnvironmentTimeLineLocation,
+	EnvironmentTimeLineKeyframe,
+};
+
+export const environmentTimeLineResourceSchema: ResourceSchema = {
+	key: 'environmentTimeLine',
+	name: 'Environment Timeline',
+	rootType: 'ParsedEnvironmentTimeLine',
+	registry,
+};

--- a/src/lib/schema/resources/font.test.ts
+++ b/src/lib/schema/resources/font.test.ts
@@ -1,0 +1,186 @@
+// Schema coverage tests for fontResourceSchema.
+//
+// Coverage fixtures: CHINESE_SIMPLIFIED.FONT (single page, largest glyph
+// table) and CHINESE_SIMPLIFIED_LIMITED.FONT (the 2-page shape whose second
+// page imports an external Texture and carries a garbage pointer slot). The
+// same schema must cover both — only the page count differs.
+//
+// Mirrors staticSoundMap.test.ts: parse each model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseFont, FONT_TYPE_ID, type ParsedFont } from '../../core/font';
+
+import { fontResourceSchema, charIdLabel } from './font';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+function loadModel(fontFile: string): ParsedFont {
+	const fileBytes = fs.readFileSync(path.resolve(REPO_ROOT, 'example/FONTS', fontFile));
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const res = bundle.resources.find((r) => r.resourceTypeId === FONT_TYPE_ID);
+	if (!res) throw new Error(`${fontFile}: no Font resource`);
+	return parseFont(extractResourceRaw(buffer.buffer, bundle, res), ctx.littleEndian);
+}
+
+for (const [label, file] of [
+	['single-page font', 'CHINESE_SIMPLIFIED.FONT'],
+	['2-page font', 'CHINESE_SIMPLIFIED_LIMITED.FONT'],
+] as const) {
+	describe(`fontResourceSchema coverage — ${label}`, () => {
+		const model = loadModel(file);
+
+		it('fixture parses with non-trivial content', () => {
+			expect(model.chars.length).toBeGreaterThan(0);
+			expect(model.texturePages.length).toBeGreaterThan(0);
+		});
+
+		it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+			const missing: string[] = [];
+			for (const [recordName, rec] of Object.entries(fontResourceSchema.registry)) {
+				for (const [fieldName, field] of Object.entries(rec.fields)) {
+					checkField(field, `${recordName}.${fieldName}`, missing);
+				}
+			}
+			if (missing.length > 0) {
+				throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+			}
+			function checkField(f: FieldSchema, where: string, out: string[]) {
+				if (f.kind === 'record') {
+					if (!fontResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+					return;
+				}
+				if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+			}
+		});
+
+		it('ref fields target lists that exist on the parsed model', () => {
+			for (const rec of Object.values(fontResourceSchema.registry)) {
+				for (const [fieldName, field] of Object.entries(rec.fields)) {
+					if (field.kind !== 'ref') continue;
+					let target: unknown = model;
+					for (const seg of field.target.listPath) {
+						target = (target as Record<string | number, unknown>)[seg];
+					}
+					expect(Array.isArray(target), `${rec.name}.${fieldName} target`).toBe(true);
+					expect(fontResourceSchema.registry[field.target.itemType], `${rec.name}.${fieldName} itemType`).toBeDefined();
+				}
+			}
+		});
+
+		it('walkResource visits every parsed field without throwing', () => {
+			let recordCount = 0;
+			let fieldCount = 0;
+			walkResource(fontResourceSchema, model, (_p, _v, field, rec) => {
+				if (rec) recordCount++;
+				if (field) fieldCount++;
+			});
+			expect(recordCount).toBeGreaterThan(0);
+			expect(fieldCount).toBeGreaterThan(0);
+		});
+
+		it('no parsed record has fields absent from the schema', () => {
+			const missing: string[] = [];
+			walkResource(fontResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const declared = new Set(Object.keys(rec.fields));
+				for (const key of Object.keys(value as Record<string, unknown>)) {
+					if (!declared.has(key)) {
+						missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+
+		it('every schema field is represented in the parsed data', () => {
+			const missing: string[] = [];
+			walkResource(fontResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const obj = value as Record<string, unknown>;
+				for (const fieldName of Object.keys(rec.fields)) {
+					if (!(fieldName in obj)) {
+						missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+	});
+}
+
+describe('font path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(fontResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedFont');
+	});
+
+	it('resolves chars[0] as a FontChar', () => {
+		const loc = resolveSchemaAtPath(fontResourceSchema, ['chars', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('FontChar');
+	});
+
+	it('resolves chars[0].mTopLeftUV as vec2', () => {
+		const loc = resolveSchemaAtPath(fontResourceSchema, ['chars', 0, 'mTopLeftUV']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('vec2');
+	});
+
+	it('resolves chars[0].mu16TexturePageId as a ref into texturePages', () => {
+		const loc = resolveSchemaAtPath(fontResourceSchema, ['chars', 0, 'mu16TexturePageId']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('ref');
+		if (loc!.field?.kind === 'ref') {
+			expect(loc!.field.target.listPath).toEqual(['texturePages']);
+		}
+	});
+
+	it('resolves texturePages[0] as a FontTexturePage with a hex bigint id', () => {
+		const loc = resolveSchemaAtPath(fontResourceSchema, ['texturePages', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('FontTexturePage');
+		const idLoc = resolveSchemaAtPath(fontResourceSchema, ['texturePages', 0, 'textureId']);
+		expect(idLoc!.field?.kind).toBe('bigint');
+	});
+
+	it('resolves macTypefaceFamilyName as string', () => {
+		const loc = resolveSchemaAtPath(fontResourceSchema, ['macTypefaceFamilyName']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('string');
+	});
+});
+
+describe('charIdLabel', () => {
+	it('shows the actual character where printable', () => {
+		expect(charIdLabel(0x4e00)).toBe("'一' U+4E00");
+		expect(charIdLabel(0x41)).toBe("'A' U+0041");
+		expect(charIdLabel(0x0e01)).toBe("'ก' U+0E01");
+	});
+
+	it('falls back to codepoint-only for spaces, controls, and the Latin-1 gap', () => {
+		expect(charIdLabel(0x20)).toBe('U+0020');
+		expect(charIdLabel(0xa0)).toBe('U+00A0');
+		expect(charIdLabel(0x3000)).toBe('U+3000');
+		expect(charIdLabel(0x7f)).toBe('U+007F');
+	});
+});

--- a/src/lib/schema/resources/font.ts
+++ b/src/lib/schema/resources/font.ts
@@ -1,0 +1,258 @@
+// Hand-written schema for ParsedFont (resource type 0x21).
+//
+// Mirrors the types in `src/lib/core/font.ts`. Keep these in lockstep with
+// the parser/writer — any field added to the parser needs a matching entry
+// here, or the schema walker reports it as drift.
+//
+// Domain: a Font maps UTF-16 code units to glyph rectangles on texture atlas
+// pages. Glyph UVs are normalized [0..1] over the bound Texture; multiply by
+// the texture's pixel dimensions to get the atlas rect (a future extension
+// could render a glyph-atlas preview from exactly these fields). The three
+// space characters (U+0020, U+00A0, U+3000) are non-renderable and store the
+// (-1,-1) UV sentinel — they only contribute advance.
+//
+// Why both lists are fixed-size: glyph count changes move the inline import
+// table at the payload tail, and the bundle-level importOffset that points at
+// it is not recomputed by every export path; page count changes additionally
+// change the bundle-level importCount. Field edits keep the payload length
+// and are safe. Char ids are editable but must keep the array grouped by
+// ascending hash bucket (charId & 0x7F) — the writer throws otherwise.
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring staticSoundMap.ts)
+// ---------------------------------------------------------------------------
+
+const f32 = (): FieldSchema => ({ kind: 'f32' });
+const u16 = (): FieldSchema => ({ kind: 'u16' });
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const vec2 = (): FieldSchema => ({ kind: 'vec2' });
+const bool = (): FieldSchema => ({ kind: 'bool' });
+const str = (): FieldSchema => ({ kind: 'string' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+
+const fixedRecordList = (
+	type: string,
+	itemLabel?: (item: unknown, index: number) => string,
+): FieldSchema => ({
+	kind: 'list',
+	item: record(type),
+	addable: false,
+	removable: false,
+	itemLabel: itemLabel ? (item, index) => itemLabel(item, index) : undefined,
+});
+
+// ---------------------------------------------------------------------------
+// Tree-label helpers
+// ---------------------------------------------------------------------------
+
+/** Human reading of a UTF-16 code unit: the actual character where printable,
+ *  always with the U+XXXX codepoint. Control chars, spaces, the Latin-1 gap,
+ *  and surrogates fall back to codepoint-only. */
+export function charIdLabel(charId: number): string {
+	const hex = `U+${charId.toString(16).toUpperCase().padStart(4, '0')}`;
+	const printable =
+		charId > 0x20 &&
+		charId !== 0x7f &&
+		!(charId >= 0x80 && charId <= 0xa0) &&
+		!(charId >= 0xd800 && charId <= 0xdfff) &&
+		charId !== 0x3000;
+	return printable ? `'${String.fromCharCode(charId)}' ${hex}` : hex;
+}
+
+function fontCharLabel(item: unknown, index: number): string {
+	try {
+		if (!item || typeof item !== 'object') return `#${index}`;
+		const c = item as { charId?: number; mbIsRenderable?: boolean; mu16TexturePageId?: number };
+		if (c.charId == null) return `#${index}`;
+		const space = c.mbIsRenderable === false ? ' · space' : '';
+		const page = (c.mu16TexturePageId ?? 0) > 0 ? ` · pg ${c.mu16TexturePageId}` : '';
+		return `#${index} · ${charIdLabel(c.charId)}${space}${page}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function texturePageLabel(item: unknown, index: number): string {
+	try {
+		if (!item || typeof item !== 'object') return `#${index}`;
+		const p = item as { textureId?: bigint };
+		if (p.textureId == null) return `#${index}`;
+		return `#${index} · 0x${p.textureId.toString(16).toUpperCase().padStart(8, '0')}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const FontChar: RecordSchema = {
+	name: 'FontChar',
+	description: 'One glyph — a UTF-16 code unit mapped to a normalized UV rectangle on an atlas page, plus layout metrics. Multiply the UVs by the bound texture\'s pixel dimensions to get the atlas rect.',
+	fields: {
+		charId: u16(),
+		mTopLeftUV: vec2(),
+		mDimensionsUV: vec2(),
+		mStart: vec2(),
+		mfAdvance: f32(),
+		mu16TexturePageId: {
+			kind: 'ref',
+			storage: 'u16',
+			target: { listPath: ['texturePages'], itemType: 'FontTexturePage', displayName: 'Texture page' },
+		},
+		mbIsLowerCaseScale: bool(),
+		mbIsRenderable: bool(),
+	},
+	fieldMetadata: {
+		charId: {
+			label: 'Character',
+			description: 'UTF-16 code unit (CgsUtf16) this glyph renders. Editable, but the char list must stay grouped by ascending hash bucket (charId & 0x7F) — the writer rejects the edit otherwise. Retail fonts never duplicate an id.',
+		},
+		mTopLeftUV: {
+			label: 'Top-left UV',
+			description: 'Normalized [0..1] top-left corner of the glyph on its atlas page. (-1,-1) sentinel on the three non-renderable space chars.',
+		},
+		mDimensionsUV: {
+			label: 'Size UV',
+			description: 'Normalized glyph width/height on the atlas page.',
+		},
+		mStart: {
+			label: 'Start offset',
+			description: 'Offset of the glyph quad from the pen position, in UV-scaled glyph units (multiply by Scale UV for glyph space).',
+		},
+		mfAdvance: {
+			label: 'Advance',
+			description: 'Pen advance after this glyph, in UV-scaled glyph units.',
+		},
+		mu16TexturePageId: {
+			label: 'Texture page',
+			description: 'Atlas page this glyph lives on. Only the two LIMITED Chinese fonts use more than one page.',
+		},
+		mbIsLowerCaseScale: {
+			label: 'Lower-case scale',
+			description: 'Scales the glyph by the font\'s lower-case scale factor when set. Never set in any retail font (the factor is 0 everywhere too).',
+		},
+		mbIsRenderable: {
+			label: 'Renderable',
+			description: 'Off for the three space chars (U+0020, U+00A0, U+3000), which carry the (-1,-1) UV sentinel and only contribute advance.',
+		},
+	},
+	propertyGroups: [
+		{ title: 'Character', properties: ['charId', 'mbIsRenderable'] },
+		{ title: 'Atlas rect', properties: ['mTopLeftUV', 'mDimensionsUV', 'mu16TexturePageId'] },
+		{ title: 'Metrics', properties: ['mStart', 'mfAdvance', 'mbIsLowerCaseScale'] },
+	],
+	label: (value, index) => fontCharLabel(value, index ?? 0),
+};
+
+const FontTexturePage: RecordSchema = {
+	name: 'FontTexturePage',
+	description: 'One atlas page — a BND2 import binding the page to a Texture resource by id. Single-page fonts always bind the Texture shipped in the same .FONT bundle; the LIMITED Chinese fonts import their second page from another bundle.',
+	fields: {
+		textureId: { kind: 'bigint', bytes: 8, hex: true },
+		_ptrSlot: u32(),
+	},
+	fieldMetadata: {
+		textureId: {
+			label: 'Texture resource',
+			description: 'Resource id of the Texture (type 0x0) this page binds. Must reference a loadable texture — the glyph UVs are meaningless without it.',
+		},
+		_ptrSlot: {
+			label: 'Pointer slot',
+			description: 'On-disk value of the page\'s runtime pointer slot, overwritten by the import patcher at load. 0 except the second page of the LIMITED fonts, which carries build-time garbage. Preserved for byte-exact round-trip.',
+			hidden: true,
+		},
+	},
+	label: (value, index) => texturePageLabel(value, index ?? 0),
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedFont: RecordSchema = {
+	name: 'ParsedFont',
+	description: 'Root record for the Font resource (0x21): typeface metadata, the glyph table, and the texture atlas pages the glyphs index into. Consumed by Apt UI scripts and debug text.',
+	fields: {
+		muVersionId: u32(),
+		mScaleUV: vec2(),
+		mfLowerCaseScale: f32(),
+		mfBaseLine: f32(),
+		mfXHeight: f32(),
+		muFontHeightInPixels: u32(),
+		macTypefaceFamilyName: str(),
+		macTypefaceStyleName: str(),
+		chars: fixedRecordList('FontChar', fontCharLabel),
+		texturePages: fixedRecordList('FontTexturePage', texturePageLabel),
+	},
+	fieldMetadata: {
+		muVersionId: {
+			label: 'Version',
+			description: 'Font layout version — 10 in every retail font; the parser rejects anything else.',
+			readOnly: true,
+		},
+		mScaleUV: {
+			label: 'Scale UV',
+			description: 'Converts UV-space metrics (start offset, advance) to glyph space. For most fonts Scale UV × font height equals the atlas pixel dimensions exactly; the Thai pair breaks that pattern.',
+		},
+		mfLowerCaseScale: {
+			label: 'Lower-case scale',
+			description: 'Scale factor applied to glyphs flagged lower-case-scale. 0 in every retail font — the flag is never set either.',
+		},
+		mfBaseLine: {
+			label: 'Baseline',
+			description: 'Baseline height as a fraction of the line cell (~0.77 across retail).',
+		},
+		mfXHeight: {
+			label: 'x-height',
+			description: 'x-height as a fraction of the line cell.',
+		},
+		muFontHeightInPixels: {
+			label: 'Font height (px)',
+			description: 'Source rasterization size in pixels (35–288 across retail).',
+		},
+		macTypefaceFamilyName: {
+			label: 'Typeface family',
+			description: 'char[128] on disk — at most 127 bytes; the writer rejects longer names.',
+		},
+		macTypefaceStyleName: {
+			label: 'Typeface style',
+			description: 'char[128] on disk — at most 127 bytes.',
+		},
+		chars: {
+			label: 'Glyphs',
+			description: 'Every glyph in disk order, grouped by ascending hash bucket (charId & 0x7F) — the char-lookup table is re-derived from this order on write. Fixed-size: adding/removing glyphs would move the inline import table the bundle-level importOffset points at.',
+		},
+		texturePages: {
+			label: 'Atlas pages',
+			description: 'The Texture resources glyphs index into. Fixed-size: the page count is mirrored by the bundle-level import count. Retargeting a page\'s texture id is safe.',
+		},
+	},
+	propertyGroups: [
+		{ title: 'Typeface', properties: ['macTypefaceFamilyName', 'macTypefaceStyleName', 'muFontHeightInPixels', 'muVersionId'] },
+		{ title: 'Metrics', properties: ['mScaleUV', 'mfLowerCaseScale', 'mfBaseLine', 'mfXHeight'] },
+		{ title: 'Glyphs', properties: ['chars'] },
+		{ title: 'Atlas', properties: ['texturePages'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedFont,
+	FontChar,
+	FontTexturePage,
+};
+
+export const fontResourceSchema: ResourceSchema = {
+	key: 'font',
+	name: 'Font',
+	rootType: 'ParsedFont',
+	registry,
+};

--- a/src/lib/schema/resources/index.ts
+++ b/src/lib/schema/resources/index.ts
@@ -11,6 +11,8 @@
 import type { ResourceSchema } from '../types';
 import { aiSectionsResourceSchema } from './aiSections';
 import { challengeListResourceSchema } from './challengeList';
+import { environmentKeyframeResourceSchema } from './environmentKeyframe';
+import { environmentTimeLineResourceSchema } from './environmentTimeLine';
 import { guiPopupResourceSchema } from './guiPopup';
 import { hudMessageResourceSchema } from './hudMessage';
 import { hudMessageSequenceResourceSchema } from './hudMessageSequence';
@@ -36,6 +38,8 @@ import { zoneListResourceSchema } from './zoneList';
 const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	aiSections: aiSectionsResourceSchema,
 	challengeList: challengeListResourceSchema,
+	environmentKeyframe: environmentKeyframeResourceSchema,
+	environmentTimeLine: environmentTimeLineResourceSchema,
 	guiPopup: guiPopupResourceSchema,
 	hudMessage: hudMessageResourceSchema,
 	hudMessageSequence: hudMessageSequenceResourceSchema,

--- a/src/lib/schema/resources/index.ts
+++ b/src/lib/schema/resources/index.ts
@@ -11,6 +11,8 @@
 import type { ResourceSchema } from '../types';
 import { aiSectionsResourceSchema } from './aiSections';
 import { challengeListResourceSchema } from './challengeList';
+import { colourCubeResourceSchema } from './colourCube';
+import { environmentDictionaryResourceSchema } from './environmentDictionary';
 import { environmentKeyframeResourceSchema } from './environmentKeyframe';
 import { environmentTimeLineResourceSchema } from './environmentTimeLine';
 import { guiPopupResourceSchema } from './guiPopup';
@@ -38,6 +40,8 @@ import { zoneListResourceSchema } from './zoneList';
 const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	aiSections: aiSectionsResourceSchema,
 	challengeList: challengeListResourceSchema,
+	colourCube: colourCubeResourceSchema,
+	environmentDictionary: environmentDictionaryResourceSchema,
 	environmentKeyframe: environmentKeyframeResourceSchema,
 	environmentTimeLine: environmentTimeLineResourceSchema,
 	guiPopup: guiPopupResourceSchema,

--- a/src/lib/schema/resources/index.ts
+++ b/src/lib/schema/resources/index.ts
@@ -15,6 +15,7 @@ import { colourCubeResourceSchema } from './colourCube';
 import { environmentDictionaryResourceSchema } from './environmentDictionary';
 import { environmentKeyframeResourceSchema } from './environmentKeyframe';
 import { environmentTimeLineResourceSchema } from './environmentTimeLine';
+import { fontResourceSchema } from './font';
 import { guiPopupResourceSchema } from './guiPopup';
 import { hudMessageResourceSchema } from './hudMessage';
 import { hudMessageSequenceResourceSchema } from './hudMessageSequence';
@@ -22,7 +23,9 @@ import { hudMessageSequenceDictionaryResourceSchema } from './hudMessageSequence
 import { iceTakeDictionaryResourceSchema } from './iceTakeDictionary';
 import { instanceListResourceSchema } from './instanceList';
 import { languageResourceSchema } from './language';
+import { massiveLookupTableResourceSchema } from './massiveLookupTable';
 import { playerCarColoursResourceSchema } from './playerCarColours';
+import { registryResourceSchema } from './registry';
 import { polygonSoupListResourceSchema } from './polygonSoupList';
 import { propGraphicsListResourceSchema } from './propGraphicsList';
 import { propInstanceDataResourceSchema } from './propInstanceData';
@@ -44,6 +47,7 @@ const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	environmentDictionary: environmentDictionaryResourceSchema,
 	environmentKeyframe: environmentKeyframeResourceSchema,
 	environmentTimeLine: environmentTimeLineResourceSchema,
+	font: fontResourceSchema,
 	guiPopup: guiPopupResourceSchema,
 	hudMessage: hudMessageResourceSchema,
 	hudMessageSequence: hudMessageSequenceResourceSchema,
@@ -51,7 +55,9 @@ const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	iceTakeDictionary: iceTakeDictionaryResourceSchema,
 	instanceList: instanceListResourceSchema,
 	language: languageResourceSchema,
+	massiveLookupTable: massiveLookupTableResourceSchema,
 	playerCarColours: playerCarColoursResourceSchema,
+	registry: registryResourceSchema,
 	polygonSoupList: polygonSoupListResourceSchema,
 	propGraphicsList: propGraphicsListResourceSchema,
 	propInstanceData: propInstanceDataResourceSchema,

--- a/src/lib/schema/resources/massiveLookupTable.test.ts
+++ b/src/lib/schema/resources/massiveLookupTable.test.ts
@@ -1,0 +1,139 @@
+// Schema coverage tests for massiveLookupTableResourceSchema.
+//
+// Coverage fixture: example/MASSIVETABLE.BIN — the single retail
+// MassiveLookupTable (20 ad placements).
+//
+// Mirrors staticSoundMap.test.ts: parse the model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseMassiveLookupTable, type ParsedMassiveLookupTable } from '../../core/massiveLookupTable';
+
+import { massiveLookupTableResourceSchema } from './massiveLookupTable';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/MASSIVETABLE.BIN');
+const MASSIVE_LOOKUP_TABLE_TYPE_ID = 0x1001a;
+
+function loadModel(fixturePath: string): ParsedMassiveLookupTable {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === MASSIVE_LOOKUP_TABLE_TYPE_ID)!;
+	return parseMassiveLookupTable(extractResourceRaw(buffer.buffer, bundle, resource), ctx.littleEndian);
+}
+
+const model = loadModel(BUNDLE_FIXTURE);
+
+describe('massiveLookupTableResourceSchema coverage', () => {
+	it('fixture parses with non-trivial content', () => {
+		expect(model.items.length).toBeGreaterThan(0);
+	});
+
+	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+		const missing: string[] = [];
+		for (const [recordName, rec] of Object.entries(massiveLookupTableResourceSchema.registry)) {
+			for (const [fieldName, field] of Object.entries(rec.fields)) {
+				checkField(field, `${recordName}.${fieldName}`, missing);
+			}
+		}
+		if (missing.length > 0) {
+			throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+		}
+		function checkField(f: FieldSchema, where: string, out: string[]) {
+			if (f.kind === 'record') {
+				if (!massiveLookupTableResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+				return;
+			}
+			if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+		}
+	});
+
+	it('walkResource visits every parsed field without throwing', () => {
+		let recordCount = 0;
+		let fieldCount = 0;
+		walkResource(massiveLookupTableResourceSchema, model, (_p, _v, field, rec) => {
+			if (rec) recordCount++;
+			if (field) fieldCount++;
+		});
+		expect(recordCount).toBeGreaterThan(0);
+		expect(fieldCount).toBeGreaterThan(0);
+	});
+
+	it('no parsed record has fields absent from the schema', () => {
+		const missing: string[] = [];
+		walkResource(massiveLookupTableResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const declared = new Set(Object.keys(rec.fields));
+			for (const key of Object.keys(value as Record<string, unknown>)) {
+				if (!declared.has(key)) {
+					missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+
+	it('every schema field is represented in the parsed data', () => {
+		const missing: string[] = [];
+		walkResource(massiveLookupTableResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const obj = value as Record<string, unknown>;
+			for (const fieldName of Object.keys(rec.fields)) {
+				if (!(fieldName in obj)) {
+					missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+});
+
+describe('massiveLookupTable path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(massiveLookupTableResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedMassiveLookupTable');
+	});
+
+	it('resolves items[0] as a MassiveLookupTableItem', () => {
+		const loc = resolveSchemaAtPath(massiveLookupTableResourceSchema, ['items', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('MassiveLookupTableItem');
+	});
+
+	it('resolves items[0].mBoundingBoxMin as vec3', () => {
+		const loc = resolveSchemaAtPath(massiveLookupTableResourceSchema, ['items', 0, 'mBoundingBoxMin']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('vec3');
+	});
+
+	it('resolves items[0].mSceneId as a hex bigint', () => {
+		const loc = resolveSchemaAtPath(massiveLookupTableResourceSchema, ['items', 0, 'mSceneId']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('bigint');
+	});
+
+	it('resolves items[0].miIEIndex as i32', () => {
+		const loc = resolveSchemaAtPath(massiveLookupTableResourceSchema, ['items', 0, 'miIEIndex']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('i32');
+	});
+});

--- a/src/lib/schema/resources/massiveLookupTable.ts
+++ b/src/lib/schema/resources/massiveLookupTable.ts
@@ -1,0 +1,155 @@
+// Hand-written schema for ParsedMassiveLookupTable (resource type 0x1001A).
+//
+// Mirrors the types in `src/lib/core/massiveLookupTable.ts`. Keep these in
+// lockstep with the parser/writer — any field added to the parser needs a
+// matching entry here, or the schema walker reports it as drift.
+//
+// Domain: the lookup table the now-defunct Massive Incorporated ad service
+// used to place served ads in the world. Each item is one placement: the ad
+// quad's local-space bounding box, the Scene resource it lives in, an ad
+// inventory slot ("IE index", -1 when unassigned), and the index of the
+// Renderable whose texture the served ad replaced. The service is dead, so
+// edits here are inert in retail — but the resource still parses and loads.
+
+import type { FieldSchema, RecordSchema, ResourceSchema, SchemaRegistry } from '../types';
+import { makeEmptyMassiveItem } from '@/lib/core/massiveLookupTable';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring staticSoundMap.ts)
+// ---------------------------------------------------------------------------
+
+const f32 = (): FieldSchema => ({ kind: 'f32' });
+const i32 = (): FieldSchema => ({ kind: 'i32' });
+const u8 = (): FieldSchema => ({ kind: 'u8' });
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const vec3 = (): FieldSchema => ({ kind: 'vec3' });
+const resourceId = (): FieldSchema => ({ kind: 'bigint', bytes: 8, hex: true });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+const rawBytes = (): FieldSchema => ({ kind: 'custom', component: 'rawBytes' });
+
+// ---------------------------------------------------------------------------
+// Tree-label helpers
+// ---------------------------------------------------------------------------
+
+function itemLabel(item: unknown, index: number): string {
+	try {
+		if (!item || typeof item !== 'object') return `#${index}`;
+		const it = item as { mSceneId?: bigint; miIEIndex?: number; muRenderableIndex?: number };
+		const scene = typeof it.mSceneId === 'bigint' ? `0x${it.mSceneId.toString(16).toUpperCase()}` : '?';
+		const slot = it.miIEIndex != null && it.miIEIndex >= 0 ? `slot ${it.miIEIndex}` : 'no slot';
+		return `#${index} · scene ${scene} · ${slot} · rend ${it.muRenderableIndex ?? '?'}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const MassiveLookupTableItem: RecordSchema = {
+	name: 'MassiveLookupTableItem',
+	description: 'One ad placement: where the ad quad sits (local-space AABB), which Scene owns it, which inventory slot it serves, and which Renderable\'s texture the ad replaces.',
+	fields: {
+		mBoundingBoxMin: vec3(),
+		mBoundingBoxMax: vec3(),
+		mSceneId: resourceId(),
+		miIEIndex: i32(),
+		muRenderableIndex: u8(),
+		_minW: f32(),
+		_maxW: f32(),
+		_mpSubscriber: u32(),
+		_pad31: rawBytes(),
+	},
+	fieldMetadata: {
+		mBoundingBoxMin: {
+			label: 'Bounding box min',
+			description: 'Local-space AABB min corner of the ad quad in metres, relative to the owning Scene. Most retail placements are flat billboards (zero-depth boxes).',
+		},
+		mBoundingBoxMax: {
+			label: 'Bounding box max',
+			description: 'Local-space AABB max corner of the ad quad.',
+		},
+		mSceneId: {
+			label: 'Scene ID',
+			description: 'Resource ID of the Scene this placement belongs to.',
+		},
+		miIEIndex: {
+			label: 'IE index',
+			description: 'Ad inventory slot index the Massive client filled; -1 for placements without an assigned slot (retail uses 0-8 across 9 of the 20 items).',
+		},
+		muRenderableIndex: {
+			label: 'Renderable index',
+			description: 'Index of the Renderable whose texture the served ad replaced. Sequential 0-19 in retail.',
+		},
+		_minW: {
+			label: 'min unused lane',
+			description: 'Unused 4th vpu lane of the min vector (0 in retail). Preserved for byte-exact round-trip.',
+			hidden: true,
+		},
+		_maxW: {
+			label: 'max unused lane',
+			description: 'Unused 4th vpu lane of the max vector (0 in retail). Preserved for byte-exact round-trip.',
+			hidden: true,
+		},
+		_mpSubscriber: {
+			label: 'Subscriber pointer',
+			description: 'Runtime BrnMassiveSubscriber pointer — 0 on disk, set when the ad client subscribed. Preserved verbatim.',
+			hidden: true,
+		},
+		_pad31: {
+			label: 'pad +0x31',
+			description: '15 pad bytes (0 in retail); preserved verbatim.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Placement', properties: ['mBoundingBoxMin', 'mBoundingBoxMax', 'mSceneId'] },
+		{ title: 'Ad binding', properties: ['miIEIndex', 'muRenderableIndex'] },
+	],
+	label: (value, index) => itemLabel(value, index ?? 0),
+};
+
+const ParsedMassiveLookupTable: RecordSchema = {
+	name: 'ParsedMassiveLookupTable',
+	description: 'Root record for the MassiveLookupTable resource (0x1001A): every in-game ad placement of the defunct Massive Incorporated service. One retail resource exists (MASSIVETABLE.BIN, 20 placements).',
+	fields: {
+		items: {
+			kind: 'list',
+			item: record('MassiveLookupTableItem'),
+			itemLabel: (item, index) => itemLabel(item, index),
+			makeEmpty: () => makeEmptyMassiveItem(),
+		},
+		_pad08: rawBytes(),
+	},
+	fieldMetadata: {
+		items: {
+			label: 'Ad placements',
+			description: 'Every placement in disk order. Count and the item-array pointer are re-derived on write, so adding/removing is safe.',
+		},
+		_pad08: {
+			label: 'Header pad',
+			description: '8 pad bytes aligning the item array to 16 (0 in retail); preserved verbatim.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Placements', properties: ['items'] },
+	],
+};
+
+// ---------------------------------------------------------------------------
+// Registry export
+// ---------------------------------------------------------------------------
+
+const registry: SchemaRegistry = {
+	ParsedMassiveLookupTable,
+	MassiveLookupTableItem,
+};
+
+export const massiveLookupTableResourceSchema: ResourceSchema = {
+	key: 'massiveLookupTable',
+	name: 'Massive Lookup Table',
+	rootType: 'ParsedMassiveLookupTable',
+	registry,
+};

--- a/src/lib/schema/resources/registry.test.ts
+++ b/src/lib/schema/resources/registry.test.ts
@@ -1,0 +1,168 @@
+// Schema coverage tests for registryResourceSchema.
+//
+// Coverage fixtures: BOTH retail registries, because they exercise disjoint
+// payload shapes — PLAYBACKREGISTRY carries five entity kinds (ContentClass /
+// ContentType / SlotSchema / ParameterSchema / FeatureSchema), while
+// RWACFEATUREREGISTRY is all GenericRwacFeatureImplementation. Entities are
+// heterogeneous: payload record fields are null on the kinds that don't use
+// them, which the walker must tolerate.
+//
+// Mirrors staticSoundMap.test.ts: parse each model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseRegistry, soundHash, type ParsedRegistry } from '../../core/soundRegistry';
+
+import { registryResourceSchema, resolveHash } from './registry';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const REGISTRY_TYPE_ID = 0xa000;
+
+function loadModel(bundleFile: string): ParsedRegistry {
+	const fileBytes = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === REGISTRY_TYPE_ID)!;
+	return parseRegistry(extractResourceRaw(buffer.buffer, bundle, resource), ctx.littleEndian);
+}
+
+for (const [label, bundleFile] of [
+	['playback registry (five entity kinds)', 'example/PLAYBACKREGISTRY.BUNDLE'],
+	['rwac feature registry (one entity kind)', 'example/RWACFEATUREREGISTRY.BUNDLE'],
+] as const) {
+	const model = loadModel(bundleFile);
+
+	describe(`registryResourceSchema coverage — ${label}`, () => {
+		it('fixture parses with non-trivial content', () => {
+			expect(model.entities.length).toBeGreaterThan(0);
+			expect(model.strings.length).toBeGreaterThan(0);
+		});
+
+		it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+			const missing: string[] = [];
+			for (const [recordName, rec] of Object.entries(registryResourceSchema.registry)) {
+				for (const [fieldName, field] of Object.entries(rec.fields)) {
+					checkField(field, `${recordName}.${fieldName}`, missing);
+				}
+			}
+			if (missing.length > 0) {
+				throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+			}
+			function checkField(f: FieldSchema, where: string, out: string[]) {
+				if (f.kind === 'record') {
+					if (!registryResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+					return;
+				}
+				if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+			}
+		});
+
+		it('walkResource visits every parsed field without throwing', () => {
+			let recordCount = 0;
+			let fieldCount = 0;
+			walkResource(registryResourceSchema, model, (_p, _v, field, rec) => {
+				if (rec) recordCount++;
+				if (field) fieldCount++;
+			});
+			expect(recordCount).toBeGreaterThan(0);
+			expect(fieldCount).toBeGreaterThan(0);
+		});
+
+		it('no parsed record has fields absent from the schema', () => {
+			const missing: string[] = [];
+			walkResource(registryResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const declared = new Set(Object.keys(rec.fields));
+				for (const key of Object.keys(value as Record<string, unknown>)) {
+					if (!declared.has(key)) {
+						missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+
+		it('every schema field is represented in the parsed data', () => {
+			const missing: string[] = [];
+			walkResource(registryResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const obj = value as Record<string, unknown>;
+				for (const fieldName of Object.keys(rec.fields)) {
+					if (!(fieldName in obj)) {
+						missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+	});
+}
+
+describe('registry path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(registryResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedRegistry');
+	});
+
+	it('resolves entities[0] as a RegistryEntity', () => {
+		const loc = resolveSchemaAtPath(registryResourceSchema, ['entities', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('RegistryEntity');
+	});
+
+	it('resolves entities[0].parameterSchema.mu32Direction as an enum', () => {
+		const loc = resolveSchemaAtPath(registryResourceSchema, ['entities', 0, 'parameterSchema', 'mu32Direction']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('enum');
+	});
+
+	it('resolves entities[0].rwacFeature.blocks[0].code as a string', () => {
+		const loc = resolveSchemaAtPath(registryResourceSchema, ['entities', 0, 'rwacFeature', 'blocks', 0, 'code']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('string');
+	});
+
+	it('resolves entities[0].featureSchema.parameterHashes[0] as u32', () => {
+		const loc = resolveSchemaAtPath(registryResourceSchema, ['entities', 0, 'featureSchema', 'parameterHashes', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('u32');
+	});
+
+	it('resolves strings[0] as a string', () => {
+		const loc = resolveSchemaAtPath(registryResourceSchema, ['strings', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('string');
+	});
+});
+
+describe('resolveHash (label hash → string pool lookup)', () => {
+	const model = loadModel('example/PLAYBACKREGISTRY.BUNDLE');
+
+	it('resolves a pooled hash to its plain-text name', () => {
+		expect(resolveHash(model, soundHash('GinsuPlayer'))).toBe('GinsuPlayer');
+		expect(resolveHash(model, soundHash('~ParameterSchema~'))).toBe('~ParameterSchema~');
+	});
+
+	it('falls back to hex when the pool has no match', () => {
+		expect(resolveHash(model, 0xdeadbeef)).toBe('0xDEADBEEF');
+		expect(resolveHash(undefined, 0x12)).toBe('0x00000012');
+	});
+});

--- a/src/lib/schema/resources/registry.ts
+++ b/src/lib/schema/resources/registry.ts
@@ -1,0 +1,343 @@
+// Hand-written schema for ParsedRegistry (resource type 0xA000).
+//
+// Mirrors the types in `src/lib/core/soundRegistry.ts`. Keep these in
+// lockstep with the parser/writer — any field added to the parser needs a
+// matching entry here, or the schema walker reports it as drift.
+//
+// Domain: a Registry is the sound engine's name-hash phone book. Every
+// entity is (name hash, type hash, payload); the payload shape follows the
+// type. Exactly ONE of an entity's payload fields is non-null — except
+// ContentClass entities, which have no payload at all. The hash table,
+// counts, sizes, and pointers are all re-derived on write, so renaming,
+// adding, and removing entities is safe; what is NOT safe is editing
+// mTypeName without swapping the payload to match, which is why it is
+// read-only here.
+//
+// Hashes are CgsSound sound hashes of the strings in the resource's own
+// debug string pool — labels below resolve them back to plain text via
+// soundHash() over `strings`, so the tree shows 'GinsuPlayer', not
+// 0x720B821B.
+
+import type { FieldSchema, RecordSchema, ResourceSchema, SchemaRegistry } from '../types';
+import {
+	makeEmptyRegistryEntity,
+	soundHash,
+	REGISTRY_TYPE_LABELS,
+	type ParsedRegistry,
+} from '@/lib/core/soundRegistry';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring staticSoundMap.ts)
+// ---------------------------------------------------------------------------
+
+const f32 = (): FieldSchema => ({ kind: 'f32' });
+const u16 = (): FieldSchema => ({ kind: 'u16' });
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const str = (): FieldSchema => ({ kind: 'string' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+const rawBytes = (): FieldSchema => ({ kind: 'custom', component: 'rawBytes' });
+
+// ---------------------------------------------------------------------------
+// Hash → string resolution against the resource's own string pool
+// ---------------------------------------------------------------------------
+
+/** Resolve a sound hash to its plain-text name via the registry's debug
+ *  string pool. Falls back to uppercase hex when the pool has no match
+ *  (e.g. after the user renamed an entity by hash). */
+export function resolveHash(root: unknown, hash: number | undefined): string {
+	if (hash == null) return '?';
+	const strings = (root as ParsedRegistry | undefined)?.strings;
+	if (Array.isArray(strings)) {
+		for (const s of strings) {
+			if (typeof s === 'string' && soundHash(s) === hash) return s;
+		}
+	}
+	return `0x${(hash >>> 0).toString(16).toUpperCase().padStart(8, '0')}`;
+}
+
+function entityLabel(item: unknown, index: number, root: unknown): string {
+	try {
+		if (!item || typeof item !== 'object') return `#${index}`;
+		const e = item as { mName?: number; mTypeName?: number };
+		const kind = e.mTypeName != null ? REGISTRY_TYPE_LABELS[e.mTypeName] ?? resolveHash(root, e.mTypeName) : '?';
+		return `#${index} · ${kind} · ${resolveHash(root, e.mName)}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function paramBindingLabel(item: unknown, index: number, root: unknown): string {
+	try {
+		if (!item || typeof item !== 'object') return `#${index}`;
+		const p = item as { mParamName?: number; mu16BlockIndex?: number; mu16ParamIndex?: number };
+		return `#${index} · ${resolveHash(root, p.mParamName)} → block ${p.mu16BlockIndex ?? '?'}[${p.mu16ParamIndex ?? '?'}]`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function slotBindingLabel(item: unknown, index: number, root: unknown): string {
+	try {
+		if (!item || typeof item !== 'object') return `#${index}`;
+		const s = item as { mSlotName?: number };
+		return `#${index} · ${resolveHash(root, s.mSlotName)}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const RegistryParameterSchema: RecordSchema = {
+	name: 'RegistryParameterSchema',
+	description: 'ParameterSchema payload — the legal range and direction of one named sound parameter.',
+	fields: {
+		mf32Minimum: f32(),
+		mf32Maximum: f32(),
+		mu32Direction: {
+			kind: 'enum',
+			storage: 'u32',
+			values: [
+				{ value: 0, label: 'Input', description: 'Set by the game (E_PARAMETER_INPUT).' },
+				{ value: 1, label: 'Output', description: 'Read back from the DSP ("Get*" parameters, E_PARAMETER_OUTPUT).' },
+			],
+		},
+	},
+	fieldMetadata: {
+		mf32Minimum: { label: 'Minimum', description: 'Lower bound of the parameter value (units depend on the parameter — Hz for frequencies, ratios for pitch).' },
+		mf32Maximum: { label: 'Maximum', description: 'Upper bound of the parameter value.' },
+		mu32Direction: { label: 'Direction' },
+	},
+};
+
+const RegistryFeatureSchema: RecordSchema = {
+	name: 'RegistryFeatureSchema',
+	description: 'FeatureSchema payload — declares which parameters and slots a sound feature exposes, each referenced by sound hash. The on-disk counts are re-derived from the two lists on write.',
+	fields: {
+		mu32OutputParamCount: u32(),
+		parameterHashes: { kind: 'list', item: u32(), makeEmpty: () => 0 },
+		slotHashes: { kind: 'list', item: u32(), makeEmpty: () => 0 },
+	},
+	fieldMetadata: {
+		mu32OutputParamCount: {
+			label: 'Output param count',
+			description: 'Always 0 in retail; its on-disk meaning is unverified, so treat with care.',
+			readOnly: true,
+		},
+		parameterHashes: {
+			label: 'Parameter hashes',
+			description: 'Sound hashes of the feature\'s ParameterSchema entities, in declaration order (stored before the slot hashes on disk).',
+		},
+		slotHashes: {
+			label: 'Slot hashes',
+			description: 'Sound hashes of the feature\'s SlotSchema entities.',
+		},
+	},
+};
+
+const RwacDspBlock: RecordSchema = {
+	name: 'RwacDspBlock',
+	description: 'One DSP block inside an RWAC feature, identified by a 4-character code (Pn21 panner, Rsp0 resampler, Pau0 pause, Gns0 Ginsu music decoder, JStr stream reader, …).',
+	fields: {
+		code: str(),
+		mUnknown04: u32(),
+		mUnknown08: u32(),
+	},
+	fieldMetadata: {
+		code: {
+			label: 'Block code',
+			description: 'Exactly 4 printable characters; stored byte-reversed on disk as a multi-char constant.',
+		},
+		mUnknown04: { label: 'Unknown +0x4', description: '0 in every retail block; meaning unknown.' },
+		mUnknown08: { label: 'Unknown +0x8', description: 'Varies per block kind (6 on Pn21, 2 on RM10, 0/1 elsewhere); meaning unknown.' },
+	},
+	label: (value, index) => {
+		const code = (value as { code?: string }).code;
+		return `#${index ?? 0} · ${code ?? '?'}`;
+	},
+};
+
+const RwacParamBinding: RecordSchema = {
+	name: 'RwacParamBinding',
+	description: 'Routes one named parameter to a (block, parameter) pair inside the feature\'s DSP chain — e.g. GinsuSetPitch → resampler block, parameter 0.',
+	fields: {
+		mParamName: u32(),
+		mu16BlockIndex: u16(),
+		mu16ParamIndex: u16(),
+	},
+	fieldMetadata: {
+		mParamName: { label: 'Parameter hash', description: 'Sound hash of the parameter name (the matching ParameterSchema lives in the playback registry).' },
+		mu16BlockIndex: { label: 'Block index', description: 'Index into this feature\'s DSP block list.' },
+		mu16ParamIndex: { label: 'Param index', description: 'Parameter index within that block.' },
+	},
+	label: (value, index, ctx) => paramBindingLabel(value, index ?? 0, ctx.root),
+};
+
+const RwacSlotBinding: RecordSchema = {
+	name: 'RwacSlotBinding',
+	description: 'Binds one named content slot to its implementation class — where the feature\'s audio content gets plugged in.',
+	fields: {
+		mSlotName: u32(),
+		mSlotClass: u32(),
+		mu16Index: u16(),
+		_pad0A: u16(),
+	},
+	fieldMetadata: {
+		mSlotName: { label: 'Slot hash', description: 'Sound hash of the slot name (matches a SlotSchema in the playback registry).' },
+		mSlotClass: { label: 'Slot class hash', description: 'Sound hash of the slot implementation class, e.g. ~GenericRwacContentSlot~.' },
+		mu16Index: { label: 'Index', description: '0 in retail (single-slot features).' },
+		_pad0A: {
+			label: 'pad +0xA',
+			description: 'Uninitialised tail bytes (0xCDCD allocator fill in retail); preserved verbatim.',
+			hidden: true,
+		},
+	},
+	label: (value, index, ctx) => slotBindingLabel(value, index ?? 0, ctx.root),
+};
+
+const RegistryRwacFeature: RecordSchema = {
+	name: 'RegistryRwacFeature',
+	description: 'GenericRwacFeatureImplementation payload (undocumented on the wiki) — a concrete DSP feature: its block chain, parameter routing, and content slots. All three counts are re-derived from the lists on write.',
+	fields: {
+		blocks: {
+			kind: 'list',
+			item: record('RwacDspBlock'),
+			itemLabel: (item, index) => `#${index} · ${(item as { code?: string })?.code ?? '?'}`,
+			makeEmpty: () => ({ code: 'Xxx0', mUnknown04: 0, mUnknown08: 0 }),
+		},
+		params: {
+			kind: 'list',
+			item: record('RwacParamBinding'),
+			itemLabel: (item, index, ctx) => paramBindingLabel(item, index, ctx.root),
+			makeEmpty: () => ({ mParamName: 0, mu16BlockIndex: 0, mu16ParamIndex: 0 }),
+		},
+		slots: {
+			kind: 'list',
+			item: record('RwacSlotBinding'),
+			itemLabel: (item, index, ctx) => slotBindingLabel(item, index, ctx.root),
+			makeEmpty: () => ({ mSlotName: 0, mSlotClass: 0, mu16Index: 0, _pad0A: 0xcdcd }),
+		},
+		_uninit08: u32(),
+	},
+	fieldMetadata: {
+		blocks: { label: 'DSP blocks', description: 'The feature\'s processing chain in execution order; param bindings reference blocks by index, so reordering needs the bindings updated too.' },
+		params: { label: 'Parameter bindings' },
+		slots: { label: 'Slot bindings' },
+		_uninit08: {
+			label: 'uninit +0x8',
+			description: 'Uninitialised u32 at the payload start (0xCDCDCDCD allocator fill in retail); preserved verbatim.',
+			hidden: true,
+		},
+	},
+};
+
+const RegistryEntity: RecordSchema = {
+	name: 'RegistryEntity',
+	description: 'One registry entry: a name hash plus a typed payload. Exactly one payload field is populated, matching the type — ContentClass entities have none. The hash-table slot is re-derived from the name on write, so renaming is safe.',
+	fields: {
+		mName: u32(),
+		mTypeName: u32(),
+		mpContentClass: u32(),
+		parameterSchema: record('RegistryParameterSchema'),
+		featureSchema: record('RegistryFeatureSchema'),
+		rwacFeature: record('RegistryRwacFeature'),
+		_unknownPayload: rawBytes(),
+	},
+	fieldMetadata: {
+		mName: {
+			label: 'Name hash',
+			description: 'Sound hash of the entity name. Compute new values with soundHash() — the hash is NOT case-folded. Add the plain-text name to the string pool so labels stay readable.',
+		},
+		mTypeName: {
+			label: 'Type hash',
+			description: 'Sound hash of the type name (~ContentClass~, ~ParameterSchema~, …). Read-only because the payload shape must match it byte-for-byte.',
+			readOnly: true,
+		},
+		mpContentClass: {
+			label: 'Content class hash',
+			description: 'ContentType / SlotSchema payload only: name hash of the ContentClass entity this one points at. Empty for other entity kinds.',
+		},
+		parameterSchema: { label: 'Parameter schema', description: 'Populated only on ParameterSchema entities.' },
+		featureSchema: { label: 'Feature schema', description: 'Populated only on FeatureSchema entities.' },
+		rwacFeature: { label: 'RWAC feature', description: 'Populated only on GenericRwacFeatureImplementation entities.' },
+		_unknownPayload: {
+			label: 'Unknown payload',
+			description: 'Verbatim payload bytes for entity types this build does not decode (ContentSpec, VoiceSchema, VoiceSpec, …); preserved for byte-exact round-trip.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Identity', properties: ['mName', 'mTypeName'] },
+		{ title: 'Payload', properties: ['mpContentClass', 'parameterSchema', 'featureSchema', 'rwacFeature'] },
+	],
+	label: (value, index, ctx) => entityLabel(value, index ?? 0, ctx.root),
+};
+
+const ParsedRegistry: RecordSchema = {
+	name: 'ParsedRegistry',
+	description: 'Root record for the Registry resource (0xA000): the sound engine\'s name-hash phone book. The open-addressed hash table, counts, sizes, and pointers are all re-derived on write — only the entities and the debug string pool are real data.',
+	fields: {
+		entities: {
+			kind: 'list',
+			item: record('RegistryEntity'),
+			itemLabel: (item, index, ctx) => entityLabel(item, index, ctx.root),
+			makeEmpty: () => makeEmptyRegistryEntity(),
+		},
+		strings: {
+			kind: 'list',
+			item: str(),
+			makeEmpty: () => '',
+		},
+		mu32EntityCapacity: u32(),
+		muNameHashMask: u32(),
+	},
+	fieldMetadata: {
+		entities: {
+			label: 'Entities',
+			description: 'All registry entries in disk (hash-table insertion) order. Order matters only for collision tie-breaks in the rebuilt table; adding and removing is safe.',
+		},
+		strings: {
+			label: 'String pool',
+			description: 'Debug reverse-lookup pool: the plain-text names behind the hashes. The game does not need it to resolve entities, but steward\'s labels do — keep it in sync when renaming.',
+		},
+		mu32EntityCapacity: {
+			label: 'Table capacity',
+			description: 'Hash-table slot count (0x800 in retail). Read-only: must stay a power of two with mask = capacity - 1.',
+			readOnly: true,
+		},
+		muNameHashMask: {
+			label: 'Name hash mask',
+			description: 'Always capacity - 1; the writer rejects anything else.',
+			readOnly: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Entities', properties: ['entities'] },
+		{ title: 'Strings', properties: ['strings'] },
+		{ title: 'Hash table', properties: ['mu32EntityCapacity', 'muNameHashMask'] },
+	],
+};
+
+// ---------------------------------------------------------------------------
+// Registry export
+// ---------------------------------------------------------------------------
+
+const registry: SchemaRegistry = {
+	ParsedRegistry,
+	RegistryEntity,
+	RegistryParameterSchema,
+	RegistryFeatureSchema,
+	RegistryRwacFeature,
+	RwacDspBlock,
+	RwacParamBinding,
+	RwacSlotBinding,
+};
+
+export const registryResourceSchema: ResourceSchema = {
+	key: 'registry',
+	name: 'Registry',
+	rootType: 'ParsedRegistry',
+	registry,
+};


### PR DESCRIPTION
> **Stacked on #117** (→ #116 → #115). GitHub retargets the base automatically as the chain merges.

## What

Seven more resource types, implemented by five parallel workflow agents and integrated serially by the conductor — same recipe as batch 1 (agents create new files only; registration is one commit per spec group). Coverage: **41/114**.

| Spec | Type | Scale |
|---|---|---|
| EnvironmentKeyframe | 0x10012 | byte-exact across **all 48** retail keyframes (8–17 per season bundle, picker sorts by time-of-day) |
| EnvironmentTimeLine | 0x10013 | all 4 retail timelines |
| EnvironmentDictionary | 0x10014 | season/location catalogue |
| ColourCube | 0x2B | all 4 retail LUTs (32³ RGB24) |
| Font | 0x21 | **all 26** retail .FONT bundles |
| MassiveLookupTable | 0x1001A | the 20-slot ad-placement table |
| Registry | 0xA000 | both retail sound registries |

## Data findings (all pinned in tests)

- **Environment**: timeline→keyframe references travel as resource ids in the inline BND2 import table (one per pointer slot, ascending patch-offset order); the wiki's timeline header is 4 bytes short; colour values are HDR-overbright linear RGB (fills reach ~3.5 — never clamp); every keyframe carries a null ColourCube import.
- **ColourCube**: the wiki's 8-byte struct is really 16 bytes; all four retail cubes are sha256-identical — the 1.6-update default, which is a perfectly separable per-channel S-curve (verified across all 32,768 texels).
- **Font**: the on-disk element order isn't on the wiki; the 129-entry hash-offset table is fully derivable (`bucket = charId & 0x7F`) and recomputed on write; the two LIMITED Chinese fonts import their second texture page from another bundle and carry build-time garbage in that pointer slot (preserved verbatim).
- **Registry**: the entity table is an **open-addressed hash table** (slot = `soundHash(name) >> 1 & mask`, forward linear probing — proven by a real retail collision) which the writer fully re-derives; `soundHash` was recovered from the wiki's `MediaWiki:SoundHash.js` gadget and resolves 48/48 names; two undocumented entity types decoded (`~ContentClass~`/`~ContentType~`), plus the entirely undocumented `~GenericRwacFeatureImplementation~` DSP-graph type (21 entities); the wiki's VoiceSchema struct is self-overlapping and provably wrong. Undecoded payload kinds round-trip verbatim so other retail registries stay safe.

## Integration catch + known pre-existing issue

- The registry suite's picker contract caught a NaN in the keyframe time-sort (`Infinity - Infinity` for two suffix-less names) — fixed in its own commit. The implementing agent couldn't run that suite (handlers register at conductor time), which is exactly the failure mode the serial integration step exists to catch.
- The environment agent identified a **pre-existing** export-pipeline bug (not introduced or fixed here): `writeBundleFresh`'s import-table copy reads from the original file buffer at `resource.importOffset`, but BND2 import tables are inline in the resource payload and the offset is resource-relative. This affects count-changing edits on every imports-bearing type on repack; the environment schema carries a warning until it's fixed separately.

## Tests

Full suite: **2,812 passing** (+423 from this batch; the only failures are the 3 pre-existing missing-prototype-fixture cases). Registry fixture suite auto-enrolled all seven handlers: parse, byte round-trip, describe, picker contracts, 24 stress scenarios.

Specs: https://burnout.wiki/wiki/Environment_Keyframe · https://burnout.wiki/wiki/Environment_Time_Line · https://burnout.wiki/wiki/Environment_Dictionary · https://burnout.wiki/wiki/Colour_Cube · https://burnout.wiki/wiki/Font · https://burnout.wiki/wiki/Massive_Lookup_Table · https://burnout.wiki/wiki/Registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)