### PR TITLE
feat: batch 4 — the sound family + FlaptFile (7 types) + registry entities decoded

### DIFF
--- a/src/lib/core/__tests__/aemsBank.test.ts
+++ b/src/lib/core/__tests__/aemsBank.test.ts
@@ -1,0 +1,156 @@
+// Gold coverage for parseAemsBank / writeAemsBank.
+//
+// The registry fixture suite exercises five representative banks; this suite
+// sweeps ALL 23 retail banks in example/SOUND/AEMS (every .BUNDLE except
+// CSIS.BUNDLE carries exactly one 0xA022), pins hand-verified decoded values
+// from the smallest bank (GEARWHINEPATCHBANK), pins the two-module INAIR
+// shape the wiki says cannot exist, and asserts the retail constants the
+// parser preserves verbatim instead of validating ('AKH' pads, S10A banks).
+// The bank↔Csis CrcAndKey links are pinned in csis.test.ts.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseAemsBank, writeAemsBank, aemsSfxBankInfo, type ParsedAemsBank } from '../aemsBank';
+import { parseBundle } from '../bundle';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const AEMS_DIR = path.resolve(REPO_ROOT, 'example/SOUND/AEMS');
+const AEMS_BANK_TYPE_ID = 0xa022;
+
+function loadBanks(bundleFile: string): Uint8Array[] {
+	const buf = fs.readFileSync(path.resolve(AEMS_DIR, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	return bundle.resources
+		.filter((r) => r.resourceTypeId === AEMS_BANK_TYPE_ID)
+		.map((r) => new Uint8Array(extractResourceRaw(buffer, bundle, r)));
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+const allBundles = fs.readdirSync(AEMS_DIR).filter((f) => f.toUpperCase().endsWith('.BUNDLE'));
+const bankBundles = allBundles.filter((f) => f.toUpperCase() !== 'CSIS.BUNDLE');
+
+describe('AemsBank gold values (example/SOUND/AEMS/GEARWHINEPATCHBANK.BUNDLE)', () => {
+	const raw = loadBanks('GEARWHINEPATCHBANK.BUNDLE')[0];
+	const m = parseAemsBank(raw);
+
+	it('decodes the envelope and header', () => {
+		expect(raw.byteLength).toBe(9536);
+		expect(m.platform).toBe(0); // PC
+		expect(m.targetType).toBe(3); // SND10
+		expect(m.numModules).toBe(1);
+		expect(m._envelopePad.byteLength).toBe(8);
+	});
+
+	it('splits the interior blobs at the derived offsets', () => {
+		// sfxbankoffset 0xA80 − header 0x5C; sfxbanksizepadded 0x1A54.
+		expect(m._moduleData.byteLength).toBe(0xa24);
+		expect(m._sfxBank.byteLength).toBe(0x1a54);
+		expect(aemsSfxBankInfo(m)).toEqual({ id: 'S10A', version: 0, serialNumber: 0, numSamples: 1 });
+	});
+
+	it('decodes the fixup tables', () => {
+		expect(m.funcFixups).toEqual([0xa3, 0xb2, 0x102, 0x119, 0x125, 0x131, 0x13d, 0x146]);
+		expect(m.staticDataFixups).toEqual([0x1e0, 0x200]);
+	});
+
+	it('decodes the CSIS subscription', () => {
+		expect(m.interfaceRefs).toEqual([{
+			handleOffset: 0x60,
+			type: 1, // class
+			idCrc: 0x419c, // GearWhineCsis system crc
+			idKey: 0x419c, // GearWhineClass entry crc
+			idName: 'GearWhineClass',
+			_pad: [0x41, 0x4b, 0x48], // uninit 'AKH'
+		}]);
+	});
+});
+
+describe('AemsBank INAIR shape (wiki divergence: nummodules > 1)', () => {
+	const m = parseAemsBank(loadBanks('INAIR.BUNDLE')[0]);
+
+	it('has two modules and two subscriptions', () => {
+		expect(m.numModules).toBe(2);
+		expect(m.interfaceRefs.map((r) => [r.idName, r.handleOffset, r.idCrc, r.idKey])).toEqual([
+			['PlayTakeOff', 0x60, 0x0ed7, 0x1641],
+			['PlayInAir', 0xa4, 0x0ed7, 0x7896],
+		]);
+	});
+});
+
+describe('AemsBank retail sweep (all 23 banks)', () => {
+	it('every non-CSIS bundle in the directory carries exactly one bank', () => {
+		expect(allBundles.length).toBe(24);
+		expect(bankBundles.length).toBe(23);
+		expect(loadBanks('CSIS.BUNDLE')).toHaveLength(0);
+	});
+
+	const models = new Map<string, { raw: Uint8Array; model: ParsedAemsBank }>();
+	for (const file of bankBundles) {
+		const banks = loadBanks(file);
+		models.set(file, { raw: banks[0], model: parseAemsBank(banks[0]) });
+	}
+
+	it('round-trips every bank byte-for-byte, idempotently', () => {
+		for (const [file, { raw }] of models) {
+			const write1 = writeAemsBank(parseAemsBank(raw));
+			expect(write1.byteLength, file).toBe(raw.byteLength);
+			expect(bytesEqual(write1, raw), file).toBe(true);
+			const write2 = writeAemsBank(parseAemsBank(write1));
+			expect(bytesEqual(write2, write1), `${file} idempotence`).toBe(true);
+		}
+	});
+
+	it('pins the constants preserved verbatim rather than asserted', () => {
+		for (const [file, { model }] of models) {
+			// Every retail bank is a PC SND10 bank with ≥1 class subscription.
+			expect(model.platform, file).toBe(0);
+			expect(model.targetType, file).toBe(3);
+			expect(model.interfaceRefs.length, file).toBeGreaterThan(0);
+			for (const ref of model.interfaceRefs) {
+				expect(ref.type, `${file}/${ref.idName}`).toBe(1); // class
+				expect(ref._pad, `${file}/${ref.idName}`).toEqual([0x41, 0x4b, 0x48]); // 'AKH'
+			}
+			// SND10 header: 'S10A', version 0, serial 0; numSamples is stored
+			// big-endian and lands in a sane 1–309 range across retail.
+			const sfx = aemsSfxBankInfo(model)!;
+			expect(sfx.id, file).toBe('S10A');
+			expect(sfx.version, file).toBe(0);
+			expect(sfx.serialNumber, file).toBe(0);
+			expect(sfx.numSamples, file).toBeGreaterThanOrEqual(1);
+			expect(sfx.numSamples, file).toBeLessThanOrEqual(309);
+		}
+	});
+
+	it('only INAIR carries more than one module', () => {
+		for (const [file, { model }] of models) {
+			expect(model.numModules, file).toBe(file === 'INAIR.BUNDLE' ? 2 : 1);
+		}
+	});
+});
+
+describe('AemsBank writer validation', () => {
+	const m = parseAemsBank(loadBanks('GEARWHINEPATCHBANK.BUNDLE')[0]);
+
+	it('rejects an SFX bank whose size is not a multiple of 4', () => {
+		expect(() => writeAemsBank({ ...m, _sfxBank: m._sfxBank.slice(0, m._sfxBank.byteLength - 1) }))
+			.toThrow(/multiple of 4/);
+	});
+
+	it('rejects a malformed envelope pad', () => {
+		expect(() => writeAemsBank({ ...m, _envelopePad: new Uint8Array(0) })).toThrow(/_envelopePad/);
+	});
+
+	it('rejects byte-unrepresentable interface names', () => {
+		const interfaceRefs = [{ ...m.interfaceRefs[0], idName: 'badĀname' }];
+		expect(() => writeAemsBank({ ...m, interfaceRefs })).toThrow(/unrepresentable/);
+	});
+});

--- a/src/lib/core/__tests__/csis.test.ts
+++ b/src/lib/core/__tests__/csis.test.ts
@@ -1,0 +1,180 @@
+// Gold coverage for parseCsis / writeCsis.
+//
+// All ten retail Csis resources live in one bundle (SOUND/AEMS/CSIS.BUNDLE,
+// alongside 30 Registry resources this suite ignores), but the auto-generated
+// registry fixture suite only exercises the first resource of the type — so
+// this suite walks ALL ten, pins hand-verified decoded values, pins the
+// system-crc derivation, and pins the cross-resource CrcAndKey links from
+// every AEMS bank (0xA022) interface reference back to its Csis class.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseCsis, writeCsis, csisSystemCrc, type ParsedCsis } from '../csis';
+import { parseAemsBank } from '../aemsBank';
+import { parseBundle } from '../bundle';
+import { parseDebugDataFromXml, findDebugResourceById } from '../bundle/debugData';
+import { extractResourceRaw } from '../registry';
+import { shortCsisName } from '../registry/handlers/csis';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const AEMS_DIR = path.resolve(REPO_ROOT, 'example/SOUND/AEMS');
+const CSIS_TYPE_ID = 0xa023;
+const AEMS_BANK_TYPE_ID = 0xa022;
+
+type Extracted = { name: string; raw: Uint8Array };
+
+function loadResources(bundleFile: string, typeId: number): Extracted[] {
+	const buf = fs.readFileSync(path.resolve(AEMS_DIR, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const debugResources = typeof bundle.debugData === 'string'
+		? parseDebugDataFromXml(bundle.debugData)
+		: [];
+	return bundle.resources
+		.filter((r) => r.resourceTypeId === typeId)
+		.map((r) => ({
+			name: findDebugResourceById(debugResources, r.resourceId.low.toString(16))?.name ?? '?',
+			raw: new Uint8Array(extractResourceRaw(buffer, bundle, r)),
+		}));
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+const resources = loadResources('CSIS.BUNDLE', CSIS_TYPE_ID);
+const byShortName = new Map<string, { raw: Uint8Array; model: ParsedCsis }>(
+	resources.map(({ name, raw }) => [shortCsisName(name), { raw, model: parseCsis(raw) }]),
+);
+
+describe('Csis gold values (example/SOUND/AEMS/CSIS.BUNDLE)', () => {
+	it('the bundle carries exactly the ten retail module descriptors', () => {
+		expect([...byShortName.keys()].sort()).toEqual([
+			'BoostCsis', 'CrumpleCsis', 'GearWhineCsis', 'HornsCsis', 'InAirCsis',
+			'ScrapesCsis', 'SkidsCsis', 'SurfaceCsis', 'TrafficCsis', 'TurboCsis',
+		]);
+	});
+
+	it('decodes TrafficCsis (single-class shape)', () => {
+		const { raw, model } = byShortName.get('TrafficCsis')!;
+		expect(raw.byteLength).toBe(96);
+		expect(model.platform).toBe(0);
+		expect(model.resolved).toBe(0);
+		expect(model.functions).toEqual([]);
+		expect(model.classes).toEqual([
+			{ name: 'TrafficEngineClass', crc: 0x73c8, _key: 0, _clients: 0 },
+		]);
+		expect(model.globalVariables).toEqual([]);
+		expect(csisSystemCrc(model)).toBe(0x73c8);
+	});
+
+	it('decodes BoostCsis (the only resource with functions)', () => {
+		const { model } = byShortName.get('BoostCsis')!;
+		expect(model.functions.map((e) => [e.name, e.crc])).toEqual([
+			['Message_1', 0x21e1],
+			['Message', 0x6e72],
+		]);
+		expect(model.classes.map((e) => [e.name, e.crc])).toEqual([['Class', 0x540e]]);
+		// The header crc is the entry-crc sum folded to 15 bits:
+		// 0x21E1 + 0x6E72 + 0x540E = 0xE461 → & 0x7FFF = 0x6461.
+		expect(csisSystemCrc(model)).toBe(0x6461);
+	});
+
+	it('decodes the two-class modules (Skids, InAir)', () => {
+		const skids = byShortName.get('SkidsCsis')!.model;
+		expect(skids.classes.map((e) => [e.name, e.crc])).toEqual([
+			['Skids', 0x3a2b],
+			['Skids_Traffic', 0x5719],
+		]);
+		expect(csisSystemCrc(skids)).toBe(0x1144); // 0x9144 & 0x7FFF
+
+		const inAir = byShortName.get('InAirCsis')!.model;
+		expect(inAir.classes.map((e) => [e.name, e.crc])).toEqual([
+			['PlayTakeOff', 0x1641],
+			['PlayInAir', 0x7896],
+		]);
+		expect(csisSystemCrc(inAir)).toBe(0x0ed7); // 0x8ED7 & 0x7FFF
+	});
+
+	it('no retail resource uses global variables or runtime fields', () => {
+		for (const [name, { model }] of byShortName) {
+			expect(model.globalVariables, name).toEqual([]);
+			expect(model.platform, name).toBe(0);
+			expect(model.resolved, name).toBe(0);
+			for (const e of [...model.functions, ...model.classes]) {
+				expect(e._key, `${name}/${e.name}`).toBe(0);
+				expect(e._clients, `${name}/${e.name}`).toBe(0);
+			}
+		}
+	});
+});
+
+describe('Csis round-trip', () => {
+	it('round-trips all ten resources byte-for-byte, idempotently', () => {
+		for (const [name, { raw }] of byShortName) {
+			const write1 = writeCsis(parseCsis(raw));
+			expect(write1.byteLength, name).toBe(raw.byteLength);
+			expect(bytesEqual(write1, raw), name).toBe(true);
+			const write2 = writeCsis(parseCsis(write1));
+			expect(bytesEqual(write2, write1), `${name} idempotence`).toBe(true);
+		}
+	});
+
+	it('writer rejects a malformed envelope pad', () => {
+		const { model } = byShortName.get('TrafficCsis')!;
+		expect(() => writeCsis({ ...model, _envelopePad: new Uint8Array(4) })).toThrow(/_envelopePad/);
+	});
+
+	it('writer rejects byte-unrepresentable entry names', () => {
+		const { model } = byShortName.get('TrafficCsis')!;
+		const classes = [{ ...model.classes[0], name: 'badĀname' }];
+		expect(() => writeCsis({ ...model, classes })).toThrow(/unrepresentable/);
+	});
+
+	it('parser rejects a corrupted system crc (derivation is asserted)', () => {
+		const { raw } = byShortName.get('TrafficCsis')!;
+		const corrupted = new Uint8Array(raw);
+		corrupted[0x20] ^= 0xff; // crc lives at payload+0x10 = raw 0x20
+		expect(() => parseCsis(corrupted)).toThrow(/crc/);
+	});
+});
+
+describe('Csis ↔ AEMS bank CrcAndKey links', () => {
+	// Every interface reference in every retail bank must resolve against one
+	// of the ten Csis resources: idCrc == that resource's system crc, and
+	// (idKey, idName) == one of its class entries. This is the load-time
+	// subscription contract the two types share.
+	const bankFiles = fs.readdirSync(AEMS_DIR)
+		.filter((f) => f.toUpperCase().endsWith('.BUNDLE') && f.toUpperCase() !== 'CSIS.BUNDLE');
+
+	it('every bank interface reference resolves to a Csis class', () => {
+		expect(bankFiles.length).toBe(23);
+		const models = [...byShortName.values()].map((v) => v.model);
+		for (const file of bankFiles) {
+			const banks = loadResources(file, AEMS_BANK_TYPE_ID);
+			expect(banks.length, file).toBe(1);
+			const bank = parseAemsBank(banks[0].raw);
+			expect(bank.interfaceRefs.length, file).toBeGreaterThan(0);
+			for (const ref of bank.interfaceRefs) {
+				const target = models.find((m) => csisSystemCrc(m) === ref.idCrc);
+				expect(target, `${file}: no Csis with system crc 0x${ref.idCrc.toString(16)}`).toBeDefined();
+				const entry = target!.classes.find((e) => e.name === ref.idName);
+				expect(entry, `${file}: '${ref.idName}' not a class of the crc-matched Csis`).toBeDefined();
+				expect(entry!.crc, `${file}: ${ref.idName} entry crc`).toBe(ref.idKey);
+			}
+		}
+	});
+
+	it('pins the GearWhine pair end to end', () => {
+		const bank = parseAemsBank(loadResources('GEARWHINEPATCHBANK.BUNDLE', AEMS_BANK_TYPE_ID)[0].raw);
+		const csis = byShortName.get('GearWhineCsis')!.model;
+		expect(bank.interfaceRefs).toHaveLength(1);
+		expect(bank.interfaceRefs[0].idName).toBe('GearWhineClass');
+		expect(bank.interfaceRefs[0].idCrc).toBe(csisSystemCrc(csis));
+		expect(bank.interfaceRefs[0].idKey).toBe(csis.classes[0].crc);
+	});
+});

--- a/src/lib/core/__tests__/flaptFile.test.ts
+++ b/src/lib/core/__tests__/flaptFile.test.ts
@@ -1,0 +1,272 @@
+// Gold coverage for parseFlaptFile / writeFlaptFile (resource type 0x10020).
+//
+// Pins hand-verified decoded values from FLAPTHUD.BUNDLE (the only retail
+// Flapt resource), the byte-exact round-trip + writer idempotence bar, the
+// fixture facts the wiki does not state (0xB0 garbage fill, index cookies in
+// the texture pointer array, import fixups targeting mpapTextures slots in
+// slot order, the un-imported "special" slot), and the cross-resource fact
+// that every imported id is a sibling Texture (0x0) resource.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+	parseFlaptFile,
+	writeFlaptFile,
+	flaptFileImportTable,
+	countFlaptTextureImports,
+	FLAPT_VERSION,
+} from '../flaptFile';
+import { parseBundle } from '../bundle';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const FLAPT_TYPE_ID = 0x10020;
+const TEXTURE_TYPE_ID = 0x0;
+const FIXTURE = 'example/FLAPTHUD.BUNDLE';
+
+type Loaded = {
+	raw: Uint8Array;
+	importOffset: number;
+	importCount: number;
+	siblingTextureIds: Set<string>;
+};
+
+function loadFlapt(): Loaded {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, FIXTURE));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const res = bundle.resources.find((r) => r.resourceTypeId === FLAPT_TYPE_ID);
+	if (!res) throw new Error(`${FIXTURE}: no 0x10020 resource`);
+	const siblingTextureIds = new Set(
+		bundle.resources
+			.filter((r) => r.resourceTypeId === TEXTURE_TYPE_ID)
+			.map((r) => ((BigInt(r.resourceId.high) << 32n) | BigInt(r.resourceId.low)).toString(16)),
+	);
+	return {
+		raw: extractResourceRaw(buffer, bundle, res),
+		importOffset: res.importOffset,
+		importCount: res.importCount,
+		siblingTextureIds,
+	};
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+const loaded = loadFlapt();
+const m = parseFlaptFile(loaded.raw);
+
+describe('FlaptFile gold values (example/FLAPTHUD.BUNDLE)', () => {
+	it('decodes the header: version 12, 30 fps frame time', () => {
+		expect(m.muVersion).toBe(FLAPT_VERSION);
+		expect(m.mfTimePerFrame).toBe(Math.fround(1 / 30));
+	});
+
+	it('decodes every section count', () => {
+		expect(loaded.raw.byteLength).toBe(1330160);
+		expect(m.movieClips.length).toBe(560);
+		expect(m.textures.length).toBe(53);
+		expect(m.vertices.length).toBe(1650);
+		expect(m.fontStyles.length).toBe(65);
+		expect(m.components.length).toBe(429);
+		expect(m.triggerParameters.length).toBe(75);
+		expect(m.strings.length).toBe(356);
+		expect(m.specialTextureNames.length).toBe(1);
+		expect(m.debugStringCount).toBe(1582);
+	});
+
+	it('keeps the payload verbatim — garbage fill is 0xB0, not 0xCD', () => {
+		expect(m._payload.byteLength).toBe(1330160);
+		// Header pad after the u8 version byte.
+		expect([m._payload[1], m._payload[2], m._payload[3]]).toEqual([0xb0, 0xb0, 0xb0]);
+		// MovieClip[0] pad byte at +0x7 (clips start at 0x58).
+		expect(m._payload[0x58 + 7]).toBe(0xb0);
+	});
+
+	it('pins HUD strings — the table is the on-screen text pool', () => {
+		expect(m.strings[0]).toBe('');
+		expect(m.strings[1]).toBe('$100');
+		expect(m.strings[100]).toBe('Achievement Awarded (12 of 49)');
+		expect(m.strings[355]).toBe('x');
+	});
+
+	it('pins font styles (name read-only, colour/height patchable)', () => {
+		expect(m.fontStyles[0]).toEqual({ fontName: 'B5EAConDisSDrop', muColour: 0xffffffff, mfFontHeight: 20 });
+		expect(m.fontStyles[5].fontName).toBe('MachineStd-BoldDrop');
+		expect(m.fontStyles[5].mfFontHeight).toBe(55);
+	});
+
+	it('pins components: language hash + debug name + index path', () => {
+		expect(m.components[0].muHash).toBe(0xe78ad201);
+		expect(m.components[0].debugName).toBe('FriendListChange_mc');
+		expect(m.components[0].pathIndices).toEqual([0, 0]);
+		expect(m.components[2].debugName).toBe('SatNavIcon0_Icon');
+		expect(m.components[2].pathIndices).toEqual([0, 1, 17]);
+	});
+
+	it('pins trigger parameters — EasyDrive lives here', () => {
+		expect(m.triggerParameters[3]).toEqual({
+			parameter0: 'RaceMainHUD',
+			parameter1: 'ON_ENTER',
+			parameter2: 'EasyDriveEntry',
+			parameter3: null,
+		});
+	});
+
+	it('decodes movie clip scalars and the rare component names', () => {
+		const c0 = m.movieClips[0];
+		expect(c0.componentName).toBeNull();
+		expect(c0.muNumChildren).toBe(4);
+		expect(c0.muNumFramesInTimeline).toBe(1);
+		const c2 = m.movieClips[2];
+		expect(c2.componentName).toBe('B5FriendListChangeIconComponent');
+		expect(c2.mxFlags).toBe(1);
+		expect(c2.muNumChildren).toBe(1);
+		expect(c2.muNumMeshes).toBe(4);
+		expect(c2.muNumRenderLayers).toBe(2);
+		expect(c2.muNumLabelledFrames).toBe(4);
+		expect(c2.muNumFScriptCommands).toBe(4);
+		expect(c2.muNumFramesInTimeline).toBe(39);
+		expect(c2.muNumKeyFrames).toBe(20);
+		expect(m.movieClips.filter((c) => c.componentName != null).length).toBe(50);
+	});
+
+	it('pins vertices: 2D pos, RGBA8 colour, UV', () => {
+		expect(m.vertices[0].mv2Pos).toEqual({ x: -30.5, y: -30.5 });
+		expect(m.vertices[0].mColour).toBe(0xffffffff);
+		expect(m.vertices[0].mv2Tex0UV).toEqual({ x: 0.5419921875, y: 0.1806640625 });
+		expect(m.vertices[1649].mColour).toBe(0xff11b5f1);
+	});
+
+	it('binds import entries to texture slots in slot order; slot 52 is the special texture', () => {
+		expect(countFlaptTextureImports(m)).toBe(52);
+		expect(m.textures[0].resourceId).toBe(0xf2247a5an);
+		expect(m.textures[51].resourceId).toBe(0x6ef569fen);
+		expect(m.textures[52].resourceId).toBeNull();
+		expect(m.specialTextureNames[0]).toBe('CustomComponentTexture.tif');
+	});
+
+	it('every imported texture id is a sibling Texture resource of this bundle', () => {
+		let checked = 0;
+		for (const t of m.textures) {
+			if (t.resourceId == null) continue;
+			expect(loaded.siblingTextureIds.has(t.resourceId.toString(16))).toBe(true);
+			checked++;
+		}
+		expect(checked).toBe(52);
+		expect(loaded.siblingTextureIds.size).toBe(52);
+	});
+});
+
+describe('FlaptFile round-trip', () => {
+	it('round-trips byte-for-byte, idempotently', () => {
+		const out = writeFlaptFile(parseFlaptFile(loaded.raw));
+		expect(out.byteLength).toBe(loaded.raw.byteLength);
+		expect(bytesEqual(out, loaded.raw)).toBe(true);
+		const out2 = writeFlaptFile(parseFlaptFile(out));
+		expect(bytesEqual(out2, out)).toBe(true);
+	});
+
+	it('patches edits in place without disturbing un-decoded bytes', () => {
+		const edited = parseFlaptFile(loaded.raw);
+		edited.mfTimePerFrame = Math.fround(1 / 60);
+		edited.vertices[0].mv2Pos = { x: 100, y: -200 };
+		edited.vertices[0].mColour = 0x12345678;
+		edited.fontStyles[3].muColour = 0xdeadbeef;
+		edited.fontStyles[3].mfFontHeight = 99;
+		edited.textures[7].resourceId = 0xcafef00dn;
+		const out = writeFlaptFile(edited);
+		expect(out.byteLength).toBe(loaded.raw.byteLength);
+
+		const re = parseFlaptFile(out);
+		expect(re.mfTimePerFrame).toBe(Math.fround(1 / 60));
+		expect(re.vertices[0].mv2Pos).toEqual({ x: 100, y: -200 });
+		expect(re.vertices[0].mColour).toBe(0x12345678);
+		expect(re.fontStyles[3].muColour).toBe(0xdeadbeef);
+		expect(re.fontStyles[3].mfFontHeight).toBe(99);
+		expect(re.textures[7].resourceId).toBe(0xcafef00dn);
+
+		// The 1.2 MB timeline region (after the texture pointer slot array,
+		// before the import table) must be untouched by any of these edits.
+		const view = new DataView(loaded.raw.buffer, loaded.raw.byteOffset, loaded.raw.byteLength);
+		const ppTextures = view.getUint32(0x18, true);
+		const timelineStart = ppTextures + 53 * 4 + 0x2000; // clear of the nearby string pools
+		const muSize = view.getUint32(0x04, true);
+		expect(bytesEqual(out.subarray(timelineStart, muSize), loaded.raw.subarray(timelineStart, muSize))).toBe(true);
+		// Strings and clip structs also untouched.
+		expect(re.strings[100]).toBe(m.strings[100]);
+		expect(re.movieClips[2]).toEqual(m.movieClips[2]);
+	});
+
+	it('writer is pure — the input model\'s _payload is not mutated', () => {
+		const model = parseFlaptFile(loaded.raw);
+		const before = new Uint8Array(model._payload);
+		model.mfTimePerFrame = 1;
+		writeFlaptFile(model);
+		expect(bytesEqual(model._payload, before)).toBe(true);
+	});
+});
+
+describe('FlaptFile writer validation (counts are fixed — patch-only writes)', () => {
+	it('rejects a changed vertex count', () => {
+		const model = parseFlaptFile(loaded.raw);
+		model.vertices.pop();
+		expect(() => writeFlaptFile(model)).toThrow(/vertices length/);
+	});
+
+	it('rejects a resourceId on the special (un-imported) texture slot', () => {
+		const model = parseFlaptFile(loaded.raw);
+		model.textures[52].resourceId = 0x1234n;
+		expect(() => writeFlaptFile(model)).toThrow(/special/);
+	});
+
+	it('rejects a null resourceId on an imported slot', () => {
+		const model = parseFlaptFile(loaded.raw);
+		model.textures[0].resourceId = null;
+		expect(() => writeFlaptFile(model)).toThrow(/resourceId is null/);
+	});
+});
+
+describe('FlaptFile inline import table (envelope metadata)', () => {
+	it('importTable() matches the bundle envelope', () => {
+		expect(flaptFileImportTable(loaded.raw)).toEqual({
+			offset: loaded.importOffset,
+			count: loaded.importCount,
+		});
+		expect(loaded.importCount).toBe(52);
+		// muSizeInBytes excludes the import table, exactly like AptData.
+		expect(loaded.importOffset + 52 * 16).toBe(loaded.raw.byteLength);
+	});
+});
+
+describe('FlaptFile parser rigidity', () => {
+	it('rejects an unsupported version byte', () => {
+		const broken = new Uint8Array(loaded.raw);
+		broken[0] = 11;
+		expect(() => parseFlaptFile(broken)).toThrow(/muVersion 11/);
+	});
+
+	it('rejects a ragged import tail', () => {
+		expect(() => parseFlaptFile(loaded.raw.subarray(0, loaded.raw.byteLength - 8))).toThrow(/import tail/);
+	});
+
+	it('rejects an import fixup that does not target a texture slot', () => {
+		const broken = new Uint8Array(loaded.raw);
+		const view = new DataView(broken.buffer);
+		const importOffset = loaded.importOffset;
+		view.setUint32(importOffset + 8, 0x10, true); // points at the header instead
+		expect(() => parseFlaptFile(broken)).toThrow(/does not target a texture slot/);
+	});
+
+	it('rejects a corrupted section pointer instead of mis-parsing', () => {
+		const broken = new Uint8Array(loaded.raw);
+		const view = new DataView(broken.buffer);
+		view.setUint32(0x20, 0xfef9e400, true); // mpaVerts -> stale-heap-style garbage
+		expect(() => parseFlaptFile(broken)).toThrow(/vertices region/);
+	});
+});

--- a/src/lib/core/__tests__/genericRwacWaveContent.test.ts
+++ b/src/lib/core/__tests__/genericRwacWaveContent.test.ts
@@ -1,0 +1,260 @@
+// Gold coverage for parseGenericRwacWaveContent / writeGenericRwacWaveContent.
+//
+// SOUND/GLOBALWAVES.BUNDLE carries 37 waves but the auto-generated registry
+// fixture suite only exercises the first resource of a type per bundle — so
+// this suite walks ALL 37, pins hand-verified decoded values, and pins the
+// spec-vs-bytes findings (chunk byte counts include their 8-byte header,
+// loop points split chunks, garbage pad bytes survive verbatim).
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+	parseGenericRwacWaveContent,
+	writeGenericRwacWaveContent,
+	waveDurationSeconds,
+	SNDPLAYER_PLAY_TYPE,
+} from '../genericRwacWaveContent';
+import { waveDisplayName, genericRwacWaveContentHandler } from '../registry/handlers/genericRwacWaveContent';
+import { parseBundle } from '../bundle';
+import { parseDebugDataFromXml, findDebugResourceById } from '../bundle/debugData';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const WAVE_TYPE_ID = 0xa020;
+const BUNDLE_FIXTURE = 'example/SOUND/GLOBALWAVES.BUNDLE';
+
+type ExtractedWave = { name: string; raw: Uint8Array };
+
+function loadWaves(bundleFile: string): ExtractedWave[] {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const debugResources = typeof bundle.debugData === 'string'
+		? parseDebugDataFromXml(bundle.debugData)
+		: [];
+	return bundle.resources
+		.filter((r) => r.resourceTypeId === WAVE_TYPE_ID)
+		.map((r) => ({
+			name: findDebugResourceById(debugResources, r.resourceId.low.toString(16))?.name ?? '?',
+			raw: new Uint8Array(extractResourceRaw(buffer, bundle, r)),
+		}));
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+const waves = loadWaves(BUNDLE_FIXTURE);
+const byName = (stem: string) => {
+	const hit = waves.find((w) => waveDisplayName(w.name) === stem);
+	if (!hit) throw new Error(`fixture wave ${stem} not found`);
+	return hit;
+};
+
+describe('GenericRwacWaveContent gold values (example/SOUND/GLOBALWAVES.BUNDLE)', () => {
+	it('finds all 37 waves, BikeToyCarHorn first in bundle order', () => {
+		expect(waves.length).toBe(37);
+		expect(waveDisplayName(waves[0].name)).toBe('BikeToyCarHorn.wav');
+	});
+
+	it('decodes BikeToyCarHorn (looped mono horn with garbage pads)', () => {
+		const m = parseGenericRwacWaveContent(byName('BikeToyCarHorn.wav').raw);
+		expect(m.version).toBe(0);
+		expect(m.codec).toBe(5); // SNDPLAYER_CODEC_EALAYER31_INT
+		expect(m.channels).toBe(1);
+		expect(m.sampleRate).toBe(48000);
+		expect(m.playType).toBe(SNDPLAYER_PLAY_TYPE.RAM);
+		expect(m.loopStartSample).toBe(0);
+		expect(m.gigaResidentSamples).toBeNull();
+		expect(m.numSamples).toBe(4890);
+		expect(m.chunks.length).toBe(1);
+		// On-disk chunk byte count (1855) INCLUDES its 8-byte header — the model
+		// keeps only the codec payload.
+		expect(m.chunks[0].data.byteLength).toBe(1855 - 8);
+		expect(m.chunks[0].samples).toBe(4890);
+		// Stale heap garbage leaked into the wrapper pad ("ation\Cg" — a path
+		// fragment from the build machine) and the alignment tail. Pin both so
+		// a "cleanup" that zeroes them breaks loudly.
+		expect(Array.from(m._binPad)).toEqual([0x61, 0x74, 0x69, 0x6f, 0x6e, 0x5c, 0x43, 0x67]);
+		expect(m._trailingPad.byteLength).toBe(5);
+		expect(m._trailingPad.some((b) => b !== 0)).toBe(true);
+	});
+
+	it('decodes HUD_counter_crit (stereo, loop point splits the chunks)', () => {
+		const m = parseGenericRwacWaveContent(byName('HUD_counter_crit.wav').raw);
+		expect(m.channels).toBe(2);
+		expect(m.sampleRate).toBe(48000);
+		expect(m.loopStartSample).toBe(23056);
+		expect(m.numSamples).toBe(34260);
+		expect(m.chunks.length).toBe(2);
+		expect(m.chunks[0].samples).toBe(23056);
+		expect(m.chunks[1].samples).toBe(34260 - 23056);
+		expect(m.chunks[0].data.byteLength).toBe(15980 - 8);
+		expect(m.chunks[1].data.byteLength).toBe(7228 - 8);
+	});
+
+	it('decodes B2FDeLorean_Down (one-shot — no loop field in the header)', () => {
+		const m = parseGenericRwacWaveContent(byName('B2FDeLorean_Down.wav').raw);
+		expect(m.loopStartSample).toBeNull();
+		expect(m.numSamples).toBe(103681);
+		expect(m.chunks.length).toBe(1);
+		expect(waveDurationSeconds(m)).toBeCloseTo(103681 / 48000, 5);
+	});
+
+	it('pins the retail population: all EALayer3 v1 RAM waves, known rate/channel mix', () => {
+		const models = waves.map((w) => parseGenericRwacWaveContent(w.raw));
+		expect(models.every((m) => m.version === 0)).toBe(true);
+		expect(models.every((m) => m.codec === 5)).toBe(true);
+		expect(models.every((m) => m.playType === SNDPLAYER_PLAY_TYPE.RAM)).toBe(true);
+		expect(models.every((m) => m.gigaResidentSamples === null)).toBe(true);
+		expect(models.every((m) => m._unchunkedData === null)).toBe(true);
+		expect(models.filter((m) => m.channels === 2).length).toBe(8);
+		expect(models.filter((m) => m.channels === 1).length).toBe(29);
+		const rates = new Map<number, number>();
+		for (const m of models) rates.set(m.sampleRate, (rates.get(m.sampleRate) ?? 0) + 1);
+		expect(rates).toEqual(new Map([[48000, 31], [44100, 2], [22050, 4]]));
+		expect(models.filter((m) => m.loopStartSample != null).length).toBe(24);
+	});
+
+	it('multi-chunk waves exist exactly where the loop starts mid-asset, split at the loop sample', () => {
+		const multi = waves
+			.map((w) => ({ name: waveDisplayName(w.name), m: parseGenericRwacWaveContent(w.raw) }))
+			.filter(({ m }) => m.chunks.length > 1);
+		expect(multi.map(({ name }) => name).sort()).toEqual([
+			'B2FDeLorean_Up.wav',
+			'B2FDeLorean_UpToy.wav',
+			'EctoSiren.wav',
+			'HUD_counter_crit.wav',
+		]);
+		for (const { name, m } of multi) {
+			expect(m.chunks.length, name).toBe(2);
+			// The decoder can only restart a loop on a chunk boundary, so the
+			// first chunk ends exactly at the loop start sample.
+			expect(m.chunks[0].samples, name).toBe(m.loopStartSample);
+		}
+		// And the converse: every single-chunk loop starts at sample 0.
+		for (const w of waves) {
+			const m = parseGenericRwacWaveContent(w.raw);
+			if (m.chunks.length === 1 && m.loopStartSample != null) {
+				expect(m.loopStartSample, waveDisplayName(w.name)).toBe(0);
+			}
+		}
+	});
+
+	it('chunk samples always sum to the header total', () => {
+		for (const w of waves) {
+			const m = parseGenericRwacWaveContent(w.raw);
+			const sum = m.chunks.reduce((acc, c) => acc + c.samples, 0);
+			expect(sum, waveDisplayName(w.name)).toBe(m.numSamples);
+		}
+	});
+
+	it('four waves carry uninitialised (non-zero) trailing pad bytes', () => {
+		const garbage = waves
+			.map((w) => ({ name: waveDisplayName(w.name), m: parseGenericRwacWaveContent(w.raw) }))
+			.filter(({ m }) => m._trailingPad.some((b) => b !== 0))
+			.map(({ name }) => name)
+			.sort();
+		expect(garbage).toEqual([
+			'BikeToyCarHorn.wav',
+			'CarsInfToyCarHorn.wav',
+			'ConGTToyCarHorn.wav',
+			'StuntScoreCounter.wav',
+		]);
+	});
+});
+
+describe('GenericRwacWaveContent round-trip', () => {
+	it('round-trips all 37 waves byte-for-byte, idempotently', () => {
+		for (const { name, raw } of waves) {
+			const label = waveDisplayName(name);
+			const once = writeGenericRwacWaveContent(parseGenericRwacWaveContent(raw));
+			expect(once.byteLength, label).toBe(raw.byteLength);
+			expect(bytesEqual(once, raw), label).toBe(true);
+			const twice = writeGenericRwacWaveContent(parseGenericRwacWaveContent(once));
+			expect(bytesEqual(twice, once), label).toBe(true);
+		}
+	});
+
+	it('re-derives sizes, sample total, and pad after a chunk edit', () => {
+		const m = parseGenericRwacWaveContent(byName('HUD_counter_crit.wav').raw);
+		const edited = { ...m, chunks: [m.chunks[0]] };
+		const written = writeGenericRwacWaveContent(edited);
+		expect(written.byteLength % 16).toBe(0);
+		const reparsed = parseGenericRwacWaveContent(written);
+		expect(reparsed.numSamples).toBe(m.chunks[0].samples);
+		expect(reparsed.chunks.length).toBe(1);
+		expect(bytesEqual(writeGenericRwacWaveContent(reparsed), written)).toBe(true);
+	});
+
+	it('drops a garbage pad whose length no longer fits, replacing it with zeros', () => {
+		const m = parseGenericRwacWaveContent(byName('BikeToyCarHorn.wav').raw);
+		// Clearing the loop shrinks the header by 4, so the captured 5-byte
+		// garbage pad can't be reused; the writer must still 16-align.
+		const written = writeGenericRwacWaveContent({ ...m, loopStartSample: null });
+		expect(written.byteLength % 16).toBe(0);
+		const reparsed = parseGenericRwacWaveContent(written);
+		expect(reparsed.loopStartSample).toBeNull();
+		expect(reparsed.numSamples).toBe(m.numSamples);
+		expect(reparsed._trailingPad.every((b) => b === 0)).toBe(true);
+	});
+
+	it('parser rejects a wrong data offset', () => {
+		const raw = new Uint8Array(byName('BikeToyCarHorn.wav').raw);
+		raw[4] = 0x18;
+		expect(() => parseGenericRwacWaveContent(raw)).toThrow(/mu32DataOffset/);
+	});
+
+	it('parser rejects a data size inconsistent with the resource length', () => {
+		const raw = new Uint8Array(byName('BikeToyCarHorn.wav').raw);
+		raw[0] = raw[0] + 1;
+		expect(() => parseGenericRwacWaveContent(raw)).toThrow(/mu32DataSize/);
+	});
+
+	it('parser rejects a truncated chunk', () => {
+		const raw = new Uint8Array(byName('BikeToyCarHorn.wav').raw).slice(0, 0x100);
+		raw[0] = 0xf0; raw[1] = 0x00; raw[2] = 0x00; raw[3] = 0x00; // dataSize 0xF0
+		expect(() => parseGenericRwacWaveContent(raw)).toThrow(/overruns|ran out/);
+	});
+
+	it('writer rejects out-of-range header fields', () => {
+		const m = parseGenericRwacWaveContent(byName('BikeToyCarHorn.wav').raw);
+		expect(() => writeGenericRwacWaveContent({ ...m, sampleRate: 0x40000 })).toThrow(/sample rate/);
+		expect(() => writeGenericRwacWaveContent({ ...m, channels: 0 })).toThrow(/channels/);
+		expect(() => writeGenericRwacWaveContent({ ...m, codec: 16 })).toThrow(/codec/);
+		expect(() => writeGenericRwacWaveContent({ ...m, gigaResidentSamples: 5 })).toThrow(/gigasample/);
+	});
+});
+
+describe('genericRwacWaveContentHandler', () => {
+	it('describes a wave in one line', () => {
+		const m = parseGenericRwacWaveContent(byName('HUD_counter_crit.wav').raw);
+		const line = genericRwacWaveContentHandler.describe(m);
+		expect(line).toContain('EALayer3 v1');
+		expect(line).toContain('48000 Hz stereo');
+		expect(line).toContain('2 chunks');
+		expect(line).toContain('loop @ sample 23056');
+	});
+
+	it('picker labels strip the gamedb URL and never sort to NaN', () => {
+		expect(waveDisplayName('gamedb://burnout5/Burnout/Sound/GlobalWaves/BikeToyCarHorn.wav.WaveFile?ID=805063'))
+			.toBe('BikeToyCarHorn.wav');
+		expect(waveDisplayName('Resource_12345678')).toBe('Resource_12345678');
+		const picker = genericRwacWaveContentHandler.picker!;
+		const entries = [
+			{ model: parseGenericRwacWaveContent(waves[0].raw), ctx: { id: '0x1', name: waves[0].name, index: 0 } },
+			{ model: null, ctx: { id: '0x2', name: 'Resource_2', index: 1 } },
+		];
+		for (const key of picker.sortKeys) {
+			const v = key.compare(entries[0], entries[1]);
+			expect(Number.isNaN(v), key.id).toBe(false);
+		}
+		const label = picker.labelOf(entries[0].model, entries[0].ctx);
+		expect(label.primary).toBe('BikeToyCarHorn.wav');
+		expect(label.badges?.[0]?.label).toBe('looped');
+	});
+});

--- a/src/lib/core/__tests__/nicotine.test.ts
+++ b/src/lib/core/__tests__/nicotine.test.ts
@@ -1,0 +1,217 @@
+// Gold coverage for parseNicotine / writeNicotine (resource type 0xA024).
+//
+// Pins hand-verified decoded values from both retail maps (probed against
+// raw bytes before the parser existed), the byte-exact round-trip, and the
+// headline finding: the stereo (Main) and surround maps share an identical
+// 9-state structure and differ ONLY in 13 master-channel mixData attenuation
+// words plus 3 stale-pointer event reserved words.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseNicotine, writeNicotine, packedExtraCount, threeDStateParamCount, type ParsedNicotine } from '../nicotine';
+import { parseBundle } from '../bundle';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const NICOTINE_TYPE_ID = 0xa024;
+const MAIN_BUNDLE = 'example/SOUND/NICOTINEASSETMAIN.BUNDLE';
+const SURROUND_BUNDLE = 'example/SOUND/NICOTINEASSETSURROUND.BUNDLE';
+
+function loadRaw(bundleFile: string): Uint8Array {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const matches = bundle.resources.filter((r) => r.resourceTypeId === NICOTINE_TYPE_ID);
+	expect(matches.length).toBe(1);
+	return extractResourceRaw(buffer, bundle, matches[0]);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+/** Collect every differing numeric leaf between two models, as path strings. */
+function numericDiffs(a: unknown, b: unknown, p: string, out: string[]) {
+	if (typeof a === 'number' && typeof b === 'number') {
+		if (a !== b) out.push(p);
+		return;
+	}
+	if (Array.isArray(a) && Array.isArray(b)) {
+		expect(b.length, p).toBe(a.length);
+		a.forEach((x, i) => numericDiffs(x, b[i], `${p}[${i}]`, out));
+		return;
+	}
+	if (a !== null && b !== null && typeof a === 'object' && typeof b === 'object') {
+		for (const k of Object.keys(a as object)) {
+			numericDiffs((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k], `${p}.${k}`, out);
+		}
+		return;
+	}
+	// null-vs-object would mean a structural divergence between the maps
+	expect(a === null ? 'null' : typeof a, p).toBe(b === null ? 'null' : typeof b);
+}
+
+const mainModel = parseNicotine(loadRaw(MAIN_BUNDLE));
+const surroundModel = parseNicotine(loadRaw(SURROUND_BUNDLE));
+
+describe('Nicotine gold values (NicotineAssetMain)', () => {
+	it('decodes the map header shape', () => {
+		expect(mainModel.mixMapId).toBe(0);
+		expect(mainModel.states.length).toBe(9);
+		// 4 trailing -1 slots after the 9 real entries — undocumented on the wiki.
+		expect(mainModel._stateTableSentinelSlots).toBe(4);
+	});
+
+	it('state indices run 0x1F0000..0x1F0008 in table order', () => {
+		mainModel.states.forEach((s, i) => expect(s.stateIndex).toBe(0x1f0000 + i));
+	});
+
+	it('pins the per-state section census', () => {
+		const census = mainModel.states.map((s) => [
+			s.mixControls?.controls.length ?? null,
+			s.threeDControls?.controls.length ?? null,
+			s.subMix?.channels.length ?? null,
+			s.masterMix?.channels.length ?? null,
+			s.presets?.length ?? null,
+			s.events?.events.length ?? null,
+		]);
+		expect(census).toEqual([
+			[15, null, 4, 25, 25, 18],
+			[24, 8, 17, 49, 49, 29],
+			[5, 2, 2, 15, 15, 5],
+			[2, 4, 1, 13, 13, 1],
+			[null, 1, 1, 3, 3, 1],
+			[2, 1, 2, 4, 4, 1],
+			[null, null, 1, null, null, null],
+			[null, 1, 1, 2, 2, null],
+			[null, null, 1, null, null, null],
+		]);
+	});
+
+	it('decodes hand-verified state[0] records', () => {
+		const s0 = mainModel.states[0];
+		const master0 = s0.masterMix!.channels[0];
+		expect(master0.mixChId).toBe(0xc0020000);
+		// mixData low i16 is the -10000 (-100.00 dB) floor; high i16 0 = no attenuation.
+		expect(master0.mixData).toBe(0x0000d8f0);
+		expect(master0.sfxObjId).toBe(0x40000000);
+		expect(master0.extraData.length).toBe(2);
+
+		const sub0 = s0.subMix!.channels[0];
+		expect(sub0.mixChId).toBe(0xd0010000);
+		expect(sub0.upperLowerSwing).toBe(0xfe60);
+		expect(sub0.procOffsets).toEqual([0x8028002]);
+
+		const ev0 = s0.events!.events[0];
+		expect(ev0.nEvtCtlId).toBe(0xa1000100);
+		expect(ev0.nUScaleCntSwing).toBe(0xd8f0);
+		expect(ev0.nTriggerId).toBe(0x60000002);
+		expect(ev0.extraData.length).toBe(0);
+
+		const ctl0 = s0.mixControls!.controls[0];
+		expect(ctl0.nInputId).toBe(0xa8000001);
+		expect(ctl0.nUScaleCntSwing).toBe(0);
+
+		const preset0 = s0.presets![0];
+		expect(preset0.header).toBe(0xe0000004);
+		expect(preset0.extraData).toEqual([0xc03fcb9, 0x1405fca4, 0x24090000, 0x1004f6e6]);
+	});
+
+	it('decodes a 3D control with multiple packed state params', () => {
+		const ctl = mainModel.states[1].threeDControls!.controls[0];
+		expect(ctl.nInputId).toBe(0x82010070);
+		expect(threeDStateParamCount(ctl.nInputId)).toBe(2);
+		expect(ctl.stateParams.length).toBe(2);
+		expect(ctl.stateParams[0].n3DStateInfoId).toBe(0x90010100);
+		expect(ctl.stateParams[0].nQ0MinMax).toBe(0x3c0004);
+	});
+
+	it('pins the record-kind prefixes of the packed id words', () => {
+		for (const s of mainModel.states) {
+			for (const ch of s.masterMix?.channels ?? []) {
+				expect([0xc0, 0xc1, 0xc2], `master 0x${ch.mixChId.toString(16)}`).toContain(ch.mixChId >>> 24);
+			}
+			for (const ch of s.subMix?.channels ?? []) {
+				expect(ch.mixChId >>> 24, `submix 0x${ch.mixChId.toString(16)}`).toBe(0xd0);
+			}
+			for (const p of s.presets ?? []) {
+				expect([0xe0, 0xe1, 0xe2], `preset 0x${p.header.toString(16)}`).toContain(p.header >>> 24);
+			}
+		}
+	});
+
+	it('event reserved words carry the garbage pattern, mirrored count first', () => {
+		for (const s of mainModel.states) {
+			if (!s.events) continue;
+			expect(s.events._reserved01).toBe(s.events.events.length);
+			// Constant across all six retail event sections — looks like a stale pointer.
+			expect(s.events._reserved02).toBe(0x8e4ef64);
+		}
+	});
+
+	it('mix control headers mirror the control count in numNewMixDataProcs', () => {
+		for (const s of mainModel.states) {
+			if (!s.mixControls) continue;
+			expect(s.mixControls.numNewMixDataProcs).toBe(s.mixControls.controls.length);
+			expect(s.mixControls.numMainMixDataProcs).toBe(0);
+			expect(s.mixControls.numMainMixCtlOut).toBe(0);
+		}
+	});
+});
+
+describe('Nicotine stereo vs surround', () => {
+	it('the maps share an identical structure and differ in exactly 16 words', () => {
+		const diffs: string[] = [];
+		numericDiffs(mainModel, surroundModel, '', diffs);
+		const mixDataDiffs = diffs.filter((p) => p.endsWith('.mixData'));
+		const reservedDiffs = diffs.filter((p) => p.endsWith('._reserved03'));
+		expect(mixDataDiffs.length).toBe(13);
+		expect(reservedDiffs.length).toBe(3);
+		expect(diffs.length).toBe(16);
+	});
+
+	it('pins one attenuation difference: surround drops master ch0 by 3 dB', () => {
+		// High i16 lane: 0 (stereo) vs 0xFED4 = -300 (surround) — hundredths of
+		// a dB, i.e. -3.00 dB. Low lane stays the -10000 (-100.00 dB) floor.
+		expect(mainModel.states[0].masterMix!.channels[0].mixData).toBe(0x0000d8f0);
+		expect(surroundModel.states[0].masterMix!.channels[0].mixData).toBe(0xfed4d8f0);
+	});
+});
+
+describe('Nicotine round-trip', () => {
+	for (const bundleFile of [MAIN_BUNDLE, SURROUND_BUNDLE]) {
+		it(`round-trips ${bundleFile} byte-for-byte and idempotently`, () => {
+			const raw = loadRaw(bundleFile);
+			const write1 = writeNicotine(parseNicotine(raw));
+			expect(write1.byteLength).toBe(raw.byteLength);
+			expect(bytesEqual(write1, raw)).toBe(true);
+			const write2 = writeNicotine(parseNicotine(write1));
+			expect(bytesEqual(write2, write1)).toBe(true);
+		});
+	}
+
+	it('writer rejects extraData inconsistent with the packed count byte', () => {
+		const m: ParsedNicotine = parseNicotine(loadRaw(MAIN_BUNDLE));
+		const ch = m.states[0].masterMix!.channels[0];
+		expect(packedExtraCount(ch.mixChId)).toBe(ch.extraData.length);
+		ch.extraData = [...ch.extraData, 0];
+		expect(() => writeNicotine(m)).toThrow(/packed count byte/);
+	});
+
+	it('writer rejects a preset array out of step with the master channels', () => {
+		const m: ParsedNicotine = parseNicotine(loadRaw(MAIN_BUNDLE));
+		m.states[0].presets = m.states[0].presets!.slice(0, -1);
+		expect(() => writeNicotine(m)).toThrow(/counts must match/);
+	});
+
+	it('writer rejects 3D stateParams out of step with the packed nibble', () => {
+		const m: ParsedNicotine = parseNicotine(loadRaw(MAIN_BUNDLE));
+		const ctl = m.states[1].threeDControls!.controls[0];
+		ctl.stateParams = ctl.stateParams.slice(0, 1);
+		expect(() => writeNicotine(m)).toThrow(/packed nibble/);
+	});
+});

--- a/src/lib/core/__tests__/snapshotData.test.ts
+++ b/src/lib/core/__tests__/snapshotData.test.ts
@@ -1,0 +1,130 @@
+// Gold coverage for parseSnapshotData / writeSnapshotData (resource type
+// 0xA029), including the cross-resource relationship to the Nicotine map
+// (0xA024) in the same bundle: every snapshot channel's mixChId is a master
+// mix MIXCHID of the companion map (and never a submix id), and the two
+// retail SnapshotData resources are byte-identical.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseSnapshotData, writeSnapshotData, type ParsedSnapshotData } from '../snapshotData';
+import { parseNicotine } from '../nicotine';
+import { parseBundle } from '../bundle';
+import { extractResourceRaw } from '../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const SNAPSHOT_TYPE_ID = 0xa029;
+const NICOTINE_TYPE_ID = 0xa024;
+const MAIN_BUNDLE = 'example/SOUND/NICOTINEASSETMAIN.BUNDLE';
+const SURROUND_BUNDLE = 'example/SOUND/NICOTINEASSETSURROUND.BUNDLE';
+
+function loadRaw(bundleFile: string, typeId: number): Uint8Array {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	const matches = bundle.resources.filter((r) => r.resourceTypeId === typeId);
+	expect(matches.length).toBe(1);
+	return extractResourceRaw(buffer, bundle, matches[0]);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+const mainModel = parseSnapshotData(loadRaw(MAIN_BUNDLE, SNAPSHOT_TYPE_ID));
+
+describe('SnapshotData gold values (NicotineAssetMain.mss)', () => {
+	it('decodes the header shape', () => {
+		expect(mainModel.snapshots.length).toBe(17);
+		expect(mainModel.channels.length).toBe(72);
+		expect(mainModel._pad08).toBe(1);
+		expect(mainModel._pad0C).toBe(0x12345678);
+	});
+
+	it('decodes hand-verified channel records', () => {
+		expect(mainModel.channels[0]).toEqual({ mixChId: 0xc0020003, channelId: 0x964954c4 });
+		expect(mainModel.channels[1]).toEqual({ mixChId: 0xc005000d, channelId: 0xedaab975 });
+		// mixChId ids are unique — the channel list is a set, not a sequence.
+		expect(new Set(mainModel.channels.map((c) => c.mixChId)).size).toBe(72);
+	});
+
+	it('the top two bits of every mixChId are set (wiki bit-field note)', () => {
+		for (const ch of mainModel.channels) {
+			expect(ch.mixChId >>> 30, `0x${ch.mixChId.toString(16)}`).toBe(3);
+		}
+	});
+
+	it('decodes hand-verified snapshot datums', () => {
+		expect(mainModel.snapshots[0].entries[0].control).toBe(64225);
+		expect(mainModel.snapshots[0].entries[0].value).toBeCloseTo(0.25, 6);
+		expect(mainModel.snapshots[16].entries[71].control).toBe(0);
+		for (const snap of mainModel.snapshots) expect(snap.entries.length).toBe(72);
+	});
+
+	it('pins observed value ranges (units still hypothetical)', () => {
+		let maxControl = 0;
+		let maxValue = -Infinity;
+		let minValue = Infinity;
+		for (const snap of mainModel.snapshots) {
+			for (const e of snap.entries) {
+				maxControl = Math.max(maxControl, e.control);
+				maxValue = Math.max(maxValue, e.value);
+				minValue = Math.min(minValue, e.value);
+			}
+		}
+		// control fits 17 bits; low i16 lane consistent with centi-dB levels.
+		expect(maxControl).toBe(130658);
+		expect(minValue).toBe(0);
+		expect(maxValue).toBeCloseTo(5.6, 5);
+	});
+});
+
+describe('SnapshotData ↔ Nicotine relationship', () => {
+	for (const bundleFile of [MAIN_BUNDLE, SURROUND_BUNDLE]) {
+		it(`every channel of ${bundleFile} references a master mix MIXCHID of its companion map`, () => {
+			const snap = parseSnapshotData(loadRaw(bundleFile, SNAPSHOT_TYPE_ID));
+			const nic = parseNicotine(loadRaw(bundleFile, NICOTINE_TYPE_ID));
+			const masterIds = new Set<number>();
+			const submixIds = new Set<number>();
+			for (const s of nic.states) {
+				for (const ch of s.masterMix?.channels ?? []) masterIds.add(ch.mixChId);
+				for (const ch of s.subMix?.channels ?? []) submixIds.add(ch.mixChId);
+			}
+			expect(masterIds.size).toBe(111);
+			for (const ch of snap.channels) {
+				expect(masterIds.has(ch.mixChId), `0x${ch.mixChId.toString(16)} not a master MIXCHID`).toBe(true);
+				expect(submixIds.has(ch.mixChId)).toBe(false);
+				// The hash-like channelId is NOT how the link works.
+				expect(masterIds.has(ch.channelId)).toBe(false);
+			}
+		});
+	}
+
+	it('the stereo and surround SnapshotData resources are byte-identical', () => {
+		// All stereo/surround divergence lives in the Nicotine maps' mixData
+		// words — snapshots are shared verbatim between output formats.
+		expect(bytesEqual(loadRaw(MAIN_BUNDLE, SNAPSHOT_TYPE_ID), loadRaw(SURROUND_BUNDLE, SNAPSHOT_TYPE_ID))).toBe(true);
+	});
+});
+
+describe('SnapshotData round-trip', () => {
+	for (const bundleFile of [MAIN_BUNDLE, SURROUND_BUNDLE]) {
+		it(`round-trips ${bundleFile} byte-for-byte and idempotently`, () => {
+			const raw = loadRaw(bundleFile, SNAPSHOT_TYPE_ID);
+			const write1 = writeSnapshotData(parseSnapshotData(raw));
+			expect(write1.byteLength).toBe(raw.byteLength);
+			expect(bytesEqual(write1, raw)).toBe(true);
+			const write2 = writeSnapshotData(parseSnapshotData(write1));
+			expect(bytesEqual(write2, write1)).toBe(true);
+		});
+	}
+
+	it('writer rejects a snapshot whose entry count disagrees with the channel list', () => {
+		const m: ParsedSnapshotData = parseSnapshotData(loadRaw(MAIN_BUNDLE, SNAPSHOT_TYPE_ID));
+		m.snapshots[3] = { entries: m.snapshots[3].entries.slice(0, -1) };
+		expect(() => writeSnapshotData(m)).toThrow(/one datum per channel/);
+	});
+});

--- a/src/lib/core/__tests__/soundRegistry.test.ts
+++ b/src/lib/core/__tests__/soundRegistry.test.ts
@@ -1,14 +1,20 @@
 // Gold coverage for parseRegistry / writeRegistry (resource type 0xA000).
 //
-// Two retail fixtures with deliberately different shapes:
+// Four retail fixtures with deliberately different shapes:
 //  - PLAYBACKREGISTRY.BUNDLE: 27 entities across FIVE payload kinds
 //    (ContentClass / ContentType / SlotSchema / ParameterSchema /
 //    FeatureSchema) — the playback graph vocabulary.
 //  - RWACFEATUREREGISTRY.BUNDLE: 21 entities of ONE kind, the wiki-
 //    undocumented ~GenericRwacFeatureImplementation~ — concrete DSP features
 //    with uninitialised 0xCDCD pads that must survive verbatim.
-// The two cross-reference each other (GinsuPlayer's FeatureSchema parameter
-// list matches its RWAC implementation's bindings), pinned below.
+//  - SOUND/SOUNDENTITY.BUNDLE: 168 entities adding the string-carrying
+//    ContentSpec plus VoiceSchema / VoiceSpec — the global voice graph.
+//  - SOUND/AEMS/CSIS.BUNDLE: THIRTY registries (an EntityReg / VoiceReg /
+//    FactoryReg trio per AEMS effect group) adding the wiki-undocumented
+//    ~AemsVoiceCsisClass~.
+// The fixtures cross-reference each other (GinsuPlayer: FeatureSchema in
+// PLAYBACK, DSP implementation in RWAC, VoiceSchema membership in
+// SOUNDENTITY), pinned below.
 
 import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
@@ -30,13 +36,19 @@ import { extractResourceRaw } from '../registry';
 const REPO_ROOT = path.resolve(__dirname, '../../../..');
 const REGISTRY_TYPE_ID = 0xa000;
 
-function loadRaw(bundleFile: string): Uint8Array {
+function loadAllRaw(bundleFile: string): Uint8Array[] {
 	const buf = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
 	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
 	const bundle = parseBundle(buffer);
-	const resources = bundle.resources.filter((r) => r.resourceTypeId === REGISTRY_TYPE_ID);
-	expect(resources.length).toBe(1);
-	return extractResourceRaw(buffer, bundle, resources[0]);
+	return bundle.resources
+		.filter((r) => r.resourceTypeId === REGISTRY_TYPE_ID)
+		.map((r) => extractResourceRaw(buffer, bundle, r));
+}
+
+function loadRaw(bundleFile: string): Uint8Array {
+	const raws = loadAllRaw(bundleFile);
+	expect(raws.length).toBe(1);
+	return raws[0];
 }
 
 function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
@@ -54,6 +66,8 @@ function byName(m: ParsedRegistry, name: string): RegistryEntity {
 
 const playbackRaw = loadRaw('example/PLAYBACKREGISTRY.BUNDLE');
 const rwacRaw = loadRaw('example/RWACFEATUREREGISTRY.BUNDLE');
+const soundEntityRaw = loadRaw('example/SOUND/SOUNDENTITY.BUNDLE');
+const csisRaws = loadAllRaw('example/SOUND/AEMS/CSIS.BUNDLE');
 
 describe('soundHash (CgsSound::Playback::Name::MakeHash)', () => {
 	it('reproduces the wiki-documented type-name hashes', () => {
@@ -69,6 +83,10 @@ describe('soundHash (CgsSound::Playback::Name::MakeHash)', () => {
 		expect(soundHash('~ContentClass~')).toBe(REGISTRY_TYPE_HASHES.CONTENT_CLASS);
 		expect(soundHash('~ContentType~')).toBe(REGISTRY_TYPE_HASHES.CONTENT_TYPE);
 		expect(soundHash('~GenericRwacFeatureImplementation~')).toBe(REGISTRY_TYPE_HASHES.RWAC_FEATURE);
+		// The wiki lists "AemsVoiceCsisClass" as a ContentClass VALUE (hash
+		// 84D7FBE7 — really ~SplicerContent::SK_CONTENT_TYPE~); it is actually
+		// an entity TYPE with its own hash.
+		expect(soundHash('~AemsVoiceCsisClass~')).toBe(REGISTRY_TYPE_HASHES.AEMS_VOICE_CSIS);
 	});
 
 	it('is NOT case-folded (unlike CgsID)', () => {
@@ -232,6 +250,200 @@ describe('Registry gold values — RWACFEATUREREGISTRY.BUNDLE', () => {
 	});
 });
 
+describe('Registry gold values — SOUND/SOUNDENTITY.BUNDLE', () => {
+	const m = parseRegistry(soundEntityRaw);
+
+	it('decodes 168 entities across five payload kinds, none verbatim', () => {
+		expect(soundEntityRaw.byteLength).toBe(0x64b0);
+		expect(m.entities.length).toBe(168);
+		expect(m.strings.length).toBe(184);
+		const count = (pred: (e: RegistryEntity) => boolean) => m.entities.filter(pred).length;
+		expect(count((e) => e.contentSpec != null)).toBe(82);
+		expect(count((e) => e.parameterSchema != null)).toBe(41);
+		expect(count((e) => e.featureSchema != null)).toBe(15);
+		expect(count((e) => e.voiceSchema != null)).toBe(14);
+		expect(count((e) => e.voiceSpec != null)).toBe(16);
+		expect(count((e) => e._unknownPayload != null)).toBe(0);
+	});
+
+	it('entity 0 is the CollisionSpliceBank ContentSpec: splice-bank content type, name = path', () => {
+		const e = m.entities[0];
+		expect(e.mName).toBe(soundHash('CollisionSpliceBank'));
+		expect(e.mTypeName).toBe(REGISTRY_TYPE_HASHES.CONTENT_SPEC);
+		expect(e.contentSpec).toEqual({
+			mpContentType: soundHash('~SplicerContent::SK_CONTENT_TYPE~'),
+			mu8LoadMethod: 1,
+			mu8LoadTime: 1,
+			path: 'CollisionSpliceBank',
+			_padTail: new Uint8Array(0),
+		});
+	});
+
+	it('a gamedb:// wave ContentSpec keeps its 0xCD alignment pad verbatim', () => {
+		const path = 'gamedb://burnout5/Burnout/Sound/World/Source/AI_Exotic_music1.wav.WaveFile?ID=567018';
+		const e = byName(m, path);
+		expect(e.contentSpec!.mpContentType).toBe(soundHash('~GenericRwacWaveContent::SK_WAVE_DATA_CONTENT_TYPE~'));
+		expect(e.contentSpec!.path).toBe(path);
+		// 84-char path + NUL = 85 bytes → 3 fill bytes reach the next 4-byte
+		// boundary; retail's allocator left 0xCD there.
+		expect(e.contentSpec!.path.length).toBe(84);
+		expect(Array.from(e.contentSpec!._padTail)).toEqual([0xcd, 0xcd, 0xcd]);
+		// This wave's entity name IS the hash of its path — but that is a
+		// convention, not a rule: 34 of the 115 retail ContentSpecs (the CSIS
+		// bank specs) use a name unrelated to the path.
+		expect(e.mName).toBe(soundHash(path));
+	});
+
+	it('VoiceSchemas list the FeatureSchema chain by name hash; the three other counts are always 0', () => {
+		expect(byName(m, 'GinsuPlayerVoiceSchema').voiceSchema!.featureSchemaHashes)
+			.toEqual([soundHash('GinsuPlayer')]);
+		expect(byName(m, 'MasterVoiceSchema').voiceSchema!.featureSchemaHashes).toEqual([
+			soundHash('LowShelf'),
+			soundHash('GainArray'),
+			soundHash('Gain'),
+			soundHash('Limiter'),
+		]);
+		expect(byName(m, 'StreamingFiltVoiceSchema').voiceSchema!.featureSchemaHashes).toEqual([
+			soundHash('StreamingPlayer'),
+			soundHash('Pause'),
+			soundHash('HighPassButterworth'),
+			soundHash('LowPassButterworth'),
+			soundHash('Panning'),
+		]);
+		for (const e of m.entities) {
+			if (e.voiceSchema == null) continue;
+			expect(e.voiceSchema.mu32SlotCount).toBe(0);
+			expect(e.voiceSchema.mu32ParameterCount).toBe(0);
+			expect(e.voiceSchema.mu32OutputParamCount).toBe(0);
+		}
+	});
+
+	it('VoiceSpecs bind a schema, channel layout, voice type, and send routing', () => {
+		const master = byName(m, 'MasterVoiceSpec').voiceSpec!;
+		expect(master).toEqual({
+			mpVoiceSchema: soundHash('MasterVoiceSchema'),
+			mu8ProcessingStage: 0,
+			mu8ChannelCount: 6,
+			mu8VoiceType: 2, // E_MASTER_VOICE — the only type-2 spec, and the only one with no sends
+			sendHashes: [],
+		});
+		const playerCar = byName(m, 'PlayerCarSubmixVoiceSpec').voiceSpec!;
+		expect(playerCar.mpVoiceSchema).toBe(soundHash('PlayerCarSubmixVoiceSchema'));
+		expect(playerCar.mu8ProcessingStage).toBe(0x3f);
+		expect(playerCar.mu8VoiceType).toBe(1);
+		expect(playerCar.sendHashes).toEqual([soundHash('Send01'), soundHash('ReverbSend')]);
+		const ginsu = byName(m, 'GinsuVoiceSpec').voiceSpec!;
+		expect(ginsu.mpVoiceSchema).toBe(soundHash('GinsuPlayerVoiceSchema'));
+		expect(ginsu.mu8VoiceType).toBe(0);
+		expect(ginsu.sendHashes).toEqual([soundHash('Send01')]);
+	});
+});
+
+describe('Registry gold values — SOUND/AEMS/CSIS.BUNDLE (30 registries)', () => {
+	const models = csisRaws.map((raw) => parseRegistry(raw));
+
+	it('all 30 registries parse: 198 entities across seven kinds, none verbatim', () => {
+		expect(models.length).toBe(30);
+		expect(models.map((m) => m.entities.length)).toEqual([
+			3, 1, 1, 2, 12, 10, 12, 3, 3, 1, 1, 4, 7, 18, 3, 1, 1, 1, 12, 15, 6, 37, 1, 3, 10, 9, 8, 2, 3, 8,
+		]);
+		const all = models.flatMap((m) => m.entities);
+		const count = (pred: (e: RegistryEntity) => boolean) => all.filter(pred).length;
+		expect(count((e) => e.voiceSpec != null)).toBe(12);
+		expect(count((e) => e.contentSpec != null)).toBe(33);
+		expect(count((e) => e.aemsVoiceCsis != null)).toBe(12);
+		expect(count((e) => e.parameterSchema != null)).toBe(105);
+		expect(count((e) => e.mTypeName === REGISTRY_TYPE_HASHES.SLOT_SCHEMA)).toBe(12);
+		expect(count((e) => e.featureSchema != null)).toBe(12);
+		expect(count((e) => e.voiceSchema != null)).toBe(12);
+		expect(count((e) => e._unknownPayload != null)).toBe(0);
+	});
+
+	it('every AemsVoiceCsisClass entity is named soundHash("AEMS_" + label) with mUnknown0C = 2', () => {
+		for (const m of models) {
+			for (const e of m.entities) {
+				if (e.aemsVoiceCsis == null) continue;
+				expect(e.mName).toBe(soundHash('AEMS_' + e.aemsVoiceCsis.label));
+				expect(e.aemsVoiceCsis.mUnknown0C).toBe(2);
+				expect(Array.from(e.aemsVoiceCsis._padTail).every((b) => b === 0xcd)).toBe(true);
+			}
+		}
+	});
+
+	it('AemsVoiceCsisClass entities in the same registry share mUnknown10 (bank id?)', () => {
+		// The InAir factory registry holds PlayInAir + PlayTakeOff.
+		const inAir = models.find((m) => m.entities.some((e) => e.aemsVoiceCsis?.label === 'PlayInAir'))!;
+		const playInAir = byName(inAir, 'AEMS_PlayInAir').aemsVoiceCsis!;
+		const takeOff = byName(inAir, 'AEMS_PlayTakeOff').aemsVoiceCsis!;
+		expect(playInAir.mUnknown10).toBe(0x0ed7);
+		expect(takeOff.mUnknown10).toBe(0x0ed7);
+		expect(playInAir.mUnknown14).toBe(0x7896);
+		expect(takeOff.mUnknown14).toBe(0x1641);
+		expect(playInAir.mUnknown08).toBe(8);
+	});
+
+	it('CSIS ContentSpecs introduce the ~CsisContent::SK_CONTENT_TYPE~ content type', () => {
+		const boost = models.find((m) => m.entities.some((e) => e.contentSpec?.path.includes('BoostCsis')))!;
+		const spec = byName(boost, 'BoostCsis');
+		expect(spec.contentSpec!.mpContentType).toBe(soundHash('~CsisContent::SK_CONTENT_TYPE~'));
+		expect(spec.contentSpec!.path).toBe('gamedb://burnout5/Burnout/Sound/AEMS/Boost/PC/BoostCsis.Csis?ID=683624');
+		// CSIS bank specs are the proof that ContentSpec names are independent
+		// of their paths.
+		expect(spec.mName).not.toBe(soundHash(spec.contentSpec!.path));
+	});
+
+	it('the Scrapes voice registry links its VoiceSpec to a VoiceSchema in ANOTHER registry', () => {
+		// models[0] holds only the AEMS_ScrapeGranulator VoiceSpec + content;
+		// the schema it references lives in the Scrapes entity registry.
+		const voiceReg = models[0];
+		expect(voiceReg.entities.length).toBe(3);
+		const spec = byName(voiceReg, 'AEMS_ScrapeGranulator');
+		expect(spec.voiceSpec).not.toBeNull();
+		const schemaHash = spec.voiceSpec!.mpVoiceSchema;
+		const owner = models.find((m) => m.entities.some(
+			(e) => e.mName === schemaHash && e.voiceSchema != null,
+		));
+		expect(owner).toBeDefined();
+		expect(owner).not.toBe(voiceReg);
+	});
+});
+
+describe('Registry cross-fixture invariants', () => {
+	const allModels = [
+		parseRegistry(playbackRaw),
+		parseRegistry(rwacRaw),
+		parseRegistry(soundEntityRaw),
+		...csisRaws.map((raw) => parseRegistry(raw)),
+	];
+
+	it('every retail ContentSpec uses load method 1 (resource module) and load time 1 (immediate)', () => {
+		let n = 0;
+		for (const m of allModels) {
+			for (const e of m.entities) {
+				if (e.contentSpec == null) continue;
+				n++;
+				expect(e.contentSpec.mu8LoadMethod).toBe(1);
+				expect(e.contentSpec.mu8LoadTime).toBe(1);
+				expect(Array.from(e.contentSpec._padTail).every((b) => b === 0xcd)).toBe(true);
+			}
+		}
+		expect(n).toBe(115);
+	});
+
+	it('every retail VoiceSpec voice type is a valid EVoiceType and sends resolve in the string pool', () => {
+		for (const m of allModels) {
+			const pool = new Set(m.strings.map(soundHash));
+			for (const e of m.entities) {
+				if (e.voiceSpec == null) continue;
+				expect(e.voiceSpec.mu8VoiceType).toBeLessThanOrEqual(2);
+				expect([1, 2, 4, 6]).toContain(e.voiceSpec.mu8ChannelCount);
+				for (const h of e.voiceSpec.sendHashes) expect(pool.has(h)).toBe(true);
+				expect(pool.has(e.voiceSpec.mpVoiceSchema)).toBe(true);
+			}
+		}
+	});
+});
+
 describe('Registry cross-fixture relationships', () => {
 	it('GinsuPlayer schema (playback) and implementation (rwac) agree on the parameter list', () => {
 		const schema = byName(parseRegistry(playbackRaw), 'GinsuPlayer').featureSchema!;
@@ -246,12 +458,21 @@ describe('Registry cross-fixture relationships', () => {
 		const impl = byName(parseRegistry(rwacRaw), '~GenericRwacPlayerVoice::SK_PLAYER_FEATURE~');
 		expect(impl.rwacFeature!.blocks.map((b) => b.code)).toEqual(['SnP1', 'Rch0', 'Rsp0']);
 	});
+
+	it('GinsuPlayer spans three fixtures: schema (playback), DSP impl (rwac), voice membership (soundentity)', () => {
+		const hash = soundHash('GinsuPlayer');
+		expect(byName(parseRegistry(playbackRaw), 'GinsuPlayer').featureSchema).not.toBeNull();
+		expect(byName(parseRegistry(rwacRaw), 'GinsuPlayer').rwacFeature).not.toBeNull();
+		const voiceSchema = byName(parseRegistry(soundEntityRaw), 'GinsuPlayerVoiceSchema').voiceSchema!;
+		expect(voiceSchema.featureSchemaHashes).toContain(hash);
+	});
 });
 
 describe('Registry round-trip', () => {
 	for (const [label, raw] of [
 		['PLAYBACKREGISTRY', playbackRaw],
 		['RWACFEATUREREGISTRY', rwacRaw],
+		['SOUNDENTITY', soundEntityRaw],
 	] as const) {
 		it(`round-trips ${label} byte-for-byte and the writer is idempotent`, () => {
 			const first = writeRegistry(parseRegistry(raw));
@@ -261,18 +482,102 @@ describe('Registry round-trip', () => {
 		});
 	}
 
+	it('round-trips all 30 CSIS registries byte-for-byte with an idempotent writer', () => {
+		for (let i = 0; i < csisRaws.length; i++) {
+			const raw = csisRaws[i];
+			const first = writeRegistry(parseRegistry(raw));
+			expect(bytesEqual(first, raw), `CSIS registry ${i}`).toBe(true);
+			const second = writeRegistry(parseRegistry(first));
+			expect(bytesEqual(second, first), `CSIS registry ${i} (second pass)`).toBe(true);
+		}
+	});
+
 	it('an undecoded entity type round-trips its payload verbatim', () => {
 		const m = parseRegistry(playbackRaw);
 		const added: RegistryEntity = {
 			...makeEmptyRegistryEntity(),
 			mName: soundHash('StewardSynthetic'),
-			mTypeName: REGISTRY_TYPE_HASHES.CONTENT_SPEC,
+			// All nine retail type names decode now, so a verbatim payload
+			// needs a type hash the parser has never seen.
+			mTypeName: soundHash('~StewardUnknownType~'),
 			_unknownPayload: new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0x01]),
 		};
 		const reparsed = parseRegistry(writeRegistry({ ...m, entities: [...m.entities, added] }));
 		const back = reparsed.entities[reparsed.entities.length - 1];
 		expect(back.mName).toBe(soundHash('StewardSynthetic'));
 		expect(Array.from(back._unknownPayload!)).toEqual([0xde, 0xad, 0xbe, 0xef, 0x01]);
+	});
+
+	it('resizing a ContentSpec path recomputes the alignment pad with 0xCD fill', () => {
+		const m = parseRegistry(soundEntityRaw);
+		const idx = m.entities.findIndex((e) => e.contentSpec != null);
+		const e = m.entities[idx];
+		// 18 chars + NUL = 19 → 1 fill byte; the stale 0-length _padTail no
+		// longer fits, so the writer falls back to the retail 0xCD fill.
+		const edited = {
+			...e,
+			contentSpec: { ...e.contentSpec!, path: 'StewardEditedPath1' },
+		};
+		const entities = m.entities.slice();
+		entities[idx] = edited;
+		const reparsed = parseRegistry(writeRegistry({ ...m, entities }));
+		const back = reparsed.entities[idx].contentSpec!;
+		expect(back.path).toBe('StewardEditedPath1');
+		expect(Array.from(back._padTail)).toEqual([0xcd]);
+	});
+
+	it('editing an AemsVoiceCsisClass label round-trips through the recomputed length and pad', () => {
+		const models = csisRaws.map((raw) => parseRegistry(raw));
+		const m = models.find((mm) => mm.entities.some((e) => e.aemsVoiceCsis != null))!;
+		const idx = m.entities.findIndex((e) => e.aemsVoiceCsis != null);
+		const e = m.entities[idx];
+		const edited = {
+			...e,
+			mName: soundHash('AEMS_StewardClass'),
+			aemsVoiceCsis: { ...e.aemsVoiceCsis!, label: 'StewardClass' },
+		};
+		const entities = m.entities.slice();
+		entities[idx] = edited;
+		const reparsed = parseRegistry(writeRegistry({ ...m, entities }));
+		const back = reparsed.entities.find((x) => x.mName === soundHash('AEMS_StewardClass'))!;
+		expect(back.aemsVoiceCsis!.label).toBe('StewardClass');
+		// 12 chars + NUL = 13 → 3 fill bytes.
+		expect(Array.from(back.aemsVoiceCsis!._padTail)).toEqual([0xcd, 0xcd, 0xcd]);
+	});
+
+	it('adding a VoiceSpec send re-derives the u8 send count', () => {
+		const m = parseRegistry(soundEntityRaw);
+		const idx = m.entities.findIndex((e) => e.voiceSpec != null);
+		const e = m.entities[idx];
+		const edited = {
+			...e,
+			voiceSpec: { ...e.voiceSpec!, sendHashes: [...e.voiceSpec!.sendHashes, soundHash('ReverbSend')] },
+		};
+		const entities = m.entities.slice();
+		entities[idx] = edited;
+		const reparsed = parseRegistry(writeRegistry({ ...m, entities }));
+		expect(reparsed.entities[idx].voiceSpec!.sendHashes).toEqual(edited.voiceSpec.sendHashes);
+	});
+
+	it('writer rejects a ContentSpec path with a byte-unrepresentable character', () => {
+		const m = parseRegistry(soundEntityRaw);
+		const idx = m.entities.findIndex((e) => e.contentSpec != null);
+		const entities = m.entities.slice();
+		entities[idx] = {
+			...entities[idx],
+			contentSpec: { ...entities[idx].contentSpec!, path: 'badĀpath' },
+		};
+		expect(() => writeRegistry({ ...m, entities })).toThrow(/byte-unrepresentable/);
+	});
+
+	it('parser rejects a ContentSpec whose declared path length disagrees with the payload', () => {
+		const broken = new Uint8Array(soundEntityRaw);
+		const dv = new DataView(broken.buffer);
+		// Entity 0 (CollisionSpliceBank) sits at the data start; its u16
+		// pathLength lives at +0xC into the entity.
+		const dataStart = 0x1c + 0x800 * 4;
+		dv.setUint16(dataStart + 0xc, 5, true);
+		expect(() => parseRegistry(broken)).toThrow(/path length/);
 	});
 
 	it('appending a string re-derives sizes and the 16-byte trailing pad', () => {

--- a/src/lib/core/__tests__/splicer.test.ts
+++ b/src/lib/core/__tests__/splicer.test.ts
@@ -1,0 +1,247 @@
+// Gold coverage for parseSplicer / writeSplicer (resource type 0xA025).
+//
+// Sweeps all six retail SOUND/SPLICER bundles (one 0xA025 each — verified
+// here too, since "samples are embedded, not sibling resources" is a
+// load-bearing claim), pins hand-decoded values from BIKESOUNDS (the
+// smallest fixture), and pins the cross-fixture invariants the parser's
+// asserts and the schema's descriptions rely on.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseSplicer, writeSplicer, splicerSampleInfo, type ParsedSplicer } from '../splicer';
+import { parseBundle } from '../bundle';
+import { extractResourceRaw } from '../registry';
+import { splicerHandler } from '../registry/handlers/splicer';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const SPLICER_TYPE_ID = 0xa025;
+
+const FIXTURES = [
+	'example/SOUND/SPLICER/AGGDRIVINGSPLICE_ASSET.BUNDLE',
+	'example/SOUND/SPLICER/BIKESOUNDS.BUNDLE',
+	'example/SOUND/SPLICER/COLLISIONSPLICEBANK.BUNDLE',
+	'example/SOUND/SPLICER/FX_SPLICE.BUNDLE',
+	'example/SOUND/SPLICER/PASSBYASSET.BUNDLE',
+	'example/SOUND/SPLICER/PRESENTATIONASSET.BUNDLE',
+];
+
+function loadSplicerRaw(bundleFile: string): Uint8Array {
+	const buf = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	const bundle = parseBundle(buffer);
+	// Every retail splicer bundle is exactly one 0xA025 — the samples are
+	// embedded, so there are no wave-content siblings to find.
+	expect(bundle.resources.length, bundleFile).toBe(1);
+	expect(bundle.resources[0].resourceTypeId, bundleFile).toBe(SPLICER_TYPE_ID);
+	return extractResourceRaw(buffer, bundle, bundle.resources[0]);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+function totalRefs(m: ParsedSplicer): number {
+	return m.splices.reduce((a, s) => a + s.sampleRefs.length, 0);
+}
+
+describe('Splicer gold values (example/SOUND/SPLICER/BIKESOUNDS.BUNDLE)', () => {
+	const m = parseSplicer(loadSplicerRaw('example/SOUND/SPLICER/BIKESOUNDS.BUNDLE'));
+
+	it('decodes the splice table', () => {
+		expect(m.splices.length).toBe(6);
+		expect(totalRefs(m)).toBe(23);
+		expect(m.samples.length).toBe(9);
+		expect(m.splices.map((s) => s.sampleRefs.length)).toEqual([2, 3, 5, 4, 5, 4]);
+		// Splice volumes step on the 2^(n/6) ladder (≈1 dB per step, 6 dB per
+		// doubling): 2^(1/6), 2^(7/6), 2^(10/6).
+		expect(m.splices[0].Volume).toBe(1.1224620342254639);
+		expect(m.splices[2].Volume).toBe(2.2449240684509277);
+		expect(m.splices[4].Volume).toBe(3.17480206489563);
+		for (const s of m.splices) {
+			expect(s.RND_Pitch).toBe(0);
+			expect(s.RND_Vol).toBe(1);
+		}
+	});
+
+	it('decodes splice 0\'s SampleRefs (hand-verified from bytes at 0xAC)', () => {
+		const [r0, r1] = m.splices[0].sampleRefs;
+		expect(r0.SampleIndex).toBe(7);
+		expect(r0.Volume).toBe(2);
+		expect(r0.Pitch).toBe(1);
+		expect(r0.Offset).toBe(0);
+		expect(r0.Az).toBe(0);
+		expect(r0.Duration).toBe(0.4155833423137665);
+		expect(r0.FadeIn).toBe(0);
+		expect(r0.FadeOut).toBe(0);
+		expect(r0.RND_Vol).toBe(1);
+		expect(r0.RND_Pitch).toBe(-0.15910357236862183);
+		expect(r1.SampleIndex).toBe(8);
+		expect(r1.Volume).toBe(1.2599210739135742); // 2^(2/6)
+		expect(r1.Duration).toBe(0.6626666784286499);
+	});
+
+	it('assigns the flat SampleRef array to splices in SpliceIndex order', () => {
+		// Splice 1's first two refs are the 3rd and 4th records of the shared
+		// array — pitch 2^(-3/12) (three semitones down) on the first.
+		const [r0, r1] = m.splices[1].sampleRefs;
+		expect(r0.SampleIndex).toBe(6);
+		expect(r0.Pitch).toBe(0.8408964276313782);
+		expect(r0.RND_Pitch).toBe(-0.13378961384296417);
+		expect(r1.SampleIndex).toBe(0);
+		expect(r1.Volume).toBe(0.25);
+		expect(r1.Duration).toBe(0.44085416197776794);
+	});
+
+	it('slices the embedded samples by the TOC', () => {
+		expect(m.samples.map((s) => s.byteLength)).toEqual([5979, 2232, 2387, 6463, 4459, 7177, 5452, 5449, 8106]);
+		const info = splicerSampleInfo(m.samples[0])!;
+		expect(info.codec).toBe(7); // EA-XAS
+		expect(info.channels).toBe(1);
+		expect(info.sampleRate).toBe(48000);
+		expect(info.sampleCount).toBe(21161);
+		expect(info.seconds).toBeCloseTo(0.441, 3);
+	});
+});
+
+describe('Splicer cross-fixture invariants', () => {
+	for (const fixture of FIXTURES) {
+		it(`${path.basename(fixture)} holds the retail invariants`, () => {
+			const m = parseSplicer(loadSplicerRaw(fixture));
+			expect(m.splices.length).toBeGreaterThan(0);
+			expect(m.samples.length).toBeGreaterThan(0);
+			// The wrapper pad is zero in every retail resource.
+			expect([...m._wrapperPad]).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+			const usedSamples = new Set<number>();
+			for (let i = 0; i < m.splices.length; i++) {
+				const s = m.splices[i];
+				// SpliceIndex is identity in all retail data — game events bind
+				// to splices by this order.
+				expect(s.SpliceIndex, `splice ${i}`).toBe(i);
+				expect(s.NameHash).toBe(0);
+				expect(s.eSpliceType).toBe(0);
+				for (const ref of s.sampleRefs) {
+					expect(ref.eSpliceType).toBe(0);
+					expect(ref._pad03).toBe(0);
+					expect(ref.Priority).toBe(0);
+					expect(ref.eRollOffType).toBe(0);
+					expect(ref._pad2A).toBe(0);
+					expect(ref.Duration).toBeGreaterThan(0);
+					usedSamples.add(ref.SampleIndex);
+				}
+			}
+			// Every embedded sample is referenced by at least one SampleRef in
+			// every retail splicer — no orphans.
+			expect(usedSamples.size).toBe(m.samples.length);
+			// Every sample decodes as 48 kHz EA-XAS, mono or stereo.
+			for (const sample of m.samples) {
+				const info = splicerSampleInfo(sample);
+				expect(info).not.toBeNull();
+				expect(info!.codec).toBe(7);
+				expect(info!.sampleRate).toBe(48000);
+				expect([1, 2]).toContain(info!.channels);
+			}
+		});
+	}
+
+	it('pins each fixture\'s shape (drift alarm for the fixtures themselves)', () => {
+		const shapes = FIXTURES.map((f) => {
+			const m = parseSplicer(loadSplicerRaw(f));
+			return [m.splices.length, totalRefs(m), m.samples.length];
+		});
+		expect(shapes).toEqual([
+			[31, 61, 15], // AGGDRIVINGSPLICE_ASSET
+			[6, 23, 9], // BIKESOUNDS
+			[359, 955, 368], // COLLISIONSPLICEBANK
+			[9, 16, 11], // FX_SPLICE
+			[143, 245, 45], // PASSBYASSET
+			[219, 631, 134], // PRESENTATIONASSET
+		]);
+	});
+
+	it('zero-ref splices exist in retail (CollisionSpliceBank, PresentationAsset)', () => {
+		const collision = parseSplicer(loadSplicerRaw('example/SOUND/SPLICER/COLLISIONSPLICEBANK.BUNDLE'));
+		expect(collision.splices.filter((s) => s.sampleRefs.length === 0).length).toBe(1);
+		const presentation = parseSplicer(loadSplicerRaw('example/SOUND/SPLICER/PRESENTATIONASSET.BUNDLE'));
+		expect(presentation.splices.filter((s) => s.sampleRefs.length === 0).length).toBe(2);
+		// PresentationAsset's splice 0 is one of them — handler stress
+		// scenarios must not assume splices[0] has refs.
+		expect(presentation.splices[0].sampleRefs.length).toBe(0);
+	});
+});
+
+describe('Splicer round-trip', () => {
+	for (const fixture of FIXTURES) {
+		it(`round-trips ${path.basename(fixture)} byte-for-byte (and idempotently)`, () => {
+			const raw = loadSplicerRaw(fixture);
+			const write1 = writeSplicer(parseSplicer(raw));
+			expect(write1.byteLength).toBe(raw.byteLength);
+			expect(bytesEqual(write1, raw)).toBe(true);
+			const write2 = writeSplicer(parseSplicer(write1));
+			expect(bytesEqual(write2, write1)).toBe(true);
+		});
+	}
+
+	it('reorders SampleRef batches by SpliceIndex rank when splices are stored permuted', () => {
+		const m = parseSplicer(loadSplicerRaw('example/SOUND/SPLICER/BIKESOUNDS.BUNDLE'));
+		// Store splice 1 before splice 0 without touching their SpliceIndex.
+		const permuted: ParsedSplicer = { ...m, splices: [m.splices[1], m.splices[0], ...m.splices.slice(2)] };
+		const reparsed = parseSplicer(writeSplicer(permuted));
+		expect(reparsed.splices[0].SpliceIndex).toBe(1);
+		expect(reparsed.splices[0].sampleRefs).toEqual(m.splices[1].sampleRefs);
+		expect(reparsed.splices[1].SpliceIndex).toBe(0);
+		expect(reparsed.splices[1].sampleRefs).toEqual(m.splices[0].sampleRefs);
+		// And the permuted layout itself stays byte-stable.
+		expect(bytesEqual(writeSplicer(reparsed), writeSplicer(permuted))).toBe(true);
+	});
+
+	it('writer rejects a SampleRef pointing past the sample table', () => {
+		const m = parseSplicer(loadSplicerRaw('example/SOUND/SPLICER/BIKESOUNDS.BUNDLE'));
+		m.splices[0].sampleRefs[0].SampleIndex = m.samples.length;
+		expect(() => writeSplicer(m)).toThrow(/references sample/);
+	});
+
+	it('writer rejects duplicate SpliceIndex values', () => {
+		const m = parseSplicer(loadSplicerRaw('example/SOUND/SPLICER/BIKESOUNDS.BUNDLE'));
+		m.splices[1].SpliceIndex = m.splices[0].SpliceIndex;
+		expect(() => writeSplicer(m)).toThrow(/duplicate SpliceIndex/);
+	});
+
+	it('parser rejects a corrupted version field', () => {
+		const raw = new Uint8Array(loadSplicerRaw('example/SOUND/SPLICER/BIKESOUNDS.BUNDLE'));
+		raw[0x10] = 2;
+		expect(() => parseSplicer(raw)).toThrow(/versionOfData/);
+	});
+});
+
+// The handler isn't registered yet when this suite is authored, so the
+// registry auto-suite can't exercise its fixtures/scenarios — pre-flight them
+// here the same way registry.test.ts will (deep clone → mutate → write →
+// reparse → verify), across EVERY fixture. PresentationAsset matters most:
+// its splice 0 has zero refs, which the ref-editing scenarios must survive.
+describe('splicerHandler stress scenarios pre-flight', () => {
+	const ctx = { littleEndian: true, platform: 1 };
+
+	it('describe() summarises every fixture', () => {
+		for (const fixture of FIXTURES) {
+			const model = splicerHandler.parseRaw(loadSplicerRaw(fixture), ctx);
+			expect(splicerHandler.describe(model)).toMatch(/\d+ splices, \d+ sample refs, \d+ samples/);
+		}
+	});
+
+	for (const scenario of splicerHandler.stressScenarios!) {
+		it(`scenario '${scenario.name}' verifies on every byteRoundTrip fixture`, () => {
+			for (const fixture of FIXTURES) {
+				const baseModel = splicerHandler.parseRaw(loadSplicerRaw(fixture), ctx);
+				const afterMutate = scenario.mutate(structuredClone(baseModel));
+				const written = splicerHandler.writeRaw!(afterMutate, ctx);
+				const afterReparse = splicerHandler.parseRaw(written, ctx);
+				const problems = scenario.verify ? scenario.verify(afterMutate, afterReparse) : [];
+				expect(problems, `${scenario.name} on ${fixture}`).toEqual([]);
+			}
+		});
+	}
+});

--- a/src/lib/core/aemsBank.ts
+++ b/src/lib/core/aemsBank.ts
@@ -1,0 +1,426 @@
+// AemsBank parser and writer (resource type 0xA022, AemsDef::ModuleBank).
+//
+// AEMS (Audio Event Management System) banks carry the event-driven vehicle
+// sounds — boost, in-air, skids, scrapes, gear whine, horns, surface and
+// traffic effects. A bank is a COMPILED artifact: its module region contains
+// x86 glue code plus static data the engine patches at load time, and its SFX
+// region is an SND10 sample bank holding the actual audio. Banks link to the
+// CSIS subscription system (0xA023) through tail-end InterfaceReferences:
+// each names a Csis class and stores its CrcAndKey (the Csis resource's
+// system crc + the class entry's crc), which is how e.g. SKIDS.BUNDLE binds
+// to SkidsCsis's 'Skids' class.
+//
+// On-disk layout (32-bit PC, little-endian; all 23 retail banks validated):
+//   0x00 u32  mu32DataSize    — BinaryFile envelope: payload size (align16)
+//   0x04 u32  mu32DataOffset  — always 0x10
+//   0x08 u8[8]                — uninitialised heap garbage, preserved verbatim
+//   ---- payload base B = 0x10; every offset below is B-relative ----
+//   B+0x00 char[4] 'ABKC', u8 ver=1, veraimex 1.2.2
+//   B+0x08 u8 platform (0 = PC), u8 targetType (3 = SND10)
+//   B+0x0A u16 nummodules — the wiki claims "always 1", but retail INAIR has 2
+//   B+0x0C u32 debugcrc = 0, B+0x10 u32 uniqueid = 0
+//   B+0x14 u32 totalsize     — align4(interface-ID blob end); derived
+//   B+0x18 u32 residentsize  — always == sfxbankoffset (everything before the
+//          SFX bank stays resident in memory); derived
+//   B+0x1C u32 moduleoffset = 0x5C (modules start right after this header)
+//   B+0x20 u32 sfxbankoffset, B+0x24 u32 sfxbanksizepadded (multiple of 4)
+//   B+0x28/0x2C u32 midibankoffset/midibanksizepadded — 0 in every retail bank
+//   B+0x30/0x34/0x38 u32 funcfixupoffset / staticdatafixupoffset /
+//          interfaceOffset — the three tail tables, packed back to back
+//          immediately after the SFX bank; derived
+//   B+0x3C u32 modulebankhandle = 0
+//   B+0x40 u32 pSnd10SampleBankHeader = 0xFFFFFFFF (runtime pointer sentinel)
+//   B+0x44 u32 midibhandle = 0xFFFFFFFF
+//   B+0x48/0x4C u32 streamfilepath/streamfileoffset = 0
+//   B+0x50 CListDNode ln = {0,0}, B+0x58 u32 ptweakheader = 0
+//   B+0x5C module data — modules, compiled x86 glue code, static data.
+//          Opaque: preserved verbatim (_moduleData).
+//   then   SND10 SFX sample bank ('S10A' header; numSamples at +0x8 is stored
+//          BIG-endian even in this little-endian resource). Opaque (_sfxBank).
+//   then   FUNCFIXUPHEADER:       u32 count + u32[count] code-patch offsets
+//   then   STATICDATAFIXUPHEADER: u32 count + u32[count] data-patch offsets
+//   then   InterfaceFixupHeader:  u32 count + count × 0xC InterfaceReference
+//          { u32 handleOffset (Csis::ClassHandle slot in module data),
+//            u32 IDOffset, u8 type (1 = class), u8[3] uninit pad — the bytes
+//            'AKH' in every retail bank }
+//   then   per-reference ID blobs, in reference order: u32 CrcAndKey
+//          (lo16 = target Csis SystemDesc crc, hi16 = target entry crc)
+//          followed by the NUL-terminated entry name
+//   then   zero pad to align4 (= totalsize), zero pad to align16 (= dataSize)
+//
+// Round-trip strategy (structural slice, like aptData): the two big interior
+// regions are verbatim blobs; every offset/size and the three tail tables are
+// decoded and recomputed on write. The parser asserts the rigid layout
+// (section adjacency, zero/sentinel constants, contiguous ID blobs) and
+// throws on violation so the writer's derivation is provably byte-exact.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Enumerations
+// =============================================================================
+
+// AemsDef platform — NOT the CsisDef table (PS3 is 10 here, 7 there).
+export const AEMS_PLATFORMS = [
+	{ value: 0, label: 'PC (Win)' },
+	{ value: 1, label: 'Mac' },
+	{ value: 2, label: 'PlayStation 2' },
+	{ value: 3, label: 'Xbox' },
+	{ value: 4, label: 'GameCube' },
+	{ value: 5, label: 'Xbox 360' },
+	{ value: 10, label: 'PlayStation 3' },
+] as const;
+
+export const AEMS_TARGET_TYPES = [
+	{ value: 0, label: 'Original' },
+	{ value: 1, label: 'Uncompressed proxy' },
+	{ value: 2, label: 'SND9' },
+	{ value: 3, label: 'SND10' },
+] as const;
+
+export const AEMS_INTERFACE_TYPES = [
+	{ value: 0, label: 'Global variable' },
+	{ value: 1, label: 'Class' },
+	{ value: 2, label: 'Function' },
+] as const;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type AemsInterfaceReference = {
+	/** B-relative offset of the Csis::ClassHandle inside the module data that
+	 *  the loader patches once the named Csis entry resolves. */
+	handleOffset: number; // u32
+	/** AemsDef::InterfaceType — 1 (class) in every retail bank. */
+	type: number; // u8
+	/** Low u16 of the ID CrcAndKey — the target Csis resource's system crc. */
+	idCrc: number;
+	/** High u16 — the target entry's own crc inside that Csis resource. */
+	idKey: number;
+	/** Name of the Csis entry this bank subscribes to, e.g. 'GearWhineClass'. */
+	idName: string;
+	/** 3 uninitialised pad bytes — 'AKH' (0x41,0x4B,0x48) in every retail bank. */
+	_pad: number[];
+};
+
+export type ParsedAemsBank = {
+	/** AEMS_PLATFORMS — 0 (PC) in every retail bank. */
+	platform: number; // u8
+	/** AEMS_TARGET_TYPES — 3 (SND10) in every retail bank. */
+	targetType: number; // u8
+	/** Module count. 1 in 22 retail banks; INAIR.BUNDLE has 2. */
+	numModules: number; // u16
+	/** Modules + compiled x86 glue code + static data, [0x5C, sfxbankoffset).
+	 *  Opaque and position-dependent — preserved verbatim. */
+	_moduleData: Uint8Array;
+	/** SND10 sample bank (the audio). Opaque — preserved verbatim. */
+	_sfxBank: Uint8Array;
+	/** Code-patch offsets the loader fixes up inside the glue code. */
+	funcFixups: number[];
+	/** Static-data-patch offsets, same mechanism. */
+	staticDataFixups: number[];
+	/** Csis subscriptions — see AemsInterfaceReference. */
+	interfaceRefs: AemsInterfaceReference[];
+	/** 8 uninitialised bytes in the BinaryFile envelope — preserved verbatim. */
+	_envelopePad: Uint8Array;
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const ENVELOPE_SIZE = 0x10;
+const MODULE_BANK_HEADER_SIZE = 0x5c;
+const INTERFACE_REFERENCE_SIZE = 0xc;
+
+const align4 = (n: number) => (n + 3) & ~3;
+const align16 = (n: number) => (n + 15) & ~15;
+
+function fail(msg: string): never {
+	throw new Error(`AemsBank: ${msg}`);
+}
+
+/**
+ * Decoded SND10 sample-bank header from the verbatim blob, for display.
+ * numSamples is stored big-endian inside this otherwise little-endian
+ * resource (sweep-verified: 1–53 samples across retail, BE-read).
+ */
+export function aemsSfxBankInfo(model: ParsedAemsBank): { id: string; version: number; serialNumber: number; numSamples: number } | null {
+	const b = model._sfxBank;
+	if (b.byteLength < 12) return null;
+	const v = new DataView(b.buffer, b.byteOffset, b.byteLength);
+	return {
+		id: String.fromCharCode(b[0], b[1], b[2], b[3]),
+		version: b[4],
+		serialNumber: v.getUint16(6, true),
+		numSamples: v.getUint32(8, false),
+	};
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+export function parseAemsBank(raw: Uint8Array, littleEndian = true): ParsedAemsBank {
+	// Copy up front — extractResourceRaw may hand back a Buffer view, and the
+	// verbatim blob fields below must not alias the caller's bytes.
+	const bytes = new Uint8Array(raw);
+	const r = new BinReader(bytes.buffer, littleEndian);
+
+	if (bytes.byteLength < ENVELOPE_SIZE + MODULE_BANK_HEADER_SIZE) {
+		fail(`resource is ${bytes.byteLength} bytes, smaller than envelope + ModuleBank header`);
+	}
+
+	// --- BinaryFile envelope ---
+	const dataSize = r.readU32();
+	const dataOffset = r.readU32();
+	if (dataOffset !== ENVELOPE_SIZE) fail(`mu32DataOffset 0x${dataOffset.toString(16)}, expected 0x10`);
+	if (dataSize + ENVELOPE_SIZE !== bytes.byteLength) {
+		fail(`mu32DataSize 0x${dataSize.toString(16)} + 0x10 != resource size 0x${bytes.byteLength.toString(16)}`);
+	}
+	const _envelopePad = bytes.slice(8, ENVELOPE_SIZE);
+
+	// --- ModuleBank header ---
+	const B = ENVELOPE_SIZE;
+	r.position = B;
+	const magic = r.readFixedString(4);
+	if (magic !== 'ABKC') fail(`id '${magic}', expected 'ABKC'`);
+	const ver = r.readU8();
+	const verMajor = r.readU8();
+	const verMinor = r.readU8();
+	const verPatch = r.readU8();
+	if (ver !== 1 || verMajor !== 1 || verMinor !== 2 || verPatch !== 2) {
+		fail(`aimex version ${ver}/${verMajor}.${verMinor}.${verPatch}, expected 1/1.2.2`);
+	}
+	const platform = r.readU8();
+	const targetType = r.readU8();
+	const numModules = r.readU16();
+	const totals = {
+		debugcrc: r.readU32(),
+		uniqueid: r.readU32(),
+		totalsize: r.readU32(),
+		residentsize: r.readU32(),
+		moduleoffset: r.readU32(),
+		sfxbankoffset: r.readU32(),
+		sfxbanksizepadded: r.readU32(),
+		midibankoffset: r.readU32(),
+		midibanksizepadded: r.readU32(),
+		funcfixupoffset: r.readU32(),
+		staticdatafixupoffset: r.readU32(),
+		interfaceOffset: r.readU32(),
+		modulebankhandle: r.readU32(),
+		pSnd10SampleBankHeader: r.readU32(),
+		midibhandle: r.readU32(),
+		streamfilepath: r.readU32(),
+		streamfileoffset: r.readU32(),
+		lnNext: r.readU32(),
+		lnPrev: r.readU32(),
+		ptweakheader: r.readU32(),
+	};
+	// The layout is rigid; bail loudly on violations rather than silently
+	// producing a model that won't round-trip.
+	for (const [name, expected] of [
+		['debugcrc', 0], ['uniqueid', 0], ['moduleoffset', MODULE_BANK_HEADER_SIZE],
+		['midibankoffset', 0], ['midibanksizepadded', 0], ['modulebankhandle', 0],
+		['pSnd10SampleBankHeader', 0xffffffff], ['midibhandle', 0xffffffff],
+		['streamfilepath', 0], ['streamfileoffset', 0], ['lnNext', 0], ['lnPrev', 0],
+		['ptweakheader', 0],
+	] as const) {
+		if (totals[name] !== expected) {
+			fail(`${name} is 0x${totals[name].toString(16)}, expected 0x${expected.toString(16)}`);
+		}
+	}
+	if (totals.residentsize !== totals.sfxbankoffset) {
+		fail(`residentsize 0x${totals.residentsize.toString(16)} != sfxbankoffset 0x${totals.sfxbankoffset.toString(16)}`);
+	}
+	if (totals.sfxbankoffset < MODULE_BANK_HEADER_SIZE || totals.sfxbankoffset + totals.sfxbanksizepadded > dataSize) {
+		fail(`SFX bank [0x${totals.sfxbankoffset.toString(16)}, +0x${totals.sfxbanksizepadded.toString(16)}) overruns the 0x${dataSize.toString(16)}-byte payload`);
+	}
+	if (totals.sfxbanksizepadded % 4 !== 0) {
+		fail(`sfxbanksizepadded 0x${totals.sfxbanksizepadded.toString(16)} is not a multiple of 4`);
+	}
+	if (totals.funcfixupoffset !== totals.sfxbankoffset + totals.sfxbanksizepadded) {
+		fail(`funcfixupoffset 0x${totals.funcfixupoffset.toString(16)} != SFX bank end 0x${(totals.sfxbankoffset + totals.sfxbanksizepadded).toString(16)}`);
+	}
+
+	// --- Verbatim interior blobs ---
+	const _moduleData = bytes.slice(B + MODULE_BANK_HEADER_SIZE, B + totals.sfxbankoffset);
+	const _sfxBank = bytes.slice(B + totals.sfxbankoffset, B + totals.funcfixupoffset);
+
+	// --- Fixup tables (packed back to back after the SFX bank) ---
+	const readFixupTable = (at: number, what: string): number[] => {
+		r.position = B + at;
+		const count = r.readU32();
+		if (at + 4 + count * 4 > dataSize) fail(`${what} table at 0x${at.toString(16)} with ${count} entries overruns the payload`);
+		const out: number[] = [];
+		for (let i = 0; i < count; i++) out.push(r.readU32());
+		return out;
+	};
+	const funcFixups = readFixupTable(totals.funcfixupoffset, 'func fixup');
+	if (totals.staticdatafixupoffset !== totals.funcfixupoffset + 4 + funcFixups.length * 4) {
+		fail(`staticdatafixupoffset 0x${totals.staticdatafixupoffset.toString(16)} not adjacent to func fixup table`);
+	}
+	const staticDataFixups = readFixupTable(totals.staticdatafixupoffset, 'static data fixup');
+	if (totals.interfaceOffset !== totals.staticdatafixupoffset + 4 + staticDataFixups.length * 4) {
+		fail(`interfaceOffset 0x${totals.interfaceOffset.toString(16)} not adjacent to static data fixup table`);
+	}
+
+	// --- Interface references + their ID blobs ---
+	r.position = B + totals.interfaceOffset;
+	const numRefs = r.readU32();
+	let idCursor = totals.interfaceOffset + 4 + numRefs * INTERFACE_REFERENCE_SIZE;
+	const interfaceRefs: AemsInterfaceReference[] = [];
+	for (let i = 0; i < numRefs; i++) {
+		r.position = B + totals.interfaceOffset + 4 + i * INTERFACE_REFERENCE_SIZE;
+		const handleOffset = r.readU32();
+		const idOffset = r.readU32();
+		const type = r.readU8();
+		const _pad = [r.readU8(), r.readU8(), r.readU8()];
+		if (idOffset !== idCursor) {
+			fail(`interfaceRefs[${i}] IDOffset 0x${idOffset.toString(16)}, expected 0x${idCursor.toString(16)} (ID blobs are contiguous in reference order)`);
+		}
+		r.position = B + idOffset;
+		const crcAndKey = r.readU32();
+		let end = B + idOffset + 4;
+		while (end < bytes.byteLength && bytes[end] !== 0) end++;
+		if (end >= bytes.byteLength) fail(`unterminated interface ID string at 0x${idOffset.toString(16)}`);
+		let idName = '';
+		for (let j = B + idOffset + 4; j < end; j++) idName += String.fromCharCode(bytes[j]);
+		interfaceRefs.push({
+			handleOffset,
+			type,
+			idCrc: crcAndKey & 0xffff,
+			idKey: crcAndKey >>> 16,
+			idName,
+			_pad,
+		});
+		idCursor = end - B + 1;
+	}
+
+	// --- Tail sizes: totalsize aligns the ID blobs to 4, the envelope size
+	// aligns the whole payload to 16, and everything in between is zero. ---
+	if (totals.totalsize !== align4(idCursor)) {
+		fail(`totalsize 0x${totals.totalsize.toString(16)} != align4(ID blob end 0x${idCursor.toString(16)})`);
+	}
+	if (dataSize !== align16(totals.totalsize)) {
+		fail(`mu32DataSize 0x${dataSize.toString(16)} != align16(totalsize 0x${totals.totalsize.toString(16)})`);
+	}
+	for (let i = B + idCursor; i < bytes.byteLength; i++) {
+		if (bytes[i] !== 0) fail(`nonzero tail pad byte 0x${bytes[i].toString(16)} at payload offset 0x${(i - B).toString(16)}`);
+	}
+
+	return {
+		platform,
+		targetType,
+		numModules,
+		_moduleData,
+		_sfxBank,
+		funcFixups,
+		staticDataFixups,
+		interfaceRefs,
+		_envelopePad,
+	};
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+export function writeAemsBank(model: ParsedAemsBank, littleEndian = true): Uint8Array {
+	if (model._envelopePad.byteLength !== 8) {
+		fail(`_envelopePad must be exactly 8 bytes, got ${model._envelopePad.byteLength}`);
+	}
+	if (model._sfxBank.byteLength % 4 !== 0) {
+		fail(`_sfxBank length 0x${model._sfxBank.byteLength.toString(16)} must be a multiple of 4 (sfxbanksizepadded)`);
+	}
+	for (const ref of model.interfaceRefs) {
+		if (ref._pad.length !== 3) fail(`interface reference '${ref.idName}' _pad must be 3 bytes`);
+		for (let i = 0; i < ref.idName.length; i++) {
+			const c = ref.idName.charCodeAt(i);
+			if (c === 0 || c > 0xff) fail(`interface ID name "${ref.idName}" has a byte-unrepresentable character`);
+		}
+	}
+
+	// --- Layout pass: every offset/size is derived, nothing stored. ---
+	const sfxbankoffset = MODULE_BANK_HEADER_SIZE + model._moduleData.byteLength;
+	const funcfixupoffset = sfxbankoffset + model._sfxBank.byteLength;
+	const staticdatafixupoffset = funcfixupoffset + 4 + model.funcFixups.length * 4;
+	const interfaceOffset = staticdatafixupoffset + 4 + model.staticDataFixups.length * 4;
+	let idCursor = interfaceOffset + 4 + model.interfaceRefs.length * INTERFACE_REFERENCE_SIZE;
+	const idOffsets: number[] = [];
+	for (const ref of model.interfaceRefs) {
+		idOffsets.push(idCursor);
+		idCursor += 4 + ref.idName.length + 1;
+	}
+	const totalsize = align4(idCursor);
+	const dataSize = align16(totalsize);
+
+	const w = new BinWriter(ENVELOPE_SIZE + dataSize, littleEndian);
+	w.writeU32(dataSize);
+	w.writeU32(ENVELOPE_SIZE);
+	w.writeBytes(model._envelopePad);
+
+	// Not writeFixedString — that reserves the last byte for a NUL terminator.
+	for (const c of 'ABKC') w.writeU8(c.charCodeAt(0));
+	w.writeU8(1); // ver
+	w.writeU8(1); // veraimexmajor
+	w.writeU8(2); // veraimexminor
+	w.writeU8(2); // veraimexpatch
+	w.writeU8(model.platform);
+	w.writeU8(model.targetType);
+	w.writeU16(model.numModules);
+	w.writeU32(0); // debugcrc
+	w.writeU32(0); // uniqueid
+	w.writeU32(totalsize);
+	w.writeU32(sfxbankoffset); // residentsize — always the pre-SFX portion
+	w.writeU32(MODULE_BANK_HEADER_SIZE); // moduleoffset
+	w.writeU32(sfxbankoffset);
+	w.writeU32(model._sfxBank.byteLength); // sfxbanksizepadded
+	w.writeU32(0); // midibankoffset
+	w.writeU32(0); // midibanksizepadded
+	w.writeU32(funcfixupoffset);
+	w.writeU32(staticdatafixupoffset);
+	w.writeU32(interfaceOffset);
+	w.writeU32(0); // modulebankhandle
+	w.writeU32(0xffffffff); // pSnd10SampleBankHeader (runtime sentinel)
+	w.writeU32(0xffffffff); // midibhandle
+	w.writeU32(0); // streamfilepath
+	w.writeU32(0); // streamfileoffset
+	w.writeU32(0); // ln.pnext
+	w.writeU32(0); // ln.pprev
+	w.writeU32(0); // ptweakheader
+	if (w.offset !== ENVELOPE_SIZE + MODULE_BANK_HEADER_SIZE) {
+		fail(`writer header ended at 0x${w.offset.toString(16)}, expected 0x${(ENVELOPE_SIZE + MODULE_BANK_HEADER_SIZE).toString(16)}`);
+	}
+
+	// --- Verbatim interiors ---
+	w.writeBytes(model._moduleData);
+	w.writeBytes(model._sfxBank);
+
+	// --- Fixup tables ---
+	w.writeU32(model.funcFixups.length);
+	for (const f of model.funcFixups) w.writeU32(f);
+	w.writeU32(model.staticDataFixups.length);
+	for (const f of model.staticDataFixups) w.writeU32(f);
+
+	// --- Interface references + ID blobs ---
+	w.writeU32(model.interfaceRefs.length);
+	for (let i = 0; i < model.interfaceRefs.length; i++) {
+		const ref = model.interfaceRefs[i];
+		w.writeU32(ref.handleOffset);
+		w.writeU32(idOffsets[i]);
+		w.writeU8(ref.type);
+		for (const p of ref._pad) w.writeU8(p);
+	}
+	for (const ref of model.interfaceRefs) {
+		w.writeU32(((ref.idKey & 0xffff) << 16 | (ref.idCrc & 0xffff)) >>> 0);
+		for (let i = 0; i < ref.idName.length; i++) w.writeU8(ref.idName.charCodeAt(i));
+		w.writeU8(0);
+	}
+	if (w.offset !== ENVELOPE_SIZE + idCursor) {
+		fail(`writer ID blobs ended at 0x${w.offset.toString(16)}, expected 0x${(ENVELOPE_SIZE + idCursor).toString(16)}`);
+	}
+	w.writeZeroes(ENVELOPE_SIZE + dataSize - w.offset);
+	return w.bytes;
+}

--- a/src/lib/core/csis.ts
+++ b/src/lib/core/csis.ts
@@ -1,0 +1,340 @@
+// Csis parser and writer (resource type 0xA023, CsisDef::SystemDesc).
+//
+// CSIS (Customizable Subscription-based Interfacing System) is the glue layer
+// between AEMS audio banks: each Csis resource declares the named functions /
+// classes / global variables one audio module exposes, and AEMS banks (0xA022)
+// subscribe to them via CrcAndKey references — the bank's InterfaceReference
+// ID stores (this resource's system crc, the entry's crc) plus the entry name.
+// All ten retail Csis resources live in SOUND/AEMS/CSIS.BUNDLE, one per audio
+// module (BoostCsis, SkidsCsis, GearWhineCsis, …).
+//
+// On-disk layout (32-bit PC, little-endian; all retail fixtures validated):
+//   0x00 u32  mu32DataSize    — BinaryFile envelope: payload size (align16)
+//   0x04 u32  mu32DataOffset  — always 0x10
+//   0x08 u8[8]                — uninitialised heap garbage (UTF-16 path
+//                               fragments in retail) — preserved verbatim
+//   ---- payload base B = 0x10; every pointer below is B-relative ----
+//   B+0x00 char[4] 'MOIR'
+//   B+0x04 u8 ver=0, verCsisxMajor=3, verCsisxMinor=1, verCsisxPatch=0
+//   B+0x08 u8 platform (0 = PLATFORM_WIN in retail), u8 resolved (0 on disk)
+//   B+0x0A u16 numFunctions, B+0x0C u16 numClasses, B+0x0E u16 numGlobalVariables
+//   B+0x10 u16 crc — (Σ all entry crcs) & 0x7FFF; derived on write, asserted
+//          on parse (validated on all 10 retail resources incl. 3 multi-entry)
+//   B+0x12 u8[2] pad = 0
+//   B+0x14/0x18/0x1C u32 pFunctionDesc/pClassDesc/pGlobalVariableDesc — 0 on
+//          disk (runtime pointer fixups; the desc arrays sit at fixed offsets)
+//   B+0x20 CListDNode linkNode = {0, 0}
+//   B+0x28 FunctionDesc[numFunctions] — 0xC each: u32 clients (0 on disk),
+//          u32 pStringId, u32 u (CrcAndKey union: crc lo16, key hi16 = 0)
+//   then   ClassDesc[numClasses] — SAME 0xC shape. The wiki types ClassDesc
+//          as FunctionDesc but claims length 0x10 for 32-bit; real PC bytes
+//          use the plain 0xC FunctionDesc stride (InAirCsis pins it).
+//   then   GlobalVariableDesc[numGlobalVariables] — 0x10 each: clients,
+//          curVal (Parameter union, raw bits), pStringId, u. NO retail
+//          resource carries one, so this shape is wiki-only, fixture-unvalidated.
+//   then   NUL-terminated entry names, contiguous, in entry order
+//          (functions, classes, globals)
+//   then   uninitialised garbage to align16 — preserved verbatim
+//
+// Round-trip strategy: counts, pStringIds, the system crc, and both envelope
+// sizes are recomputed from the entry arrays on write; the parser asserts the
+// stored values match that derivation (throwing instead of mis-parsing), so
+// the writer's recomputation is provably byte-exact. The entry crc itself is
+// NOT derivable from the name (no standard CRC-16 nor soundHash reproduces
+// it), so it stays a stored field the editor must keep in sync with banks.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Enumerations
+// =============================================================================
+
+// CsisDef::Platform — note this is a DIFFERENT table from AemsDef's platform
+// enum (PS3 is 7 here, 10 there).
+export const CSIS_PLATFORMS = [
+	{ value: 0, label: 'PC (Win32)' },
+	{ value: 1, label: 'Mac' },
+	{ value: 2, label: 'PlayStation 2' },
+	{ value: 3, label: 'Xbox' },
+	{ value: 4, label: 'GameCube' },
+	{ value: 5, label: 'Xbox 360' },
+	{ value: 6, label: 'PSP' },
+	{ value: 7, label: 'PlayStation 3' },
+	{ value: 8, label: 'Wii' },
+	{ value: 9, label: 'PC (Win64)' },
+] as const;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type CsisEntry = {
+	/** Entry name, e.g. 'GearWhineClass' — what AEMS bank references are matched against. */
+	name: string;
+	/**
+	 * 15-bit checksum of this entry. AEMS banks store it as the high u16 of
+	 * their InterfaceReference CrcAndKey, so renaming an entry without
+	 * updating the subscribing banks (or vice versa) breaks the link.
+	 * Derivation unknown — not reproducible via CRC-16 variants or soundHash.
+	 */
+	crc: number; // u16
+	/** High u16 of the CrcAndKey union — 0 on disk; runtime fills the key. */
+	_key: number; // u16
+	/** CListDStack subscriber-list head — 0 on disk (runtime pointer). */
+	_clients: number; // u32
+};
+
+export type CsisGlobalVariable = CsisEntry & {
+	/** CsisDef::Parameter union (intVal / floatVal) — raw u32 bits. */
+	curVal: number;
+};
+
+export type ParsedCsis = {
+	/** CsisDef::Platform — 0 (PC) in every retail resource. */
+	platform: number; // u8
+	/** 0 on disk; the runtime sets it once pointers are fixed up. */
+	resolved: number; // u8
+	functions: CsisEntry[];
+	classes: CsisEntry[];
+	/** Empty in every retail resource — the on-disk shape is wiki-only. */
+	globalVariables: CsisGlobalVariable[];
+	/** 8 uninitialised bytes in the BinaryFile envelope — preserved verbatim. */
+	_envelopePad: Uint8Array;
+	/** Uninitialised garbage padding the payload to 16 bytes — verbatim. */
+	_tailGarbage: Uint8Array;
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const ENVELOPE_SIZE = 0x10;
+const SYSTEM_DESC_SIZE = 0x28;
+const FUNCTION_DESC_SIZE = 0xc;
+const GLOBAL_DESC_SIZE = 0x10;
+
+const align16 = (n: number) => (n + 15) & ~15;
+
+function fail(msg: string): never {
+	throw new Error(`Csis: ${msg}`);
+}
+
+/** SystemDesc.crc — sum of every entry crc folded to 15 bits. */
+export function csisSystemCrc(model: Pick<ParsedCsis, 'functions' | 'classes' | 'globalVariables'>): number {
+	let sum = 0;
+	for (const e of [...model.functions, ...model.classes, ...model.globalVariables]) sum += e.crc;
+	return sum & 0x7fff;
+}
+
+export function makeEmptyCsisEntry(): CsisEntry {
+	return { name: '', crc: 0, _key: 0, _clients: 0 };
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+export function parseCsis(raw: Uint8Array, littleEndian = true): ParsedCsis {
+	// Copy up front — extractResourceRaw may hand back a Buffer view, and the
+	// verbatim pad fields below must not alias the caller's bytes.
+	const bytes = new Uint8Array(raw);
+	const r = new BinReader(bytes.buffer, littleEndian);
+
+	if (bytes.byteLength < ENVELOPE_SIZE + SYSTEM_DESC_SIZE) {
+		fail(`resource is ${bytes.byteLength} bytes, smaller than envelope + SystemDesc`);
+	}
+
+	// --- BinaryFile envelope ---
+	const dataSize = r.readU32();
+	const dataOffset = r.readU32();
+	if (dataOffset !== ENVELOPE_SIZE) fail(`mu32DataOffset 0x${dataOffset.toString(16)}, expected 0x10`);
+	if (dataSize + ENVELOPE_SIZE !== bytes.byteLength) {
+		fail(`mu32DataSize 0x${dataSize.toString(16)} + 0x10 != resource size 0x${bytes.byteLength.toString(16)}`);
+	}
+	const _envelopePad = bytes.slice(8, ENVELOPE_SIZE);
+
+	// --- SystemDesc ---
+	const B = ENVELOPE_SIZE;
+	r.position = B;
+	const magic = r.readFixedString(4);
+	if (magic !== 'MOIR') fail(`id '${magic}', expected 'MOIR'`);
+	const ver = r.readU8();
+	const verMajor = r.readU8();
+	const verMinor = r.readU8();
+	const verPatch = r.readU8();
+	if (ver !== 0 || verMajor !== 3 || verMinor !== 1 || verPatch !== 0) {
+		fail(`csisx version ${ver}/${verMajor}.${verMinor}.${verPatch}, expected 0/3.1.0`);
+	}
+	const platform = r.readU8();
+	const resolved = r.readU8();
+	const numFunctions = r.readU16();
+	const numClasses = r.readU16();
+	const numGlobalVariables = r.readU16();
+	const crc = r.readU16();
+	const pad12 = r.readU16();
+	if (pad12 !== 0) fail(`header pad at +0x12 is 0x${pad12.toString(16)}, expected 0`);
+	for (const [name, value] of [
+		['pFunctionDesc', r.readU32()],
+		['pClassDesc', r.readU32()],
+		['pGlobalVariableDesc', r.readU32()],
+		['linkNode.pnext', r.readU32()],
+		['linkNode.pprev', r.readU32()],
+	] as const) {
+		if (value !== 0) fail(`${name} is 0x${value.toString(16)}, expected 0 (fixed up at runtime)`);
+	}
+
+	// --- Desc arrays (functions, classes, globals — back to back) ---
+	const descStart = SYSTEM_DESC_SIZE;
+	let stringCursor = descStart
+		+ (numFunctions + numClasses) * FUNCTION_DESC_SIZE
+		+ numGlobalVariables * GLOBAL_DESC_SIZE;
+
+	const readString = (pStringId: number, what: string): string => {
+		if (pStringId !== stringCursor) {
+			fail(`${what} pStringId 0x${pStringId.toString(16)}, expected 0x${stringCursor.toString(16)} (strings are contiguous in entry order)`);
+		}
+		let end = B + pStringId;
+		while (end < bytes.byteLength && bytes[end] !== 0) end++;
+		if (end >= bytes.byteLength) fail(`unterminated ${what} string at 0x${pStringId.toString(16)}`);
+		let s = '';
+		for (let j = B + pStringId; j < end; j++) s += String.fromCharCode(bytes[j]);
+		stringCursor = end - B + 1;
+		return s;
+	};
+
+	type RawDesc = { clients: number; pStringId: number; u: number; curVal?: number };
+	const rawDescs: RawDesc[] = [];
+	r.position = B + descStart;
+	for (let i = 0; i < numFunctions + numClasses; i++) {
+		rawDescs.push({ clients: r.readU32(), pStringId: r.readU32(), u: r.readU32() });
+	}
+	for (let i = 0; i < numGlobalVariables; i++) {
+		const clients = r.readU32();
+		const curVal = r.readU32();
+		const pStringId = r.readU32();
+		const u = r.readU32();
+		rawDescs.push({ clients, pStringId, u, curVal });
+	}
+
+	const toEntry = (d: RawDesc, what: string): CsisEntry => ({
+		name: readString(d.pStringId, what),
+		crc: d.u & 0xffff,
+		_key: d.u >>> 16,
+		_clients: d.clients,
+	});
+
+	const functions: CsisEntry[] = [];
+	const classes: CsisEntry[] = [];
+	const globalVariables: CsisGlobalVariable[] = [];
+	for (let i = 0; i < numFunctions; i++) functions.push(toEntry(rawDescs[i], `function[${i}]`));
+	for (let i = 0; i < numClasses; i++) classes.push(toEntry(rawDescs[numFunctions + i], `class[${i}]`));
+	for (let i = 0; i < numGlobalVariables; i++) {
+		const d = rawDescs[numFunctions + numClasses + i];
+		globalVariables.push({ ...toEntry(d, `global[${i}]`), curVal: d.curVal! });
+	}
+
+	// --- System crc must reproduce from the entries, or the writer's
+	// derivation would not be byte-exact. ---
+	const derived = csisSystemCrc({ functions, classes, globalVariables });
+	if (crc !== derived) {
+		fail(`stored crc 0x${crc.toString(16)} != (Σ entry crcs) & 0x7FFF = 0x${derived.toString(16)}`);
+	}
+
+	// --- Garbage tail to the 16-byte-aligned payload end — verbatim ---
+	if (dataSize !== align16(stringCursor)) {
+		fail(`mu32DataSize 0x${dataSize.toString(16)} != align16(content end 0x${stringCursor.toString(16)})`);
+	}
+	const _tailGarbage = bytes.slice(B + stringCursor, bytes.byteLength);
+
+	return { platform, resolved, functions, classes, globalVariables, _envelopePad, _tailGarbage };
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+export function writeCsis(model: ParsedCsis, littleEndian = true): Uint8Array {
+	if (model._envelopePad.byteLength !== 8) {
+		fail(`_envelopePad must be exactly 8 bytes, got ${model._envelopePad.byteLength}`);
+	}
+	const all = [...model.functions, ...model.classes, ...model.globalVariables];
+	for (const e of all) {
+		for (let i = 0; i < e.name.length; i++) {
+			const c = e.name.charCodeAt(i);
+			if (c === 0 || c > 0xff) fail(`entry name "${e.name}" has a byte-unrepresentable character`);
+		}
+	}
+
+	// --- Layout pass: every offset/size/crc is derived, nothing stored. ---
+	const descStart = SYSTEM_DESC_SIZE;
+	let cursor = descStart
+		+ (model.functions.length + model.classes.length) * FUNCTION_DESC_SIZE
+		+ model.globalVariables.length * GLOBAL_DESC_SIZE;
+	const stringOffsets: number[] = [];
+	for (const e of all) {
+		stringOffsets.push(cursor);
+		cursor += e.name.length + 1;
+	}
+	const contentEnd = cursor;
+	const dataSize = align16(contentEnd);
+
+	const w = new BinWriter(ENVELOPE_SIZE + dataSize, littleEndian);
+	w.writeU32(dataSize);
+	w.writeU32(ENVELOPE_SIZE);
+	w.writeBytes(model._envelopePad);
+
+	// Not writeFixedString — that reserves the last byte for a NUL terminator.
+	for (const c of 'MOIR') w.writeU8(c.charCodeAt(0));
+	w.writeU8(0); // ver
+	w.writeU8(3); // verCsisxMajor
+	w.writeU8(1); // verCsisxMinor
+	w.writeU8(0); // verCsisxPatch
+	w.writeU8(model.platform);
+	w.writeU8(model.resolved);
+	w.writeU16(model.functions.length);
+	w.writeU16(model.classes.length);
+	w.writeU16(model.globalVariables.length);
+	w.writeU16(csisSystemCrc(model));
+	w.writeU16(0); // pad
+	w.writeU32(0); // pFunctionDesc
+	w.writeU32(0); // pClassDesc
+	w.writeU32(0); // pGlobalVariableDesc
+	w.writeU32(0); // linkNode.pnext
+	w.writeU32(0); // linkNode.pprev
+	if (w.offset !== ENVELOPE_SIZE + SYSTEM_DESC_SIZE) {
+		fail(`writer SystemDesc ended at 0x${w.offset.toString(16)}, expected 0x${(ENVELOPE_SIZE + SYSTEM_DESC_SIZE).toString(16)}`);
+	}
+
+	// --- Desc arrays ---
+	let stringIndex = 0;
+	const writeU = (e: CsisEntry) => w.writeU32(((e._key & 0xffff) << 16 | (e.crc & 0xffff)) >>> 0);
+	for (const e of [...model.functions, ...model.classes]) {
+		w.writeU32(e._clients);
+		w.writeU32(stringOffsets[stringIndex++]);
+		writeU(e);
+	}
+	for (const g of model.globalVariables) {
+		w.writeU32(g._clients);
+		w.writeU32(g.curVal);
+		w.writeU32(stringOffsets[stringIndex++]);
+		writeU(g);
+	}
+
+	// --- Strings (latin1, NUL-terminated, entry order) ---
+	for (const e of all) {
+		for (let i = 0; i < e.name.length; i++) w.writeU8(e.name.charCodeAt(i));
+		w.writeU8(0);
+	}
+	if (w.offset !== ENVELOPE_SIZE + contentEnd) {
+		fail(`writer strings ended at 0x${w.offset.toString(16)}, expected 0x${(ENVELOPE_SIZE + contentEnd).toString(16)}`);
+	}
+
+	// --- Garbage tail: verbatim when the layout is unchanged; zero-filled
+	// where an edit changed the pad length (the bytes are uninitialised
+	// junk, so synthesising zeros is as faithful as anything). ---
+	const needed = dataSize - contentEnd;
+	for (let i = 0; i < needed; i++) {
+		w.writeU8(i < model._tailGarbage.byteLength ? model._tailGarbage[i] : 0);
+	}
+	return w.bytes;
+}

--- a/src/lib/core/flaptFile.ts
+++ b/src/lib/core/flaptFile.ts
@@ -1,0 +1,415 @@
+// FlaptFile parser and writer (resource type 0x10020).
+//
+// Flapt ("Friends List Apt", per the wiki's best guess) is the in-game HUD —
+// a Flash-derived GUI like AptData (0x1E) but compiled flat: one FlaptFile
+// resource in FLAPTHUD.BUNDLE plus the 52 sibling Texture (0x0) pages its
+// meshes sample. Unlike AptData's section-relative blob, EVERY pointer here is
+// a payload-relative absolute offset, including pointers buried inside the
+// 560 MovieClip structs (frame maps, render layers, keyframe anims, FScript
+// streams). Shifting any byte therefore breaks pointers in regions this
+// module does not decode — so the round-trip strategy is the inverse of
+// AptData's: keep the WHOLE payload verbatim (_payload) and write by patching
+// fixed-width fields in place. Layout never changes, byte-exactness is
+// structural, and the un-decoded 1.2 MB of timeline data is untouched.
+//
+// Payload map (retail FLAPTHUD, fixture-grounded):
+//   0x00     BrnFlapt::FlaptFile header (0x58): version 12, muSizeInBytes,
+//            mfTimePerFrame, then 9 count+pointer pairs and FileDebugData.
+//   0x58     MovieClip[560] — 0x44 each; this module decodes the scalar
+//            counts and the component-name string, nothing deeper.
+//   ....     GuiVertex[1650] (0x14 each), FontStyle[65] (0xC each),
+//            HashedString[429] component names, IndexPath[429] (0x21 each),
+//            debug-string pointer table, string pools, TriggerParameters[75],
+//            CgsUtf8* string table, GuiTexture*[53], timeline sub-data.
+//   tail     Inline BND2 import table at align16(muSizeInBytes) — one
+//            16-byte entry (u64 texture id, u32 fixup, u32 zero) per imported
+//            texture slot. Fixup k targets mpapTextures + k*4: the loader
+//            patches the texture POINTER ARRAY itself, not mesh fields.
+//
+// Fixture facts the wiki does not state:
+//   - Padding/garbage fill is 0xB0 (header pad, MovieClip pad, align gaps) —
+//     not the usual 0xCD. Preserved verbatim by the patch-write strategy.
+//   - mpapTextures slots hold their own 0-based index as a cookie; the one
+//     slot WITHOUT an import entry (slot 52) holds 0 and is resolved at
+//     runtime by name via mpapSpecialTextureNames ('CustomComponentTexture.tif').
+//   - MovieClip pointers whose count is 0 can hold stale heap garbage
+//     (0xFEF9E400) — only count>0 pointers are meaningful.
+//   - mpFile is 0 on disk for all 560 clips (runtime back-pointer).
+//   - muSizeInBytes excludes the import table, exactly like AptData's
+//     muSizeOfHeader.
+//
+// Editable surface (fixed-width, patched in place): mfTimePerFrame, GuiVertex
+// fields, FontStyle colour/height, and import-table texture ids. Everything
+// pointer-bearing (strings, components, clip structure) is decoded read-only.
+//
+// Scope: 32-bit PC little-endian (the only layout fixture-validated).
+
+export const FLAPT_VERSION = 12;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type FlaptGuiVertex = {
+	/** 2D screen-space position (HUD coordinate space, origin at element anchor). */
+	mv2Pos: { x: number; y: number };
+	/** renderengine::RGBA8 packed colour (u32). 0xFFFFFFFF = untinted. */
+	mColour: number;
+	/** Texture coordinates (0..1 into the mesh's texture page). */
+	mv2Tex0UV: { x: number; y: number };
+};
+
+export type FlaptFontStyle = {
+	/** Font face name (pooled string; pointer not relocatable, so read-only). */
+	fontName: string;
+	muColour: number; // u32 RGBA8
+	mfFontHeight: number; // f32, pixels
+};
+
+export type FlaptTexture = {
+	/**
+	 * Sibling Texture (0x0) resource bound to this mpapTextures slot via the
+	 * inline import table. null for slots with no import entry — those are
+	 * "special" textures the game resolves by name at runtime (see
+	 * specialTextureNames).
+	 */
+	resourceId: bigint | null;
+};
+
+export type FlaptComponent = {
+	/** Language hash of the component name (burnout.wiki/wiki/Language_hash). */
+	muHash: number;
+	/** Debug string the hash was computed from. */
+	debugName: string;
+	/** IndexPath — child indices walked from the root clip to reach this component. */
+	pathIndices: number[];
+};
+
+export type FlaptTriggerParameters = {
+	parameter0: string | null;
+	parameter1: string | null;
+	parameter2: string | null;
+	parameter3: string | null;
+};
+
+export type FlaptMovieClip = {
+	mxFlags: number; // u8
+	muNumChildren: number;
+	muNumMeshes: number;
+	muNumTextFields: number;
+	muNumRenderLayers: number;
+	muNumLabelledFrames: number;
+	muNumFScriptCommands: number;
+	muNumFramesInTimeline: number; // u16
+	muNumKeyFrames: number; // u16
+	/** Component name when this clip is an addressable component, else null. */
+	componentName: string | null;
+};
+
+export type ParsedFlaptFile = {
+	/** Format version — 12 in retail; the parser rejects anything else. */
+	muVersion: number;
+	/** Seconds per timeline frame (0.0333… = 30 fps in retail). */
+	mfTimePerFrame: number;
+	movieClips: FlaptMovieClip[];
+	/** One entry per mpapTextures slot, in slot order. */
+	textures: FlaptTexture[];
+	vertices: FlaptGuiVertex[];
+	fontStyles: FlaptFontStyle[];
+	components: FlaptComponent[];
+	triggerParameters: FlaptTriggerParameters[];
+	/** CgsUtf8 string table — the HUD's display text ('$100', countdowns, …). */
+	strings: string[];
+	/** Names of textures resolved at runtime instead of imported. */
+	specialTextureNames: string[];
+	/** FileDebugData.muNumStrings — the debug string pool is not decoded. */
+	debugStringCount: number;
+	/** Verbatim payload INCLUDING the import-table tail. The writer patches
+	 *  fixed-width fields into a copy of this; layout never changes. */
+	_payload: Uint8Array;
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const HEADER_SIZE = 0x58;
+const CLIP_SIZE = 0x44;
+const VERTEX_SIZE = 0x14;
+const FONT_SIZE = 0xc;
+const HASHED_STRING_SIZE = 8;
+const INDEX_PATH_SIZE = 0x21;
+const INDEX_PATH_MAX_DEPTH = 32;
+const TRIGGER_PARAMS_SIZE = 0x10;
+const IMPORT_ENTRY_SIZE = 16;
+
+const align16 = (n: number) => (n + 15) & ~15;
+
+function fail(msg: string): never {
+	throw new Error(`FlaptFile: ${msg}`);
+}
+
+type Header = {
+	muSizeInBytes: number;
+	numClips: number; pClips: number;
+	numTextures: number; ppTextures: number;
+	numVerts: number; pVerts: number;
+	numFonts: number; pFonts: number;
+	numComponents: number; pCompNames: number; pCompPaths: number;
+	numTriggers: number; pTriggers: number;
+	numStrings: number; ppStrings: number;
+	numSpecialTextures: number; ppSpecialTextureNames: number;
+	debugStringCount: number;
+};
+
+function readHeader(view: DataView, length: number, littleEndian: boolean): Header {
+	if (length < HEADER_SIZE) fail(`payload too small (${length} bytes) for the 0x58 header`);
+	const u32 = (o: number) => view.getUint32(o, littleEndian);
+	if (view.getUint8(0) !== FLAPT_VERSION) fail(`muVersion ${view.getUint8(0)}, only version ${FLAPT_VERSION} is supported`);
+	const h: Header = {
+		muSizeInBytes: u32(0x04),
+		numClips: u32(0x0c), pClips: u32(0x10),
+		numTextures: u32(0x14), ppTextures: u32(0x18),
+		numVerts: u32(0x1c), pVerts: u32(0x20),
+		numFonts: u32(0x24), pFonts: u32(0x28),
+		numComponents: u32(0x2c), pCompNames: u32(0x30), pCompPaths: u32(0x34),
+		numTriggers: u32(0x38), pTriggers: u32(0x3c),
+		numStrings: u32(0x40), ppStrings: u32(0x44),
+		numSpecialTextures: u32(0x48), ppSpecialTextureNames: u32(0x4c),
+		debugStringCount: u32(0x50),
+	};
+	if (h.muSizeInBytes < HEADER_SIZE || h.muSizeInBytes > length) {
+		fail(`muSizeInBytes 0x${h.muSizeInBytes.toString(16)} out of range for ${length}-byte payload`);
+	}
+	const tail = length - align16(h.muSizeInBytes);
+	if (tail < 0 || tail % IMPORT_ENTRY_SIZE !== 0) fail(`import tail ${tail} bytes is not a multiple of ${IMPORT_ENTRY_SIZE}`);
+	return h;
+}
+
+function checkRegion(h: Header, ptr: number, count: number, stride: number, what: string) {
+	if (count === 0) return; // count-0 pointers can hold stale heap garbage
+	if (ptr < HEADER_SIZE || ptr + count * stride > h.muSizeInBytes) {
+		fail(`${what} region 0x${ptr.toString(16)}+${count}*0x${stride.toString(16)} escapes the payload body`);
+	}
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+export function parseFlaptFile(raw: Uint8Array, littleEndian = true): ParsedFlaptFile {
+	// Copy up front: raw may be a Buffer view into a larger zlib output, and
+	// _payload must be an independent verbatim copy.
+	const bytes = new Uint8Array(raw);
+	const view = new DataView(bytes.buffer);
+	const u8 = (o: number) => view.getUint8(o);
+	const u16 = (o: number) => view.getUint16(o, littleEndian);
+	const u32 = (o: number) => view.getUint32(o, littleEndian);
+	const f32 = (o: number) => view.getFloat32(o, littleEndian);
+	const u64 = (o: number) => (BigInt(u32(o + 4)) << 32n) | BigInt(u32(o));
+	const h = readHeader(view, bytes.length, littleEndian);
+	const cstr = (off: number, what: string) => {
+		if (off < HEADER_SIZE || off >= h.muSizeInBytes) fail(`${what}: string pointer 0x${off.toString(16)} out of bounds`);
+		let end = off;
+		while (end < h.muSizeInBytes && bytes[end] !== 0) end++;
+		if (end >= h.muSizeInBytes) fail(`${what}: unterminated string at 0x${off.toString(16)}`);
+		return new TextDecoder().decode(bytes.subarray(off, end));
+	};
+
+	checkRegion(h, h.pClips, h.numClips, CLIP_SIZE, 'movie clips');
+	checkRegion(h, h.ppTextures, h.numTextures, 4, 'texture pointer array');
+	checkRegion(h, h.pVerts, h.numVerts, VERTEX_SIZE, 'vertices');
+	checkRegion(h, h.pFonts, h.numFonts, FONT_SIZE, 'font styles');
+	checkRegion(h, h.pCompNames, h.numComponents, HASHED_STRING_SIZE, 'component names');
+	checkRegion(h, h.pCompPaths, h.numComponents, INDEX_PATH_SIZE, 'component paths');
+	checkRegion(h, h.pTriggers, h.numTriggers, TRIGGER_PARAMS_SIZE, 'trigger parameters');
+	checkRegion(h, h.ppStrings, h.numStrings, 4, 'string pointer array');
+	checkRegion(h, h.ppSpecialTextureNames, h.numSpecialTextures, 4, 'special texture name pointers');
+
+	const movieClips: FlaptMovieClip[] = [];
+	for (let i = 0; i < h.numClips; i++) {
+		const o = h.pClips + i * CLIP_SIZE;
+		const namePtr = u32(o + 0x40);
+		movieClips.push({
+			mxFlags: u8(o),
+			muNumChildren: u8(o + 1),
+			muNumMeshes: u8(o + 2),
+			muNumTextFields: u8(o + 3),
+			muNumRenderLayers: u8(o + 4),
+			muNumLabelledFrames: u8(o + 5),
+			muNumFScriptCommands: u8(o + 6),
+			muNumFramesInTimeline: u16(o + 8),
+			muNumKeyFrames: u16(o + 0xa),
+			componentName: namePtr === 0 ? null : cstr(namePtr, `clip[${i}] componentName`),
+		});
+	}
+
+	const vertices: FlaptGuiVertex[] = [];
+	for (let i = 0; i < h.numVerts; i++) {
+		const o = h.pVerts + i * VERTEX_SIZE;
+		vertices.push({
+			mv2Pos: { x: f32(o), y: f32(o + 4) },
+			mColour: u32(o + 8),
+			mv2Tex0UV: { x: f32(o + 12), y: f32(o + 16) },
+		});
+	}
+
+	const fontStyles: FlaptFontStyle[] = [];
+	for (let i = 0; i < h.numFonts; i++) {
+		const o = h.pFonts + i * FONT_SIZE;
+		fontStyles.push({
+			fontName: cstr(u32(o), `fontStyle[${i}] name`),
+			muColour: u32(o + 4),
+			mfFontHeight: f32(o + 8),
+		});
+	}
+
+	const components: FlaptComponent[] = [];
+	for (let i = 0; i < h.numComponents; i++) {
+		const no = h.pCompNames + i * HASHED_STRING_SIZE;
+		const po = h.pCompPaths + i * INDEX_PATH_SIZE;
+		const depth = u8(po);
+		if (depth > INDEX_PATH_MAX_DEPTH) fail(`component[${i}] path depth ${depth} exceeds ${INDEX_PATH_MAX_DEPTH}`);
+		const pathIndices: number[] = [];
+		for (let d = 0; d < depth; d++) pathIndices.push(u8(po + 1 + d));
+		components.push({
+			muHash: u32(no),
+			debugName: cstr(u32(no + 4), `component[${i}] debugName`),
+			pathIndices,
+		});
+	}
+
+	const triggerParameters: FlaptTriggerParameters[] = [];
+	for (let i = 0; i < h.numTriggers; i++) {
+		const o = h.pTriggers + i * TRIGGER_PARAMS_SIZE;
+		const p = (j: number) => {
+			const ptr = u32(o + j * 4);
+			return ptr === 0 ? null : cstr(ptr, `trigger[${i}].parameter${j}`);
+		};
+		triggerParameters.push({ parameter0: p(0), parameter1: p(1), parameter2: p(2), parameter3: p(3) });
+	}
+
+	const strings: string[] = [];
+	for (let i = 0; i < h.numStrings; i++) strings.push(cstr(u32(h.ppStrings + i * 4), `string[${i}]`));
+
+	const specialTextureNames: string[] = [];
+	for (let i = 0; i < h.numSpecialTextures; i++) {
+		specialTextureNames.push(cstr(u32(h.ppSpecialTextureNames + i * 4), `specialTexture[${i}] name`));
+	}
+
+	// --- Inline BND2 import table: entry k binds texture slot (fixup-ppTextures)/4 ---
+	const textures: FlaptTexture[] = Array.from({ length: h.numTextures }, () => ({ resourceId: null }));
+	const importStart = align16(h.muSizeInBytes);
+	const importCount = (bytes.length - importStart) / IMPORT_ENTRY_SIZE;
+	for (let k = 0; k < importCount; k++) {
+		const e = importStart + k * IMPORT_ENTRY_SIZE;
+		const fixup = u32(e + 8);
+		if (u32(e + 12) !== 0) fail(`import[${k}] pad word nonzero`);
+		const rel = fixup - h.ppTextures;
+		if (rel < 0 || rel % 4 !== 0 || rel / 4 >= h.numTextures) {
+			fail(`import[${k}] fixup 0x${fixup.toString(16)} does not target a texture slot`);
+		}
+		const slot = rel / 4;
+		if (textures[slot].resourceId !== null) fail(`import[${k}] targets slot ${slot} twice`);
+		textures[slot].resourceId = u64(e);
+	}
+
+	return {
+		muVersion: u8(0),
+		mfTimePerFrame: f32(8),
+		movieClips,
+		textures,
+		vertices,
+		fontStyles,
+		components,
+		triggerParameters,
+		strings,
+		specialTextureNames,
+		debugStringCount: h.debugStringCount,
+		_payload: bytes,
+	};
+}
+
+// =============================================================================
+// Writer — verbatim payload + in-place patches (layout never moves)
+// =============================================================================
+
+export function writeFlaptFile(model: ParsedFlaptFile, littleEndian = true): Uint8Array {
+	const src = model._payload;
+	if (!(src instanceof Uint8Array)) fail('_payload missing — the model must come from parseFlaptFile');
+	const out = new Uint8Array(src);
+	const view = new DataView(out.buffer);
+	const u32 = (o: number) => view.getUint32(o, littleEndian);
+	const h = readHeader(view, out.length, littleEndian);
+
+	const expect = (got: number, want: number, what: string) => {
+		if (got !== want) fail(`${what} length ${got} != payload's ${want} — counts are fixed, the writer only patches in place`);
+	};
+	expect(model.movieClips.length, h.numClips, 'movieClips');
+	expect(model.textures.length, h.numTextures, 'textures');
+	expect(model.vertices.length, h.numVerts, 'vertices');
+	expect(model.fontStyles.length, h.numFonts, 'fontStyles');
+	expect(model.components.length, h.numComponents, 'components');
+	expect(model.triggerParameters.length, h.numTriggers, 'triggerParameters');
+	expect(model.strings.length, h.numStrings, 'strings');
+	expect(model.specialTextureNames.length, h.numSpecialTextures, 'specialTextureNames');
+
+	view.setFloat32(8, model.mfTimePerFrame, littleEndian);
+
+	for (let i = 0; i < model.vertices.length; i++) {
+		const o = h.pVerts + i * VERTEX_SIZE;
+		const v = model.vertices[i];
+		view.setFloat32(o, v.mv2Pos.x, littleEndian);
+		view.setFloat32(o + 4, v.mv2Pos.y, littleEndian);
+		view.setUint32(o + 8, v.mColour >>> 0, littleEndian);
+		view.setFloat32(o + 12, v.mv2Tex0UV.x, littleEndian);
+		view.setFloat32(o + 16, v.mv2Tex0UV.y, littleEndian);
+	}
+
+	for (let i = 0; i < model.fontStyles.length; i++) {
+		const o = h.pFonts + i * FONT_SIZE;
+		view.setUint32(o + 4, model.fontStyles[i].muColour >>> 0, littleEndian);
+		view.setFloat32(o + 8, model.fontStyles[i].mfFontHeight, littleEndian);
+	}
+
+	// Re-emit import-table texture ids through the payload's own slot mapping.
+	const importStart = align16(h.muSizeInBytes);
+	const importCount = (out.length - importStart) / IMPORT_ENTRY_SIZE;
+	const importedSlots = new Set<number>();
+	for (let k = 0; k < importCount; k++) {
+		const e = importStart + k * IMPORT_ENTRY_SIZE;
+		const slot = (u32(e + 8) - h.ppTextures) / 4;
+		if (!Number.isInteger(slot) || slot < 0 || slot >= h.numTextures) {
+			fail(`import[${k}] fixup does not target a texture slot`);
+		}
+		importedSlots.add(slot);
+		const rid = model.textures[slot].resourceId;
+		if (rid == null) fail(`texture slot ${slot} has an import entry but resourceId is null`);
+		view.setUint32(e, Number(rid & 0xffffffffn), littleEndian);
+		view.setUint32(e + 4, Number((rid >> 32n) & 0xffffffffn), littleEndian);
+	}
+	for (let s = 0; s < h.numTextures; s++) {
+		if (!importedSlots.has(s) && model.textures[s].resourceId != null) {
+			fail(`texture slot ${s} is special (resolved by name at runtime) and cannot carry a resourceId`);
+		}
+	}
+
+	return out;
+}
+
+// =============================================================================
+// Helpers shared with the registry handler
+// =============================================================================
+
+export function countFlaptTextureImports(model: ParsedFlaptFile): number {
+	return model.textures.reduce((n, t) => n + (t.resourceId != null ? 1 : 0), 0);
+}
+
+/** Payload-relative import-table location for the envelope writer. */
+export function flaptFileImportTable(payload: Uint8Array, littleEndian = true): { offset: number; count: number } {
+	const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
+	const h = readHeader(view, payload.byteLength, littleEndian);
+	const offset = align16(h.muSizeInBytes);
+	const count = (payload.byteLength - offset) / IMPORT_ENTRY_SIZE;
+	return count === 0 ? { offset: 0, count: 0 } : { offset, count };
+}

--- a/src/lib/core/genericRwacWaveContent.ts
+++ b/src/lib/core/genericRwacWaveContent.ts
@@ -1,0 +1,317 @@
+// GenericRwacWaveContent parser and writer (resource type 0xA020).
+//
+// The primary sound asset of Burnout Paradise: a container for one EA
+// SndPlayer wave (RWAC = RenderWare Audio Core). Car horns, sirens, HUD
+// counters, UI whooshes — SOUND/GLOBALWAVES.BUNDLE alone carries 37.
+//
+// On-disk layout, validated against all 37 retail GLOBALWAVES resources:
+//   0x00  u32 mu32DataSize    — platform-endian BinaryFile wrapper; always
+//   0x04  u32 mu32DataOffset    rawLen-0x10 and 0x10 respectively
+//   0x08  8B  uninitialised    — undocumented gap between the documented
+//                                8-byte BinaryFileResource and the data at
+//                                0x10; carries stale heap garbage (PATH
+//                                fragments etc.) in 4 of 37 retail resources
+//   0x10  BIG-ENDIAN SndPlayer header, bit-packed (BE regardless of platform):
+//         u32  version(4) | codec(4) | channels-1(6) | sampleRate(18)
+//         u32  playType(2) | loopFlag(1) | numSamples(29)
+//         [u32 loopStartSample]      iff loopFlag
+//         [u32 gigaResidentSamples]  iff playType == gigasample
+//   then  chunks until the decoded sample count reaches numSamples:
+//         u32 BE byteCount, u32 BE samples, then byteCount-8 codec bytes —
+//         the byte count INCLUDES the 8-byte chunk header (the wiki's
+//         "number of bytes in the chunk" is ambiguous; the exclusive reading
+//         overruns most retail resources)
+//   then  0-15 pad bytes to 16-byte alignment — usually zero but
+//         uninitialised garbage in 4 of 37 retail resources; preserved
+//         verbatim, regenerated as zeros when an edit changes the length.
+//
+// Spec-vs-bytes findings beyond the chunk-byte-count one:
+//  - Multi-chunk waves exist only when loopStartSample > 0, and the first
+//    chunk boundary lands EXACTLY on the loop start sample — the decoder can
+//    only restart a loop on a chunk boundary. Observed, not asserted: other
+//    bundles may chunk differently.
+//  - Every GLOBALWAVES asset is version 0, codec 5 (EALayer3 v1 int),
+//    play type RAM. Stream/gigasample shapes are unvalidated; their
+//    post-header bytes are preserved as an opaque verbatim blob because the
+//    optional stream-loop-offset header field makes even the header length
+//    undecidable from bytes alone (it exists only "if loop start is in the
+//    stream portion", which is not recoverable without the stream file).
+//  - Resource ids are NOT soundHash/CgsID of the gamedb debug name (tested
+//    full URL, lowercased, basename, and stem variants — no matches).
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Enumerations
+// =============================================================================
+
+// EA::Audio::Core::SndPlayerCodec. Burnout uses EALayer3 v1 int (5) for
+// nearly everything on PC, XAS (0) for some engine sounds.
+export const SNDPLAYER_CODECS = [
+	'XAS',
+	'EALayer3',
+	'Sign16 (big-endian PCM)',
+	'EA-XMA',
+	'XAS v1',
+	'EALayer3 v1',
+	'EALayer3 v2 PCM',
+	'EALayer3 v2 Spike',
+	'GameCube ADPCM',
+	'EASpeex',
+	'ATRAC9',
+	'EAMP3',
+	'EAOpus',
+	'EA-ATRAC9',
+	'MultiStream Opus',
+	'MultiStream Opus (uncoupled)',
+] as const;
+
+// EA::Audio::Core::SndPlayerPlayType. RAM waves are self-contained; stream /
+// gigasample waves keep (some of) their data outside this resource.
+export const SNDPLAYER_PLAY_TYPES = ['RAM', 'Stream', 'Gigasample'] as const;
+
+export const SNDPLAYER_PLAY_TYPE = {
+	RAM: 0,
+	STREAM: 1,
+	GIGASAMPLE: 2,
+} as const;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type WaveDataChunk = {
+	/** Sample frames this chunk decodes to. */
+	samples: number;
+	/** Opaque codec payload (on-disk chunk byte count = data.byteLength + 8). */
+	data: Uint8Array;
+};
+
+export type ParsedGenericRwacWaveContent = {
+	/** SNDPLAYER_VERSION_BITS — 0 in every retail resource. */
+	version: number;
+	/** Index into SNDPLAYER_CODECS. */
+	codec: number;
+	/** Human channel count (stored -1 on disk); 1 = mono, 2 = stereo. */
+	channels: number;
+	/** Sample rate in Hz (18-bit field, max 262143). */
+	sampleRate: number;
+	/** Index into SNDPLAYER_PLAY_TYPES. */
+	playType: number;
+	/** Loop start sample; null = loop flag clear (one-shot asset). */
+	loopStartSample: number | null;
+	/** Gigasample only: samples of the RAM-resident portion. Null otherwise. */
+	gigaResidentSamples: number | null;
+	/** Total samples. Derived from the chunks on write for RAM waves. */
+	numSamples: number;
+	/** Codec data, in playback order. RAM waves only; empty otherwise. */
+	chunks: WaveDataChunk[];
+	/** Bytes 0x08-0x0F of the BinaryFile wrapper — uninitialised, preserved verbatim. */
+	_binPad: Uint8Array;
+	/** 0-15 pad bytes to 16-byte alignment — preserved verbatim while the
+	 *  length still fits, regenerated as zeros after a size-changing edit. */
+	_trailingPad: Uint8Array;
+	/** Stream/gigasample waves: everything after the header, verbatim
+	 *  (unvalidated shape — no fixture exercises it). Null for RAM. */
+	_unchunkedData: Uint8Array | null;
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const DATA_OFFSET = 0x10;
+const CHUNK_HEADER_SIZE = 8;
+const align16 = (n: number) => (n + 15) & ~15;
+
+/** Playback length in seconds, NaN-safe for picker sort keys. */
+export function waveDurationSeconds(model: { numSamples: number; sampleRate: number }): number {
+	return model.sampleRate > 0 ? model.numSamples / model.sampleRate : 0;
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+export function parseGenericRwacWaveContent(
+	raw: Uint8Array,
+	littleEndian = true,
+): ParsedGenericRwacWaveContent {
+	// Copy up front — extractResourceRaw may hand back a Buffer view, and the
+	// verbatim chunk/pad fields below must not alias the caller's bytes.
+	const bytes = new Uint8Array(raw);
+	if (bytes.byteLength < DATA_OFFSET + 8) {
+		throw new Error(`GenericRwacWaveContent: ${bytes.byteLength} bytes is too small for wrapper + header`);
+	}
+	const wrap = new BinReader(bytes.buffer, littleEndian);
+	const dataSize = wrap.readU32();
+	const dataOffset = wrap.readU32();
+
+	// The layout is rigid; bail loudly on violations rather than silently
+	// producing a model that won't round-trip.
+	if (dataOffset !== DATA_OFFSET) {
+		throw new Error(`GenericRwacWaveContent: mu32DataOffset is 0x${dataOffset.toString(16)}, expected 0x10`);
+	}
+	if (dataOffset + dataSize !== bytes.byteLength) {
+		throw new Error(`GenericRwacWaveContent: mu32DataSize 0x${dataSize.toString(16)} + offset != resource size 0x${bytes.byteLength.toString(16)}`);
+	}
+	const _binPad = bytes.slice(8, DATA_OFFSET);
+
+	// SndPlayer header — big-endian regardless of platform.
+	const be = new BinReader(bytes.buffer, false);
+	be.position = DATA_OFFSET;
+	const h1 = be.readU32();
+	const version = h1 >>> 28;
+	const codec = (h1 >>> 24) & 0xf;
+	const channels = ((h1 >>> 18) & 0x3f) + 1;
+	const sampleRate = h1 & 0x3ffff;
+	const h2 = be.readU32();
+	const playType = h2 >>> 30;
+	const loopFlag = (h2 >>> 29) & 1;
+	const numSamples = h2 & 0x1fffffff;
+	if (playType >= SNDPLAYER_PLAY_TYPES.length) {
+		throw new Error(`GenericRwacWaveContent: play type ${playType} is out of range`);
+	}
+	const loopStartSample = loopFlag ? be.readU32() : null;
+	const gigaResidentSamples = playType === SNDPLAYER_PLAY_TYPE.GIGASAMPLE ? be.readU32() : null;
+
+	if (playType !== SNDPLAYER_PLAY_TYPE.RAM) {
+		// Header length is undecidable past this point (see file header), so
+		// everything else is one verbatim blob.
+		return {
+			version, codec, channels, sampleRate, playType,
+			loopStartSample, gigaResidentSamples, numSamples,
+			chunks: [],
+			_binPad,
+			_trailingPad: new Uint8Array(0),
+			_unchunkedData: bytes.slice(be.position),
+		};
+	}
+
+	// --- Chunks: walk until the decoded sample count reaches numSamples. ---
+	const chunks: WaveDataChunk[] = [];
+	let decoded = 0;
+	while (decoded < numSamples) {
+		if (be.position + CHUNK_HEADER_SIZE > bytes.byteLength) {
+			throw new Error(`GenericRwacWaveContent: ran out of bytes at 0x${be.position.toString(16)} with ${decoded}/${numSamples} samples decoded`);
+		}
+		const byteCount = be.readU32();
+		const samples = be.readU32();
+		if (byteCount <= CHUNK_HEADER_SIZE) {
+			throw new Error(`GenericRwacWaveContent: chunk at 0x${(be.position - CHUNK_HEADER_SIZE).toString(16)} claims ${byteCount} bytes (must exceed its 8-byte header)`);
+		}
+		const end = be.position + (byteCount - CHUNK_HEADER_SIZE);
+		if (end > bytes.byteLength) {
+			throw new Error(`GenericRwacWaveContent: chunk data overruns the resource (ends 0x${end.toString(16)} of 0x${bytes.byteLength.toString(16)})`);
+		}
+		decoded += samples;
+		if (decoded > numSamples) {
+			throw new Error(`GenericRwacWaveContent: chunk samples sum to ${decoded}, exceeding the header's ${numSamples}`);
+		}
+		chunks.push({ samples, data: bytes.slice(be.position, end) });
+		be.position = end;
+	}
+
+	// --- Trailing pad: 0-15 bytes to 16-byte alignment, captured verbatim. ---
+	const padLen = bytes.byteLength - be.position;
+	if (padLen >= 16 || align16(be.position) !== bytes.byteLength) {
+		throw new Error(`GenericRwacWaveContent: ${padLen} trailing bytes after the last chunk — expected 0-15 zero/garbage pad bytes to 16-byte alignment`);
+	}
+	const _trailingPad = bytes.slice(be.position);
+
+	return {
+		version, codec, channels, sampleRate, playType,
+		loopStartSample, gigaResidentSamples, numSamples,
+		chunks,
+		_binPad,
+		_trailingPad,
+		_unchunkedData: null,
+	};
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+function writeU32BE(w: BinWriter, v: number) {
+	w.writeU8((v >>> 24) & 0xff);
+	w.writeU8((v >>> 16) & 0xff);
+	w.writeU8((v >>> 8) & 0xff);
+	w.writeU8(v & 0xff);
+}
+
+export function writeGenericRwacWaveContent(
+	model: ParsedGenericRwacWaveContent,
+	littleEndian = true,
+): Uint8Array {
+	const { version, codec, channels, sampleRate, playType } = model;
+	if (version < 0 || version > 0xf) throw new Error(`GenericRwacWaveContent writer: version ${version} exceeds 4 bits`);
+	if (codec < 0 || codec > 0xf) throw new Error(`GenericRwacWaveContent writer: codec ${codec} exceeds 4 bits`);
+	if (channels < 1 || channels > 64) throw new Error(`GenericRwacWaveContent writer: ${channels} channels outside 1-64`);
+	if (sampleRate < 0 || sampleRate > 0x3ffff) throw new Error(`GenericRwacWaveContent writer: sample rate ${sampleRate} exceeds 18 bits`);
+	if (playType < 0 || playType >= SNDPLAYER_PLAY_TYPES.length) throw new Error(`GenericRwacWaveContent writer: play type ${playType} out of range`);
+	if (model._binPad.byteLength !== 8) throw new Error(`GenericRwacWaveContent writer: _binPad must be exactly 8 bytes, got ${model._binPad.byteLength}`);
+
+	const isRam = playType === SNDPLAYER_PLAY_TYPE.RAM;
+	if (isRam && model._unchunkedData != null) {
+		throw new Error('GenericRwacWaveContent writer: RAM waves store data in chunks, not _unchunkedData');
+	}
+	if ((model.gigaResidentSamples != null) !== (playType === SNDPLAYER_PLAY_TYPE.GIGASAMPLE)) {
+		throw new Error('GenericRwacWaveContent writer: gigaResidentSamples must be set exactly when play type is gigasample');
+	}
+	if (!isRam && model.chunks.length > 0) {
+		throw new Error('GenericRwacWaveContent writer: stream/gigasample waves carry no chunks in this resource');
+	}
+
+	// Total samples is the source of truth in the chunks for RAM waves; the
+	// header field is re-derived so chunk edits can't desync it.
+	const numSamples = isRam
+		? model.chunks.reduce((sum, c) => sum + c.samples, 0)
+		: model.numSamples;
+	if (numSamples > 0x1fffffff) throw new Error(`GenericRwacWaveContent writer: ${numSamples} samples exceeds 29 bits`);
+	if (model.loopStartSample != null && (model.loopStartSample < 0 || model.loopStartSample > 0xffffffff)) {
+		throw new Error(`GenericRwacWaveContent writer: loop start ${model.loopStartSample} is not a u32`);
+	}
+
+	const headerLen = 8
+		+ (model.loopStartSample != null ? 4 : 0)
+		+ (model.gigaResidentSamples != null ? 4 : 0);
+	const chunksLen = isRam
+		? model.chunks.reduce((sum, c) => sum + CHUNK_HEADER_SIZE + c.data.byteLength, 0)
+		: (model._unchunkedData?.byteLength ?? 0);
+	const contentEnd = DATA_OFFSET + headerLen + chunksLen;
+	// Reuse the captured garbage pad while the length still fits so untouched
+	// models round-trip byte-exact; regenerate as zeros after an edit moved
+	// the end.
+	const padLen = isRam ? align16(contentEnd) - contentEnd : 0;
+	const pad = model._trailingPad.byteLength === padLen
+		? model._trailingPad
+		: new Uint8Array(padLen);
+	const totalSize = contentEnd + padLen;
+
+	const w = new BinWriter(totalSize, littleEndian);
+	w.writeU32(totalSize - DATA_OFFSET); // mu32DataSize
+	w.writeU32(DATA_OFFSET); // mu32DataOffset
+	w.writeBytes(model._binPad);
+
+	writeU32BE(w, ((version & 0xf) << 28) | ((codec & 0xf) << 24) | (((channels - 1) & 0x3f) << 18) | sampleRate);
+	writeU32BE(w, ((playType & 3) << 30) | (model.loopStartSample != null ? 1 << 29 : 0) | numSamples);
+	if (model.loopStartSample != null) writeU32BE(w, model.loopStartSample);
+	if (model.gigaResidentSamples != null) writeU32BE(w, model.gigaResidentSamples);
+
+	if (isRam) {
+		for (const chunk of model.chunks) {
+			writeU32BE(w, CHUNK_HEADER_SIZE + chunk.data.byteLength);
+			writeU32BE(w, chunk.samples);
+			w.writeBytes(chunk.data);
+		}
+		if (pad.byteLength > 0) w.writeBytes(pad);
+	} else if (model._unchunkedData != null) {
+		w.writeBytes(model._unchunkedData);
+	}
+
+	if (w.offset !== totalSize) {
+		throw new Error(`GenericRwacWaveContent writer: wrote 0x${w.offset.toString(16)} bytes, expected 0x${totalSize.toString(16)}`);
+	}
+	return w.bytes;
+}

--- a/src/lib/core/nicotine.ts
+++ b/src/lib/core/nicotine.ts
@@ -1,0 +1,537 @@
+// Nicotine parser and writer (resource type 0xA024, "Nicotine Map").
+//
+// Nicotine is EA's sound-mixing middleware (names from ProStreet PS2
+// symbols). A Nicotine map holds the mixer graph the game drives at runtime:
+// a set of mix STATES (engine-selected by index 0x1F0000+n), each carrying up
+// to six sections — mix controls, event controls, 3D mix controls, submix
+// channels, master mix channels, and per-channel preset data. Retail ships
+// exactly two maps: NicotineAssetMain (stereo) and NicotineAssetSurround
+// (5.1). Both have identical structure (9 states, 141 channels); they differ
+// in only 16 u32 words — attenuation values, consistent with i16 lanes in
+// hundredths of a dB (0xD8F0 = -10000 = -100.00 dB floor; deltas -100..-1200
+// = -1..-12 dB). The companion SnapshotData (0xA029) resource references this
+// map's MASTER mix channels by their MIXCHID word (verified: all 72 snapshot
+// channel ids appear verbatim among the 111 master MIXCHIDs; none among the
+// submix ids).
+//
+// On-disk layout (32-bit PC LE; offsets are integers, never pointers, so the
+// wiki notes there is no 64-bit variant):
+//   CgsResource::BinaryFileResource wrapper: u32 dataSize, u32 dataOffset(=8).
+//   All offsets below are relative to dataOffset (the "data base").
+//   +0x00 stMixMapHeader: MixMapID(0), NumStates, StateTableOffset(=0x10),
+//         DynamicMapOffset(=-1).
+//   +0x10 state table: NumStates data-relative offsets, then trailing -1
+//         sentinel slots (4 in retail — the wiki doesn't mention them).
+//   States pack back-to-back. Each starts with an 8-u32 stMixMapStateHdr
+//   (StateIndex + 6 section offsets + Reserved_07=-1) whose section offsets
+//   are STATE-relative (the wiki doesn't say relative to what; validated by
+//   walking both retail maps). Sections always appear in the order mixCtl,
+//   event, 3D, submix, master, preset — absent ones store -1.
+//
+// Variable-length record rules (wiki phrasing decoded against real bytes —
+// "second byte" means the second-highest byte, bits 16-23; "last byte" the
+// least-significant byte):
+//   stMixCtlParams / stMixEvtParams: extra u32 count = bits 16-23 of
+//     nUScaleCntSwing.
+//   stSubMixChParams / stMasterMixChParams: extra count = bits 16-23 of
+//     MIXCHID.
+//   st3DMixCtlParams: total st3DStateParams = low nibble of the top byte of
+//     nINPUTID, minimum 1 (the inline one counts).
+//   Preset entries: no own header — entry count = the master section's
+//     NumMixChannels; per-entry extra count = bits 0-7 of the first word.
+//   Walking both fixtures with these rules lands exactly on every section,
+//   state, and resource boundary.
+//
+// Nearly every value word is an undocumented bit field — preserved verbatim.
+// The writer recomputes the BinaryFile sizes, all section/state/table
+// offsets, and the primary counts; embedded per-record counts live inside
+// bit-field words we can't safely rewrite, so the writer validates array
+// lengths against them and throws on mismatch. Event header Reserved_02/03
+// carry garbage (0x08E50064 + stale heap pointers) — preserved verbatim.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type NicotineMixControl = {
+	nInputId: number; // u32 bit field
+	/** Bit field; bits 16-23 are extraData.length — edit both together. */
+	nUScaleCntSwing: number;
+	extraData: number[]; // u32[]
+};
+
+export type Nicotine3DStateParams = {
+	n3DStateInfoId: number;
+	nCurveIdDoppler: number;
+	nQ0MinMax: number;
+	nQ1MinMax: number;
+	nQ2MinMax: number;
+	nQ3MinMax: number;
+};
+
+export type Nicotine3DMixControl = {
+	/** Bit field; low nibble of the top byte is stateParams.length (min 1). */
+	nInputId: number;
+	stateParams: Nicotine3DStateParams[];
+};
+
+export type NicotineSubMixChannel = {
+	/** Bit field (0xD0-prefixed in retail); bits 16-23 are procOffsets.length. */
+	mixChId: number;
+	upperLowerSwing: number;
+	/** stSubMixStateParams nOffsetSubMixProc words — meaning undocumented. */
+	procOffsets: number[];
+};
+
+export type NicotineMasterMixChannel = {
+	/**
+	 * Bit field (0xC0/0xC1/0xC2-prefixed in retail); bits 16-23 are
+	 * extraData.length. SnapshotData channels reference master channels by
+	 * this exact word.
+	 */
+	mixChId: number;
+	mixData: number;
+	sfxObjId: number;
+	extraData: number[];
+};
+
+export type NicotinePresetEntry = {
+	/** Bit field (0xE0-prefixed in retail); bits 0-7 are extraData.length. */
+	header: number;
+	extraData: number[];
+};
+
+export type NicotineMixEvent = {
+	nEvtCtlId: number;
+	/** Bit field; bits 16-23 are extraData.length. */
+	nUScaleCntSwing: number;
+	nTriggerId: number;
+	nParam00: number;
+	nParam01: number;
+	nParam02: number;
+	extraData: number[];
+};
+
+export type NicotineMixCtlSection = {
+	/** Equals controls.length in every retail section — preserved verbatim. */
+	numNewMixDataProcs: number;
+	numMainMixDataProcs: number;
+	numMainMixCtlOut: number;
+	controls: NicotineMixControl[];
+};
+
+export type Nicotine3DSection = {
+	numMainMap3DMixCtls: number;
+	_reserved02: number;
+	_reserved03: number;
+	controls: Nicotine3DMixControl[];
+};
+
+// stMixChHdr — shared by the submix and master sections.
+export type NicotineChannelSection<C> = {
+	numUniqueSfxObjs: number;
+	numMainIn: number;
+	numSecIn: number;
+	channels: C[];
+};
+
+export type NicotineEventSection = {
+	/** Mirrors events.length in every retail section — preserved verbatim. */
+	_reserved01: number;
+	/** 0x08E50064 in every retail section — looks like a stale pointer. */
+	_reserved02: number;
+	/** Varies per section — stale heap garbage, preserved verbatim. */
+	_reserved03: number;
+	events: NicotineMixEvent[];
+};
+
+export type NicotineState = {
+	/** Engine lookup id — 0x1F0000 + state position in retail. */
+	stateIndex: number;
+	mixControls: NicotineMixCtlSection | null;
+	threeDControls: Nicotine3DSection | null;
+	subMix: NicotineChannelSection<NicotineSubMixChannel> | null;
+	masterMix: NicotineChannelSection<NicotineMasterMixChannel> | null;
+	/** Per-master-channel preset data; length must equal masterMix.channels.length. */
+	presets: NicotinePresetEntry[] | null;
+	events: NicotineEventSection | null;
+};
+
+export type ParsedNicotine = {
+	/** Always 0 in retail. */
+	mixMapId: number;
+	states: NicotineState[];
+	/** Trailing -1 slots after the state table's real entries (4 in retail). */
+	_stateTableSentinelSlots: number;
+};
+
+// =============================================================================
+// Constants / helpers
+// =============================================================================
+
+const WRAPPER_SIZE = 0x8;
+const STATE_TABLE_OFFSET = 0x10;
+const STATE_HEADER_SIZE = 0x20;
+
+const align16 = (n: number) => (n + 15) & ~15;
+/** Byte i of a u32 counting from the most-significant end (wiki's "first byte"). */
+const byteFromTop = (v: number, i: number) => (v >>> (8 * (3 - i))) & 0xff;
+
+/** Total st3DStateParams a 3D control owns, decoded from its nINPUTID. */
+export const threeDStateParamCount = (nInputId: number) => Math.max((nInputId >>> 24) & 0xf, 1);
+/** Extra-u32 count packed into bits 16-23 of swing/MIXCHID words. */
+export const packedExtraCount = (word: number) => byteFromTop(word, 1);
+/** Preset extra-u32 count packed into bits 0-7 of the entry's first word. */
+export const presetExtraCount = (header: number) => header & 0xff;
+
+function fail(msg: string): never {
+	throw new Error(`Nicotine: ${msg}`);
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+function readExtras(r: BinReader, count: number): number[] {
+	const out: number[] = [];
+	for (let i = 0; i < count; i++) out.push(r.readU32());
+	return out;
+}
+
+export function parseNicotine(raw: Uint8Array, littleEndian = true): ParsedNicotine {
+	const buf = raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength);
+	const bytes = new Uint8Array(buf);
+	const r = new BinReader(buf, littleEndian);
+
+	// --- BinaryFile wrapper ---
+	const dataSize = r.readU32();
+	const dataOffset = r.readU32();
+	if (dataOffset !== WRAPPER_SIZE) fail(`dataOffset is 0x${dataOffset.toString(16)}, expected 0x8 (rigid layout)`);
+	if (raw.byteLength !== align16(dataOffset + dataSize)) {
+		fail(`resource is 0x${raw.byteLength.toString(16)} bytes, expected 0x${align16(dataOffset + dataSize).toString(16)} (dataSize + 16-byte alignment pad)`);
+	}
+	for (let i = dataOffset + dataSize; i < raw.byteLength; i++) {
+		if (bytes[i] !== 0) fail(`non-zero alignment-pad byte at 0x${i.toString(16)}`);
+	}
+	const D = dataOffset;
+
+	// --- stMixMapHeader ---
+	const mixMapId = r.readU32();
+	const numStates = r.readU32();
+	const stateTableOffset = r.readU32();
+	if (stateTableOffset !== STATE_TABLE_OFFSET) fail(`StateTableOffset is 0x${stateTableOffset.toString(16)}, expected 0x10 (rigid layout)`);
+	const dynamicMapOffset = r.readI32();
+	if (dynamicMapOffset !== -1) fail(`DynamicMapOffset is ${dynamicMapOffset}, expected -1 (rigid layout)`);
+
+	// --- State table (real entries + trailing -1 sentinels) ---
+	if (numStates === 0) fail('zero states — sentinel-slot count would be ambiguous');
+	const stateOffs: number[] = [];
+	for (let i = 0; i < numStates; i++) {
+		const off = r.readI32();
+		if (off < 0 || D + off + STATE_HEADER_SIZE > D + dataSize) fail(`state table entry [${i}] = ${off} out of range`);
+		stateOffs.push(off);
+	}
+	const sentinelSlots = (stateOffs[0] - STATE_TABLE_OFFSET) / 4 - numStates;
+	if (!Number.isInteger(sentinelSlots) || sentinelSlots < 0) fail(`state table does not end on the first state (first offset 0x${stateOffs[0].toString(16)})`);
+	for (let i = 0; i < sentinelSlots; i++) {
+		const v = r.readI32();
+		if (v !== -1) fail(`state table sentinel slot [${i}] is ${v}, expected -1`);
+	}
+
+	const states: NicotineState[] = [];
+	for (let s = 0; s < numStates; s++) {
+		const end = s + 1 < numStates ? stateOffs[s + 1] : dataSize;
+		states.push(parseState(r, D, stateOffs[s], end, s));
+	}
+
+	return { mixMapId, states, _stateTableSentinelSlots: sentinelSlots };
+}
+
+function parseState(r: BinReader, D: number, stateOff: number, stateEnd: number, s: number): NicotineState {
+	const S = D + stateOff;
+	r.position = S;
+	const stateIndex = r.readU32();
+	const offMixCtl = r.readI32();
+	const off3D = r.readI32();
+	const offSubMix = r.readI32();
+	const offMaster = r.readI32();
+	const offPreset = r.readI32();
+	const offEvent = r.readI32();
+	const offReserved07 = r.readI32();
+	if (offReserved07 !== -1) fail(`state[${s}] Offset_Reserved_07 is ${offReserved07}, expected -1`);
+
+	const state: NicotineState = {
+		stateIndex,
+		mixControls: null,
+		threeDControls: null,
+		subMix: null,
+		masterMix: null,
+		presets: null,
+		events: null,
+	};
+
+	// Sections live in a fixed canonical order; assert each present section
+	// starts exactly where the previous one ended so the writer's offset
+	// recomputation is provably byte-exact.
+	let cursor = STATE_HEADER_SIZE;
+	const expectAt = (name: string, off: number) => {
+		if (off !== cursor) fail(`state[${s}] ${name} section at +0x${off.toString(16)}, expected +0x${cursor.toString(16)} (canonical order: mixCtl, event, 3D, submix, master, preset)`);
+		r.position = S + off;
+	};
+
+	if (offMixCtl !== -1) {
+		expectAt('mixCtl', offMixCtl);
+		const num = r.readU32();
+		const numNewMixDataProcs = r.readU32();
+		const numMainMixDataProcs = r.readU32();
+		const numMainMixCtlOut = r.readU32();
+		const controls: NicotineMixControl[] = [];
+		for (let i = 0; i < num; i++) {
+			const nInputId = r.readU32();
+			const nUScaleCntSwing = r.readU32();
+			controls.push({ nInputId, nUScaleCntSwing, extraData: readExtras(r, packedExtraCount(nUScaleCntSwing)) });
+		}
+		state.mixControls = { numNewMixDataProcs, numMainMixDataProcs, numMainMixCtlOut, controls };
+		cursor = r.position - S;
+	}
+
+	if (offEvent !== -1) {
+		expectAt('event', offEvent);
+		const num = r.readU32();
+		const _reserved01 = r.readU32();
+		const _reserved02 = r.readU32();
+		const _reserved03 = r.readU32();
+		const events: NicotineMixEvent[] = [];
+		for (let i = 0; i < num; i++) {
+			const nEvtCtlId = r.readU32();
+			const nUScaleCntSwing = r.readU32();
+			const nTriggerId = r.readU32();
+			const nParam00 = r.readU32();
+			const nParam01 = r.readU32();
+			const nParam02 = r.readU32();
+			events.push({ nEvtCtlId, nUScaleCntSwing, nTriggerId, nParam00, nParam01, nParam02, extraData: readExtras(r, packedExtraCount(nUScaleCntSwing)) });
+		}
+		state.events = { _reserved01, _reserved02, _reserved03, events };
+		cursor = r.position - S;
+	}
+
+	if (off3D !== -1) {
+		expectAt('3D', off3D);
+		const num = r.readU32();
+		const numMainMap3DMixCtls = r.readU32();
+		const _reserved02 = r.readU32();
+		const _reserved03 = r.readU32();
+		const controls: Nicotine3DMixControl[] = [];
+		for (let i = 0; i < num; i++) {
+			const nInputId = r.readU32();
+			const stateParams: Nicotine3DStateParams[] = [];
+			for (let p = 0; p < threeDStateParamCount(nInputId); p++) {
+				stateParams.push({
+					n3DStateInfoId: r.readU32(),
+					nCurveIdDoppler: r.readU32(),
+					nQ0MinMax: r.readU32(),
+					nQ1MinMax: r.readU32(),
+					nQ2MinMax: r.readU32(),
+					nQ3MinMax: r.readU32(),
+				});
+			}
+			controls.push({ nInputId, stateParams });
+		}
+		state.threeDControls = { numMainMap3DMixCtls, _reserved02, _reserved03, controls };
+		cursor = r.position - S;
+	}
+
+	if (offSubMix !== -1) {
+		expectAt('submix', offSubMix);
+		const num = r.readU32();
+		const numUniqueSfxObjs = r.readU32();
+		const numMainIn = r.readU32();
+		const numSecIn = r.readU32();
+		const channels: NicotineSubMixChannel[] = [];
+		for (let i = 0; i < num; i++) {
+			const mixChId = r.readU32();
+			const upperLowerSwing = r.readU32();
+			channels.push({ mixChId, upperLowerSwing, procOffsets: readExtras(r, packedExtraCount(mixChId)) });
+		}
+		state.subMix = { numUniqueSfxObjs, numMainIn, numSecIn, channels };
+		cursor = r.position - S;
+	}
+
+	if (offMaster !== -1) {
+		expectAt('master', offMaster);
+		const num = r.readU32();
+		const numUniqueSfxObjs = r.readU32();
+		const numMainIn = r.readU32();
+		const numSecIn = r.readU32();
+		const channels: NicotineMasterMixChannel[] = [];
+		for (let i = 0; i < num; i++) {
+			const mixChId = r.readU32();
+			const mixData = r.readU32();
+			const sfxObjId = r.readU32();
+			channels.push({ mixChId, mixData, sfxObjId, extraData: readExtras(r, packedExtraCount(mixChId)) });
+		}
+		state.masterMix = { numUniqueSfxObjs, numMainIn, numSecIn, channels };
+		cursor = r.position - S;
+	}
+
+	if (offPreset !== -1) {
+		expectAt('preset', offPreset);
+		if (state.masterMix == null) fail(`state[${s}] has preset data but no master mix section to size it`);
+		const presets: NicotinePresetEntry[] = [];
+		for (let i = 0; i < state.masterMix.channels.length; i++) {
+			const header = r.readU32();
+			presets.push({ header, extraData: readExtras(r, presetExtraCount(header)) });
+		}
+		state.presets = presets;
+		cursor = r.position - S;
+	}
+
+	if (cursor !== stateEnd - stateOff) {
+		fail(`state[${s}] sections end at +0x${cursor.toString(16)}, expected +0x${(stateEnd - stateOff).toString(16)}`);
+	}
+	return state;
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+function writeExtras(w: BinWriter, extras: number[], expected: number, what: string) {
+	if (extras.length !== expected) {
+		throw new Error(`Nicotine writer: ${what} has ${extras.length} extra words but its packed count byte says ${expected} — edit both together`);
+	}
+	for (const v of extras) w.writeU32(v);
+}
+
+export function writeNicotine(model: ParsedNicotine, littleEndian = true): Uint8Array {
+	if (model.states.length === 0) throw new Error('Nicotine writer: at least one state is required');
+	const w = new BinWriter(8192, littleEndian);
+	w.writeU32(0); // dataSize — fixed up below
+	w.writeU32(WRAPPER_SIZE);
+	const D = WRAPPER_SIZE;
+
+	w.writeU32(model.mixMapId);
+	w.writeU32(model.states.length);
+	w.writeU32(STATE_TABLE_OFFSET);
+	w.writeI32(-1); // DynamicMapOffset
+
+	const tableAt = w.offset;
+	for (let i = 0; i < model.states.length + model._stateTableSentinelSlots; i++) w.writeI32(-1);
+
+	model.states.forEach((state, s) => {
+		w.setU32(tableAt + s * 4, w.offset - D);
+		writeState(w, state, s);
+	});
+
+	w.setU32(0, w.offset - D); // dataSize excludes the alignment pad
+	const pad = (16 - (w.offset % 16)) % 16;
+	w.writeZeroes(pad);
+	return w.bytes;
+}
+
+function writeState(w: BinWriter, state: NicotineState, s: number) {
+	const S = w.offset;
+	w.writeU32(state.stateIndex);
+	for (let i = 0; i < 6; i++) w.writeI32(-1); // section offsets — fixed up below
+	w.writeI32(-1); // Offset_Reserved_07
+	const fixup = (slot: number) => w.setU32(S + 4 + slot * 4, w.offset - S);
+
+	if (state.mixControls) {
+		fixup(0);
+		const sec = state.mixControls;
+		w.writeU32(sec.controls.length);
+		w.writeU32(sec.numNewMixDataProcs);
+		w.writeU32(sec.numMainMixDataProcs);
+		w.writeU32(sec.numMainMixCtlOut);
+		sec.controls.forEach((c, i) => {
+			w.writeU32(c.nInputId);
+			w.writeU32(c.nUScaleCntSwing);
+			writeExtras(w, c.extraData, packedExtraCount(c.nUScaleCntSwing), `state[${s}] mixControls[${i}]`);
+		});
+	}
+
+	if (state.events) {
+		fixup(5);
+		const sec = state.events;
+		w.writeU32(sec.events.length);
+		w.writeU32(sec._reserved01);
+		w.writeU32(sec._reserved02);
+		w.writeU32(sec._reserved03);
+		sec.events.forEach((e, i) => {
+			w.writeU32(e.nEvtCtlId);
+			w.writeU32(e.nUScaleCntSwing);
+			w.writeU32(e.nTriggerId);
+			w.writeU32(e.nParam00);
+			w.writeU32(e.nParam01);
+			w.writeU32(e.nParam02);
+			writeExtras(w, e.extraData, packedExtraCount(e.nUScaleCntSwing), `state[${s}] events[${i}]`);
+		});
+	}
+
+	if (state.threeDControls) {
+		fixup(1);
+		const sec = state.threeDControls;
+		w.writeU32(sec.controls.length);
+		w.writeU32(sec.numMainMap3DMixCtls);
+		w.writeU32(sec._reserved02);
+		w.writeU32(sec._reserved03);
+		sec.controls.forEach((c, i) => {
+			if (c.stateParams.length !== threeDStateParamCount(c.nInputId)) {
+				throw new Error(`Nicotine writer: state[${s}] threeDControls[${i}] has ${c.stateParams.length} state params but nInputId's packed nibble says ${threeDStateParamCount(c.nInputId)}`);
+			}
+			w.writeU32(c.nInputId);
+			for (const p of c.stateParams) {
+				w.writeU32(p.n3DStateInfoId);
+				w.writeU32(p.nCurveIdDoppler);
+				w.writeU32(p.nQ0MinMax);
+				w.writeU32(p.nQ1MinMax);
+				w.writeU32(p.nQ2MinMax);
+				w.writeU32(p.nQ3MinMax);
+			}
+		});
+	}
+
+	if (state.subMix) {
+		fixup(2);
+		const sec = state.subMix;
+		w.writeU32(sec.channels.length);
+		w.writeU32(sec.numUniqueSfxObjs);
+		w.writeU32(sec.numMainIn);
+		w.writeU32(sec.numSecIn);
+		sec.channels.forEach((c, i) => {
+			w.writeU32(c.mixChId);
+			w.writeU32(c.upperLowerSwing);
+			writeExtras(w, c.procOffsets, packedExtraCount(c.mixChId), `state[${s}] subMix[${i}]`);
+		});
+	}
+
+	if (state.masterMix) {
+		fixup(3);
+		const sec = state.masterMix;
+		w.writeU32(sec.channels.length);
+		w.writeU32(sec.numUniqueSfxObjs);
+		w.writeU32(sec.numMainIn);
+		w.writeU32(sec.numSecIn);
+		sec.channels.forEach((c, i) => {
+			w.writeU32(c.mixChId);
+			w.writeU32(c.mixData);
+			w.writeU32(c.sfxObjId);
+			writeExtras(w, c.extraData, packedExtraCount(c.mixChId), `state[${s}] masterMix[${i}]`);
+		});
+	}
+
+	if (state.presets) {
+		fixup(4);
+		// The preset array has no header — the runtime sizes it from the master
+		// section's NumMixChannels, so the two must agree.
+		if (state.masterMix == null || state.presets.length !== state.masterMix.channels.length) {
+			throw new Error(`Nicotine writer: state[${s}] has ${state.presets.length} presets but ${state.masterMix?.channels.length ?? 'no'} master mix channels — counts must match`);
+		}
+		state.presets.forEach((p, i) => {
+			w.writeU32(p.header);
+			writeExtras(w, p.extraData, presetExtraCount(p.header), `state[${s}] presets[${i}]`);
+		});
+	}
+}

--- a/src/lib/core/registry/handlers/aemsBank.ts
+++ b/src/lib/core/registry/handlers/aemsBank.ts
@@ -1,0 +1,124 @@
+// AemsBank registry handler — thin wrapper around parseAemsBank /
+// writeAemsBank in src/lib/core/aemsBank.ts.
+//
+// Every retail AEMS bundle carries exactly ONE bank resource, so no picker.
+// Read is marked partial: the compiled module (x86 glue code) and the SND10
+// sample bank are preserved as opaque blobs — only the envelope, fixup
+// tables, and CSIS interface references are decoded.
+
+import {
+	parseAemsBank,
+	writeAemsBank,
+	aemsSfxBankInfo,
+	type ParsedAemsBank,
+} from '../../aemsBank';
+import type { ResourceHandler } from '../handler';
+
+export const aemsBankHandler: ResourceHandler<ParsedAemsBank> = {
+	typeId: 0xa022,
+	key: 'aemsBank',
+	name: 'AEMS Bank',
+	description: 'Event-driven audio bank — a compiled AEMS module (x86 glue code + static data) plus an SND10 sample bank holding the boost / skid / scrape / horn / surface sounds; binds to the CSIS subscription system via tail interface references',
+	category: 'Audio',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/AEMS_Bank',
+	notes: 'The module interior (compiled x86 glue) and the SND10 sample bank are opaque verbatim blobs — the decoded surface is the envelope, the load-time fixup tables, and the CSIS class subscriptions.',
+	capabilityOverrides: { read: 'partial' },
+
+	parseRaw(raw, ctx) {
+		return parseAemsBank(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeAemsBank(model, ctx.littleEndian);
+	},
+	describe(model) {
+		const sfx = aemsSfxBankInfo(model);
+		const refs = model.interfaceRefs.map((r) => r.idName).join(', ') || 'none';
+		return `${sfx ? `${sfx.numSamples} sample${sfx.numSamples === 1 ? '' : 's'} (${sfx.id})` : 'no SFX bank'}, ${model.numModules} module${model.numModules === 1 ? '' : 's'}, fixups ${model.funcFixups.length}+${model.staticDataFixups.length}, subscribes ${refs}`;
+	},
+
+	fixtures: [
+		// All 23 retail banks (plus the CSIS cross-links) are swept in
+		// __tests__/aemsBank.test.ts; these five cover the size extremes, the
+		// two-module shape (INAIR — the wiki claims nummodules is always 1),
+		// and the multi-interface-reference shape.
+		{ bundle: 'example/SOUND/AEMS/BOOST_BANK_EXOTIC.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/SOUND/AEMS/SKIDS.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/SOUND/AEMS/TRAFFIC_BANK.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/SOUND/AEMS/GEARWHINEPATCHBANK.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/SOUND/AEMS/INAIR.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.funcFixups.length !== before.funcFixups.length) {
+					problems.push(`func fixup count ${after.funcFixups.length} != ${before.funcFixups.length}`);
+				}
+				if (after.interfaceRefs.length !== before.interfaceRefs.length) {
+					problems.push(`interface ref count ${after.interfaceRefs.length} != ${before.interfaceRefs.length}`);
+				}
+				if (after._sfxBank.byteLength !== before._sfxBank.byteLength) {
+					problems.push(`SFX bank size ${after._sfxBank.byteLength} != ${before._sfxBank.byteLength}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'rename-interface',
+			description: 'rename interfaceRefs[0] to a longer name — the ID blob, totalsize, and both alignment pads must re-derive',
+			mutate: (m) => {
+				const interfaceRefs = m.interfaceRefs.slice();
+				interfaceRefs[0] = { ...interfaceRefs[0], idName: 'RenamedSubscriptionClass' };
+				return { ...m, interfaceRefs };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const ref = afterReparse.interfaceRefs[0];
+				if (ref.idName !== 'RenamedSubscriptionClass') problems.push(`idName '${ref.idName}'`);
+				// The CrcAndKey shares the ID blob with the name — renaming must
+				// not perturb it.
+				if (ref.idCrc !== afterMutate.interfaceRefs[0].idCrc) problems.push(`idCrc drifted to 0x${ref.idCrc.toString(16)}`);
+				if (ref.idKey !== afterMutate.interfaceRefs[0].idKey) problems.push(`idKey drifted to 0x${ref.idKey.toString(16)}`);
+				return problems;
+			},
+		},
+		{
+			name: 'retarget-crc-key',
+			description: 'point interfaceRefs[0] at a different CSIS entry by CrcAndKey and verify both u16 lanes survive',
+			mutate: (m) => {
+				const interfaceRefs = m.interfaceRefs.slice();
+				interfaceRefs[0] = { ...interfaceRefs[0], idCrc: 0x1234, idKey: 0x5678 };
+				return { ...m, interfaceRefs };
+			},
+			verify: (_before, after) => {
+				const ref = after.interfaceRefs[0];
+				return ref.idCrc === 0x1234 && ref.idKey === 0x5678
+					? []
+					: [`CrcAndKey (0x${ref.idCrc.toString(16)}, 0x${ref.idKey.toString(16)}), expected (0x1234, 0x5678)`];
+			},
+		},
+		{
+			name: 'add-func-fixup',
+			description: 'append a func fixup — the three tail tables and every derived offset must shift consistently',
+			mutate: (m) => ({ ...m, funcFixups: [...m.funcFixups, 0xdead] }),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.funcFixups.length !== afterMutate.funcFixups.length) {
+					problems.push(`func fixup count ${afterReparse.funcFixups.length} != ${afterMutate.funcFixups.length}`);
+				}
+				if (afterReparse.funcFixups[afterReparse.funcFixups.length - 1] !== 0xdead) {
+					problems.push('appended fixup value lost');
+				}
+				if (afterReparse.staticDataFixups.length !== afterMutate.staticDataFixups.length) {
+					problems.push('static data fixup table perturbed');
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/csis.ts
+++ b/src/lib/core/registry/handlers/csis.ts
@@ -1,0 +1,189 @@
+// Csis registry handler — thin wrapper around parseCsis / writeCsis in
+// src/lib/core/csis.ts.
+//
+// All ten retail Csis resources live in one bundle (SOUND/AEMS/CSIS.BUNDLE),
+// so the handler ships a picker. Debug names are gamedb URLs
+// (gamedb://…/Traffic/PC/TrafficCsis.Csis?ID=683680) — the picker shortens
+// them to the basename so the tree stays readable.
+
+import {
+	parseCsis,
+	writeCsis,
+	csisSystemCrc,
+	makeEmptyCsisEntry,
+	type ParsedCsis,
+} from '../../csis';
+import type { ResourceHandler, PickerEntry } from '../handler';
+
+/** 'gamedb://…/TrafficCsis.Csis?ID=683680' → 'TrafficCsis'. Non-gamedb names pass through. */
+export function shortCsisName(name: string): string {
+	const base = name.split('/').pop() ?? name;
+	return base.replace(/\.Csis(\?ID=\d+)?$/i, '');
+}
+
+function entryCount(model: ParsedCsis | null): number {
+	if (model == null) return -1;
+	return model.functions.length + model.classes.length + model.globalVariables.length;
+}
+
+function compareByName(a: PickerEntry<ParsedCsis>, b: PickerEntry<ParsedCsis>): number {
+	return shortCsisName(a.ctx.name).localeCompare(shortCsisName(b.ctx.name), undefined, { numeric: true });
+}
+
+export const csisHandler: ResourceHandler<ParsedCsis> = {
+	typeId: 0xa023,
+	key: 'csis',
+	name: 'CSIS',
+	description: 'Customizable Subscription-based Interfacing System descriptor — the named functions / classes / global variables one AEMS audio module exposes; AEMS banks subscribe to them by CrcAndKey through their tail interface references',
+	category: 'Audio',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/CSIS',
+	notes: 'Entry crcs are matched against AEMS bank interface references at load — renaming or re-crcing an entry without updating the subscribing banks (or vice versa) silently breaks the audio link.',
+
+	parseRaw(raw, ctx) {
+		return parseCsis(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeCsis(model, ctx.littleEndian);
+	},
+	describe(model) {
+		const parts = [
+			`${model.functions.length} function${model.functions.length === 1 ? '' : 's'}`,
+			`${model.classes.length} class${model.classes.length === 1 ? '' : 'es'}`,
+		];
+		if (model.globalVariables.length > 0) parts.push(`${model.globalVariables.length} globals`);
+		return `${parts.join(', ')}, system crc 0x${csisSystemCrc(model).toString(16).toUpperCase()}`;
+	},
+
+	picker: {
+		labelOf(model, { name }) {
+			const primary = shortCsisName(name);
+			if (model == null) {
+				return {
+					primary,
+					secondary: 'parse failed',
+					badges: [{ label: 'parse failed', tone: 'warn' }],
+				};
+			}
+			const count = entryCount(model);
+			if (count === 0) {
+				return { primary, secondary: 'no entries', badges: [{ label: 'empty', tone: 'muted' }] };
+			}
+			const parts: string[] = [];
+			if (model.classes.length > 0) parts.push(`${model.classes.length} class${model.classes.length === 1 ? '' : 'es'}`);
+			if (model.functions.length > 0) parts.push(`${model.functions.length} fn`);
+			if (model.globalVariables.length > 0) parts.push(`${model.globalVariables.length} gv`);
+			return {
+				primary,
+				secondary: `${parts.join(' · ')} · crc 0x${csisSystemCrc(model).toString(16).toUpperCase()}`,
+			};
+		},
+		sortKeys: [
+			{ id: 'name', label: 'Name (A→Z)', compare: compareByName },
+			{ id: 'index', label: 'Bundle order', compare: (a, b) => a.ctx.index - b.ctx.index },
+			{
+				id: 'entries-desc',
+				label: 'Entry count (high→low)',
+				compare: (a, b) => entryCount(b.model) - entryCount(a.model),
+			},
+		],
+		defaultSort: 'name',
+		searchText(model, { name }) {
+			const entries = model == null
+				? []
+				: [...model.functions, ...model.classes, ...model.globalVariables].map((e) => e.name);
+			return [shortCsisName(name), ...entries].join(' ');
+		},
+	},
+
+	fixtures: [
+		// CSIS.BUNDLE is the only retail carrier (10 Csis + 30 Registry
+		// resources); the auto suite exercises the first in bundle order
+		// (TrafficCsis). All ten, plus the bank↔csis CrcAndKey links, are
+		// covered in __tests__/csis.test.ts.
+		{ bundle: 'example/SOUND/AEMS/CSIS.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.classes.length !== before.classes.length) {
+					problems.push(`class count ${after.classes.length} != ${before.classes.length}`);
+				}
+				if (csisSystemCrc(after) !== csisSystemCrc(before)) {
+					problems.push(`system crc 0x${csisSystemCrc(after).toString(16)} != 0x${csisSystemCrc(before).toString(16)}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'rename-class',
+			description: 'rename classes[0] to a longer name — string table, sizes, and the garbage pad must re-derive',
+			mutate: (m) => {
+				const classes = m.classes.slice();
+				classes[0] = { ...classes[0], name: 'RenamedAudioModuleClass' };
+				return { ...m, classes };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.classes[0].name !== 'RenamedAudioModuleClass') {
+					problems.push(`name '${afterReparse.classes[0].name}'`);
+				}
+				// Renaming does NOT change the crc (it is not name-derived) —
+				// the link to subscribing banks is by CrcAndKey.
+				if (afterReparse.classes[0].crc !== afterMutate.classes[0].crc) {
+					problems.push(`crc drifted to 0x${afterReparse.classes[0].crc.toString(16)}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-entry-crc',
+			description: 'change classes[0].crc — the header system crc must re-derive as (Σ entry crcs) & 0x7FFF',
+			mutate: (m) => {
+				const classes = m.classes.slice();
+				classes[0] = { ...classes[0], crc: 0x1234 };
+				return { ...m, classes };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.classes[0].crc !== 0x1234) {
+					problems.push(`crc 0x${afterReparse.classes[0].crc.toString(16)}, expected 0x1234`);
+				}
+				// The parser asserts stored crc == derivation, so reparse
+				// succeeding already proves the writer re-derived; double-check
+				// the value matches the mutated model's derivation anyway.
+				if (csisSystemCrc(afterReparse) !== csisSystemCrc(afterMutate)) {
+					problems.push(`system crc 0x${csisSystemCrc(afterReparse).toString(16)} != 0x${csisSystemCrc(afterMutate).toString(16)}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'add-function',
+			description: 'append a function entry — counts, desc array, string table, and system crc all re-derive',
+			mutate: (m) => ({
+				...m,
+				functions: [...m.functions, { ...makeEmptyCsisEntry(), name: 'NewFunction', crc: 0x42 }],
+			}),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.functions.length !== afterMutate.functions.length) {
+					problems.push(`function count ${afterReparse.functions.length} != ${afterMutate.functions.length}`);
+				}
+				const added = afterReparse.functions[afterReparse.functions.length - 1];
+				if (!added || added.name !== 'NewFunction' || added.crc !== 0x42) {
+					problems.push(`appended entry came back as ${added ? `'${added.name}'/0x${added.crc.toString(16)}` : 'nothing'}`);
+				}
+				if (afterReparse.classes.length !== afterMutate.classes.length) {
+					problems.push('class array perturbed');
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/flaptFile.ts
+++ b/src/lib/core/registry/handlers/flaptFile.ts
@@ -1,0 +1,154 @@
+// FlaptFile registry handler — thin wrapper around parseFlaptFile /
+// writeFlaptFile in src/lib/core/flaptFile.ts.
+//
+// FLAPTHUD.BUNDLE carries exactly one 0x10020 resource (the whole in-game
+// HUD), so no picker config. The payload is preserved verbatim and writes are
+// in-place patches — see the core file's header for why pointers buried in
+// the un-decoded timeline data forbid layout shifts. The inline import table
+// binds mpapTextures slots to the bundle's 52 sibling Texture (0x0) pages.
+
+import {
+	parseFlaptFile,
+	writeFlaptFile,
+	flaptFileImportTable,
+	countFlaptTextureImports,
+	type ParsedFlaptFile,
+} from '../../flaptFile';
+import type { ResourceHandler } from '../handler';
+
+function firstImportedSlot(model: ParsedFlaptFile): number {
+	return model.textures.findIndex((t) => t.resourceId != null);
+}
+
+export const flaptFileHandler: ResourceHandler<ParsedFlaptFile> = {
+	typeId: 0x10020,
+	key: 'flaptFile',
+	name: 'Flapt File',
+	description: 'The in-game HUD — a Flash-derived GUI ("Friends List Apt") with movie clips, 2D vertices, font styles, the HUD string table, component index paths, and texture-slot imports binding the bundle\'s sibling Texture resources',
+	category: 'Graphics',
+	caps: { read: true, write: true },
+	// Reads decode the header arrays (clips, verts, fonts, strings, components,
+	// triggers, imports) but not the 1.2 MB of timeline sub-data the clip
+	// pointers reach into. Writes are honest-but-narrow: fixed-width in-place
+	// patches only (frame time, vertices, font colour/height, texture
+	// retargets) — anything that would move bytes is rejected.
+	capabilityOverrides: { read: 'partial', write: 'partial' },
+	wikiUrl: 'https://burnout.wiki/wiki/Flapt_File',
+	notes: 'Every pointer is a payload-absolute offset (including inside un-decoded timeline data), so the payload is preserved verbatim and writes patch fixed-width fields in place. Strings, clip structure, and counts are read-only.',
+
+	parseRaw(raw, ctx) {
+		return parseFlaptFile(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeFlaptFile(model, ctx.littleEndian);
+	},
+	importTable(payload, ctx) {
+		return flaptFileImportTable(payload, ctx.littleEndian);
+	},
+	describe(model) {
+		const named = model.movieClips.filter((c) => c.componentName != null).length;
+		return `${model.movieClips.length} movie clips (${named} named), ${model.vertices.length} verts, `
+			+ `${model.fontStyles.length} font styles, ${model.strings.length} strings, `
+			+ `${countFlaptTextureImports(model)} texture imports (+${model.specialTextureNames.length} special), `
+			+ `${model.components.length} components @ ${(1 / model.mfTimePerFrame).toFixed(0)} fps`;
+	},
+
+	// Random structural mutations legitimately violate the patch-writer's
+	// fixed-count invariants; those rejections are expected, not crashes. The
+	// `_payload missing` pattern covers the CLI's JSON-based clone, which
+	// cannot preserve a Uint8Array field.
+	fuzz: {
+		tolerateErrors: [
+			/length \d+ != payload's \d+/,
+			/_payload missing/,
+			/resourceId is null/,
+			/cannot carry a resourceId/,
+		],
+	},
+
+	fixtures: [
+		{ bundle: 'example/FLAPTHUD.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the patch-writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.movieClips.length !== before.movieClips.length) {
+					problems.push(`clip count ${after.movieClips.length} != ${before.movieClips.length}`);
+				}
+				if (countFlaptTextureImports(after) !== countFlaptTextureImports(before)) {
+					problems.push(`import count ${countFlaptTextureImports(after)} != ${countFlaptTextureImports(before)}`);
+				}
+				if (after.strings.length !== before.strings.length) {
+					problems.push(`string count ${after.strings.length} != ${before.strings.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'retime',
+			description: 'change the global frame time to 60 fps',
+			mutate: (m) => ({ ...m, mfTimePerFrame: Math.fround(1 / 60) }),
+			verify: (afterMutate, afterReparse) =>
+				afterReparse.mfTimePerFrame === afterMutate.mfTimePerFrame
+					? []
+					: [`mfTimePerFrame ${afterReparse.mfTimePerFrame}, expected ${afterMutate.mfTimePerFrame}`],
+		},
+		{
+			name: 'move-vertex',
+			description: 'translate the first vertex and tint it',
+			mutate: (m) => {
+				const v = m.vertices[0];
+				v.mv2Pos = { x: v.mv2Pos.x + 5, y: v.mv2Pos.y + 7 };
+				v.mColour = 0x12345678;
+				return m;
+			},
+			verify: (afterMutate, afterReparse) => {
+				const a = afterMutate.vertices[0];
+				const b = afterReparse.vertices[0];
+				const problems: string[] = [];
+				if (a.mv2Pos.x !== b.mv2Pos.x || a.mv2Pos.y !== b.mv2Pos.y) {
+					problems.push(`vertex pos (${b.mv2Pos.x}, ${b.mv2Pos.y}), expected (${a.mv2Pos.x}, ${a.mv2Pos.y})`);
+				}
+				if (b.mColour !== 0x12345678) problems.push(`mColour 0x${b.mColour.toString(16)}, expected 0x12345678`);
+				return problems;
+			},
+		},
+		{
+			name: 'recolour-font',
+			description: 'tint the first font style and bump its height',
+			mutate: (m) => {
+				m.fontStyles[0].muColour = 0xdeadbeef;
+				m.fontStyles[0].mfFontHeight = 42;
+				return m;
+			},
+			verify: (afterMutate, afterReparse) => {
+				const got = afterReparse.fontStyles[0];
+				const problems: string[] = [];
+				if (got.muColour !== 0xdeadbeef) problems.push(`muColour 0x${got.muColour.toString(16)}, expected 0xdeadbeef`);
+				if (got.mfFontHeight !== 42) problems.push(`mfFontHeight ${got.mfFontHeight}, expected 42`);
+				if (got.fontName !== afterMutate.fontStyles[0].fontName) problems.push(`fontName drifted to '${got.fontName}'`);
+				return problems;
+			},
+		},
+		{
+			name: 'retarget-texture-import',
+			description: 'point the first imported texture slot at a different resource id',
+			mutate: (m) => {
+				const slot = firstImportedSlot(m);
+				if (slot >= 0) m.textures[slot].resourceId = 0xdeadbeefn;
+				return m;
+			},
+			verify: (afterMutate, afterReparse) => {
+				const slot = firstImportedSlot(afterMutate);
+				if (slot < 0) return [];
+				const got = afterReparse.textures[slot].resourceId;
+				return got === 0xdeadbeefn ? [] : [`textures[${slot}].resourceId 0x${got?.toString(16)}, expected 0xdeadbeef`];
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/genericRwacWaveContent.ts
+++ b/src/lib/core/registry/handlers/genericRwacWaveContent.ts
@@ -1,0 +1,167 @@
+// GenericRwacWaveContent (0xA020) registry handler — thin wrapper around
+// parseGenericRwacWaveContent / writeGenericRwacWaveContent in
+// src/lib/core/genericRwacWaveContent.ts.
+//
+// SOUND/GLOBALWAVES.BUNDLE carries 37 of these in one bundle, so the handler
+// ships a picker config. Debug names are gamedb asset URLs
+// (gamedb://burnout5/Burnout/Sound/GlobalWaves/<name>.wav.WaveFile?ID=<n>);
+// the picker shows just the basename. The wave bytes are an opaque codec
+// payload (EALayer3 in retail) — steward edits the header metadata and
+// preserves the audio verbatim; re-encoding needs external tools (EALayer3 /
+// EA Sound Exchange, see the wiki's modding page).
+
+import {
+	parseGenericRwacWaveContent,
+	writeGenericRwacWaveContent,
+	waveDurationSeconds,
+	SNDPLAYER_CODECS,
+	SNDPLAYER_PLAY_TYPES,
+	type ParsedGenericRwacWaveContent,
+} from '../../genericRwacWaveContent';
+import type { PickerEntry, ResourceHandler } from '../handler';
+
+/** Basename of a gamedb wave URL — 'gamedb://…/BikeToyCarHorn.wav.WaveFile?ID=805063'
+ *  → 'BikeToyCarHorn.wav'. Non-gamedb names pass through unchanged. */
+export function waveDisplayName(name: string): string {
+	const base = name.split('/').pop() ?? name;
+	return base.replace(/\.WaveFile(\?ID=\d+)?$/, '');
+}
+
+function codecLabel(codec: number): string {
+	return SNDPLAYER_CODECS[codec] ?? `codec ${codec}`;
+}
+
+function describeWave(model: ParsedGenericRwacWaveContent): string {
+	const dur = waveDurationSeconds(model);
+	const loop = model.loopStartSample != null ? `, loop @ sample ${model.loopStartSample}` : '';
+	const play = model.playType === 0 ? '' : `, ${SNDPLAYER_PLAY_TYPES[model.playType] ?? '?'}`;
+	return `${codecLabel(model.codec)}, ${model.sampleRate} Hz ${model.channels === 1 ? 'mono' : model.channels === 2 ? 'stereo' : `${model.channels}ch`}, `
+		+ `${model.numSamples} samples (${dur.toFixed(2)} s), ${model.chunks.length} chunk${model.chunks.length === 1 ? '' : 's'}${loop}${play}`;
+}
+
+function compareByName(a: PickerEntry<ParsedGenericRwacWaveContent>, b: PickerEntry<ParsedGenericRwacWaveContent>): number {
+	return waveDisplayName(a.ctx.name).localeCompare(waveDisplayName(b.ctx.name), undefined, { numeric: true });
+}
+
+export const genericRwacWaveContentHandler: ResourceHandler<ParsedGenericRwacWaveContent> = {
+	typeId: 0xa020,
+	key: 'genericRwacWaveContent',
+	name: 'Generic RWAC Wave Content',
+	description: 'One EA SndPlayer wave asset (RWAC = RenderWare Audio Core) — the primary sound container: codec/rate/channel header plus the encoded audio in load-play-unload chunks. Car horns, sirens, and HUD sounds live in GLOBALWAVES',
+	category: 'Audio',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Wave/Burnout_Paradise',
+	notes: 'Header metadata (sample rate, loop point) is editable; the audio itself is an opaque codec payload preserved verbatim — re-encoding needs EALayer3 / EA Sound Exchange. Stream/gigasample waves round-trip as opaque blobs (no fixture validates their chunking).',
+
+	parseRaw(raw, ctx) {
+		return parseGenericRwacWaveContent(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeGenericRwacWaveContent(model, ctx.littleEndian);
+	},
+	describe(model) {
+		return describeWave(model);
+	},
+
+	picker: {
+		labelOf(model, { name }) {
+			const primary = waveDisplayName(name);
+			if (model == null) {
+				return { primary, secondary: 'parse failed', badges: [{ label: 'parse failed', tone: 'warn' }] };
+			}
+			const kHz = model.sampleRate >= 1000 ? `${(model.sampleRate / 1000).toFixed(model.sampleRate % 1000 === 0 ? 0 : 1)} kHz` : `${model.sampleRate} Hz`;
+			const ch = model.channels === 1 ? 'mono' : model.channels === 2 ? 'stereo' : `${model.channels}ch`;
+			return {
+				primary,
+				secondary: `${kHz} ${ch} · ${waveDurationSeconds(model).toFixed(2)} s · ${codecLabel(model.codec)}`,
+				badges: model.loopStartSample != null ? [{ label: 'looped', tone: 'accent' as const }] : undefined,
+			};
+		},
+		sortKeys: [
+			{ id: 'name', label: 'Name (A→Z)', compare: compareByName },
+			{ id: 'index', label: 'Bundle order', compare: (a, b) => a.ctx.index - b.ctx.index },
+			{
+				id: 'duration-desc',
+				label: 'Duration (long→short)',
+				// waveDurationSeconds is 0 for rate 0 and the null-model fallback
+				// is -1, so this can never return NaN (picker contract).
+				compare: (a, b) =>
+					(b.model ? waveDurationSeconds(b.model) : -1) - (a.model ? waveDurationSeconds(a.model) : -1),
+			},
+		],
+		defaultSort: 'name',
+		searchText(model, { name }) {
+			return `${waveDisplayName(name)} ${model ? codecLabel(model.codec) : ''}`;
+		},
+	},
+
+	fixtures: [
+		// The auto suite only exercises the first wave in bundle order
+		// (BikeToyCarHorn — looped, single chunk, garbage pads); all 37,
+		// including the four two-chunk loop-split waves, are swept in
+		// __tests__/genericRwacWaveContent.test.ts.
+		{ bundle: 'example/SOUND/GLOBALWAVES.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.codec !== before.codec) problems.push(`codec ${after.codec} != ${before.codec}`);
+				if (after.sampleRate !== before.sampleRate) problems.push(`sampleRate ${after.sampleRate} != ${before.sampleRate}`);
+				if (after.chunks.length !== before.chunks.length) problems.push(`chunk count ${after.chunks.length} != ${before.chunks.length}`);
+				return problems;
+			},
+		},
+		{
+			name: 'retune-sample-rate',
+			description: 'change the sample rate (pitch shift without re-encoding) and verify it survives round-trip',
+			mutate: (m) => ({ ...m, sampleRate: 32000 }),
+			verify: (_before, after) =>
+				after.sampleRate === 32000 ? [] : [`sampleRate ${after.sampleRate}, expected 32000`],
+		},
+		{
+			name: 'clear-loop',
+			description: 'drop the loop point — the header shrinks 4 bytes and the alignment pad is re-derived',
+			mutate: (m) => ({ ...m, loopStartSample: null }),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.loopStartSample !== null) problems.push(`loopStartSample ${afterReparse.loopStartSample}, expected null`);
+				if (afterReparse.numSamples !== afterMutate.numSamples) {
+					problems.push(`numSamples ${afterReparse.numSamples} != ${afterMutate.numSamples}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'set-loop-start',
+			description: 'set a nonzero loop point (adding the optional header field when absent) and verify it survives',
+			mutate: (m) => ({ ...m, loopStartSample: 1000 }),
+			verify: (_before, after) =>
+				after.loopStartSample === 1000 ? [] : [`loopStartSample ${after.loopStartSample}, expected 1000`],
+		},
+		{
+			name: 'swap-chunk-data',
+			description: 'replace the first chunk with a different-sized payload — sizes, sample total, and pad must all re-derive',
+			mutate: (m) => {
+				const chunks = m.chunks.slice();
+				chunks[0] = { samples: 123, data: new Uint8Array(257).fill(0xab) };
+				return { ...m, chunks };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const c = afterReparse.chunks[0];
+				if (c?.samples !== 123) problems.push(`chunks[0].samples ${c?.samples}, expected 123`);
+				if (c?.data.byteLength !== 257) problems.push(`chunks[0].data ${c?.data.byteLength} bytes, expected 257`);
+				const expected = afterMutate.chunks.reduce((sum, ch) => sum + ch.samples, 0);
+				if (afterReparse.numSamples !== expected) {
+					problems.push(`numSamples ${afterReparse.numSamples}, expected re-derived ${expected}`);
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/nicotine.ts
+++ b/src/lib/core/registry/handlers/nicotine.ts
@@ -1,0 +1,118 @@
+// Nicotine registry handler — thin wrapper around parseNicotine /
+// writeNicotine in src/lib/core/nicotine.ts.
+//
+// Retail ships exactly two Nicotine maps, one resource per bundle:
+// NicotineAssetMain (stereo) and NicotineAssetSurround (5.1). Both carry the
+// same 9-state mixer graph; only 13 master-channel mixData attenuation words
+// (and 3 stale-pointer reserved words) differ, so editing mixData is THE
+// use case this type exists for. The companion SnapshotData (0xA029) in the
+// same bundle references this map's master channels by MIXCHID.
+
+import { parseNicotine, writeNicotine, type ParsedNicotine } from '../../nicotine';
+import type { ResourceHandler } from '../handler';
+
+const countChannels = (m: ParsedNicotine, section: 'masterMix' | 'subMix') =>
+	m.states.reduce((n, s) => n + (s[section]?.channels.length ?? 0), 0);
+
+export const nicotineHandler: ResourceHandler<ParsedNicotine> = {
+	typeId: 0xa024,
+	key: 'nicotine',
+	name: 'Nicotine Map',
+	description: 'Sound-mixing map (EA Nicotine middleware) — per-state mix/3D/submix/master channel graphs with event controls and presets; one map for stereo output and one for 5.1 surround',
+	category: 'Audio',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Nicotine_Map',
+	notes: 'Nearly every value word is an undocumented bit field — counts are recomputed on write but packed per-record count bytes are validated, not rewritten. Stereo and surround maps differ only in master-channel mixData attenuation.',
+
+	parseRaw(raw, ctx) {
+		return parseNicotine(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeNicotine(model, ctx.littleEndian);
+	},
+	describe(model) {
+		return `${model.states.length} states, ${countChannels(model, 'masterMix')} master + ${countChannels(model, 'subMix')} submix channels`;
+	},
+
+	fixtures: [
+		{ bundle: 'example/SOUND/NICOTINEASSETMAIN.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/SOUND/NICOTINEASSETSURROUND.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	// Both fixtures carry the identical 9-state structure (states[0] has 25
+	// master channels + 18 events, states[1] has 8 3D controls), so every
+	// scenario below can index the same paths on either fixture.
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.states.length !== before.states.length) {
+					problems.push(`state count ${after.states.length} != ${before.states.length}`);
+				}
+				if (countChannels(after, 'masterMix') !== countChannels(before, 'masterMix')) {
+					problems.push('master channel count changed');
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-master-mix-data',
+			description: 'set states[0].masterMix.channels[0].mixData (the attenuation word — the only field differing between stereo and surround maps) and verify it survives',
+			mutate: (m) => {
+				m.states[0].masterMix!.channels[0].mixData = 0xff9cd8f0; // -100 centi-dB over the -10000 floor
+				return m;
+			},
+			verify: (_afterMutate, afterReparse) => {
+				const ch = afterReparse.states[0].masterMix?.channels[0];
+				return ch?.mixData === 0xff9cd8f0 ? [] : [`mixData = 0x${ch?.mixData.toString(16)}, expected 0xff9cd8f0`];
+			},
+		},
+		{
+			name: 'edit-event-trigger',
+			description: 'change states[0].events.events[0].nTriggerId and verify it survives alongside untouched params',
+			mutate: (m) => {
+				m.states[0].events!.events[0].nTriggerId = 0x12345678;
+				return m;
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const ev = afterReparse.states[0].events?.events[0];
+				if (ev?.nTriggerId !== 0x12345678) problems.push(`nTriggerId = 0x${ev?.nTriggerId.toString(16)}, expected 0x12345678`);
+				if (ev?.nParam00 !== afterMutate.states[0].events!.events[0].nParam00) problems.push('nParam00 changed');
+				return problems;
+			},
+		},
+		{
+			name: 'edit-3d-state-params',
+			description: 'change states[1].threeDControls.controls[0].stateParams[0].nQ0MinMax and verify it survives',
+			mutate: (m) => {
+				m.states[1].threeDControls!.controls[0].stateParams[0].nQ0MinMax = 0x00400040;
+				return m;
+			},
+			verify: (_afterMutate, afterReparse) => {
+				const q = afterReparse.states[1].threeDControls?.controls[0].stateParams[0].nQ0MinMax;
+				return q === 0x00400040 ? [] : [`nQ0MinMax = 0x${q?.toString(16)}, expected 0x400040`];
+			},
+		},
+		{
+			name: 'remove-last-state',
+			description: 'drop the final (submix-only) state — NumStates and every state-table offset are re-derived',
+			mutate: (m) => ({ ...m, states: m.states.slice(0, -1) }),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.states.length !== afterMutate.states.length) {
+					problems.push(`state count ${afterReparse.states.length} != ${afterMutate.states.length}`);
+				}
+				const last = afterReparse.states[afterReparse.states.length - 1];
+				const expected = afterMutate.states[afterMutate.states.length - 1];
+				if (last?.stateIndex !== expected?.stateIndex) {
+					problems.push(`last stateIndex 0x${last?.stateIndex.toString(16)}, expected 0x${expected?.stateIndex.toString(16)}`);
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/registry.ts
+++ b/src/lib/core/registry/handlers/registry.ts
@@ -3,11 +3,14 @@
 // name registry.ts because `src/lib/core/registry` is this folder; the
 // handler key stays 'registry', matching the wiki type name.)
 //
-// Our fixtures carry one Registry each, but retail bundles can carry many
-// (SOUND/AEMS/CSIS.BUNDLE packs nine: *CsisEntityReg / *CsisVoiceReg /
-// *CsisFactoryReg per surface type), so a picker config is included.
+// Retail bundles can carry many registries — SOUND/AEMS/CSIS.BUNDLE packs 30
+// (a *CsisEntityReg / *CsisVoiceReg / *CsisFactoryReg trio per AEMS effect
+// group: Boost, Traffic, Skids, Horns, …) — so a picker config is included.
+// The fixture harness only exercises the first resource per bundle; the gold
+// suite in __tests__/soundRegistry.test.ts sweeps all 30.
 
 import {
+	makeEmptyRegistryEntity,
 	parseRegistry,
 	writeRegistry,
 	soundHash,
@@ -39,7 +42,7 @@ export const registryHandler: ResourceHandler<ParsedRegistry> = {
 	category: 'Audio',
 	caps: { read: true, write: true },
 	wikiUrl: 'https://burnout.wiki/wiki/Registry',
-	notes: 'Entity payloads validated against PLAYBACKREGISTRY + RWACFEATUREREGISTRY; type names absent from those fixtures (ContentSpec, VoiceSchema, VoiceSpec) round-trip as verbatim payload blobs.',
+	notes: 'All nine retail entity kinds decode (validated against PLAYBACKREGISTRY, RWACFEATUREREGISTRY, SOUNDENTITY, and the 30 registries in SOUND/AEMS/CSIS.BUNDLE); any still-unknown type name round-trips as a verbatim payload blob.',
 
 	parseRaw(raw, ctx) {
 		return parseRegistry(raw, ctx.littleEndian);
@@ -83,11 +86,15 @@ export const registryHandler: ResourceHandler<ParsedRegistry> = {
 	fixtures: [
 		// Deliberately different shapes: PLAYBACK mixes five payload kinds;
 		// RWAC is all GenericRwacFeatureImplementation with 0xCD uninitialised
-		// fills that must survive verbatim. Per-kind payload edits live in
+		// fills that must survive verbatim; SOUNDENTITY adds the string-
+		// carrying ContentSpec plus VoiceSchema/VoiceSpec; CSIS adds the
+		// wiki-undocumented AemsVoiceCsisClass. Per-kind payload edits live in
 		// __tests__/soundRegistry.test.ts — the scenarios below only mutate
-		// shapes both fixtures share (names, entity list, string pool).
+		// shapes every fixture supports (names, entity list, string pool).
 		{ bundle: 'example/PLAYBACKREGISTRY.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
 		{ bundle: 'example/RWACFEATUREREGISTRY.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/SOUND/SOUNDENTITY.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/SOUND/AEMS/CSIS.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
 	],
 
 	stressScenarios: [
@@ -131,13 +138,9 @@ export const registryHandler: ResourceHandler<ParsedRegistry> = {
 			mutate: (m) => ({
 				...m,
 				entities: [...m.entities, {
+					...makeEmptyRegistryEntity(),
 					mName: soundHash('StewardStressClass'),
 					mTypeName: REGISTRY_TYPE_HASHES.CONTENT_CLASS,
-					mpContentClass: null,
-					parameterSchema: null,
-					featureSchema: null,
-					rwacFeature: null,
-					_unknownPayload: null,
 				}],
 				strings: [...m.strings, 'StewardStressClass'],
 			}),
@@ -149,6 +152,38 @@ export const registryHandler: ResourceHandler<ParsedRegistry> = {
 				}
 				if (afterReparse.strings[afterReparse.strings.length - 1] !== 'StewardStressClass') {
 					problems.push('appended string did not survive round-trip');
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'add-content-spec',
+			description: 'append a ContentSpec with an odd-length path — exercises the inline string, derived u16 length, and the recomputed 0xCD pad to 4-byte alignment',
+			mutate: (m) => ({
+				...m,
+				entities: [...m.entities, {
+					...makeEmptyRegistryEntity(),
+					mName: soundHash('StewardStressSpec'),
+					mTypeName: REGISTRY_TYPE_HASHES.CONTENT_SPEC,
+					contentSpec: {
+						mpContentType: soundHash('~GenericRwacWaveContent::SK_WAVE_DATA_CONTENT_TYPE~'),
+						mu8LoadMethod: 1,
+						mu8LoadTime: 1,
+						path: 'gamedb://steward/Stress1.wav', // 28 chars + NUL → 3 pad bytes
+						_padTail: new Uint8Array(0),
+					},
+				}],
+				strings: [...m.strings, 'StewardStressSpec'],
+			}),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const last = afterReparse.entities[afterReparse.entities.length - 1];
+				if (last?.contentSpec?.path !== 'gamedb://steward/Stress1.wav') {
+					problems.push('appended ContentSpec path did not survive round-trip');
+				}
+				if (last?.contentSpec != null
+					&& (last.contentSpec._padTail.byteLength !== 3 || [...last.contentSpec._padTail].some((b) => b !== 0xcd))) {
+					problems.push('recomputed pad is not 3 bytes of 0xCD fill');
 				}
 				return problems;
 			},

--- a/src/lib/core/registry/handlers/snapshotData.ts
+++ b/src/lib/core/registry/handlers/snapshotData.ts
@@ -1,0 +1,119 @@
+// SnapshotData registry handler — thin wrapper around parseSnapshotData /
+// writeSnapshotData in src/lib/core/snapshotData.ts.
+//
+// One resource per Nicotine bundle (NicotineAssetMain.mss / .Surround.mss).
+// Each channel record references a MASTER mix channel of the companion
+// Nicotine map (0xA024) by its exact MIXCHID word; each snapshot is one
+// mixer preset carrying a (control, value) datum per channel. The two
+// retail resources are byte-identical (17 snapshots × 72 channels) — the
+// stereo/surround differences live entirely in the Nicotine maps.
+
+import { parseSnapshotData, writeSnapshotData, type ParsedSnapshotData } from '../../snapshotData';
+import type { ResourceHandler } from '../handler';
+
+export const snapshotDataHandler: ResourceHandler<ParsedSnapshotData> = {
+	typeId: 0xa029,
+	key: 'snapshotData',
+	name: 'Snapshot Data',
+	description: 'Mixer-channel snapshots for the companion Nicotine map — each snapshot is one mixer preset with a (control, value) datum per referenced master mix channel',
+	category: 'Audio',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Snapshot_Data',
+	notes: 'Channels reference the companion Nicotine map\'s master mix channels by MIXCHID — removing or renumbering channels there orphans snapshot data here.',
+
+	parseRaw(raw, ctx) {
+		return parseSnapshotData(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeSnapshotData(model, ctx.littleEndian);
+	},
+	describe(model) {
+		return `${model.snapshots.length} snapshots × ${model.channels.length} channels`;
+	},
+
+	fixtures: [
+		{ bundle: 'example/SOUND/NICOTINEASSETMAIN.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/SOUND/NICOTINEASSETSURROUND.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios: [
+		{
+			name: 'baseline',
+			description: 'no mutation — exercises the writer on the read model unchanged',
+			mutate: (m) => m,
+			verify: (before, after) => {
+				const problems: string[] = [];
+				if (after.channels.length !== before.channels.length) {
+					problems.push(`channel count ${after.channels.length} != ${before.channels.length}`);
+				}
+				if (after.snapshots.length !== before.snapshots.length) {
+					problems.push(`snapshot count ${after.snapshots.length} != ${before.snapshots.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-snapshot-value',
+			description: 'change snapshots[0].entries[0].value (possibly a volume) and verify it survives',
+			mutate: (m) => {
+				m.snapshots[0].entries[0].value = 0.75;
+				return m;
+			},
+			verify: (_afterMutate, afterReparse) => {
+				const v = afterReparse.snapshots[0]?.entries[0]?.value;
+				return Math.abs((v ?? NaN) - 0.75) < 1e-6 ? [] : [`value = ${v}, expected 0.75`];
+			},
+		},
+		{
+			name: 'edit-control-word',
+			description: 'change snapshots[0].entries[0].control and verify it survives alongside an untouched value',
+			mutate: (m) => {
+				m.snapshots[0].entries[0].control = 60000;
+				return m;
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.snapshots[0]?.entries[0]?.control !== 60000) {
+					problems.push(`control = ${afterReparse.snapshots[0]?.entries[0]?.control}, expected 60000`);
+				}
+				if (afterReparse.snapshots[0]?.entries[0]?.value !== afterMutate.snapshots[0].entries[0].value) {
+					problems.push('value changed');
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'remove-last-snapshot',
+			description: 'drop the final snapshot — miNumSnapshots, dataSize, and the alignment pad are all re-derived',
+			mutate: (m) => ({ ...m, snapshots: m.snapshots.slice(0, -1) }),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.snapshots.length !== afterMutate.snapshots.length) {
+					problems.push(`snapshot count ${afterReparse.snapshots.length} != ${afterMutate.snapshots.length}`);
+				}
+				if (afterReparse.channels.length !== afterMutate.channels.length) {
+					problems.push(`channel count ${afterReparse.channels.length} != ${afterMutate.channels.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-channel-id',
+			description: 'change channels[0].channelId (the hash-like id) and verify it survives with mixChId untouched',
+			mutate: (m) => {
+				m.channels[0].channelId = 0xdeadbeef;
+				return m;
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.channels[0]?.channelId !== 0xdeadbeef) {
+					problems.push(`channelId = 0x${afterReparse.channels[0]?.channelId.toString(16)}, expected 0xdeadbeef`);
+				}
+				if (afterReparse.channels[0]?.mixChId !== afterMutate.channels[0].mixChId) {
+					problems.push('mixChId changed');
+				}
+				return problems;
+			},
+		},
+	],
+};

--- a/src/lib/core/registry/handlers/splicer.ts
+++ b/src/lib/core/registry/handlers/splicer.ts
@@ -1,0 +1,157 @@
+// Splicer registry handler — thin wrapper around parseSplicer / writeSplicer
+// in src/lib/core/splicer.ts.
+//
+// Every retail splicer bundle holds exactly ONE 0xA025 resource and nothing
+// else — the audio samples live embedded inside the splicer, not in sibling
+// wave-content resources — so no picker config and no importTable hook
+// (retail importCount is 0 on all six fixtures).
+
+import { parseSplicer, writeSplicer, splicerSampleInfo, type ParsedSplicer } from '../../splicer';
+import type { ResourceHandler, StressScenario } from '../handler';
+
+function totalRefs(model: ParsedSplicer): number {
+	return model.splices.reduce((a, s) => a + s.sampleRefs.length, 0);
+}
+
+/** Index of the first splice that has at least one SampleRef. Scenarios use
+ *  it because zero-ref splices exist in retail (CollisionSpliceBank has one,
+ *  PresentationAsset two — and PresentationAsset's is splice 0). */
+function firstSpliceWithRefs(model: ParsedSplicer): number {
+	const i = model.splices.findIndex((s) => s.sampleRefs.length > 0);
+	if (i < 0) throw new Error('stress scenario expects at least one splice with SampleRefs');
+	return i;
+}
+
+const stressScenarios: StressScenario<ParsedSplicer>[] = [
+	{
+		name: 'baseline',
+		description: 'no mutation — exercises the writer on the read model unchanged',
+		mutate: (m) => m,
+		verify: (before, after) => {
+			const problems: string[] = [];
+			if (after.splices.length !== before.splices.length) {
+				problems.push(`splice count ${after.splices.length} != ${before.splices.length}`);
+			}
+			if (totalRefs(after) !== totalRefs(before)) {
+				problems.push(`ref count ${totalRefs(after)} != ${totalRefs(before)}`);
+			}
+			if (after.samples.length !== before.samples.length) {
+				problems.push(`sample count ${after.samples.length} != ${before.samples.length}`);
+			}
+			return problems;
+		},
+	},
+	{
+		name: 'edit-splice-volume',
+		// 2.5 is an exact f32 value, so equality (not closeTo) holds.
+		description: 'boost splices[0].Volume and verify it survives round-trip',
+		mutate: (m) => {
+			m.splices[0] = { ...m.splices[0], Volume: 2.5 };
+			return m;
+		},
+		verify: (_before, after) =>
+			after.splices[0].Volume === 2.5 ? [] : [`splices[0].Volume ${after.splices[0].Volume}, expected 2.5`],
+	},
+	{
+		name: 'edit-ref-pitch',
+		description: 'retune the first populated splice\'s first SampleRef and verify its untouched neighbour fields survive',
+		mutate: (m) => {
+			const i = firstSpliceWithRefs(m);
+			const refs = m.splices[i].sampleRefs.slice();
+			refs[0] = { ...refs[0], Pitch: 0.5, Volume: 1.5 };
+			m.splices[i] = { ...m.splices[i], sampleRefs: refs };
+			return m;
+		},
+		verify: (afterMutate, afterReparse) => {
+			const i = firstSpliceWithRefs(afterReparse);
+			const got = afterReparse.splices[i].sampleRefs[0];
+			const problems: string[] = [];
+			if (got.Pitch !== 0.5) problems.push(`Pitch ${got.Pitch} != 0.5`);
+			if (got.Volume !== 1.5) problems.push(`Volume ${got.Volume} != 1.5`);
+			if (got.Duration !== afterMutate.splices[i].sampleRefs[0].Duration) {
+				problems.push(`Duration drifted to ${got.Duration}`);
+			}
+			if (got.SampleIndex !== afterMutate.splices[i].sampleRefs[0].SampleIndex) {
+				problems.push(`SampleIndex drifted to ${got.SampleIndex}`);
+			}
+			return problems;
+		},
+	},
+	{
+		name: 'retime-ref',
+		description: 'delay and fade the first populated splice\'s first SampleRef (seconds-domain fields)',
+		mutate: (m) => {
+			const i = firstSpliceWithRefs(m);
+			const refs = m.splices[i].sampleRefs.slice();
+			refs[0] = { ...refs[0], Offset: 0.25, FadeIn: 0.125, FadeOut: 0.5 };
+			m.splices[i] = { ...m.splices[i], sampleRefs: refs };
+			return m;
+		},
+		verify: (_before, after) => {
+			const got = after.splices[firstSpliceWithRefs(after)].sampleRefs[0];
+			const problems: string[] = [];
+			if (got.Offset !== 0.25) problems.push(`Offset ${got.Offset} != 0.25`);
+			if (got.FadeIn !== 0.125) problems.push(`FadeIn ${got.FadeIn} != 0.125`);
+			if (got.FadeOut !== 0.5) problems.push(`FadeOut ${got.FadeOut} != 0.5`);
+			return problems;
+		},
+	},
+	{
+		name: 'remove-last-splice',
+		// Dropping the LAST splice keeps the remaining SpliceIndex set gap-free
+		// in retail (identity indices), and the samples list is untouched — the
+		// removed refs just shrink the shared SampleRef array.
+		description: 'drop the final splice (with its refs) and verify counts and sample table survive',
+		mutate: (m) => {
+			m.splices = m.splices.slice(0, -1);
+			return m;
+		},
+		verify: (afterMutate, afterReparse) => {
+			const problems: string[] = [];
+			if (afterReparse.splices.length !== afterMutate.splices.length) {
+				problems.push(`splice count ${afterReparse.splices.length} != ${afterMutate.splices.length}`);
+			}
+			if (totalRefs(afterReparse) !== totalRefs(afterMutate)) {
+				problems.push(`ref count ${totalRefs(afterReparse)} != ${totalRefs(afterMutate)}`);
+			}
+			if (afterReparse.samples.length !== afterMutate.samples.length) {
+				problems.push(`sample count ${afterReparse.samples.length} != ${afterMutate.samples.length}`);
+			}
+			return problems;
+		},
+	},
+];
+
+export const splicerHandler: ResourceHandler<ParsedSplicer> = {
+	typeId: 0xa025,
+	key: 'splicer',
+	name: 'Splicer',
+	description: 'Bank of triggered sounds — each splice plays one or more embedded 48 kHz EA-XAS samples with volume/pitch/delay/fade controls; game events bind to splices by hardcoded order',
+	category: 'Audio',
+	caps: { read: true, write: true },
+	wikiUrl: 'https://burnout.wiki/wiki/Splicer',
+	notes: 'Self-contained: the audio sample payloads are embedded in the resource (no imports, no sibling wave resources). Volumes are linear amplitude multipliers; pitches are frequency ratios.',
+
+	parseRaw(raw, ctx) {
+		return parseSplicer(raw, ctx.littleEndian);
+	},
+	writeRaw(model, ctx) {
+		return writeSplicer(model, ctx.littleEndian);
+	},
+	describe(model) {
+		const refs = totalRefs(model);
+		const seconds = model.samples.reduce((a, s) => a + (splicerSampleInfo(s)?.seconds ?? 0), 0);
+		return `${model.splices.length} splices, ${refs} sample refs, ${model.samples.length} samples (${seconds.toFixed(1)} s of audio)`;
+	},
+
+	fixtures: [
+		{ bundle: 'example/SOUND/SPLICER/AGGDRIVINGSPLICE_ASSET.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/SOUND/SPLICER/BIKESOUNDS.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/SOUND/SPLICER/COLLISIONSPLICEBANK.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/SOUND/SPLICER/FX_SPLICE.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/SOUND/SPLICER/PASSBYASSET.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+		{ bundle: 'example/SOUND/SPLICER/PRESENTATIONASSET.BUNDLE', expect: { parseOk: true, byteRoundTrip: true } },
+	],
+
+	stressScenarios,
+};

--- a/src/lib/core/registry/index.ts
+++ b/src/lib/core/registry/index.ts
@@ -55,6 +55,13 @@ import { colourCubeHandler } from './handlers/colourCube';
 import { fontHandler } from './handlers/font';
 import { massiveLookupTableHandler } from './handlers/massiveLookupTable';
 import { registryHandler } from './handlers/registry';
+import { genericRwacWaveContentHandler } from './handlers/genericRwacWaveContent';
+import { aemsBankHandler } from './handlers/aemsBank';
+import { csisHandler } from './handlers/csis';
+import { splicerHandler } from './handlers/splicer';
+import { nicotineHandler } from './handlers/nicotine';
+import { snapshotDataHandler } from './handlers/snapshotData';
+import { flaptFileHandler } from './handlers/flaptFile';
 import { textFileHandler } from './handlers/textFile';
 
 export const registry: ResourceHandler[] = [
@@ -106,6 +113,13 @@ export const registry: ResourceHandler[] = [
 	wheelListHandler,
 	idListHandler,
 	aptDataHandler,
+	genericRwacWaveContentHandler,
+	aemsBankHandler,
+	csisHandler,
+	splicerHandler,
+	nicotineHandler,
+	snapshotDataHandler,
+	flaptFileHandler,
 	textFileHandler,
 ];
 

--- a/src/lib/core/snapshotData.ts
+++ b/src/lib/core/snapshotData.ts
@@ -1,0 +1,180 @@
+// SnapshotData parser and writer (resource type 0xA029).
+//
+// SnapshotData stores mixer-channel snapshots for the companion Nicotine map
+// (0xA024) in the same bundle (NicotineAssetMain.mss / .Surround.mss). A
+// snapshot is one mixer preset — "engine view", "crash slow-mo", … — captured
+// as one (control, value) datum per channel; the game crossfades between
+// snapshots at runtime. Each channel record names the Nicotine MASTER mix
+// channel it drives: its mixChId word matches a stMasterMixChParams MIXCHID
+// verbatim (verified: all 72 channel ids of both retail resources appear
+// among the companion map's 111 master MIXCHIDs, and none among the submix
+// ids). The channelId hash does NOT appear anywhere in the Nicotine map.
+//
+// Both retail resources (stereo and surround) are byte-identical: 17
+// snapshots × 72 channels — the output-format differences live entirely in
+// the Nicotine maps.
+//
+// On-disk layout (32-bit PC LE):
+//   CgsResource::BinaryFileResource wrapper: u32 dataSize, u32 dataOffset(=8).
+//   +0x00 Nicotine::SnapshotHeader: miNumSnapshots, miNumChannels,
+//         maiPad[2] = [1, 0x12345678] in retail (preserved verbatim).
+//   +0x10 channel records, miNumChannels × 12 bytes:
+//         u32 mixChId   — bit field, top two bits always set (0xC0-prefixed
+//                         in retail); references the Nicotine master channel
+//         u32 channelId — 32-bit hash-like id (not a CgsID; source unknown)
+//         i32 -1        — always -1; asserted on read, regenerated on write
+//   then snapshot data, miNumSnapshots × miNumChannels × 8 bytes, snapshot-
+//   major (snapshot s's datum for channel c is at index s*numChannels + c):
+//         u32 control   — packed word; low i16 looks like a level in
+//                         hundredths of a dB (0xD8F0 = -10000 = -100.00 dB
+//                         floor, retail range 0..130658), high u16 ∈ {0,1}
+//         f32 value     — wiki suggests volume; retail range 0..5.6
+//   then zero pad to a 16-byte-aligned total (dataSize excludes the pad).
+//
+// Round-trip strategy: counts and the BinaryFile sizes are recomputed from
+// the arrays on write; the layout is rigid, so the parser THROWS on any
+// stored value that disagrees with the derived one.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type SnapshotChannel = {
+	/** Master-mix MIXCHID in the companion Nicotine map (exact u32 match). */
+	mixChId: number;
+	/** Hash-like channel id — appears nowhere in the Nicotine map. */
+	channelId: number;
+};
+
+export type SnapshotEntry = {
+	/** Packed word — low i16 plausibly a level in hundredths of a dB. */
+	control: number; // u32
+	/** Unknown float — wiki suggests volume; retail range 0..5.6. */
+	value: number; // f32
+};
+
+export type Snapshot = {
+	/** One datum per channel, in channel-array order. */
+	entries: SnapshotEntry[];
+};
+
+export type ParsedSnapshotData = {
+	channels: SnapshotChannel[];
+	snapshots: Snapshot[];
+	/** maiPad[0] — 1 in retail (wiki: "mixer state?"); preserved verbatim. */
+	_pad08: number;
+	/** maiPad[1] — 0x12345678 in retail; preserved verbatim. */
+	_pad0C: number;
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const WRAPPER_SIZE = 0x8;
+const HEADER_SIZE = 0x10;
+const CHANNEL_RECORD_SIZE = 0xc;
+const SNAPSHOT_ENTRY_SIZE = 0x8;
+
+const align16 = (n: number) => (n + 15) & ~15;
+
+function fail(msg: string): never {
+	throw new Error(`SnapshotData: ${msg}`);
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+export function parseSnapshotData(raw: Uint8Array, littleEndian = true): ParsedSnapshotData {
+	const buf = raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength);
+	const bytes = new Uint8Array(buf);
+	const r = new BinReader(buf, littleEndian);
+
+	// --- BinaryFile wrapper ---
+	const dataSize = r.readU32();
+	const dataOffset = r.readU32();
+	if (dataOffset !== WRAPPER_SIZE) fail(`dataOffset is 0x${dataOffset.toString(16)}, expected 0x8 (rigid layout)`);
+	if (raw.byteLength !== align16(dataOffset + dataSize)) {
+		fail(`resource is 0x${raw.byteLength.toString(16)} bytes, expected 0x${align16(dataOffset + dataSize).toString(16)} (dataSize + 16-byte alignment pad)`);
+	}
+	for (let i = dataOffset + dataSize; i < raw.byteLength; i++) {
+		if (bytes[i] !== 0) fail(`non-zero alignment-pad byte at 0x${i.toString(16)}`);
+	}
+
+	// --- Nicotine::SnapshotHeader ---
+	const numSnapshots = r.readU32();
+	const numChannels = r.readU32();
+	const _pad08 = r.readU32();
+	const _pad0C = r.readU32();
+	const derivedSize = HEADER_SIZE + numChannels * CHANNEL_RECORD_SIZE + numSnapshots * numChannels * SNAPSHOT_ENTRY_SIZE;
+	if (dataSize !== derivedSize) {
+		fail(`dataSize 0x${dataSize.toString(16)} != derived 0x${derivedSize.toString(16)} for ${numSnapshots} snapshots × ${numChannels} channels`);
+	}
+
+	// --- Channel records ---
+	const channels: SnapshotChannel[] = [];
+	for (let c = 0; c < numChannels; c++) {
+		const mixChId = r.readU32();
+		const channelId = r.readU32();
+		const minusOne = r.readI32();
+		if (minusOne !== -1) fail(`channel[${c}] third word is ${minusOne}, expected -1`);
+		channels.push({ mixChId, channelId });
+	}
+
+	// --- Snapshot data (snapshot-major) ---
+	const snapshots: Snapshot[] = [];
+	for (let s = 0; s < numSnapshots; s++) {
+		const entries: SnapshotEntry[] = [];
+		for (let c = 0; c < numChannels; c++) {
+			entries.push({ control: r.readU32(), value: r.readF32() });
+		}
+		snapshots.push({ entries });
+	}
+
+	return { channels, snapshots, _pad08, _pad0C };
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+export function writeSnapshotData(model: ParsedSnapshotData, littleEndian = true): Uint8Array {
+	const numChannels = model.channels.length;
+	model.snapshots.forEach((snap, s) => {
+		if (snap.entries.length !== numChannels) {
+			throw new Error(`SnapshotData writer: snapshots[${s}] has ${snap.entries.length} entries but there are ${numChannels} channels — every snapshot carries one datum per channel`);
+		}
+	});
+
+	const dataSize = HEADER_SIZE + numChannels * CHANNEL_RECORD_SIZE + model.snapshots.length * numChannels * SNAPSHOT_ENTRY_SIZE;
+	const totalSize = align16(WRAPPER_SIZE + dataSize);
+	const w = new BinWriter(totalSize, littleEndian);
+
+	w.writeU32(dataSize); // excludes the alignment pad
+	w.writeU32(WRAPPER_SIZE);
+	w.writeU32(model.snapshots.length);
+	w.writeU32(numChannels);
+	w.writeU32(model._pad08);
+	w.writeU32(model._pad0C);
+
+	for (const ch of model.channels) {
+		w.writeU32(ch.mixChId);
+		w.writeU32(ch.channelId);
+		w.writeI32(-1);
+	}
+	for (const snap of model.snapshots) {
+		for (const e of snap.entries) {
+			w.writeU32(e.control);
+			w.writeF32(e.value);
+		}
+	}
+
+	if (w.offset !== WRAPPER_SIZE + dataSize) {
+		throw new Error(`SnapshotData writer: wrote 0x${w.offset.toString(16)} bytes, expected 0x${(WRAPPER_SIZE + dataSize).toString(16)}`);
+	}
+	w.writeZeroes(totalSize - w.offset);
+	return w.bytes;
+}

--- a/src/lib/core/soundRegistry.ts
+++ b/src/lib/core/soundRegistry.ts
@@ -33,8 +33,9 @@
 //   then     zero pad to 16-byte alignment.
 //
 // Every entity starts with (mName u32, mTypeName u32) sound hashes; mTypeName
-// selects the payload shape. Decoded payloads (validated against both retail
-// fixtures):
+// selects the payload shape. Decoded payloads (validated against the four
+// retail fixtures — PLAYBACKREGISTRY, RWACFEATUREREGISTRY, SOUNDENTITY, and
+// the 30 registries inside SOUND/AEMS/CSIS.BUNDLE):
 //   ~ContentClass~      1F4F9B6F  no payload
 //   ~ContentType~       9E25A791  u32 ContentClass name hash
 //   ~SlotSchema~        EB396D83  u32 ContentClass name hash
@@ -49,23 +50,57 @@
 //       name hash, u16 block index, u16 param index within block }, slotCount
 //       × { u32 slot name hash, u32 slot class hash, u16 index, u16
 //       uninitialised pad (0xCDCD) }.
-// Any other type (~ContentSpec~, ~VoiceSchema~, ~VoiceSpec~ are known to
-// exist in other retail registries but not in these fixtures) is preserved as
-// a verbatim payload blob so unknown registries still round-trip byte-exact.
+//   ~ContentSpec~       511A448B  see soundRegistryEntities.ts
+//   ~VoiceSchema~       C7382281  see soundRegistryEntities.ts
+//   ~VoiceSpec~         3597AD9B  see soundRegistryEntities.ts
+//   ~AemsVoiceCsisClass~ 12B39DC5 (absent from the wiki) — see
+//                                 soundRegistryEntities.ts
+// Any other type is preserved as a verbatim payload blob so unknown
+// registries still round-trip byte-exact.
 //
 // Wiki divergences found against real bytes (burnout.wiki/wiki/Registry):
-//  - ~ContentType~ / ~ContentClass~ type hashes and the entire
-//    GenericRwacFeatureImplementation entity type are undocumented.
+//  - ~ContentType~ / ~ContentClass~ type hashes and the
+//    GenericRwacFeatureImplementation and AemsVoiceCsisClass entity types are
+//    undocumented.
 //  - The wiki's "ContentClass possible class values" hashes are actually the
 //    NAMES of ContentType entities: 84D7FBE7 = ~SplicerContent::
 //    SK_CONTENT_TYPE~, 7CCDA2E7 = ~GenericRwacWaveContent::
-//    SK_WAVE_DATA_CONTENT_TYPE~.
+//    SK_WAVE_DATA_CONTENT_TYPE~. (The wiki calls 84D7FBE7 "AemsVoiceCsisClass"
+//    — that string is really an entity TYPE with its own hash, 12B39DC5.)
 //  - The hash-table slot function and probe order are undocumented ("randomly
 //    placed").
 //  - The wiki's VoiceSchema offsets (0x8/0x10/0x11/0x12 for four u32s) are
-//    self-overlapping and cannot be the real layout.
+//    self-overlapping and wrong — the real layout is four u32 counts followed
+//    by featureSchemaCount name hashes (see soundRegistryEntities.ts).
+//  - String-carrying payloads (ContentSpec, AemsVoiceCsisClass) are padded to
+//    4-byte alignment with 0xCD fill; the wiki doesn't mention alignment.
 
 import { BinReader, BinWriter } from './binTools';
+import {
+	parseContentSpec,
+	parseVoiceSchema,
+	parseVoiceSpec,
+	parseAemsVoiceCsis,
+	writeContentSpec,
+	writeVoiceSchema,
+	writeVoiceSpec,
+	writeAemsVoiceCsis,
+	contentSpecPayloadSize,
+	voiceSchemaPayloadSize,
+	voiceSpecPayloadSize,
+	aemsVoiceCsisPayloadSize,
+	type RegistryContentSpec,
+	type RegistryVoiceSchema,
+	type RegistryVoiceSpec,
+	type RegistryAemsVoiceCsis,
+} from './soundRegistryEntities';
+
+export type {
+	RegistryContentSpec,
+	RegistryVoiceSchema,
+	RegistryVoiceSpec,
+	RegistryAemsVoiceCsis,
+} from './soundRegistryEntities';
 
 // =============================================================================
 // Sound hash
@@ -100,11 +135,10 @@ export const REGISTRY_TYPE_HASHES = {
 	PARAMETER_SCHEMA: 0x8d2c6829, // soundHash('~ParameterSchema~')
 	FEATURE_SCHEMA: 0xcb8b64c5, // soundHash('~FeatureSchema~')
 	RWAC_FEATURE: 0xb8083a05, // soundHash('~GenericRwacFeatureImplementation~')
-	// Known from the wiki / string tables but not present in our fixtures —
-	// parsed as verbatim payload blobs:
 	CONTENT_SPEC: 0x511a448b, // soundHash('~ContentSpec~')
 	VOICE_SCHEMA: 0xc7382281, // soundHash('~VoiceSchema~')
 	VOICE_SPEC: 0x3597ad9b, // soundHash('~VoiceSpec~')
+	AEMS_VOICE_CSIS: 0x12b39dc5, // soundHash('~AemsVoiceCsisClass~')
 } as const;
 
 export const REGISTRY_TYPE_LABELS: Record<number, string> = {
@@ -117,6 +151,7 @@ export const REGISTRY_TYPE_LABELS: Record<number, string> = {
 	[REGISTRY_TYPE_HASHES.CONTENT_SPEC]: 'ContentSpec',
 	[REGISTRY_TYPE_HASHES.VOICE_SCHEMA]: 'VoiceSchema',
 	[REGISTRY_TYPE_HASHES.VOICE_SPEC]: 'VoiceSpec',
+	[REGISTRY_TYPE_HASHES.AEMS_VOICE_CSIS]: 'AemsVoiceCsisClass',
 };
 
 export const PARAMETER_DIRECTIONS = [
@@ -179,7 +214,7 @@ export type RegistryRwacFeature = {
 };
 
 // Exactly one payload field is non-null, selected by mTypeName — except
-// ContentClass entities (no payload), where all five are null. ContentType
+// ContentClass entities (no payload), where all are null. ContentType
 // and SlotSchema share mpContentClass.
 export type RegistryEntity = {
 	/** Sound hash of the entity name (plain text usually in `strings`). */
@@ -191,6 +226,10 @@ export type RegistryEntity = {
 	parameterSchema: RegistryParameterSchema | null;
 	featureSchema: RegistryFeatureSchema | null;
 	rwacFeature: RegistryRwacFeature | null;
+	contentSpec: RegistryContentSpec | null;
+	voiceSchema: RegistryVoiceSchema | null;
+	voiceSpec: RegistryVoiceSpec | null;
+	aemsVoiceCsis: RegistryAemsVoiceCsis | null;
 	/** Verbatim payload for type names this parser doesn't decode. */
 	_unknownPayload: Uint8Array | null;
 };
@@ -221,6 +260,10 @@ export function makeEmptyRegistryEntity(): RegistryEntity {
 		parameterSchema: null,
 		featureSchema: null,
 		rwacFeature: null,
+		contentSpec: null,
+		voiceSchema: null,
+		voiceSpec: null,
+		aemsVoiceCsis: null,
 		_unknownPayload: null,
 	};
 }
@@ -235,6 +278,10 @@ function entityPayloadSize(e: RegistryEntity): number {
 		const f = e.rwacFeature;
 		return 16 + f.blocks.length * 12 + f.params.length * 8 + f.slots.length * 12;
 	}
+	if (e.contentSpec != null) return contentSpecPayloadSize(e.contentSpec);
+	if (e.voiceSchema != null) return voiceSchemaPayloadSize(e.voiceSchema);
+	if (e.voiceSpec != null) return voiceSpecPayloadSize(e.voiceSpec);
+	if (e.aemsVoiceCsis != null) return aemsVoiceCsisPayloadSize(e.aemsVoiceCsis);
 	if (e._unknownPayload != null) return e._unknownPayload.byteLength;
 	return 0;
 }
@@ -402,6 +449,18 @@ function parseEntity(r: BinReader, bytes: Uint8Array, start: number, end: number
 			entity.rwacFeature = { _uninit08, blocks, params, slots };
 			break;
 		}
+		case REGISTRY_TYPE_HASHES.CONTENT_SPEC:
+			entity.contentSpec = parseContentSpec(r, bytes, end, `entity 0x${mName.toString(16)}`);
+			break;
+		case REGISTRY_TYPE_HASHES.VOICE_SCHEMA:
+			entity.voiceSchema = parseVoiceSchema(r, avail, `entity 0x${mName.toString(16)}`);
+			break;
+		case REGISTRY_TYPE_HASHES.VOICE_SPEC:
+			entity.voiceSpec = parseVoiceSpec(r, avail, `entity 0x${mName.toString(16)}`);
+			break;
+		case REGISTRY_TYPE_HASHES.AEMS_VOICE_CSIS:
+			entity.aemsVoiceCsis = parseAemsVoiceCsis(r, bytes, end, `entity 0x${mName.toString(16)}`);
+			break;
 		default:
 			entity._unknownPayload = bytes.slice(start + 8, end);
 			break;
@@ -557,6 +616,14 @@ function writeEntity(w: BinWriter, e: RegistryEntity) {
 			w.writeU16(s.mu16Index);
 			w.writeU16(s._pad0A);
 		}
+	} else if (e.contentSpec != null) {
+		writeContentSpec(w, e.contentSpec);
+	} else if (e.voiceSchema != null) {
+		writeVoiceSchema(w, e.voiceSchema);
+	} else if (e.voiceSpec != null) {
+		writeVoiceSpec(w, e.voiceSpec);
+	} else if (e.aemsVoiceCsis != null) {
+		writeAemsVoiceCsis(w, e.aemsVoiceCsis);
 	} else if (e._unknownPayload != null) {
 		w.writeBytes(e._unknownPayload);
 	}

--- a/src/lib/core/soundRegistryEntities.ts
+++ b/src/lib/core/soundRegistryEntities.ts
@@ -1,0 +1,263 @@
+// Payload codecs for the Registry (0xA000) entity kinds that carry inline
+// strings or per-voice arrays: ContentSpec, VoiceSchema, VoiceSpec, and the
+// wiki-undocumented AemsVoiceCsisClass. Split out of soundRegistry.ts, which
+// owns the container format (header, hash table, string pool) and the
+// fixed-shape payloads; this file owns the variable-shape ones found in
+// SOUND/SOUNDENTITY.BUNDLE and SOUND/AEMS/CSIS.BUNDLE.
+//
+// Layouts validated against every instance in those fixtures (115 ContentSpec,
+// 26 VoiceSchema, 28 VoiceSpec, 12 AemsVoiceCsisClass):
+//
+//   ~ContentSpec~ payload — what a named sound loads:
+//     u32 mpContentType   name hash of a ContentType entity ("not actually a
+//                         pointer", per the wiki)
+//     u16 pathLength      length of the inline string, NUL excluded (derived)
+//     u8  mu8LoadMethod   EContentLoadMethod — 1 in every fixture instance
+//     u8  mu8LoadTime     EContentLoadTime — 1 in every fixture instance
+//     then the path string + NUL + 0xCD pad to the next 4-byte boundary.
+//     The path is usually a gamedb:// URL (wave or AEMS bank) but plain names
+//     occur too. The entity name hash often equals soundHash(path) — but NOT
+//     always (34 of 115 differ), so the name is independent data.
+//
+//   ~VoiceSchema~ payload — which DSP features a voice class instantiates.
+//     The wiki's struct table is self-overlapping garbage; the real layout:
+//     u32 featureSchemaCount (derived), u32 ×3 always 0 in retail (named
+//     after the wiki's remaining fields, order unverifiable), then
+//     featureSchemaCount × u32 FeatureSchema entity name hashes.
+//
+//   ~VoiceSpec~ payload — a concrete voice the engine can allocate:
+//     u32 mpVoiceSchema   name hash of a VoiceSchema entity
+//     u8  sendCount       (derived from the send list)
+//     u8  mu8ProcessingStage  bitmask-looking values (0x00..0xF0) — unknown
+//     u8  mu8ChannelCount 1/2/4/6 in retail
+//     u8  mu8VoiceType    EVoiceType — 0 player, 1 submix, 2 master
+//     then sendCount × u32 send-target name hashes (submix/master voices).
+//
+//   ~AemsVoiceCsisClass~ payload (absent from the wiki) — binds a CSIS voice
+//   class to its AEMS bank content:
+//     u32 mUnknown08      small varying value (6..28 in retail)
+//     u16 mUnknown0C      2 in every fixture instance
+//     u16 labelLength     length of the inline string, NUL excluded (derived)
+//     u32 mUnknown10      shared by entities in the same registry (bank id?)
+//     u32 mUnknown14      distinct per entity
+//     then the label string + NUL + 0xCD pad to 4. The entity name is
+//     soundHash('AEMS_' + label) in all 12 retail instances.
+
+import { BinReader, BinWriter } from './binTools';
+
+export type RegistryContentSpec = {
+	/** Name hash of a ContentType entity (e.g. ~GenericRwacWaveContent::SK_WAVE_DATA_CONTENT_TYPE~). */
+	mpContentType: number;
+	/** EContentLoadMethod — 1 (resource module) in every fixture instance. */
+	mu8LoadMethod: number;
+	/** EContentLoadTime — 1 (immediate) in every fixture instance. */
+	mu8LoadTime: number;
+	/** Inline content path, usually a gamedb:// URL. Length is re-derived on write. */
+	path: string;
+	/** 0–3 uninitialised alignment bytes after the NUL (0xCD in retail) — preserved verbatim. */
+	_padTail: Uint8Array;
+};
+
+export type RegistryVoiceSchema = {
+	/** Always 0 in retail; which of the wiki's three remaining counts sits here is unverifiable. */
+	mu32SlotCount: number;
+	mu32ParameterCount: number;
+	mu32OutputParamCount: number;
+	/** Name hashes of the FeatureSchema entities this voice class instantiates. */
+	featureSchemaHashes: number[];
+};
+
+export type RegistryVoiceSpec = {
+	/** Name hash of a VoiceSchema entity (may live in a different registry). */
+	mpVoiceSchema: number;
+	mu8ProcessingStage: number;
+	mu8ChannelCount: number;
+	/** EVoiceType — 0 player, 1 submix, 2 master. */
+	mu8VoiceType: number;
+	/** Name hashes of the send targets (submix/master voices) this voice feeds. */
+	sendHashes: number[];
+};
+
+export type RegistryAemsVoiceCsis = {
+	mUnknown08: number;
+	/** 2 in every retail instance; meaning unknown. */
+	mUnknown0C: number;
+	/** Shared by all AemsVoiceCsisClass entities in the same registry (bank id?). */
+	mUnknown10: number;
+	mUnknown14: number;
+	/** Inline class label; the entity name is soundHash('AEMS_' + label) in retail. */
+	label: string;
+	/** 0–3 uninitialised alignment bytes after the NUL (0xCD in retail) — preserved verbatim. */
+	_padTail: Uint8Array;
+};
+
+// Entities are packed at 4-byte alignment, so a string payload is followed by
+// 0–3 fill bytes. `fixedSize` counts everything before the string, entity
+// header included — always a multiple of 4, so only string + NUL matter.
+function tailPadLength(stringLength: number): number {
+	return (4 - ((stringLength + 1) & 3)) & 3;
+}
+
+export function contentSpecPayloadSize(cs: RegistryContentSpec): number {
+	return 8 + cs.path.length + 1 + tailPadLength(cs.path.length);
+}
+
+export function voiceSchemaPayloadSize(vs: RegistryVoiceSchema): number {
+	return 16 + 4 * vs.featureSchemaHashes.length;
+}
+
+export function voiceSpecPayloadSize(vs: RegistryVoiceSpec): number {
+	return 8 + 4 * vs.sendHashes.length;
+}
+
+export function aemsVoiceCsisPayloadSize(a: RegistryAemsVoiceCsis): number {
+	return 16 + a.label.length + 1 + tailPadLength(a.label.length);
+}
+
+// ---------------------------------------------------------------------------
+// Inline-string helpers (latin1, NUL-terminated, 0xCD pad to 4)
+// ---------------------------------------------------------------------------
+
+function readInlineString(bytes: Uint8Array, at: number, length: number, who: string): string {
+	let s = '';
+	for (let i = 0; i < length; i++) {
+		const b = bytes[at + i];
+		if (b === 0) throw new Error(`Registry: ${who} inline string has an embedded NUL at +${i}`);
+		s += String.fromCharCode(b);
+	}
+	if (bytes[at + length] !== 0) {
+		throw new Error(`Registry: ${who} inline string is not NUL-terminated at 0x${(at + length).toString(16)}`);
+	}
+	return s;
+}
+
+function writeInlineString(w: BinWriter, s: string, padTail: Uint8Array, who: string) {
+	for (let i = 0; i < s.length; i++) {
+		const c = s.charCodeAt(i);
+		if (c === 0 || c > 0xff) {
+			throw new Error(`Registry writer: ${who} string "${s}" has a byte-unrepresentable character`);
+		}
+		w.writeU8(c);
+	}
+	w.writeU8(0);
+	// The pad is uninitialised allocator fill — write it back verbatim when the
+	// string is untouched; a resized string gets the retail 0xCD fill instead.
+	const need = tailPadLength(s.length);
+	if (padTail.byteLength === need) {
+		w.writeBytes(padTail);
+	} else {
+		for (let i = 0; i < need; i++) w.writeU8(0xcd);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Parsers — `r` is positioned at the payload start (entity start + 8);
+// `end` bounds the payload (the next entity's offset, or the data end).
+// ---------------------------------------------------------------------------
+
+export function parseContentSpec(r: BinReader, bytes: Uint8Array, end: number, who: string): RegistryContentSpec {
+	const mpContentType = r.readU32();
+	const pathLength = r.readU16();
+	const mu8LoadMethod = r.readU8();
+	const mu8LoadTime = r.readU8();
+	const strAt = r.position;
+	const expectedEnd = strAt + pathLength + 1 + tailPadLength(pathLength);
+	if (expectedEnd !== end) {
+		throw new Error(`Registry: ${who} ContentSpec path length ${pathLength} implies payload end 0x${expectedEnd.toString(16)}, actual 0x${end.toString(16)}`);
+	}
+	const path = readInlineString(bytes, strAt, pathLength, who);
+	const _padTail = bytes.slice(strAt + pathLength + 1, end);
+	r.position = end;
+	return { mpContentType, mu8LoadMethod, mu8LoadTime, path, _padTail };
+}
+
+export function parseVoiceSchema(r: BinReader, payloadSize: number, who: string): RegistryVoiceSchema {
+	const count = r.readU32();
+	const mu32SlotCount = r.readU32();
+	const mu32ParameterCount = r.readU32();
+	const mu32OutputParamCount = r.readU32();
+	if (payloadSize !== 16 + 4 * count) {
+		throw new Error(`Registry: ${who} VoiceSchema has ${payloadSize} payload bytes, expected ${16 + 4 * count} for ${count} features`);
+	}
+	const featureSchemaHashes: number[] = [];
+	for (let i = 0; i < count; i++) featureSchemaHashes.push(r.readU32());
+	return { mu32SlotCount, mu32ParameterCount, mu32OutputParamCount, featureSchemaHashes };
+}
+
+export function parseVoiceSpec(r: BinReader, payloadSize: number, who: string): RegistryVoiceSpec {
+	const mpVoiceSchema = r.readU32();
+	const sendCount = r.readU8();
+	const mu8ProcessingStage = r.readU8();
+	const mu8ChannelCount = r.readU8();
+	const mu8VoiceType = r.readU8();
+	if (payloadSize !== 8 + 4 * sendCount) {
+		throw new Error(`Registry: ${who} VoiceSpec has ${payloadSize} payload bytes, expected ${8 + 4 * sendCount} for ${sendCount} sends`);
+	}
+	const sendHashes: number[] = [];
+	for (let i = 0; i < sendCount; i++) sendHashes.push(r.readU32());
+	return { mpVoiceSchema, mu8ProcessingStage, mu8ChannelCount, mu8VoiceType, sendHashes };
+}
+
+export function parseAemsVoiceCsis(r: BinReader, bytes: Uint8Array, end: number, who: string): RegistryAemsVoiceCsis {
+	const mUnknown08 = r.readU32();
+	const mUnknown0C = r.readU16();
+	const labelLength = r.readU16();
+	const mUnknown10 = r.readU32();
+	const mUnknown14 = r.readU32();
+	const strAt = r.position;
+	const expectedEnd = strAt + labelLength + 1 + tailPadLength(labelLength);
+	if (expectedEnd !== end) {
+		throw new Error(`Registry: ${who} AemsVoiceCsisClass label length ${labelLength} implies payload end 0x${expectedEnd.toString(16)}, actual 0x${end.toString(16)}`);
+	}
+	const label = readInlineString(bytes, strAt, labelLength, who);
+	const _padTail = bytes.slice(strAt + labelLength + 1, end);
+	r.position = end;
+	return { mUnknown08, mUnknown0C, mUnknown10, mUnknown14, label, _padTail };
+}
+
+// ---------------------------------------------------------------------------
+// Writers
+// ---------------------------------------------------------------------------
+
+export function writeContentSpec(w: BinWriter, cs: RegistryContentSpec) {
+	if (cs.path.length > 0xffff) {
+		throw new Error(`Registry writer: ContentSpec path is ${cs.path.length} chars, max 65535`);
+	}
+	w.writeU32(cs.mpContentType);
+	w.writeU16(cs.path.length);
+	w.writeU8(cs.mu8LoadMethod);
+	w.writeU8(cs.mu8LoadTime);
+	writeInlineString(w, cs.path, cs._padTail, 'ContentSpec');
+}
+
+export function writeVoiceSchema(w: BinWriter, vs: RegistryVoiceSchema) {
+	w.writeU32(vs.featureSchemaHashes.length);
+	w.writeU32(vs.mu32SlotCount);
+	w.writeU32(vs.mu32ParameterCount);
+	w.writeU32(vs.mu32OutputParamCount);
+	for (const h of vs.featureSchemaHashes) w.writeU32(h);
+}
+
+export function writeVoiceSpec(w: BinWriter, vs: RegistryVoiceSpec) {
+	if (vs.sendHashes.length > 0xff) {
+		throw new Error(`Registry writer: VoiceSpec has ${vs.sendHashes.length} sends, max 255`);
+	}
+	w.writeU32(vs.mpVoiceSchema);
+	w.writeU8(vs.sendHashes.length);
+	w.writeU8(vs.mu8ProcessingStage);
+	w.writeU8(vs.mu8ChannelCount);
+	w.writeU8(vs.mu8VoiceType);
+	for (const h of vs.sendHashes) w.writeU32(h);
+}
+
+export function writeAemsVoiceCsis(w: BinWriter, a: RegistryAemsVoiceCsis) {
+	if (a.label.length > 0xffff) {
+		throw new Error(`Registry writer: AemsVoiceCsisClass label is ${a.label.length} chars, max 65535`);
+	}
+	w.writeU32(a.mUnknown08);
+	w.writeU16(a.mUnknown0C);
+	w.writeU16(a.label.length);
+	w.writeU32(a.mUnknown10);
+	w.writeU32(a.mUnknown14);
+	writeInlineString(w, a.label, a._padTail, 'AemsVoiceCsisClass');
+}

--- a/src/lib/core/splicer.ts
+++ b/src/lib/core/splicer.ts
@@ -1,0 +1,382 @@
+// Splicer parser and writer (resource type 0xA025).
+//
+// A Splicer is a self-contained bank of triggered sounds: each *splice* is
+// one playable event (a collision hit, a menu popup, a passby whoosh) built
+// from one or more *sample refs* — playback instructions (volume, pitch,
+// delay, fades) that point into a table of audio *samples* embedded at the
+// tail of the same resource. The samples are EA SNR-style streams (byte 0
+// codec nibble 7 = EA-XAS, 48 kHz in every retail splicer) kept opaque here.
+// Nothing references wave assets outside the resource: every retail splicer
+// bundle holds exactly one 0xA025 with importCount 0, and SampleIndex is an
+// index into the internal table of contents. Which splice plays for which
+// game event is hardcoded by splice order (see the wiki's "sweeteners" note),
+// so reordering or removing splices changes game behaviour.
+//
+// On-disk layout (32-bit PC, little-endian), validated against all six
+// retail SOUND/SPLICER bundles:
+//   0x00 u32 mu32DataSize    — bytes after mu32DataOffset (= total - 0x10)
+//   0x04 u32 mu32DataOffset  — 0x10 (CgsResource::BinaryFileResource header
+//                              padded to 16; pointers below ignore it)
+//   0x08 u8[8]               — wrapper pad (zero in retail), kept verbatim
+//   0x10 u32 versionOfData   — KI_SPLICE_DATA_VERSION, must be 1
+//   0x14 u32 sizedata        — SPLICE_Data + SPLICE_SampleRef bytes combined
+//   0x18 u32 numsplices
+//   0x1C     numsplices × SPLICE_Data (0x18 each), packed back to back
+//   then     ΣNum_SampleRefs × SPLICE_SampleRef (0x2C each) — one shared
+//            array, consumed in SpliceIndex order (identity in retail)
+//   then     u32 numSamples (mNumSamples, at pdata + sizedata)
+//   then     numSamples × u32 TOC — byte offsets into the sample data,
+//            0-based, strictly increasing, NOT aligned
+//   then     sample data to end of resource (last sample owns any pad)
+//
+// Wiki divergence (burnout.wiki/wiki/Splicer): the page describes both
+// record types but not their arrangement — SPLICE_Data records are NOT
+// interleaved with their SampleRefs; all splice records come first, then one
+// flat SampleRef array. "SpliceIndex determines the order in which
+// SampleRefs are read" is the only hint. In every retail resource
+// SpliceIndex equals the record's position; the parser still consumes ref
+// batches in SpliceIndex rank order so a permuted file would round-trip.
+//
+// Round-trip strategy: rigid-layout violations THROW; sizedata / counts /
+// the TOC are recomputed from array lengths on write; sample payloads, pads
+// and NameHash are preserved verbatim. parse(write(parse(x))) is byte-exact
+// on all six retail fixtures.
+
+import { BinReader, BinWriter } from './binTools';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type SpliceSampleRef = {
+	/** Index into the splicer's embedded sample table (samples[]). */
+	SampleIndex: number; // u16
+	/** eSpliceType — undocumented enum, 0 in every retail ref. */
+	eSpliceType: number; // i8
+	/** Pad byte at +0x3 (0 in retail) — preserved verbatim. */
+	_pad03: number; // u8
+	/** Linear amplitude multiplier (1 = as authored). */
+	Volume: number; // f32
+	/** Frequency ratio (1 = original pitch; 2^(n/12) = n semitones). */
+	Pitch: number; // f32
+	/** Playback delay in seconds from the splice trigger. */
+	Offset: number; // f32
+	/** Azimuth — wiki: "typically 0 or -127"; retail range -127..121. */
+	Az: number; // f32
+	/** Playback duration in seconds (always > 0 in retail). */
+	Duration: number; // f32
+	/** Fade-in duration in seconds. */
+	FadeIn: number; // f32
+	/** Fade-out duration in seconds. */
+	FadeOut: number; // f32
+	/** Random volume bound (1 = no randomisation; retail 0.5..1.2). */
+	RND_Vol: number; // f32
+	/** Random pitch offset (0 = none; retail -0.41..0.79). */
+	RND_Pitch: number; // f32
+	/** Priority — 0 in every retail ref. */
+	Priority: number; // u8
+	/** eRollOffType — undocumented enum, 0 in every retail ref. */
+	eRollOffType: number; // u8
+	/** Pad u16 at +0x2A (0 in retail) — preserved verbatim. */
+	_pad2A: number; // u16
+};
+
+export type SpliceData = {
+	/** Always 0 in retail (the wiki marks it "Always null") — preserved. */
+	NameHash: number; // u32
+	/**
+	 * Rank in the shared SampleRef array: the splice with the lowest
+	 * SpliceIndex owns the first batch of refs, and so on. Equals the
+	 * splice's position in every retail resource. Game events bind to
+	 * splices by this hardcoded order.
+	 */
+	SpliceIndex: number; // u16
+	/** eSpliceType — undocumented enum, 0 in every retail splice. */
+	eSpliceType: number; // i8
+	/** Linear amplitude multiplier applied to the whole splice. */
+	Volume: number; // f32
+	/** Random pitch offset for the splice (0 in every retail splice). */
+	RND_Pitch: number; // f32
+	/** Random volume bound for the splice (1 in every retail splice). */
+	RND_Vol: number; // f32
+	/** This splice's playback instructions (Num_SampleRefs is derived). */
+	sampleRefs: SpliceSampleRef[];
+};
+
+export type ParsedSplicer = {
+	splices: SpliceData[];
+	/**
+	 * Embedded audio streams, addressed by SpliceSampleRef.SampleIndex.
+	 * Opaque EA SNR/EA-XAS payloads — see splicerSampleInfo for the
+	 * decodable header lanes. Boundaries come from the TOC; the last
+	 * sample owns the file's trailing pad bytes.
+	 */
+	samples: Uint8Array[];
+	/** BinaryFile wrapper bytes 0x8..0xF (zero in retail) — preserved verbatim. */
+	_wrapperPad: Uint8Array;
+};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const DATA_OFFSET = 0x10;
+const SPLICE_HEADER_SIZE = 0xc; // versionOfData + sizedata + numsplices
+const SPLICE_DATA_SIZE = 0x18;
+const SAMPLE_REF_SIZE = 0x2c;
+const SPLICE_DATA_VERSION = 1;
+
+// =============================================================================
+// Sample-header peek (labels / describe only — never written back)
+// =============================================================================
+
+/**
+ * Decode the first two big-endian words of an embedded sample: an EA SNR
+ * "headerB"-style header (the rest of the audio toolchain is BE even on PC).
+ * Every retail splicer sample decodes to codec 7 (EA-XAS) at 48000 Hz with
+ * channelConfig 0 (mono) or 1 (stereo). Returns null when the blob is too
+ * short or the rate lane is zero — callers fall back to a byte-count label.
+ */
+export function splicerSampleInfo(data: Uint8Array): {
+	codec: number;
+	channels: number;
+	sampleRate: number;
+	sampleCount: number;
+	seconds: number;
+} | null {
+	if (data.byteLength < 8) return null;
+	const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+	const w0 = view.getUint32(0, false);
+	const w1 = view.getUint32(4, false);
+	const sampleRate = w0 & 0x3ffff;
+	if (sampleRate === 0) return null;
+	const sampleCount = w1 & 0x3fffffff;
+	return {
+		codec: (w0 >>> 24) & 0xf,
+		channels: ((w0 >>> 18) & 0x3f) + 1,
+		sampleRate,
+		sampleCount,
+		seconds: sampleCount / sampleRate,
+	};
+}
+
+// =============================================================================
+// Reader
+// =============================================================================
+
+export function parseSplicer(raw: Uint8Array, littleEndian = true): ParsedSplicer {
+	// Copy up front — extractResourceRaw may hand back a Buffer view, and the
+	// verbatim sample/pad fields below must not alias the caller's bytes.
+	const bytes = new Uint8Array(raw);
+	const r = new BinReader(bytes.buffer, littleEndian);
+
+	// --- BinaryFile wrapper ---
+	const dataSize = r.readU32();
+	const dataOffset = r.readU32();
+	if (dataOffset !== DATA_OFFSET) {
+		throw new Error(`Splicer: mu32DataOffset is 0x${dataOffset.toString(16)}, expected 0x10`);
+	}
+	if (dataSize !== bytes.byteLength - DATA_OFFSET) {
+		throw new Error(`Splicer: mu32DataSize 0x${dataSize.toString(16)} != resource size 0x${bytes.byteLength.toString(16)} - 0x10`);
+	}
+	const _wrapperPad = bytes.slice(8, DATA_OFFSET);
+
+	// --- Splice header ---
+	r.position = DATA_OFFSET;
+	const version = r.readU32();
+	if (version !== SPLICE_DATA_VERSION) {
+		throw new Error(`Splicer: versionOfData ${version}, expected ${SPLICE_DATA_VERSION}`);
+	}
+	const sizedata = r.readU32();
+	const numsplices = r.readU32();
+	const pdata = DATA_OFFSET + SPLICE_HEADER_SIZE;
+	const refsStart = pdata + numsplices * SPLICE_DATA_SIZE;
+	const refsBytes = pdata + sizedata - refsStart;
+	if (refsBytes < 0 || refsBytes % SAMPLE_REF_SIZE !== 0) {
+		throw new Error(`Splicer: sizedata 0x${sizedata.toString(16)} leaves 0x${refsBytes.toString(16)} SampleRef bytes for ${numsplices} splices (not a multiple of 0x2c)`);
+	}
+	const totalRefs = refsBytes / SAMPLE_REF_SIZE;
+
+	// --- SPLICE_Data records (packed, refs assigned below) ---
+	const splices: SpliceData[] = [];
+	let sumRefs = 0;
+	const numRefsPer: number[] = [];
+	for (let i = 0; i < numsplices; i++) {
+		const NameHash = r.readU32();
+		const SpliceIndex = r.readU16();
+		const eSpliceType = r.readI8();
+		const numRefs = r.readU8();
+		const Volume = r.readF32();
+		const RND_Pitch = r.readF32();
+		const RND_Vol = r.readF32();
+		const pSampleRefList = r.readU32();
+		if (pSampleRefList !== 0) {
+			throw new Error(`Splicer: splice ${i} has pSampleRefList 0x${pSampleRefList.toString(16)}, expected nullptr in asset`);
+		}
+		numRefsPer.push(numRefs);
+		sumRefs += numRefs;
+		splices.push({ NameHash, SpliceIndex, eSpliceType, Volume, RND_Pitch, RND_Vol, sampleRefs: [] });
+	}
+	if (sumRefs !== totalRefs) {
+		throw new Error(`Splicer: splices claim ${sumRefs} SampleRefs but sizedata holds ${totalRefs}`);
+	}
+
+	// --- SampleRefs: one flat array, consumed in SpliceIndex rank order ---
+	const rankOrder = spliceRankOrder(splices);
+	r.position = refsStart;
+	for (const spliceIdx of rankOrder) {
+		for (let j = 0; j < numRefsPer[spliceIdx]; j++) {
+			splices[spliceIdx].sampleRefs.push({
+				SampleIndex: r.readU16(),
+				eSpliceType: r.readI8(),
+				_pad03: r.readU8(),
+				Volume: r.readF32(),
+				Pitch: r.readF32(),
+				Offset: r.readF32(),
+				Az: r.readF32(),
+				Duration: r.readF32(),
+				FadeIn: r.readF32(),
+				FadeOut: r.readF32(),
+				RND_Vol: r.readF32(),
+				RND_Pitch: r.readF32(),
+				Priority: r.readU8(),
+				eRollOffType: r.readU8(),
+				_pad2A: r.readU16(),
+			});
+		}
+	}
+
+	// --- Sample table of contents + payloads ---
+	const numSamplesAt = pdata + sizedata;
+	r.position = numSamplesAt;
+	const numSamples = r.readU32();
+	const sampleDataAt = numSamplesAt + 4 + numSamples * 4;
+	if (sampleDataAt > bytes.byteLength) {
+		throw new Error(`Splicer: ${numSamples}-entry TOC overruns the 0x${bytes.byteLength.toString(16)}-byte resource`);
+	}
+	const toc: number[] = [];
+	for (let i = 0; i < numSamples; i++) toc.push(r.readU32());
+	const avail = bytes.byteLength - sampleDataAt;
+	if (numSamples === 0 && avail !== 0) {
+		throw new Error(`Splicer: 0 samples but 0x${avail.toString(16)} sample-data bytes remain`);
+	}
+	const samples: Uint8Array[] = [];
+	for (let i = 0; i < numSamples; i++) {
+		// Strict monotonicity matters: aliasing samples would duplicate bytes
+		// when the writer concatenates them back.
+		const start = toc[i];
+		const end = i + 1 < numSamples ? toc[i + 1] : avail;
+		if ((i === 0 && start !== 0) || end <= start || end > avail) {
+			throw new Error(`Splicer: TOC entry ${i} spans [0x${start.toString(16)}, 0x${end.toString(16)}) of 0x${avail.toString(16)} sample bytes`);
+		}
+		samples.push(bytes.slice(sampleDataAt + start, sampleDataAt + end));
+	}
+
+	// Refs must address real samples — catches TOC/ref drift early.
+	for (const s of splices) {
+		for (const ref of s.sampleRefs) {
+			if (ref.SampleIndex >= numSamples) {
+				throw new Error(`Splicer: SampleIndex ${ref.SampleIndex} out of range (only ${numSamples} samples)`);
+			}
+		}
+	}
+
+	return { splices, samples, _wrapperPad };
+}
+
+// =============================================================================
+// Writer
+// =============================================================================
+
+/** Splice array indices sorted by SpliceIndex — the shared SampleRef array
+ *  is stored (and consumed) in this order. Throws on duplicates because the
+ *  batches would be ambiguous. */
+function spliceRankOrder(splices: { SpliceIndex: number }[]): number[] {
+	const seen = new Set<number>();
+	for (const s of splices) {
+		if (seen.has(s.SpliceIndex)) {
+			throw new Error(`Splicer: duplicate SpliceIndex ${s.SpliceIndex} — SampleRef batches would be ambiguous`);
+		}
+		seen.add(s.SpliceIndex);
+	}
+	return splices.map((_, i) => i).sort((a, b) => splices[a].SpliceIndex - splices[b].SpliceIndex);
+}
+
+export function writeSplicer(model: ParsedSplicer, littleEndian = true): Uint8Array {
+	const { splices, samples } = model;
+	if (model._wrapperPad.byteLength !== 8) {
+		throw new Error(`Splicer writer: _wrapperPad is ${model._wrapperPad.byteLength} bytes, expected 8`);
+	}
+	let totalRefs = 0;
+	for (let i = 0; i < splices.length; i++) {
+		const n = splices[i].sampleRefs.length;
+		if (n > 0xff) {
+			throw new Error(`Splicer writer: splice ${i} has ${n} SampleRefs, Num_SampleRefs is a u8 (max 255)`);
+		}
+		for (const ref of splices[i].sampleRefs) {
+			if (ref.SampleIndex >= samples.length) {
+				throw new Error(`Splicer writer: splice ${i} references sample ${ref.SampleIndex} but only ${samples.length} samples exist`);
+			}
+		}
+		totalRefs += n;
+	}
+	const rankOrder = spliceRankOrder(splices);
+
+	// sizedata / TOC / mu32DataSize recomputed from array lengths, never stored.
+	const sizedata = splices.length * SPLICE_DATA_SIZE + totalRefs * SAMPLE_REF_SIZE;
+	const sampleBytes = samples.reduce((a, s) => a + s.byteLength, 0);
+	const totalSize = DATA_OFFSET + SPLICE_HEADER_SIZE + sizedata + 4 + samples.length * 4 + sampleBytes;
+
+	const w = new BinWriter(totalSize, littleEndian);
+	w.writeU32(totalSize - DATA_OFFSET);
+	w.writeU32(DATA_OFFSET);
+	w.writeBytes(model._wrapperPad);
+	w.writeU32(SPLICE_DATA_VERSION);
+	w.writeU32(sizedata);
+	w.writeU32(splices.length);
+
+	for (const s of splices) {
+		w.writeU32(s.NameHash);
+		w.writeU16(s.SpliceIndex);
+		w.writeI8(s.eSpliceType);
+		w.writeU8(s.sampleRefs.length);
+		w.writeF32(s.Volume);
+		w.writeF32(s.RND_Pitch);
+		w.writeF32(s.RND_Vol);
+		w.writeU32(0); // pSampleRefList — nullptr in asset, fixed up at runtime
+	}
+	for (const spliceIdx of rankOrder) {
+		for (const ref of splices[spliceIdx].sampleRefs) {
+			w.writeU16(ref.SampleIndex);
+			w.writeI8(ref.eSpliceType);
+			w.writeU8(ref._pad03);
+			w.writeF32(ref.Volume);
+			w.writeF32(ref.Pitch);
+			w.writeF32(ref.Offset);
+			w.writeF32(ref.Az);
+			w.writeF32(ref.Duration);
+			w.writeF32(ref.FadeIn);
+			w.writeF32(ref.FadeOut);
+			w.writeF32(ref.RND_Vol);
+			w.writeF32(ref.RND_Pitch);
+			w.writeU8(ref.Priority);
+			w.writeU8(ref.eRollOffType);
+			w.writeU16(ref._pad2A);
+		}
+	}
+	if (w.offset !== DATA_OFFSET + SPLICE_HEADER_SIZE + sizedata) {
+		throw new Error(`Splicer writer: splice data ends at 0x${w.offset.toString(16)}, expected 0x${(DATA_OFFSET + SPLICE_HEADER_SIZE + sizedata).toString(16)}`);
+	}
+
+	w.writeU32(samples.length);
+	let cursor = 0;
+	for (const s of samples) {
+		w.writeU32(cursor);
+		cursor += s.byteLength;
+	}
+	for (const s of samples) w.writeBytes(s);
+	if (w.offset !== totalSize) {
+		throw new Error(`Splicer writer: ended at 0x${w.offset.toString(16)}, expected 0x${totalSize.toString(16)}`);
+	}
+	return w.bytes;
+}

--- a/src/lib/editor/profiles/aemsBank.ts
+++ b/src/lib/editor/profiles/aemsBank.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedAemsBank } from '@/lib/core/aemsBank';
+import { aemsBankResourceSchema } from '@/lib/schema/resources/aemsBank';
+
+export const aemsBankProfile = defineProfile<ParsedAemsBank>({
+	kind: 'default',
+	displayName: 'AEMS Bank',
+	schema: aemsBankResourceSchema,
+});

--- a/src/lib/editor/profiles/csis.ts
+++ b/src/lib/editor/profiles/csis.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedCsis } from '@/lib/core/csis';
+import { csisResourceSchema } from '@/lib/schema/resources/csis';
+
+export const csisProfile = defineProfile<ParsedCsis>({
+	kind: 'default',
+	displayName: 'CSIS',
+	schema: csisResourceSchema,
+});

--- a/src/lib/editor/profiles/flaptFile.ts
+++ b/src/lib/editor/profiles/flaptFile.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedFlaptFile } from '@/lib/core/flaptFile';
+import { flaptFileResourceSchema } from '@/lib/schema/resources/flaptFile';
+
+export const flaptFileProfile = defineProfile<ParsedFlaptFile>({
+	kind: 'default',
+	displayName: 'Flapt File',
+	schema: flaptFileResourceSchema,
+});

--- a/src/lib/editor/profiles/genericRwacWaveContent.ts
+++ b/src/lib/editor/profiles/genericRwacWaveContent.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedGenericRwacWaveContent } from '@/lib/core/genericRwacWaveContent';
+import { genericRwacWaveContentResourceSchema } from '@/lib/schema/resources/genericRwacWaveContent';
+
+export const genericRwacWaveContentProfile = defineProfile<ParsedGenericRwacWaveContent>({
+	kind: 'default',
+	displayName: 'Generic RWAC Wave Content',
+	schema: genericRwacWaveContentResourceSchema,
+});

--- a/src/lib/editor/profiles/nicotine.ts
+++ b/src/lib/editor/profiles/nicotine.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedNicotine } from '@/lib/core/nicotine';
+import { nicotineResourceSchema } from '@/lib/schema/resources/nicotine';
+
+export const nicotineProfile = defineProfile<ParsedNicotine>({
+	kind: 'default',
+	displayName: 'Nicotine Map',
+	schema: nicotineResourceSchema,
+});

--- a/src/lib/editor/profiles/snapshotData.ts
+++ b/src/lib/editor/profiles/snapshotData.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedSnapshotData } from '@/lib/core/snapshotData';
+import { snapshotDataResourceSchema } from '@/lib/schema/resources/snapshotData';
+
+export const snapshotDataProfile = defineProfile<ParsedSnapshotData>({
+	kind: 'default',
+	displayName: 'Snapshot Data',
+	schema: snapshotDataResourceSchema,
+});

--- a/src/lib/editor/profiles/splicer.ts
+++ b/src/lib/editor/profiles/splicer.ts
@@ -1,0 +1,9 @@
+import { defineProfile } from '../types';
+import type { ParsedSplicer } from '@/lib/core/splicer';
+import { splicerResourceSchema } from '@/lib/schema/resources/splicer';
+
+export const splicerProfile = defineProfile<ParsedSplicer>({
+	kind: 'default',
+	displayName: 'Splicer',
+	schema: splicerResourceSchema,
+});

--- a/src/lib/editor/registry.ts
+++ b/src/lib/editor/registry.ts
@@ -14,13 +14,17 @@
 // only see the lookup helpers — never the registration array directly.
 
 import { aiSectionsV12Profile, aiSectionsV4Profile, aiSectionsV6Profile } from './profiles/aiSections';
+import { aemsBankProfile } from './profiles/aemsBank';
 import { aptDataProfile } from './profiles/aptData';
 import { challengeListProfile } from './profiles/challengeList';
+import { csisProfile } from './profiles/csis';
 import { colourCubeProfile } from './profiles/colourCube';
 import { environmentDictionaryProfile } from './profiles/environmentDictionary';
 import { environmentKeyframeProfile } from './profiles/environmentKeyframe';
 import { environmentTimeLineProfile } from './profiles/environmentTimeLine';
+import { flaptFileProfile } from './profiles/flaptFile';
 import { fontProfile } from './profiles/font';
+import { genericRwacWaveContentProfile } from './profiles/genericRwacWaveContent';
 import { guiPopupProfile } from './profiles/guiPopup';
 import { hudMessageProfile } from './profiles/hudMessage';
 import { hudMessageSequenceProfile } from './profiles/hudMessageSequence';
@@ -29,6 +33,7 @@ import { iceTakeDictionaryProfile } from './profiles/iceTakeDictionary';
 import { idListProfile } from './profiles/idList';
 import { languageProfile } from './profiles/language';
 import { massiveLookupTableProfile } from './profiles/massiveLookupTable';
+import { nicotineProfile } from './profiles/nicotine';
 import { particleDescriptionProfile } from './profiles/particleDescription';
 import { particleDescriptionCollectionProfile } from './profiles/particleDescriptionCollection';
 import { playerCarColoursProfile } from './profiles/playerCarColours';
@@ -38,6 +43,8 @@ import { propInstanceDataProfile } from './profiles/propInstanceData';
 import { propGraphicsListProfile } from './profiles/propGraphicsList';
 import { propPhysicsProfile } from './profiles/propPhysics';
 import { renderableProfile } from './profiles/renderable';
+import { snapshotDataProfile } from './profiles/snapshotData';
+import { splicerProfile } from './profiles/splicer';
 import { staticSoundMapProfile } from './profiles/staticSoundMap';
 import { streetDataProfile } from './profiles/streetData';
 import { textureProfile } from './profiles/texture';
@@ -246,6 +253,41 @@ const ENTRIES: RegistryEntry[] = [
 		typeId: 0x1e,
 		key: 'aptData',
 		profiles: [aptDataProfile],
+	},
+	{
+		typeId: 0xa020,
+		key: 'genericRwacWaveContent',
+		profiles: [genericRwacWaveContentProfile],
+	},
+	{
+		typeId: 0xa022,
+		key: 'aemsBank',
+		profiles: [aemsBankProfile],
+	},
+	{
+		typeId: 0xa023,
+		key: 'csis',
+		profiles: [csisProfile],
+	},
+	{
+		typeId: 0xa024,
+		key: 'nicotine',
+		profiles: [nicotineProfile],
+	},
+	{
+		typeId: 0xa025,
+		key: 'splicer',
+		profiles: [splicerProfile],
+	},
+	{
+		typeId: 0xa029,
+		key: 'snapshotData',
+		profiles: [snapshotDataProfile],
+	},
+	{
+		typeId: 0x10020,
+		key: 'flaptFile',
+		profiles: [flaptFileProfile],
 	},
 	{
 		typeId: 0x1001f,

--- a/src/lib/schema/resources/aemsBank.test.ts
+++ b/src/lib/schema/resources/aemsBank.test.ts
@@ -1,0 +1,147 @@
+// Schema coverage tests for aemsBankResourceSchema.
+//
+// Coverage fixtures: GEARWHINEPATCHBANK (the smallest retail bank) and INAIR
+// (the only two-module bank, with two interface references) — together they
+// exercise every schema field with real values.
+//
+// Mirrors staticSoundMap.test.ts: parse each model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseAemsBank, type ParsedAemsBank } from '../../core/aemsBank';
+
+import { aemsBankResourceSchema } from './aemsBank';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const AEMS_BANK_TYPE_ID = 0xa022;
+
+function loadModel(bundleFile: string): ParsedAemsBank {
+	const fileBytes = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === AEMS_BANK_TYPE_ID)!;
+	return parseAemsBank(extractResourceRaw(buffer.buffer, bundle, resource), ctx.littleEndian);
+}
+
+for (const [label, bundleFile] of [
+	['GearWhine (single module)', 'example/SOUND/AEMS/GEARWHINEPATCHBANK.BUNDLE'],
+	['InAir (two modules, two refs)', 'example/SOUND/AEMS/INAIR.BUNDLE'],
+] as const) {
+	describe(`aemsBankResourceSchema coverage — ${label}`, () => {
+		const model = loadModel(bundleFile);
+
+		it('fixture parses with non-trivial content', () => {
+			expect(model.interfaceRefs.length).toBeGreaterThan(0);
+			expect(model.funcFixups.length).toBeGreaterThan(0);
+			expect(model._sfxBank.byteLength).toBeGreaterThan(0);
+		});
+
+		it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+			const missing: string[] = [];
+			for (const [recordName, rec] of Object.entries(aemsBankResourceSchema.registry)) {
+				for (const [fieldName, field] of Object.entries(rec.fields)) {
+					checkField(field, `${recordName}.${fieldName}`, missing);
+				}
+			}
+			if (missing.length > 0) {
+				throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+			}
+			function checkField(f: FieldSchema, where: string, out: string[]) {
+				if (f.kind === 'record') {
+					if (!aemsBankResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+					return;
+				}
+				if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+			}
+		});
+
+		it('walkResource visits every parsed field without throwing', () => {
+			let recordCount = 0;
+			let fieldCount = 0;
+			walkResource(aemsBankResourceSchema, model, (_p, _v, field, rec) => {
+				if (rec) recordCount++;
+				if (field) fieldCount++;
+			});
+			expect(recordCount).toBeGreaterThan(0);
+			expect(fieldCount).toBeGreaterThan(0);
+		});
+
+		it('no parsed record has fields absent from the schema', () => {
+			const missing: string[] = [];
+			walkResource(aemsBankResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const declared = new Set(Object.keys(rec.fields));
+				for (const key of Object.keys(value as Record<string, unknown>)) {
+					if (!declared.has(key)) {
+						missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+
+		it('every schema field is represented in the parsed data', () => {
+			const missing: string[] = [];
+			walkResource(aemsBankResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const obj = value as Record<string, unknown>;
+				for (const fieldName of Object.keys(rec.fields)) {
+					if (!(fieldName in obj)) {
+						missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+	});
+}
+
+describe('aemsBank path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(aemsBankResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedAemsBank');
+	});
+
+	it('resolves interfaceRefs[0] as an AemsInterfaceReference', () => {
+		const loc = resolveSchemaAtPath(aemsBankResourceSchema, ['interfaceRefs', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('AemsInterfaceReference');
+	});
+
+	it('resolves interfaceRefs[0] CrcAndKey lanes as u16 and the name as string', () => {
+		expect(resolveSchemaAtPath(aemsBankResourceSchema, ['interfaceRefs', 0, 'idCrc'])!.field?.kind).toBe('u16');
+		expect(resolveSchemaAtPath(aemsBankResourceSchema, ['interfaceRefs', 0, 'idKey'])!.field?.kind).toBe('u16');
+		expect(resolveSchemaAtPath(aemsBankResourceSchema, ['interfaceRefs', 0, 'idName'])!.field?.kind).toBe('string');
+	});
+
+	it('resolves funcFixups as a list of u32', () => {
+		const loc = resolveSchemaAtPath(aemsBankResourceSchema, ['funcFixups']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('list');
+		expect((loc!.field as { item: FieldSchema }).item.kind).toBe('u32');
+	});
+
+	it('resolves targetType as an enum', () => {
+		const loc = resolveSchemaAtPath(aemsBankResourceSchema, ['targetType']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('enum');
+	});
+});

--- a/src/lib/schema/resources/aemsBank.ts
+++ b/src/lib/schema/resources/aemsBank.ts
@@ -1,0 +1,203 @@
+// Hand-written schema for ParsedAemsBank (resource type 0xA022).
+//
+// Mirrors the types in `src/lib/core/aemsBank.ts`. Keep these in lockstep
+// with the parser/writer — any field added to the parser needs a matching
+// entry here, or the schema walker reports it as drift.
+//
+// Domain: an AEMS bank is a COMPILED audio artifact — its module region is
+// x86 glue code + static data and its SFX region is an SND10 sample bank, so
+// both stay opaque verbatim blobs here. The editable surface is the tail:
+// the load-time fixup tables and the CSIS interface references that bind the
+// bank to a Csis resource's class by CrcAndKey. Editing a reference without
+// the matching Csis edit (or vice versa) silently breaks the audio link.
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+} from '../types';
+import { AEMS_PLATFORMS, AEMS_TARGET_TYPES, AEMS_INTERFACE_TYPES } from '@/lib/core/aemsBank';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring staticSoundMap.ts)
+// ---------------------------------------------------------------------------
+
+const u8 = (): FieldSchema => ({ kind: 'u8' });
+const u16 = (): FieldSchema => ({ kind: 'u16' });
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const str = (): FieldSchema => ({ kind: 'string' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+const rawBytes = (): FieldSchema => ({ kind: 'custom', component: 'rawBytes' });
+
+const enumOf = (storage: 'u8', values: readonly { value: number; label: string }[]): FieldSchema => ({
+	kind: 'enum',
+	storage,
+	values: values.map((v) => ({ value: v.value, label: v.label })),
+});
+
+const fixedList = (item: FieldSchema, length: number): FieldSchema => ({
+	kind: 'list',
+	item,
+	addable: false,
+	removable: false,
+	minLength: length,
+	maxLength: length,
+});
+
+// ---------------------------------------------------------------------------
+// Tree-label helpers
+// ---------------------------------------------------------------------------
+
+function refLabel(value: unknown, index: number): string {
+	try {
+		if (!value || typeof value !== 'object') return `#${index}`;
+		const r = value as { idName?: string; idCrc?: number; idKey?: number };
+		const name = r.idName || '(unnamed)';
+		const crc = r.idCrc != null ? r.idCrc.toString(16).toUpperCase() : '?';
+		const key = r.idKey != null ? r.idKey.toString(16).toUpperCase() : '?';
+		return `${name} · 0x${crc}/0x${key}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const AemsInterfaceReference: RecordSchema = {
+	name: 'AemsInterfaceReference',
+	description: 'One CSIS subscription: names a Csis class and stores its CrcAndKey (the Csis resource\'s system crc + the class entry\'s crc). The loader patches the Csis::ClassHandle at handleOffset once the class resolves.',
+	fields: {
+		handleOffset: u32(),
+		type: enumOf('u8', AEMS_INTERFACE_TYPES),
+		idCrc: u16(),
+		idKey: u16(),
+		idName: str(),
+		_pad: fixedList(u8(), 3),
+	},
+	fieldMetadata: {
+		handleOffset: {
+			label: 'Handle offset',
+			description: 'Payload-relative offset of the Csis::ClassHandle inside the compiled module data. Baked in by the AEMS compiler — read-only because steward cannot relocate slots inside the opaque module blob.',
+			readOnly: true,
+		},
+		type: {
+			label: 'Interface type',
+			description: 'AemsDef::InterfaceType — every retail bank uses Class (1).',
+			readOnly: true,
+		},
+		idCrc: {
+			label: 'System crc',
+			description: 'Low u16 of the ID CrcAndKey — must equal the target Csis resource\'s header crc ((Σ its entry crcs) & 0x7FFF).',
+			warning: 'Must match the subscribed Csis resource\'s system crc or the link silently breaks.',
+		},
+		idKey: {
+			label: 'Entry crc',
+			description: 'High u16 of the ID CrcAndKey — must equal the target class entry\'s own crc inside that Csis resource.',
+			warning: 'Must match the subscribed Csis class entry\'s crc or the link silently breaks.',
+		},
+		idName: {
+			label: 'Class name',
+			description: 'Name of the Csis class this bank subscribes to (e.g. GearWhineClass). The runtime match is by CrcAndKey; the name is the human-readable identity.',
+		},
+		_pad: {
+			label: 'pad (uninit)',
+			description: 'Three uninitialised pad bytes — the ASCII bytes \'AKH\' in every retail bank. Preserved verbatim.',
+			hidden: true,
+		},
+	},
+	label: (value, index) => refLabel(value, index ?? 0),
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedAemsBank: RecordSchema = {
+	name: 'ParsedAemsBank',
+	description: 'Root record for the AEMS Bank resource (0xA022): a compiled audio module (opaque x86 glue + static data), an opaque SND10 sample bank, the load-time fixup tables, and the CSIS subscriptions. Every size/offset in the header is derived on write.',
+	fields: {
+		platform: enumOf('u8', AEMS_PLATFORMS),
+		targetType: enumOf('u8', AEMS_TARGET_TYPES),
+		numModules: u16(),
+		funcFixups: { kind: 'list', item: u32(), addable: false, removable: false },
+		staticDataFixups: { kind: 'list', item: u32(), addable: false, removable: false },
+		interfaceRefs: {
+			kind: 'list',
+			item: record('AemsInterfaceReference'),
+			// The compiled module code expects exactly these subscriptions —
+			// adding/removing one without recompiling the module breaks loading.
+			addable: false,
+			removable: false,
+			itemLabel: (item, index) => refLabel(item, index),
+		},
+		_moduleData: rawBytes(),
+		_sfxBank: rawBytes(),
+		_envelopePad: rawBytes(),
+	},
+	fieldMetadata: {
+		platform: {
+			label: 'Platform',
+			description: 'AEMS platform the bank was compiled for — 0 (PC) in every retail bank. Note this enum differs from the CSIS one (PS3 is 10 here, 7 there).',
+			readOnly: true,
+		},
+		targetType: {
+			label: 'Target type',
+			description: 'Sample-bank flavour — SND10 (3) in every retail bank.',
+			readOnly: true,
+		},
+		numModules: {
+			label: 'Module count',
+			description: 'Modules inside the compiled region. 1 in 22 retail banks; INAIR has 2 (the wiki\'s "always 1" is wrong). Read-only: the module region is an opaque blob steward cannot restructure.',
+			readOnly: true,
+		},
+		funcFixups: {
+			label: 'Function fixups',
+			description: 'Offsets inside the compiled glue code where the loader patches call targets. Derived by the AEMS compiler from the module code — read-only.',
+			readOnly: true,
+		},
+		staticDataFixups: {
+			label: 'Static data fixups',
+			description: 'Offsets inside the module\'s static data the loader patches, same mechanism as the function fixups — read-only.',
+			readOnly: true,
+		},
+		interfaceRefs: {
+			label: 'CSIS subscriptions',
+			description: 'The Csis classes this bank binds to at load (by CrcAndKey + name). Count is fixed — the compiled module expects exactly these.',
+		},
+		_moduleData: {
+			label: 'Module blob',
+			description: 'Modules + compiled x86 glue code + static data, everything between the header and the SFX bank. Position-dependent machine code — preserved byte-for-byte.',
+			hidden: true,
+		},
+		_sfxBank: {
+			label: 'SND10 sample bank',
+			description: 'The actual audio samples (\'S10A\' header; the sample count at +0x8 is stored big-endian). Opaque — preserved byte-for-byte.',
+			hidden: true,
+		},
+		_envelopePad: {
+			label: 'Envelope pad',
+			description: '8 uninitialised bytes in the BinaryFile envelope (heap remnants in retail). Preserved verbatim.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Bank', properties: ['platform', 'targetType', 'numModules'] },
+		{ title: 'Subscriptions', properties: ['interfaceRefs'] },
+		{ title: 'Fixups', properties: ['funcFixups', 'staticDataFixups'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedAemsBank,
+	AemsInterfaceReference,
+};
+
+export const aemsBankResourceSchema: ResourceSchema = {
+	key: 'aemsBank',
+	name: 'AEMS Bank',
+	rootType: 'ParsedAemsBank',
+	registry,
+};

--- a/src/lib/schema/resources/csis.test.ts
+++ b/src/lib/schema/resources/csis.test.ts
@@ -1,0 +1,150 @@
+// Schema coverage tests for csisResourceSchema.
+//
+// Coverage fixture: example/SOUND/AEMS/CSIS.BUNDLE — all ten retail Csis
+// resources. BoostCsis matters most (the only one with functions AND a
+// class); the drift checks still walk every resource so an entry shape
+// change anywhere gets caught.
+//
+// Mirrors staticSoundMap.test.ts: parse each model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseCsis, type ParsedCsis } from '../../core/csis';
+
+import { csisResourceSchema } from './csis';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/SOUND/AEMS/CSIS.BUNDLE');
+const CSIS_TYPE_ID = 0xa023;
+
+function loadAllModels(fixturePath: string): ParsedCsis[] {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	return bundle.resources
+		.filter((r) => r.resourceTypeId === CSIS_TYPE_ID)
+		.map((r) => parseCsis(extractResourceRaw(buffer.buffer, bundle, r), ctx.littleEndian));
+}
+
+const models = loadAllModels(BUNDLE_FIXTURE);
+
+describe('csisResourceSchema coverage — all ten retail resources', () => {
+	it('fixture parses with non-trivial content', () => {
+		expect(models.length).toBe(10);
+		expect(models.some((m) => m.functions.length > 0)).toBe(true);
+		expect(models.every((m) => m.classes.length > 0)).toBe(true);
+	});
+
+	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+		const missing: string[] = [];
+		for (const [recordName, rec] of Object.entries(csisResourceSchema.registry)) {
+			for (const [fieldName, field] of Object.entries(rec.fields)) {
+				checkField(field, `${recordName}.${fieldName}`, missing);
+			}
+		}
+		if (missing.length > 0) {
+			throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+		}
+		function checkField(f: FieldSchema, where: string, out: string[]) {
+			if (f.kind === 'record') {
+				if (!csisResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+				return;
+			}
+			if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+		}
+	});
+
+	it('walkResource visits every parsed field without throwing', () => {
+		for (const model of models) {
+			let recordCount = 0;
+			let fieldCount = 0;
+			walkResource(csisResourceSchema, model, (_p, _v, field, rec) => {
+				if (rec) recordCount++;
+				if (field) fieldCount++;
+			});
+			expect(recordCount).toBeGreaterThan(0);
+			expect(fieldCount).toBeGreaterThan(0);
+		}
+	});
+
+	it('no parsed record has fields absent from the schema', () => {
+		const missing: string[] = [];
+		for (const model of models) {
+			walkResource(csisResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const declared = new Set(Object.keys(rec.fields));
+				for (const key of Object.keys(value as Record<string, unknown>)) {
+					if (!declared.has(key)) {
+						missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+					}
+				}
+			});
+		}
+		if (missing.length > 0) {
+			throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+
+	it('every schema field is represented in the parsed data', () => {
+		const missing: string[] = [];
+		for (const model of models) {
+			walkResource(csisResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const obj = value as Record<string, unknown>;
+				for (const fieldName of Object.keys(rec.fields)) {
+					if (!(fieldName in obj)) {
+						missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+					}
+				}
+			});
+		}
+		if (missing.length > 0) {
+			throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+});
+
+describe('csis path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(csisResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedCsis');
+	});
+
+	it('resolves classes[0] as a CsisEntry', () => {
+		const loc = resolveSchemaAtPath(csisResourceSchema, ['classes', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('CsisEntry');
+	});
+
+	it('resolves classes[0].name as string and .crc as u16', () => {
+		expect(resolveSchemaAtPath(csisResourceSchema, ['classes', 0, 'name'])!.field?.kind).toBe('string');
+		expect(resolveSchemaAtPath(csisResourceSchema, ['classes', 0, 'crc'])!.field?.kind).toBe('u16');
+	});
+
+	it('resolves globalVariables[0] as a CsisGlobalVariable with a curVal u32', () => {
+		const loc = resolveSchemaAtPath(csisResourceSchema, ['globalVariables', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('CsisGlobalVariable');
+		expect(resolveSchemaAtPath(csisResourceSchema, ['globalVariables', 0, 'curVal'])!.field?.kind).toBe('u32');
+	});
+
+	it('resolves platform as an enum', () => {
+		const loc = resolveSchemaAtPath(csisResourceSchema, ['platform']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('enum');
+	});
+});

--- a/src/lib/schema/resources/csis.ts
+++ b/src/lib/schema/resources/csis.ts
@@ -1,0 +1,196 @@
+// Hand-written schema for ParsedCsis (resource type 0xA023).
+//
+// Mirrors the types in `src/lib/core/csis.ts`. Keep these in lockstep with
+// the parser/writer — any field added to the parser needs a matching entry
+// here, or the schema walker reports it as drift.
+//
+// Domain: a Csis resource is one audio module's subscription surface — the
+// named functions / classes / global variables AEMS banks (0xA022) bind to.
+// The link is by CrcAndKey, not by name: a bank's interface reference stores
+// (this resource's system crc, the entry's crc). The system crc is derived
+// ((Σ entry crcs) & 0x7FFF, recomputed on write), but each entry's own crc is
+// NOT name-derived — editing it (or the entry set) without updating the
+// subscribing banks silently breaks the audio link, hence the warnings.
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+} from '../types';
+import { CSIS_PLATFORMS, makeEmptyCsisEntry } from '@/lib/core/csis';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring staticSoundMap.ts)
+// ---------------------------------------------------------------------------
+
+const u8 = (): FieldSchema => ({ kind: 'u8' });
+const u16 = (): FieldSchema => ({ kind: 'u16' });
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const str = (): FieldSchema => ({ kind: 'string' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+const rawBytes = (): FieldSchema => ({ kind: 'custom', component: 'rawBytes' });
+
+const platformEnum = (): FieldSchema => ({
+	kind: 'enum',
+	storage: 'u8',
+	values: CSIS_PLATFORMS.map((p) => ({ value: p.value, label: p.label })),
+});
+
+// ---------------------------------------------------------------------------
+// Tree-label helpers
+// ---------------------------------------------------------------------------
+
+function entryLabel(value: unknown, index: number): string {
+	try {
+		if (!value || typeof value !== 'object') return `#${index}`;
+		const e = value as { name?: string; crc?: number };
+		const name = e.name || '(unnamed)';
+		const crc = e.crc != null ? `0x${e.crc.toString(16).toUpperCase()}` : '?';
+		return `${name} · crc ${crc}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+const entryList = (type: string): FieldSchema => ({
+	kind: 'list',
+	item: record(type),
+	makeEmpty: () => makeEmptyCsisEntry(),
+	itemLabel: (item, index) => entryLabel(item, index),
+});
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const entryFields: Record<string, FieldSchema> = {
+	name: str(),
+	crc: u16(),
+	_key: u16(),
+	_clients: u32(),
+};
+
+const entryFieldMetadata = {
+	name: {
+		label: 'Name',
+		description: 'Entry name, e.g. GearWhineClass. Display/debug identity — the runtime link to AEMS banks is by crc, so renaming alone does not retarget anything.',
+	},
+	crc: {
+		label: 'Entry crc',
+		description: '15-bit checksum AEMS banks store as the high u16 of their interface-reference CrcAndKey. NOT derived from the name (no standard CRC-16 nor soundHash reproduces it) — change it only together with every subscribing bank.',
+		warning: 'Must match the idKey of the AEMS bank interface references that subscribe to this entry, or the audio link silently breaks.',
+	},
+	_key: {
+		label: 'Key (runtime)',
+		description: 'High u16 of the on-disk CrcAndKey union — 0 in every retail resource; the runtime fills the key after resolution. Preserved verbatim.',
+		hidden: true,
+	},
+	_clients: {
+		label: 'Clients (runtime)',
+		description: 'CListDStack subscriber-list head — 0 on disk (a pointer fixed up at runtime). Preserved verbatim.',
+		hidden: true,
+	},
+};
+
+const CsisEntry: RecordSchema = {
+	name: 'CsisEntry',
+	description: 'One named function or class this audio module exposes. AEMS banks subscribe by CrcAndKey (system crc + this entry\'s crc).',
+	fields: entryFields,
+	fieldMetadata: entryFieldMetadata,
+	label: (value, index) => entryLabel(value, index ?? 0),
+};
+
+const CsisGlobalVariable: RecordSchema = {
+	name: 'CsisGlobalVariable',
+	description: 'A named global variable with its serialised current value. NO retail resource carries one — this shape is wiki-documented but fixture-unvalidated.',
+	fields: {
+		...entryFields,
+		curVal: u32(),
+	},
+	fieldMetadata: {
+		...entryFieldMetadata,
+		curVal: {
+			label: 'Current value (raw bits)',
+			description: 'CsisDef::Parameter union — the same 4 bytes read as either intVal or floatVal. Stored here as raw u32 bits since the type is not recorded.',
+		},
+	},
+	label: (value, index) => entryLabel(value, index ?? 0),
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedCsis: RecordSchema = {
+	name: 'ParsedCsis',
+	description: 'Root record for the Csis resource (0xA023): one audio module\'s CSIS subscription surface. The header system crc is derived ((Σ entry crcs) & 0x7FFF) and recomputed on write.',
+	fields: {
+		platform: platformEnum(),
+		resolved: u8(),
+		functions: entryList('CsisEntry'),
+		classes: entryList('CsisEntry'),
+		globalVariables: {
+			kind: 'list',
+			item: record('CsisGlobalVariable'),
+			// No retail resource has globals, so the 0x10-byte on-disk shape is
+			// wiki-only — adding one would write fixture-unvalidated bytes.
+			addable: false,
+			removable: false,
+			itemLabel: (item, index) => entryLabel(item, index),
+		},
+		_envelopePad: rawBytes(),
+		_tailGarbage: rawBytes(),
+	},
+	fieldMetadata: {
+		platform: {
+			label: 'Platform',
+			description: 'CsisDef::Platform the resource was compiled for — 0 (PC) in every retail resource. Note this enum differs from the AEMS bank one (PS3 is 7 here, 10 there).',
+			readOnly: true,
+		},
+		resolved: {
+			label: 'Resolved (runtime)',
+			description: '0 on disk; the runtime sets it once pointers are fixed up.',
+			readOnly: true,
+		},
+		functions: {
+			label: 'Functions',
+			description: 'Named functions this module exposes. Empty in 9 of the 10 retail resources (BoostCsis declares Message_1 / Message).',
+		},
+		classes: {
+			label: 'Classes',
+			description: 'Named classes this module exposes — what AEMS bank interface references (type 1 = class) bind to.',
+		},
+		globalVariables: {
+			label: 'Global variables',
+			description: 'Named globals with serialised values. Empty in every retail resource; read-only because the on-disk shape is fixture-unvalidated.',
+		},
+		_envelopePad: {
+			label: 'Envelope pad',
+			description: '8 uninitialised bytes in the BinaryFile envelope (heap remnants — UTF-16 path fragments in retail). Preserved verbatim.',
+			hidden: true,
+		},
+		_tailGarbage: {
+			label: 'Tail garbage',
+			description: 'Uninitialised bytes padding the payload to 16-byte alignment — stale heap pointers in retail. Preserved verbatim; zero-filled where edits change the pad length.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Module', properties: ['platform', 'resolved'] },
+		{ title: 'Entries', properties: ['functions', 'classes', 'globalVariables'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedCsis,
+	CsisEntry,
+	CsisGlobalVariable,
+};
+
+export const csisResourceSchema: ResourceSchema = {
+	key: 'csis',
+	name: 'CSIS',
+	rootType: 'ParsedCsis',
+	registry,
+};

--- a/src/lib/schema/resources/flaptFile.test.ts
+++ b/src/lib/schema/resources/flaptFile.test.ts
@@ -1,0 +1,168 @@
+// Schema coverage tests for flaptFileResourceSchema.
+//
+// Coverage fixture: example/FLAPTHUD.BUNDLE — the single retail FlaptFile
+// resource (the in-game HUD).
+//
+// Mirrors staticSoundMap.test.ts: parse the model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseFlaptFile, type ParsedFlaptFile } from '../../core/flaptFile';
+
+import { flaptFileResourceSchema } from './flaptFile';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/FLAPTHUD.BUNDLE');
+const FLAPT_TYPE_ID = 0x10020;
+
+function loadModel(fixturePath: string): ParsedFlaptFile {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const res = bundle.resources.find((r) => r.resourceTypeId === FLAPT_TYPE_ID);
+	if (!res) throw new Error('no 0x10020 resource in fixture');
+	return parseFlaptFile(extractResourceRaw(buffer.buffer, bundle, res), ctx.littleEndian);
+}
+
+const model = loadModel(BUNDLE_FIXTURE);
+
+describe('flaptFileResourceSchema coverage', () => {
+	it('fixture parses with non-trivial content', () => {
+		expect(model.movieClips.length).toBeGreaterThan(0);
+		expect(model.textures.length).toBeGreaterThan(0);
+		expect(model.strings.length).toBeGreaterThan(0);
+	});
+
+	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+		const missing: string[] = [];
+		for (const [recordName, rec] of Object.entries(flaptFileResourceSchema.registry)) {
+			for (const [fieldName, field] of Object.entries(rec.fields)) {
+				checkField(field, `${recordName}.${fieldName}`, missing);
+			}
+		}
+		if (missing.length > 0) {
+			throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+		}
+		function checkField(f: FieldSchema, where: string, out: string[]) {
+			if (f.kind === 'record') {
+				if (!flaptFileResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+				return;
+			}
+			if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+		}
+	});
+
+	it('walkResource visits every parsed field without throwing', () => {
+		let recordCount = 0;
+		let fieldCount = 0;
+		walkResource(flaptFileResourceSchema, model, (_p, _v, field, rec) => {
+			if (rec) recordCount++;
+			if (field) fieldCount++;
+		});
+		expect(recordCount).toBeGreaterThan(0);
+		expect(fieldCount).toBeGreaterThan(0);
+	});
+
+	it('no parsed record has fields absent from the schema', () => {
+		const missing: string[] = [];
+		walkResource(flaptFileResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const declared = new Set(Object.keys(rec.fields));
+			for (const key of Object.keys(value as Record<string, unknown>)) {
+				if (!declared.has(key)) {
+					missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+
+	it('every schema field is represented in the parsed data', () => {
+		const missing: string[] = [];
+		walkResource(flaptFileResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const obj = value as Record<string, unknown>;
+			for (const fieldName of Object.keys(rec.fields)) {
+				if (!(fieldName in obj)) {
+					missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+
+	it('tree labels never throw on real or degenerate items', () => {
+		const reg = flaptFileResourceSchema.registry;
+		const ctx = { root: model, resource: flaptFileResourceSchema };
+		const rec = (v: unknown) => v as Record<string, unknown>;
+		expect(reg.FlaptMovieClip.label?.(rec(model.movieClips[2]), 2, ctx)).toContain('B5FriendListChangeIconComponent');
+		expect(reg.FlaptTexture.label?.(rec(model.textures[52]), 52, ctx)).toContain('special');
+		expect(reg.FlaptTexture.label?.(rec(model.textures[0]), 0, ctx)).toContain('0xF2247A5A');
+		expect(reg.FlaptFontStyle.label?.(rec(model.fontStyles[0]), 0, ctx)).toContain('B5EAConDisSDrop');
+		for (const r of Object.values(reg)) {
+			expect(r.label?.(rec(null), 3, ctx) ?? '#3').toBe('#3');
+			expect(r.label?.(rec(undefined), 3, ctx) ?? '#3').toBe('#3');
+		}
+	});
+});
+
+describe('flaptFile path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(flaptFileResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedFlaptFile');
+	});
+
+	it('resolves movieClips[0] as a FlaptMovieClip', () => {
+		const loc = resolveSchemaAtPath(flaptFileResourceSchema, ['movieClips', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('FlaptMovieClip');
+	});
+
+	it('resolves vertices[0].mv2Pos as vec2', () => {
+		const loc = resolveSchemaAtPath(flaptFileResourceSchema, ['vertices', 0, 'mv2Pos']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('vec2');
+	});
+
+	it('resolves textures[0].resourceId as bigint', () => {
+		const loc = resolveSchemaAtPath(flaptFileResourceSchema, ['textures', 0, 'resourceId']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('bigint');
+	});
+
+	it('resolves fontStyles[0].mfFontHeight as f32', () => {
+		const loc = resolveSchemaAtPath(flaptFileResourceSchema, ['fontStyles', 0, 'mfFontHeight']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('f32');
+	});
+
+	it('resolves strings[0] as string', () => {
+		const loc = resolveSchemaAtPath(flaptFileResourceSchema, ['strings', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('string');
+	});
+
+	it('resolves mfTimePerFrame as editable f32 (the one editable header scalar)', () => {
+		const loc = resolveSchemaAtPath(flaptFileResourceSchema, ['mfTimePerFrame']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('f32');
+	});
+});

--- a/src/lib/schema/resources/flaptFile.ts
+++ b/src/lib/schema/resources/flaptFile.ts
@@ -1,0 +1,367 @@
+// Hand-written schema for ParsedFlaptFile (resource type 0x10020).
+//
+// Mirrors the types in `src/lib/core/flaptFile.ts`. Keep these in lockstep
+// with the parser/writer — any field added to the parser needs a matching
+// entry here, or the schema walker reports it as drift.
+//
+// Domain: Flapt is the in-game HUD, a Flash-derived GUI compiled flat. Every
+// pointer in the payload is an absolute offset — including pointers inside
+// the un-decoded timeline data — so the writer never moves bytes; it patches
+// fixed-width fields in place. That makes the editable surface narrow and
+// explicit: frame time, vertices, font colour/height, and texture-import
+// retargets. Everything pointer-bearing (strings, components, clip structure)
+// is read-only, and every list is fixed-length.
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring aptData.ts)
+// ---------------------------------------------------------------------------
+
+const u8 = (): FieldSchema => ({ kind: 'u8' });
+const u16 = (): FieldSchema => ({ kind: 'u16' });
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const f32 = (): FieldSchema => ({ kind: 'f32' });
+const str = (): FieldSchema => ({ kind: 'string' });
+const vec2 = (): FieldSchema => ({ kind: 'vec2' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+const rawBytes = (): FieldSchema => ({ kind: 'custom', component: 'rawBytes' });
+
+const fixedList = (item: FieldSchema, itemLabel?: (item: unknown, index: number) => string): FieldSchema => ({
+	kind: 'list',
+	item,
+	addable: false,
+	removable: false,
+	...(itemLabel ? { itemLabel } : {}),
+});
+
+// ---------------------------------------------------------------------------
+// Tree-label helpers
+// ---------------------------------------------------------------------------
+
+function clipLabel(clip: unknown, index: number): string {
+	try {
+		if (!clip || typeof clip !== 'object') return `#${index}`;
+		const c = clip as { componentName?: string | null; muNumFramesInTimeline?: number; muNumChildren?: number };
+		const name = c.componentName ?? '(anonymous)';
+		return `#${index} · ${name} · ${c.muNumFramesInTimeline ?? '?'}f · ${c.muNumChildren ?? '?'}ch`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function textureLabel(tex: unknown, index: number): string {
+	try {
+		if (!tex || typeof tex !== 'object') return `#${index}`;
+		const t = tex as { resourceId?: bigint | null };
+		return t.resourceId != null
+			? `#${index} · 0x${t.resourceId.toString(16).toUpperCase()}`
+			: `#${index} · special (by name)`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function vertexLabel(vert: unknown, index: number): string {
+	try {
+		if (!vert || typeof vert !== 'object') return `#${index}`;
+		const v = vert as { mv2Pos?: { x?: number; y?: number }; mColour?: number };
+		const x = v.mv2Pos?.x != null ? v.mv2Pos.x.toFixed(1) : '?';
+		const y = v.mv2Pos?.y != null ? v.mv2Pos.y.toFixed(1) : '?';
+		const c = v.mColour != null ? v.mColour.toString(16).toUpperCase().padStart(8, '0') : '?';
+		return `#${index} · (${x}, ${y}) · #${c}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function fontLabel(font: unknown, index: number): string {
+	try {
+		if (!font || typeof font !== 'object') return `#${index}`;
+		const f = font as { fontName?: string; mfFontHeight?: number };
+		return `#${index} · ${f.fontName ?? '?'} · ${f.mfFontHeight ?? '?'} px`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function componentLabel(comp: unknown, index: number): string {
+	try {
+		if (!comp || typeof comp !== 'object') return `#${index}`;
+		const c = comp as { debugName?: string; pathIndices?: number[] };
+		return `#${index} · ${c.debugName ?? '?'} · [${(c.pathIndices ?? []).join('.')}]`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function triggerLabel(trig: unknown, index: number): string {
+	try {
+		if (!trig || typeof trig !== 'object') return `#${index}`;
+		const t = trig as { parameter0?: string | null; parameter1?: string | null; parameter2?: string | null };
+		const parts = [t.parameter0, t.parameter1, t.parameter2].filter((p) => p != null);
+		return parts.length > 0 ? `#${index} · ${parts.join(' · ')}` : `#${index}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const FlaptGuiVertex: RecordSchema = {
+	name: 'FlaptGuiVertex',
+	description: 'One Basic2dColouredTexturedVertex (0x14 bytes) — 2D HUD-space position, packed RGBA8 colour, and UV into the mesh\'s texture page. Patched in place on write.',
+	fields: {
+		mv2Pos: vec2(),
+		mColour: u32(),
+		mv2Tex0UV: vec2(),
+	},
+	fieldMetadata: {
+		mv2Pos: {
+			label: 'Position',
+			description: '2D position in HUD screen space (pixels; origin at the element anchor).',
+		},
+		mColour: {
+			label: 'Colour',
+			description: 'Packed RGBA8 vertex colour (renderengine::RGBA8). 0xFFFFFFFF = untinted.',
+		},
+		mv2Tex0UV: {
+			label: 'UV',
+			description: 'Texture coordinates (0..1) into the texture page this mesh samples.',
+		},
+	},
+	label: (value, index) => vertexLabel(value, index ?? 0),
+};
+
+const FlaptFontStyle: RecordSchema = {
+	name: 'FlaptFontStyle',
+	description: 'One BrnFlapt::FontStyle (0xC bytes) — font face, colour, and height for HUD text fields. Colour and height are patched in place; the name is a pooled-string pointer and stays read-only.',
+	fields: {
+		fontName: str(),
+		muColour: u32(),
+		mfFontHeight: f32(),
+	},
+	fieldMetadata: {
+		fontName: {
+			label: 'Font',
+			description: 'Font face name (e.g. B5EAConDisSDrop). Read-only: the name lives in a shared string pool the writer never moves.',
+			readOnly: true,
+		},
+		muColour: {
+			label: 'Colour',
+			description: 'Packed RGBA8 text colour. 0xFFFFFFFF (untinted white) throughout retail.',
+		},
+		mfFontHeight: {
+			label: 'Height',
+			description: 'Glyph height in pixels.',
+		},
+	},
+	label: (value, index) => fontLabel(value, index ?? 0),
+};
+
+const FlaptTexture: RecordSchema = {
+	name: 'FlaptTexture',
+	description: 'One mpapTextures slot. Imported slots carry the sibling Texture (0x0) resource id from the inline BND2 import table — retargeting within the bundle is safe. Slots without an import entry are "special": the game resolves them by name at runtime (see Special texture names), and the writer rejects giving them a resource id.',
+	fields: {
+		resourceId: { kind: 'bigint', bytes: 8, hex: true },
+	},
+	fieldMetadata: {
+		resourceId: {
+			label: 'Texture resource',
+			description: 'Resource id of the sibling Texture this slot binds, written into the inline import table. null on special slots (resolved by name at runtime) — null-ness cannot be toggled because the import-entry count is fixed.',
+		},
+	},
+	label: (value, index) => textureLabel(value, index ?? 0),
+};
+
+const FlaptComponent: RecordSchema = {
+	name: 'FlaptComponent',
+	description: 'One addressable HUD component: the language hash game code looks it up by, the debug name the hash came from, and the IndexPath of child indices walked from the root movie clip to reach it.',
+	fields: {
+		muHash: u32(),
+		debugName: str(),
+		pathIndices: fixedList(u8()),
+	},
+	fieldMetadata: {
+		muHash: {
+			label: 'Name hash',
+			description: 'Language hash of the component name (burnout.wiki/wiki/Language_hash). Read-only — game code addresses the component by this value.',
+			readOnly: true,
+		},
+		debugName: {
+			label: 'Name',
+			description: 'Debug string the hash was computed from (e.g. SatNavIcon0_Icon). Read-only pooled string.',
+			readOnly: true,
+		},
+		pathIndices: {
+			label: 'Index path',
+			description: 'Child indices from the root clip down to this component (max depth 32 on disk; deepest retail path is 10).',
+			readOnly: true,
+		},
+	},
+	label: (value, index) => componentLabel(value, index ?? 0),
+};
+
+const FlaptTriggerParameters: RecordSchema = {
+	name: 'FlaptTriggerParameters',
+	description: 'One BrnFlapt::TriggerParameters — four optional pooled strings. Retail rows read like (component, event, target), e.g. RaceMainHUD · ON_ENTER · EasyDriveEntry.',
+	fields: {
+		parameter0: str(),
+		parameter1: str(),
+		parameter2: str(),
+		parameter3: str(),
+	},
+	fieldMetadata: {
+		parameter0: { label: 'Parameter 0', readOnly: true },
+		parameter1: { label: 'Parameter 1', readOnly: true },
+		parameter2: { label: 'Parameter 2', readOnly: true },
+		parameter3: { label: 'Parameter 3', readOnly: true },
+	},
+	label: (value, index) => triggerLabel(value, index ?? 0),
+};
+
+const FlaptMovieClip: RecordSchema = {
+	name: 'FlaptMovieClip',
+	description: 'Scalar header of one BrnFlapt::MovieClip (0x44 bytes on disk). The clip\'s timeline data (frame maps, render layers, keyframe anims, FScript) is reached through absolute pointers steward preserves verbatim, so everything here is read-only.',
+	fields: {
+		mxFlags: u8(),
+		muNumChildren: u8(),
+		muNumMeshes: u8(),
+		muNumTextFields: u8(),
+		muNumRenderLayers: u8(),
+		muNumLabelledFrames: u8(),
+		muNumFScriptCommands: u8(),
+		muNumFramesInTimeline: u16(),
+		muNumKeyFrames: u16(),
+		componentName: str(),
+	},
+	fieldMetadata: {
+		mxFlags: { label: 'Flags', readOnly: true },
+		muNumChildren: { label: 'Children', description: 'Child movie clip count.', readOnly: true },
+		muNumMeshes: { label: 'Meshes', readOnly: true },
+		muNumTextFields: { label: 'Text fields', readOnly: true },
+		muNumRenderLayers: { label: 'Render layers', readOnly: true },
+		muNumLabelledFrames: { label: 'Labelled frames', readOnly: true },
+		muNumFScriptCommands: { label: 'FScript commands', readOnly: true },
+		muNumFramesInTimeline: { label: 'Timeline frames', readOnly: true },
+		muNumKeyFrames: { label: 'Key frames', readOnly: true },
+		componentName: {
+			label: 'Component name',
+			description: 'Set on the 50 clips that are addressable components; null on anonymous clips.',
+			readOnly: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Clip', properties: ['componentName', 'mxFlags', 'muNumFramesInTimeline', 'muNumKeyFrames'] },
+		{ title: 'Contents', properties: ['muNumChildren', 'muNumMeshes', 'muNumTextFields', 'muNumRenderLayers', 'muNumLabelledFrames', 'muNumFScriptCommands'] },
+	],
+	label: (value, index) => clipLabel(value, index ?? 0),
+};
+
+const ParsedFlaptFile: RecordSchema = {
+	name: 'ParsedFlaptFile',
+	description: 'Root record for the FlaptFile resource (0x10020): the in-game HUD. The payload is preserved verbatim — edits patch fixed-width fields in place (frame time, vertices, font colour/height, texture retargets); all lists are fixed-length and pointer-bearing data is read-only.',
+	fields: {
+		muVersion: u8(),
+		mfTimePerFrame: f32(),
+		movieClips: fixedList(record('FlaptMovieClip'), clipLabel),
+		textures: fixedList(record('FlaptTexture'), textureLabel),
+		vertices: fixedList(record('FlaptGuiVertex'), vertexLabel),
+		fontStyles: fixedList(record('FlaptFontStyle'), fontLabel),
+		components: fixedList(record('FlaptComponent'), componentLabel),
+		triggerParameters: fixedList(record('FlaptTriggerParameters'), triggerLabel),
+		strings: fixedList(str()),
+		specialTextureNames: fixedList(str()),
+		debugStringCount: u32(),
+		_payload: rawBytes(),
+	},
+	fieldMetadata: {
+		muVersion: {
+			label: 'Version',
+			description: 'Format version — 12 in every retail build; the parser rejects anything else.',
+			readOnly: true,
+		},
+		mfTimePerFrame: {
+			label: 'Frame time',
+			description: 'Seconds per timeline frame. Retail is 0.0333… (30 fps).',
+		},
+		movieClips: {
+			label: 'Movie clips',
+			description: 'All 560 clip headers in file order. Read-only — timeline data behind their pointers is preserved verbatim.',
+		},
+		textures: {
+			label: 'Textures',
+			description: 'mpapTextures slots in slot order. Imported slots can be retargeted to another sibling Texture; the un-imported slots are resolved by name at runtime.',
+		},
+		vertices: {
+			label: 'Vertices',
+			description: 'The shared GuiVertex pool meshes index into (0x14 bytes each). Freely editable in place; the count is fixed.',
+		},
+		fontStyles: {
+			label: 'Font styles',
+			description: 'Text styles referenced by text fields. Colour and height are editable.',
+		},
+		components: {
+			label: 'Components',
+			description: 'Addressable HUD components: name hash + index path from the root clip.',
+		},
+		triggerParameters: {
+			label: 'Trigger parameters',
+			description: 'Trigger wiring rows (component · event · target), e.g. the EasyDrive entry trigger.',
+		},
+		strings: {
+			label: 'Strings',
+			description: 'The CgsUtf8 HUD string table — on-screen text. Read-only: strings live in a pool the writer never moves.',
+			readOnly: true,
+		},
+		specialTextureNames: {
+			label: 'Special texture names',
+			description: 'Names of textures resolved at runtime instead of imported (retail: CustomComponentTexture.tif).',
+			readOnly: true,
+		},
+		debugStringCount: {
+			label: 'Debug strings',
+			description: 'FileDebugData.muNumStrings — count of the debug string pool steward does not decode.',
+			readOnly: true,
+		},
+		_payload: {
+			label: 'Payload bytes',
+			description: 'The verbatim payload including the import-table tail. The writer patches edits into a copy of this; layout never changes.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'File', properties: ['muVersion', 'mfTimePerFrame', 'debugStringCount'] },
+		{ title: 'Clips', properties: ['movieClips', 'components', 'triggerParameters'] },
+		{ title: 'Render', properties: ['textures', 'specialTextureNames', 'vertices', 'fontStyles'] },
+		{ title: 'Text', properties: ['strings'] },
+	],
+};
+
+// ---------------------------------------------------------------------------
+// Registry export
+// ---------------------------------------------------------------------------
+
+const registry: SchemaRegistry = {
+	ParsedFlaptFile,
+	FlaptMovieClip,
+	FlaptTexture,
+	FlaptGuiVertex,
+	FlaptFontStyle,
+	FlaptComponent,
+	FlaptTriggerParameters,
+};
+
+export const flaptFileResourceSchema: ResourceSchema = {
+	key: 'flaptFile',
+	name: 'Flapt File',
+	rootType: 'ParsedFlaptFile',
+	registry,
+};

--- a/src/lib/schema/resources/genericRwacWaveContent.test.ts
+++ b/src/lib/schema/resources/genericRwacWaveContent.test.ts
@@ -1,0 +1,163 @@
+// Schema coverage tests for genericRwacWaveContentResourceSchema.
+//
+// Coverage fixtures: two GLOBALWAVES shapes that differ structurally — a
+// looped single-chunk wave (BikeToyCarHorn, first in bundle order) and the
+// loop-split two-chunk stereo wave (HUD_counter_crit) — plus a one-shot
+// (B2FDeLorean_Down) whose model has loopStartSample null.
+//
+// Mirrors staticSoundMap.test.ts: parse each model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseGenericRwacWaveContent, type ParsedGenericRwacWaveContent } from '../../core/genericRwacWaveContent';
+
+import { genericRwacWaveContentResourceSchema } from './genericRwacWaveContent';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/SOUND/GLOBALWAVES.BUNDLE');
+const WAVE_TYPE_ID = 0xa020;
+
+function loadModels(fixturePath: string): ParsedGenericRwacWaveContent[] {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	return bundle.resources
+		.filter((r) => r.resourceTypeId === WAVE_TYPE_ID)
+		.map((r) => parseGenericRwacWaveContent(extractResourceRaw(buffer.buffer, bundle, r), ctx.littleEndian));
+}
+
+const models = loadModels(BUNDLE_FIXTURE);
+const looped = models.find((m) => m.loopStartSample === 0 && m.chunks.length === 1)!;
+const twoChunk = models.find((m) => m.chunks.length === 2)!;
+const oneShot = models.find((m) => m.loopStartSample === null)!;
+
+for (const [label, model] of [
+	['looped single-chunk wave', looped],
+	['loop-split two-chunk wave', twoChunk],
+	['one-shot wave (null loop field)', oneShot],
+] as const) {
+	describe(`genericRwacWaveContentResourceSchema coverage — ${label}`, () => {
+		it('fixture parses with non-trivial content', () => {
+			expect(model.chunks.length).toBeGreaterThan(0);
+			expect(model.numSamples).toBeGreaterThan(0);
+		});
+
+		it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+			const missing: string[] = [];
+			for (const [recordName, rec] of Object.entries(genericRwacWaveContentResourceSchema.registry)) {
+				for (const [fieldName, field] of Object.entries(rec.fields)) {
+					checkField(field, `${recordName}.${fieldName}`, missing);
+				}
+			}
+			if (missing.length > 0) {
+				throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+			}
+			function checkField(f: FieldSchema, where: string, out: string[]) {
+				if (f.kind === 'record') {
+					if (!genericRwacWaveContentResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+					return;
+				}
+				if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+			}
+		});
+
+		it('walkResource visits every parsed field without throwing', () => {
+			let recordCount = 0;
+			let fieldCount = 0;
+			walkResource(genericRwacWaveContentResourceSchema, model, (_p, _v, field, rec) => {
+				if (rec) recordCount++;
+				if (field) fieldCount++;
+			});
+			expect(recordCount).toBeGreaterThan(0);
+			expect(fieldCount).toBeGreaterThan(0);
+		});
+
+		it('no parsed record has fields absent from the schema', () => {
+			const missing: string[] = [];
+			walkResource(genericRwacWaveContentResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const declared = new Set(Object.keys(rec.fields));
+				for (const key of Object.keys(value as Record<string, unknown>)) {
+					if (!declared.has(key)) {
+						missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+
+		it('every schema field is represented in the parsed data', () => {
+			const missing: string[] = [];
+			walkResource(genericRwacWaveContentResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const obj = value as Record<string, unknown>;
+				for (const fieldName of Object.keys(rec.fields)) {
+					if (!(fieldName in obj)) {
+						missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+	});
+}
+
+describe('genericRwacWaveContent path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(genericRwacWaveContentResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedGenericRwacWaveContent');
+	});
+
+	it('resolves chunks[0] as a WaveDataChunk', () => {
+		const loc = resolveSchemaAtPath(genericRwacWaveContentResourceSchema, ['chunks', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('WaveDataChunk');
+	});
+
+	it('resolves chunks[0].samples as read-only u32', () => {
+		const loc = resolveSchemaAtPath(genericRwacWaveContentResourceSchema, ['chunks', 0, 'samples']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('u32');
+	});
+
+	it('resolves codec as a labeled enum covering all 16 SndPlayer codecs', () => {
+		const loc = resolveSchemaAtPath(genericRwacWaveContentResourceSchema, ['codec']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('enum');
+		const values = (loc!.field as { values: { value: number; label: string }[] }).values;
+		expect(values.length).toBe(16);
+		expect(values[5].label).toBe('EALayer3 v1');
+	});
+
+	it('resolves playType as a labeled enum', () => {
+		const loc = resolveSchemaAtPath(genericRwacWaveContentResourceSchema, ['playType']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('enum');
+		const values = (loc!.field as { values: { value: number; label: string }[] }).values;
+		expect(values.map((v) => v.label)).toEqual(['RAM', 'Stream', 'Gigasample']);
+	});
+
+	it('caps sampleRate at the 18-bit field width', () => {
+		const loc = resolveSchemaAtPath(genericRwacWaveContentResourceSchema, ['sampleRate']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field).toMatchObject({ kind: 'u32', max: 0x3ffff });
+	});
+});

--- a/src/lib/schema/resources/genericRwacWaveContent.ts
+++ b/src/lib/schema/resources/genericRwacWaveContent.ts
@@ -1,0 +1,188 @@
+// Hand-written schema for ParsedGenericRwacWaveContent (resource type 0xA020).
+//
+// Mirrors the types in `src/lib/core/genericRwacWaveContent.ts`. Keep these in
+// lockstep with the parser/writer — any field added to the parser needs a
+// matching entry here, or the schema walker reports it as drift.
+//
+// Domain: one EA SndPlayer wave (RWAC audio). The audio itself is an opaque
+// codec payload (EALayer3 in retail) that steward preserves verbatim — only
+// the header metadata is meaningfully editable. Sample rate retunes playback
+// (pitch shift) without re-encoding; the loop point can be moved or cleared.
+// Codec/channels/version describe how the payload bytes were ENCODED, so
+// editing them without swapping the payload corrupts playback — read-only.
+// numSamples is re-derived from the chunk list on write for RAM waves.
+
+import type { FieldSchema, RecordSchema, ResourceSchema, SchemaRegistry } from '../types';
+import { SNDPLAYER_CODECS, SNDPLAYER_PLAY_TYPES } from '@/lib/core/genericRwacWaveContent';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring staticSoundMap.ts)
+// ---------------------------------------------------------------------------
+
+const u8 = (): FieldSchema => ({ kind: 'u8' });
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+const rawBytes = (): FieldSchema => ({ kind: 'custom', component: 'rawBytes' });
+
+const codecEnum = (): FieldSchema => ({
+	kind: 'enum',
+	storage: 'u8',
+	values: SNDPLAYER_CODECS.map((label, value) => ({ value, label })),
+});
+
+const PLAY_TYPE_DESCRIPTIONS = [
+	'Self-contained — all audio data lives in this resource as chunks.',
+	'Audio data lives outside this resource in persistent memory.',
+	'Stream with a RAM-resident head so playback starts before the stream seeks.',
+];
+
+const playTypeEnum = (): FieldSchema => ({
+	kind: 'enum',
+	storage: 'u8',
+	values: SNDPLAYER_PLAY_TYPES.map((label, value) => ({
+		value,
+		label,
+		description: PLAY_TYPE_DESCRIPTIONS[value],
+	})),
+});
+
+function chunkLabel(item: unknown, index: number): string {
+	try {
+		if (!item || typeof item !== 'object') return `#${index}`;
+		const c = item as { samples?: number; data?: { byteLength?: number } };
+		return `#${index} · ${c.samples ?? '?'} samples · ${c.data?.byteLength ?? '?'} B`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const WaveDataChunk: RecordSchema = {
+	name: 'WaveDataChunk',
+	description: 'One load-play-unload unit of encoded audio. The runtime streams chunks in sequence to bound RAM usage; a looped wave\'s chunk boundary lands exactly on the loop start sample so the decoder can restart there.',
+	fields: {
+		samples: u32(),
+		data: rawBytes(),
+	},
+	fieldMetadata: {
+		samples: {
+			label: 'Samples',
+			description: 'Sample frames this chunk decodes to. Must match the encoded payload — the game trusts it for chunk scheduling.',
+			readOnly: true,
+		},
+		data: {
+			label: 'Codec data',
+			description: 'Opaque encoded audio (EALayer3 in retail). Preserved verbatim; produce replacements with EALayer3 / EA Sound Exchange.',
+			readOnly: true,
+		},
+	},
+	label: (value, index) => chunkLabel(value, index ?? 0),
+};
+
+const ParsedGenericRwacWaveContent: RecordSchema = {
+	name: 'ParsedGenericRwacWaveContent',
+	description: 'Root record for a Generic RWAC Wave Content resource (0xA020): one EA SndPlayer wave — header metadata plus the encoded audio in chunks. The big-endian bit-packed header is unpacked here; sizes and the sample total are re-derived on write.',
+	fields: {
+		version: u8(),
+		codec: codecEnum(),
+		channels: u8(),
+		sampleRate: { kind: 'u32', min: 1, max: 0x3ffff },
+		playType: playTypeEnum(),
+		numSamples: u32(),
+		loopStartSample: u32(),
+		gigaResidentSamples: u32(),
+		chunks: {
+			kind: 'list',
+			item: record('WaveDataChunk'),
+			addable: false,
+			removable: false,
+			itemLabel: (item, index) => chunkLabel(item, index),
+		},
+		_binPad: rawBytes(),
+		_trailingPad: rawBytes(),
+		_unchunkedData: rawBytes(),
+	},
+	fieldMetadata: {
+		version: {
+			label: 'Version',
+			description: 'SndPlayer header version — 0 in every Burnout resource.',
+			readOnly: true,
+		},
+		codec: {
+			label: 'Codec',
+			description: 'How the chunk payloads are encoded (EA::Audio::Core::SndPlayerCodec). Burnout PC uses EALayer3 v1 almost everywhere, XAS for some engine sounds. Read-only: the payload bytes must match.',
+			readOnly: true,
+		},
+		channels: {
+			label: 'Channels',
+			description: '1 = mono, 2 = stereo (stored as count-1 in a 6-bit field). Read-only: baked into the encoded payload.',
+			readOnly: true,
+		},
+		sampleRate: {
+			label: 'Sample rate',
+			description: 'Playback rate in Hz (18-bit field, max 262143; retail uses 22050/44100/48000). Editable — retuning pitch-shifts the sound without re-encoding.',
+		},
+		playType: {
+			label: 'Play type',
+			description: 'Where the audio data lives at runtime. Read-only: the resource layout follows it (RAM waves carry chunks; stream/gigasample waves keep an opaque blob steward does not decode).',
+			readOnly: true,
+		},
+		numSamples: {
+			label: 'Total samples',
+			description: 'Sample frames in the whole asset. Re-derived from the chunk list on write for RAM waves — duration is numSamples / sampleRate.',
+			readOnly: true,
+		},
+		loopStartSample: {
+			label: 'Loop start sample',
+			description: 'Sample the loop restarts from; empty = one-shot (the header field only exists when the loop flag is set). Retail loops restart on a chunk boundary — moving this far from one may glitch playback.',
+		},
+		gigaResidentSamples: {
+			label: 'Gigasample RAM samples',
+			description: 'Gigasample waves only: how many samples of the head live in RAM. Empty for RAM/stream waves.',
+			readOnly: true,
+		},
+		chunks: {
+			label: 'Audio chunks',
+			description: 'Encoded audio in playback order. Fixed list — chunking is decided by the encoder (and the loop point), so add/remove means re-encoding externally.',
+		},
+		_binPad: {
+			label: 'Wrapper pad',
+			description: 'Bytes 0x08-0x0F of the BinaryFile wrapper — uninitialised build-machine memory (stale path strings in 4 retail waves). Preserved verbatim.',
+			hidden: true,
+		},
+		_trailingPad: {
+			label: 'Trailing pad',
+			description: '0-15 bytes padding the resource to 16-byte alignment — sometimes uninitialised garbage. Preserved verbatim while the length fits, regenerated as zeros after a size-changing edit.',
+			hidden: true,
+		},
+		_unchunkedData: {
+			label: 'Unchunked data',
+			description: 'Stream/gigasample waves only: everything after the header, preserved verbatim (no fixture validates that shape). Empty for RAM waves.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Format', properties: ['version', 'codec', 'channels', 'sampleRate', 'playType'] },
+		{ title: 'Playback', properties: ['numSamples', 'loopStartSample', 'gigaResidentSamples'] },
+		{ title: 'Audio data', properties: ['chunks'] },
+	],
+};
+
+// ---------------------------------------------------------------------------
+// Registry export
+// ---------------------------------------------------------------------------
+
+const registry: SchemaRegistry = {
+	ParsedGenericRwacWaveContent,
+	WaveDataChunk,
+};
+
+export const genericRwacWaveContentResourceSchema: ResourceSchema = {
+	key: 'genericRwacWaveContent',
+	name: 'Generic RWAC Wave Content',
+	rootType: 'ParsedGenericRwacWaveContent',
+	registry,
+};

--- a/src/lib/schema/resources/index.ts
+++ b/src/lib/schema/resources/index.ts
@@ -9,14 +9,18 @@
 // generic schema form for any resource type.
 
 import type { ResourceSchema } from '../types';
+import { aemsBankResourceSchema } from './aemsBank';
 import { aiSectionsResourceSchema } from './aiSections';
 import { aptDataResourceSchema } from './aptData';
 import { challengeListResourceSchema } from './challengeList';
+import { csisResourceSchema } from './csis';
 import { colourCubeResourceSchema } from './colourCube';
 import { environmentDictionaryResourceSchema } from './environmentDictionary';
 import { environmentKeyframeResourceSchema } from './environmentKeyframe';
 import { environmentTimeLineResourceSchema } from './environmentTimeLine';
+import { flaptFileResourceSchema } from './flaptFile';
 import { fontResourceSchema } from './font';
+import { genericRwacWaveContentResourceSchema } from './genericRwacWaveContent';
 import { guiPopupResourceSchema } from './guiPopup';
 import { hudMessageResourceSchema } from './hudMessage';
 import { hudMessageSequenceResourceSchema } from './hudMessageSequence';
@@ -26,6 +30,7 @@ import { idListResourceSchema } from './idList';
 import { instanceListResourceSchema } from './instanceList';
 import { languageResourceSchema } from './language';
 import { massiveLookupTableResourceSchema } from './massiveLookupTable';
+import { nicotineResourceSchema } from './nicotine';
 import { particleDescriptionResourceSchema } from './particleDescription';
 import { particleDescriptionCollectionResourceSchema } from './particleDescriptionCollection';
 import { playerCarColoursResourceSchema } from './playerCarColours';
@@ -35,6 +40,8 @@ import { propGraphicsListResourceSchema } from './propGraphicsList';
 import { propInstanceDataResourceSchema } from './propInstanceData';
 import { propPhysicsResourceSchema } from './propPhysics';
 import { renderableResourceSchema } from './renderable';
+import { snapshotDataResourceSchema } from './snapshotData';
+import { splicerResourceSchema } from './splicer';
 import { staticSoundMapResourceSchema } from './staticSoundMap';
 import { streetDataResourceSchema } from './streetData';
 import { textureResourceSchema } from './texture';
@@ -51,12 +58,16 @@ import { zoneListResourceSchema } from './zoneList';
 const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	aiSections: aiSectionsResourceSchema,
 	aptData: aptDataResourceSchema,
+	aemsBank: aemsBankResourceSchema,
 	challengeList: challengeListResourceSchema,
+	csis: csisResourceSchema,
 	colourCube: colourCubeResourceSchema,
 	environmentDictionary: environmentDictionaryResourceSchema,
 	environmentKeyframe: environmentKeyframeResourceSchema,
 	environmentTimeLine: environmentTimeLineResourceSchema,
+	flaptFile: flaptFileResourceSchema,
 	font: fontResourceSchema,
+	genericRwacWaveContent: genericRwacWaveContentResourceSchema,
 	guiPopup: guiPopupResourceSchema,
 	hudMessage: hudMessageResourceSchema,
 	hudMessageSequence: hudMessageSequenceResourceSchema,
@@ -66,6 +77,7 @@ const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	instanceList: instanceListResourceSchema,
 	language: languageResourceSchema,
 	massiveLookupTable: massiveLookupTableResourceSchema,
+	nicotine: nicotineResourceSchema,
 	particleDescription: particleDescriptionResourceSchema,
 	particleDescriptionCollection: particleDescriptionCollectionResourceSchema,
 	playerCarColours: playerCarColoursResourceSchema,
@@ -75,6 +87,8 @@ const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
 	propInstanceData: propInstanceDataResourceSchema,
 	propPhysics: propPhysicsResourceSchema,
 	renderable: renderableResourceSchema,
+	snapshotData: snapshotDataResourceSchema,
+	splicer: splicerResourceSchema,
 	staticSoundMap: staticSoundMapResourceSchema,
 	streetData: streetDataResourceSchema,
 	texture: textureResourceSchema,

--- a/src/lib/schema/resources/nicotine.test.ts
+++ b/src/lib/schema/resources/nicotine.test.ts
@@ -1,0 +1,161 @@
+// Schema coverage tests for nicotineResourceSchema.
+//
+// Coverage fixtures: both retail Nicotine maps (stereo + surround) — the
+// same schema must cover both since they share an identical structure.
+// Mirrors staticSoundMap.test.ts: parse each model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds. Null sections (absent state
+// sections) are skipped by the walker, so states[0] (no 3D section) and
+// states[1] (all six sections) between them exercise every record type.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseNicotine, type ParsedNicotine } from '../../core/nicotine';
+
+import { nicotineResourceSchema, hex8 } from './nicotine';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const NICOTINE_TYPE_ID = 0xa024;
+
+function loadModel(bundleFile: string): ParsedNicotine {
+	const fileBytes = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === NICOTINE_TYPE_ID)!;
+	return parseNicotine(extractResourceRaw(buffer.buffer, bundle, resource), ctx.littleEndian);
+}
+
+for (const [label, bundleFile] of [
+	['stereo map', 'example/SOUND/NICOTINEASSETMAIN.BUNDLE'],
+	['surround map', 'example/SOUND/NICOTINEASSETSURROUND.BUNDLE'],
+] as const) {
+	describe(`nicotineResourceSchema coverage — ${label}`, () => {
+		const model = loadModel(bundleFile);
+
+		it('fixture parses with non-trivial content', () => {
+			expect(model.states.length).toBeGreaterThan(0);
+			expect(model.states[1].threeDControls?.controls.length).toBeGreaterThan(0);
+		});
+
+		it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+			const missing: string[] = [];
+			for (const [recordName, rec] of Object.entries(nicotineResourceSchema.registry)) {
+				for (const [fieldName, field] of Object.entries(rec.fields)) {
+					checkField(field, `${recordName}.${fieldName}`, missing);
+				}
+			}
+			if (missing.length > 0) {
+				throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+			}
+			function checkField(f: FieldSchema, where: string, out: string[]) {
+				if (f.kind === 'record') {
+					if (!nicotineResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+					return;
+				}
+				if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+			}
+		});
+
+		it('walkResource visits every parsed field without throwing', () => {
+			let recordCount = 0;
+			let fieldCount = 0;
+			walkResource(nicotineResourceSchema, model, (_p, _v, field, rec) => {
+				if (rec) recordCount++;
+				if (field) fieldCount++;
+			});
+			expect(recordCount).toBeGreaterThan(0);
+			expect(fieldCount).toBeGreaterThan(0);
+		});
+
+		it('no parsed record has fields absent from the schema', () => {
+			const missing: string[] = [];
+			walkResource(nicotineResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const declared = new Set(Object.keys(rec.fields));
+				for (const key of Object.keys(value as Record<string, unknown>)) {
+					if (!declared.has(key)) {
+						missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+
+		it('every schema field is represented in the parsed data', () => {
+			const missing: string[] = [];
+			walkResource(nicotineResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const obj = value as Record<string, unknown>;
+				for (const fieldName of Object.keys(rec.fields)) {
+					if (!(fieldName in obj)) {
+						missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+	});
+}
+
+describe('nicotine path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(nicotineResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedNicotine');
+	});
+
+	it('resolves states[0] as a NicotineState', () => {
+		const loc = resolveSchemaAtPath(nicotineResourceSchema, ['states', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('NicotineState');
+	});
+
+	it('resolves states[0].masterMix.channels[0].mixData as u32', () => {
+		const loc = resolveSchemaAtPath(nicotineResourceSchema, ['states', 0, 'masterMix', 'channels', 0, 'mixData']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('u32');
+	});
+
+	it('resolves states[1].threeDControls.controls[0].stateParams[0] as Nicotine3DStateParams', () => {
+		const loc = resolveSchemaAtPath(nicotineResourceSchema, ['states', 1, 'threeDControls', 'controls', 0, 'stateParams', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('Nicotine3DStateParams');
+	});
+
+	it('resolves states[0].presets[0].extraData as a fixed u32 list', () => {
+		const loc = resolveSchemaAtPath(nicotineResourceSchema, ['states', 0, 'presets', 0, 'extraData']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('list');
+		if (loc!.field?.kind === 'list') {
+			expect(loc!.field.item.kind).toBe('u32');
+			expect(loc!.field.addable).toBe(false);
+		}
+	});
+});
+
+describe('hex8 label helper', () => {
+	it('formats ids as zero-padded uppercase hex', () => {
+		expect(hex8(0xc0020003)).toBe('0xC0020003');
+		expect(hex8(0xd8f0)).toBe('0x0000D8F0');
+	});
+
+	it('never returns NaN-ish text for non-numbers', () => {
+		expect(hex8(null)).toBe('?');
+		expect(hex8(undefined)).toBe('?');
+	});
+});

--- a/src/lib/schema/resources/nicotine.ts
+++ b/src/lib/schema/resources/nicotine.ts
@@ -1,0 +1,353 @@
+// Hand-written schema for ParsedNicotine (resource type 0xA024).
+//
+// Mirrors the types in `src/lib/core/nicotine.ts`. Keep these in lockstep
+// with the parser/writer — any field added there needs a matching entry
+// here, or the schema walker reports it as drift.
+//
+// Domain: a Nicotine map is the game's sound-mixer graph — one map for
+// stereo, one for 5.1 surround. Nearly every word is an undocumented bit
+// field, so most fields are plain u32s with the packed-count words locked
+// read-only: their count bytes size sibling arrays on disk, and the writer
+// throws if they disagree. The one field PROVEN meaningful is the master
+// channel's mixData — it is the only substantive difference between the
+// retail stereo and surround maps, and its i16 lanes move in clean steps of
+// hundredths of a dB (0xD8F0 = -10000 = -100.00 dB floor; deltas -100..-1200
+// = -1..-12 dB).
+
+import type { FieldSchema, RecordSchema, ResourceSchema, SchemaRegistry } from '../types';
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+
+const fixedRecordList = (type: string): FieldSchema => ({
+	kind: 'list',
+	item: record(type),
+	addable: false,
+	removable: false,
+});
+
+// Word counts are locked by packed count bytes inside sibling bit fields, so
+// the lists are fixed-size; the u32 items themselves stay editable.
+const fixedWordList = (): FieldSchema => ({
+	kind: 'list',
+	item: u32(),
+	addable: false,
+	removable: false,
+});
+
+export const hex8 = (v: unknown): string =>
+	typeof v === 'number' ? `0x${(v >>> 0).toString(16).toUpperCase().padStart(8, '0')}` : '?';
+
+function idLabel(field: string) {
+	return (value: unknown, index: number | null): string => {
+		const v = value as Record<string, unknown> | null;
+		return `#${index ?? 0} · ${hex8(v?.[field])}`;
+	};
+}
+
+function stateLabel(value: unknown, index: number | null): string {
+	try {
+		const s = value as { stateIndex?: number; masterMix?: { channels?: unknown[] } | null; subMix?: { channels?: unknown[] } | null };
+		const parts: string[] = [];
+		if (s.masterMix?.channels) parts.push(`${s.masterMix.channels.length} master`);
+		if (s.subMix?.channels) parts.push(`${s.subMix.channels.length} submix`);
+		const idx = typeof s.stateIndex === 'number' ? `0x${s.stateIndex.toString(16).toUpperCase()}` : `#${index ?? 0}`;
+		return parts.length > 0 ? `${idx} · ${parts.join(' + ')}` : idx;
+	} catch {
+		return `#${index ?? 0}`;
+	}
+}
+
+const PACKED_COUNT_WARNING = 'Bits 16-23 size the sibling word array on disk — the writer rejects any mismatch, so this word is locked.';
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const NicotineMixControl: RecordSchema = {
+	name: 'NicotineMixControl',
+	description: 'stMixCtlParams — one mix control input. Both words are undocumented bit fields.',
+	fields: {
+		nInputId: u32(),
+		nUScaleCntSwing: u32(),
+		extraData: fixedWordList(),
+	},
+	fieldMetadata: {
+		nInputId: { label: 'Input ID', description: 'Packed control-input id (undocumented bit field).' },
+		nUScaleCntSwing: { label: 'Scale/count/swing', description: `Packed bit field. ${PACKED_COUNT_WARNING}`, readOnly: true },
+		extraData: { label: 'Extra words', description: 'Undocumented trailing words; count fixed by the packed byte in nUScaleCntSwing.' },
+	},
+	label: idLabel('nInputId'),
+};
+
+const Nicotine3DStateParams: RecordSchema = {
+	name: 'Nicotine3DStateParams',
+	description: 'st3DStateParams — one 3D positioning state: doppler curve plus four packed min/max quantity pairs.',
+	fields: {
+		n3DStateInfoId: u32(),
+		nCurveIdDoppler: u32(),
+		nQ0MinMax: u32(),
+		nQ1MinMax: u32(),
+		nQ2MinMax: u32(),
+		nQ3MinMax: u32(),
+	},
+	fieldMetadata: {
+		n3DStateInfoId: { label: '3D state info ID' },
+		nCurveIdDoppler: { label: 'Doppler curve ID' },
+		nQ0MinMax: { label: 'Q0 min/max', description: 'Packed min/max pair (undocumented units).' },
+		nQ1MinMax: { label: 'Q1 min/max', description: 'Packed min/max pair (undocumented units).' },
+		nQ2MinMax: { label: 'Q2 min/max', description: 'Packed min/max pair (undocumented units).' },
+		nQ3MinMax: { label: 'Q3 min/max', description: 'Packed min/max pair (undocumented units).' },
+	},
+	label: idLabel('n3DStateInfoId'),
+};
+
+const Nicotine3DMixControl: RecordSchema = {
+	name: 'Nicotine3DMixControl',
+	description: 'st3DMixCtlParams — one 3D mix control input owning one or more state-param blocks.',
+	fields: {
+		nInputId: u32(),
+		stateParams: fixedRecordList('Nicotine3DStateParams'),
+	},
+	fieldMetadata: {
+		nInputId: { label: 'Input ID', description: 'Packed bit field. The low nibble of the top byte sizes stateParams (min 1) — the writer rejects any mismatch, so this word is locked.', readOnly: true },
+		stateParams: { label: 'State params', description: 'One or more 3D positioning states; count fixed by the packed nibble in nInputId.' },
+	},
+	label: idLabel('nInputId'),
+};
+
+const NicotineSubMixChannel: RecordSchema = {
+	name: 'NicotineSubMixChannel',
+	description: 'stSubMixChParams — one submix channel (MIXCHID top byte 0xD0 in retail).',
+	fields: {
+		mixChId: u32(),
+		upperLowerSwing: u32(),
+		procOffsets: fixedWordList(),
+	},
+	fieldMetadata: {
+		mixChId: { label: 'Mix channel ID', description: `Packed channel id. ${PACKED_COUNT_WARNING}`, readOnly: true },
+		upperLowerSwing: { label: 'Upper/lower swing', description: 'Packed bit field (undocumented units; values like 0xFE60 suggest i16 hundredths-of-a-dB lanes).' },
+		procOffsets: { label: 'Submix proc words', description: 'stSubMixStateParams nOffsetSubMixProc words (undocumented).' },
+	},
+	label: idLabel('mixChId'),
+};
+
+const NicotineMasterMixChannel: RecordSchema = {
+	name: 'NicotineMasterMixChannel',
+	description: 'stMasterMixChParams — one master mix channel. SnapshotData (0xA029) channels in the same bundle reference these by their exact mixChId word.',
+	fields: {
+		mixChId: u32(),
+		mixData: u32(),
+		sfxObjId: u32(),
+		extraData: fixedWordList(),
+	},
+	fieldMetadata: {
+		mixChId: { label: 'Mix channel ID', description: `Packed channel id (top byte 0xC0-0xC2 in retail). The companion SnapshotData references master channels by this exact word — changing it orphans snapshot data. ${PACKED_COUNT_WARNING}`, readOnly: true },
+		mixData: { label: 'Mix data (attenuation)', description: 'Two i16 lanes in hundredths of a dB: low lane is the -10000 (-100.00 dB) floor in every retail channel; the high lane carries the channel attenuation (0 = unity; retail surround uses -100..-1200 = -1..-12 dB). The ONLY field that differs between the retail stereo and surround maps.' },
+		sfxObjId: { label: 'SFX object ID', description: 'Packed bit field (undocumented).' },
+		extraData: { label: 'Extra words', description: 'Undocumented trailing words; count fixed by the packed byte in mixChId.' },
+	},
+	label: idLabel('mixChId'),
+};
+
+const NicotinePresetEntry: RecordSchema = {
+	name: 'NicotinePresetEntry',
+	description: 'One preset entry. The array has no own header — the runtime sizes it from the master section\'s channel count, one entry per master channel in order.',
+	fields: {
+		header: u32(),
+		extraData: fixedWordList(),
+	},
+	fieldMetadata: {
+		header: { label: 'Header word', description: 'Packed bit field (top byte 0xE0-0xE2 in retail). Bits 0-7 size extraData on disk — the writer rejects any mismatch, so this word is locked.', readOnly: true },
+		extraData: { label: 'Preset words', description: 'Undocumented preset payload; count fixed by the packed byte in the header word.' },
+	},
+	label: idLabel('header'),
+};
+
+const NicotineMixEvent: RecordSchema = {
+	name: 'NicotineMixEvent',
+	description: 'stMixEvtParams — one event control binding a trigger to mixer behaviour.',
+	fields: {
+		nEvtCtlId: u32(),
+		nUScaleCntSwing: u32(),
+		nTriggerId: u32(),
+		nParam00: u32(),
+		nParam01: u32(),
+		nParam02: u32(),
+		extraData: fixedWordList(),
+	},
+	fieldMetadata: {
+		nEvtCtlId: { label: 'Event control ID' },
+		nUScaleCntSwing: { label: 'Scale/count/swing', description: `Packed bit field (values like 0xD8F0 = -10000 suggest hundredths-of-a-dB lanes). ${PACKED_COUNT_WARNING}`, readOnly: true },
+		nTriggerId: { label: 'Trigger ID' },
+		nParam00: { label: 'Param 0' },
+		nParam01: { label: 'Param 1' },
+		nParam02: { label: 'Param 2' },
+		extraData: { label: 'Extra words', description: 'Undocumented trailing words; count fixed by the packed byte in nUScaleCntSwing.' },
+	},
+	label: idLabel('nEvtCtlId'),
+};
+
+const NicotineMixCtlSection: RecordSchema = {
+	name: 'NicotineMixCtlSection',
+	description: 'stMixCtlHdr + its mix control array.',
+	fields: {
+		numNewMixDataProcs: u32(),
+		numMainMixDataProcs: u32(),
+		numMainMixCtlOut: u32(),
+		controls: fixedRecordList('NicotineMixControl'),
+	},
+	fieldMetadata: {
+		numNewMixDataProcs: { label: 'New mix data procs', description: 'Equals the control count in every retail section; preserved verbatim, not recomputed.', readOnly: true },
+		numMainMixDataProcs: { label: 'Main mix data procs', description: 'Always 0 in retail.', readOnly: true },
+		numMainMixCtlOut: { label: 'Main mix controls out', description: 'Always 0 in retail.', readOnly: true },
+		controls: { label: 'Mix controls' },
+	},
+};
+
+const Nicotine3DSection: RecordSchema = {
+	name: 'Nicotine3DSection',
+	description: 'st3DMixCtlHdr + its 3D mix control array.',
+	fields: {
+		numMainMap3DMixCtls: u32(),
+		controls: fixedRecordList('Nicotine3DMixControl'),
+		_reserved02: u32(),
+		_reserved03: u32(),
+	},
+	fieldMetadata: {
+		numMainMap3DMixCtls: { label: 'Main map 3D controls', description: 'Always 0 in retail.', readOnly: true },
+		controls: { label: '3D mix controls' },
+		_reserved02: { label: 'Reserved 02', description: 'Always 0 in retail; preserved verbatim.', hidden: true },
+		_reserved03: { label: 'Reserved 03', description: 'Always 0 in retail; preserved verbatim.', hidden: true },
+	},
+};
+
+const NicotineSubMixSection: RecordSchema = {
+	name: 'NicotineSubMixSection',
+	description: 'stMixChHdr + the submix channel array.',
+	fields: {
+		numUniqueSfxObjs: u32(),
+		numMainIn: u32(),
+		numSecIn: u32(),
+		channels: fixedRecordList('NicotineSubMixChannel'),
+	},
+	fieldMetadata: {
+		numUniqueSfxObjs: { label: 'Unique SFX objects', readOnly: true },
+		numMainIn: { label: 'Main inputs', readOnly: true },
+		numSecIn: { label: 'Secondary inputs', readOnly: true },
+		channels: { label: 'Submix channels' },
+	},
+};
+
+const NicotineMasterMixSection: RecordSchema = {
+	name: 'NicotineMasterMixSection',
+	description: 'stMixChHdr + the master mix channel array — the channels SnapshotData snapshots drive.',
+	fields: {
+		numUniqueSfxObjs: u32(),
+		numMainIn: u32(),
+		numSecIn: u32(),
+		channels: fixedRecordList('NicotineMasterMixChannel'),
+	},
+	fieldMetadata: {
+		numUniqueSfxObjs: { label: 'Unique SFX objects', readOnly: true },
+		numMainIn: { label: 'Main inputs', readOnly: true },
+		numSecIn: { label: 'Secondary inputs', readOnly: true },
+		channels: { label: 'Master mix channels' },
+	},
+};
+
+const NicotineEventSection: RecordSchema = {
+	name: 'NicotineEventSection',
+	description: 'stMixEventHdr + the event control array.',
+	fields: {
+		events: fixedRecordList('NicotineMixEvent'),
+		_reserved01: u32(),
+		_reserved02: u32(),
+		_reserved03: u32(),
+	},
+	fieldMetadata: {
+		events: { label: 'Event controls' },
+		_reserved01: { label: 'Reserved 01', description: 'Mirrors the event count in every retail section; preserved verbatim.', hidden: true },
+		_reserved02: { label: 'Reserved 02', description: '0x08E4EF64 in every retail section — stale pointer garbage, preserved verbatim.', hidden: true },
+		_reserved03: { label: 'Reserved 03', description: 'Stale heap garbage (varies even between the otherwise-identical stereo and surround maps); preserved verbatim.', hidden: true },
+	},
+};
+
+const NicotineState: RecordSchema = {
+	name: 'NicotineState',
+	description: 'One mixer state (stMixMapStateHdr + its sections). The engine selects states by stateIndex; absent sections are null.',
+	fields: {
+		stateIndex: u32(),
+		mixControls: record('NicotineMixCtlSection'),
+		threeDControls: record('Nicotine3DSection'),
+		subMix: record('NicotineSubMixSection'),
+		masterMix: record('NicotineMasterMixSection'),
+		presets: fixedRecordList('NicotinePresetEntry'),
+		events: record('NicotineEventSection'),
+	},
+	fieldMetadata: {
+		stateIndex: { label: 'State index', description: 'Engine lookup id — 0x1F0000 + position in retail. The game asks for states by this value, so renumbering breaks lookups.', readOnly: true },
+		mixControls: { label: 'Mix controls', description: 'stMixCtlHdr section; null when the state has none.' },
+		threeDControls: { label: '3D mix controls', description: 'st3DMixCtlHdr section; null when the state has none.' },
+		subMix: { label: 'Submix', description: 'Submix channel section; present in every retail state.' },
+		masterMix: { label: 'Master mix', description: 'Master mix channel section; null when the state has none.' },
+		presets: { label: 'Presets', description: 'One entry per master mix channel, in channel order — the array is sized by the master section\'s channel count on disk.' },
+		events: { label: 'Events', description: 'Event control section; null when the state has none.' },
+	},
+	propertyGroups: [
+		{ title: 'State', properties: ['stateIndex'] },
+		{ title: 'Channels', properties: ['subMix', 'masterMix', 'presets'] },
+		{ title: 'Controls', properties: ['mixControls', 'threeDControls', 'events'] },
+	],
+	label: stateLabel,
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedNicotine: RecordSchema = {
+	name: 'ParsedNicotine',
+	description: 'Root record for the Nicotine map resource (0xA024): the sound-mixer state graph for one output format (stereo or 5.1 surround). The companion SnapshotData resource references the master mix channels here.',
+	fields: {
+		mixMapId: u32(),
+		states: fixedRecordList('NicotineState'),
+		_stateTableSentinelSlots: u32(),
+	},
+	fieldMetadata: {
+		mixMapId: { label: 'Mix map ID', description: 'Always 0 in retail.', readOnly: true },
+		states: { label: 'Mixer states', description: 'Engine-selectable mix states, table order. Retail maps carry 9 (indices 0x1F0000-0x1F0008).' },
+		_stateTableSentinelSlots: { label: 'State table sentinels', description: 'Trailing -1 slots after the real state-table entries (4 in retail; undocumented on the wiki). Preserved verbatim.', hidden: true },
+	},
+	propertyGroups: [
+		{ title: 'Map', properties: ['mixMapId', 'states'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedNicotine,
+	NicotineState,
+	NicotineMixCtlSection,
+	NicotineMixControl,
+	Nicotine3DSection,
+	Nicotine3DMixControl,
+	Nicotine3DStateParams,
+	NicotineSubMixSection,
+	NicotineSubMixChannel,
+	NicotineMasterMixSection,
+	NicotineMasterMixChannel,
+	NicotinePresetEntry,
+	NicotineEventSection,
+	NicotineMixEvent,
+};
+
+export const nicotineResourceSchema: ResourceSchema = {
+	key: 'nicotine',
+	name: 'Nicotine Map',
+	rootType: 'ParsedNicotine',
+	registry,
+};

--- a/src/lib/schema/resources/registry.test.ts
+++ b/src/lib/schema/resources/registry.test.ts
@@ -1,11 +1,14 @@
 // Schema coverage tests for registryResourceSchema.
 //
-// Coverage fixtures: BOTH retail registries, because they exercise disjoint
-// payload shapes — PLAYBACKREGISTRY carries five entity kinds (ContentClass /
-// ContentType / SlotSchema / ParameterSchema / FeatureSchema), while
-// RWACFEATUREREGISTRY is all GenericRwacFeatureImplementation. Entities are
-// heterogeneous: payload record fields are null on the kinds that don't use
-// them, which the walker must tolerate.
+// Coverage fixtures: all four retail registry bundles, because they exercise
+// disjoint payload shapes — PLAYBACKREGISTRY carries five entity kinds
+// (ContentClass / ContentType / SlotSchema / ParameterSchema /
+// FeatureSchema), RWACFEATUREREGISTRY is all
+// GenericRwacFeatureImplementation, SOUNDENTITY adds ContentSpec /
+// VoiceSchema / VoiceSpec, and CSIS adds AemsVoiceCsisClass (covered via the
+// first of its 30 registries that contains one). Entities are heterogeneous:
+// payload record fields are null on the kinds that don't use them, which the
+// walker must tolerate.
 //
 // Mirrors staticSoundMap.test.ts: parse each model and walk it against the
 // schema asserting record references resolve, walkResource visits cleanly,
@@ -27,21 +30,30 @@ import type { FieldSchema } from '../types';
 const REPO_ROOT = path.resolve(__dirname, '../../../..');
 const REGISTRY_TYPE_ID = 0xa000;
 
-function loadModel(bundleFile: string): ParsedRegistry {
+function loadModels(bundleFile: string): ParsedRegistry[] {
 	const fileBytes = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
 	const buffer = new Uint8Array(fileBytes.byteLength);
 	buffer.set(fileBytes);
 	const bundle = parseBundle(buffer.buffer, { strict: false });
 	const ctx = resourceCtxFromBundle(bundle);
-	const resource = bundle.resources.find((r) => r.resourceTypeId === REGISTRY_TYPE_ID)!;
-	return parseRegistry(extractResourceRaw(buffer.buffer, bundle, resource), ctx.littleEndian);
+	return bundle.resources
+		.filter((r) => r.resourceTypeId === REGISTRY_TYPE_ID)
+		.map((r) => parseRegistry(extractResourceRaw(buffer.buffer, bundle, r), ctx.littleEndian));
 }
 
-for (const [label, bundleFile] of [
-	['playback registry (five entity kinds)', 'example/PLAYBACKREGISTRY.BUNDLE'],
-	['rwac feature registry (one entity kind)', 'example/RWACFEATUREREGISTRY.BUNDLE'],
+function loadModel(bundleFile: string): ParsedRegistry {
+	return loadModels(bundleFile)[0];
+}
+
+const csisAemsModel = loadModels('example/SOUND/AEMS/CSIS.BUNDLE')
+	.find((m) => m.entities.some((e) => e.aemsVoiceCsis != null))!;
+
+for (const [label, model] of [
+	['playback registry (five entity kinds)', loadModel('example/PLAYBACKREGISTRY.BUNDLE')],
+	['rwac feature registry (one entity kind)', loadModel('example/RWACFEATUREREGISTRY.BUNDLE')],
+	['sound entity registry (ContentSpec / VoiceSchema / VoiceSpec)', loadModel('example/SOUND/SOUNDENTITY.BUNDLE')],
+	['csis registry (AemsVoiceCsisClass)', csisAemsModel],
 ] as const) {
-	const model = loadModel(bundleFile);
 
 	describe(`registryResourceSchema coverage — ${label}`, () => {
 		it('fixture parses with non-trivial content', () => {
@@ -150,6 +162,52 @@ describe('registry path resolution', () => {
 		const loc = resolveSchemaAtPath(registryResourceSchema, ['strings', 0]);
 		expect(loc).not.toBeNull();
 		expect(loc!.field?.kind).toBe('string');
+	});
+
+	it('resolves entities[0].contentSpec.mu8LoadMethod as an enum and .path as a string', () => {
+		expect(resolveSchemaAtPath(registryResourceSchema, ['entities', 0, 'contentSpec', 'mu8LoadMethod'])!.field?.kind).toBe('enum');
+		expect(resolveSchemaAtPath(registryResourceSchema, ['entities', 0, 'contentSpec', 'path'])!.field?.kind).toBe('string');
+	});
+
+	it('resolves entities[0].voiceSchema.featureSchemaHashes[0] and voiceSpec.sendHashes[0] as u32', () => {
+		expect(resolveSchemaAtPath(registryResourceSchema, ['entities', 0, 'voiceSchema', 'featureSchemaHashes', 0])!.field?.kind).toBe('u32');
+		expect(resolveSchemaAtPath(registryResourceSchema, ['entities', 0, 'voiceSpec', 'sendHashes', 0])!.field?.kind).toBe('u32');
+	});
+
+	it('resolves entities[0].voiceSpec.mu8VoiceType as an enum', () => {
+		expect(resolveSchemaAtPath(registryResourceSchema, ['entities', 0, 'voiceSpec', 'mu8VoiceType'])!.field?.kind).toBe('enum');
+	});
+
+	it('resolves entities[0].aemsVoiceCsis.label as a string', () => {
+		expect(resolveSchemaAtPath(registryResourceSchema, ['entities', 0, 'aemsVoiceCsis', 'label'])!.field?.kind).toBe('string');
+	});
+});
+
+describe('RegistryEntity derive hook (AEMS label → name hash)', () => {
+	const RegistryEntity = registryResourceSchema.registry.RegistryEntity;
+	const aemsEntity = csisAemsModel.entities.find((e) => e.aemsVoiceCsis != null)!;
+
+	it('re-derives mName as soundHash("AEMS_" + label) when the label changes', () => {
+		const next = {
+			...aemsEntity,
+			aemsVoiceCsis: { ...aemsEntity.aemsVoiceCsis!, label: 'StewardClass' },
+		};
+		const patch = RegistryEntity.derive!(aemsEntity as never, next as never);
+		expect(patch).toEqual({ mName: soundHash('AEMS_StewardClass') });
+	});
+
+	it('returns no patch when the label is unchanged or the entity is not an AEMS class', () => {
+		expect(RegistryEntity.derive!(aemsEntity as never, aemsEntity as never)).toEqual({});
+		const plain = loadModel('example/PLAYBACKREGISTRY.BUNDLE').entities[0];
+		const renamed = { ...plain, mName: 123 };
+		expect(RegistryEntity.derive!(plain as never, renamed as never)).toEqual({});
+	});
+
+	it('matches the retail naming rule for every fixture instance', () => {
+		for (const e of csisAemsModel.entities) {
+			if (e.aemsVoiceCsis == null) continue;
+			expect(e.mName).toBe(soundHash('AEMS_' + e.aemsVoiceCsis.label));
+		}
 	});
 });
 

--- a/src/lib/schema/resources/registry.ts
+++ b/src/lib/schema/resources/registry.ts
@@ -31,6 +31,7 @@ import {
 // ---------------------------------------------------------------------------
 
 const f32 = (): FieldSchema => ({ kind: 'f32' });
+const u8 = (): FieldSchema => ({ kind: 'u8' });
 const u16 = (): FieldSchema => ({ kind: 'u16' });
 const u32 = (): FieldSchema => ({ kind: 'u32' });
 const str = (): FieldSchema => ({ kind: 'string' });
@@ -233,6 +234,116 @@ const RegistryRwacFeature: RecordSchema = {
 	},
 };
 
+const RegistryContentSpec: RecordSchema = {
+	name: 'RegistryContentSpec',
+	description: 'ContentSpec payload — what a named sound loads: an inline content path (usually a gamedb:// URL to a wave or AEMS bank) plus its load attributes. The on-disk path length and 4-byte alignment pad are re-derived on write.',
+	fields: {
+		mpContentType: u32(),
+		mu8LoadMethod: {
+			kind: 'enum',
+			storage: 'u8',
+			values: [
+				{ value: 0, label: 'Invalid', description: 'E_CONTENT_LOAD_INVALID — never seen in retail.' },
+				{ value: 1, label: 'Resource module', description: 'E_CONTENT_LOAD_RESOURCE_MODULE — the only value in retail.' },
+			],
+		},
+		mu8LoadTime: {
+			kind: 'enum',
+			storage: 'u8',
+			values: [
+				{ value: 0, label: 'Just in time', description: 'E_CONTENT_LOAD_JUST_IN_TIME — never seen in retail.' },
+				{ value: 1, label: 'Immediate', description: 'E_CONTENT_LOAD_IMMEDIATE — the only value in retail.' },
+			],
+		},
+		path: str(),
+		_padTail: rawBytes(),
+	},
+	fieldMetadata: {
+		mpContentType: { label: 'Content type hash', description: 'Name hash of a ContentType entity (in PLAYBACKREGISTRY) saying what kind of content the path points at — e.g. ~GenericRwacWaveContent::SK_WAVE_DATA_CONTENT_TYPE~ for waves, ~SplicerContent::SK_CONTENT_TYPE~ for splice banks.' },
+		mu8LoadMethod: { label: 'Load method' },
+		mu8LoadTime: { label: 'Load time' },
+		path: { label: 'Content path', description: 'Inline content locator, usually a gamedb:// URL. The entity name often equals soundHash(path) but not always (CSIS bank specs differ), so renaming the path does not rename the entity.' },
+		_padTail: {
+			label: 'pad tail',
+			description: 'Uninitialised 0–3 alignment bytes after the NUL (0xCD allocator fill in retail); preserved verbatim, recomputed when the path length changes.',
+			hidden: true,
+		},
+	},
+};
+
+const RegistryVoiceSchema: RecordSchema = {
+	name: 'RegistryVoiceSchema',
+	description: 'VoiceSchema payload — declares which DSP FeatureSchemas a voice class instantiates, each referenced by sound hash. The on-disk count is re-derived from the list on write. (The wiki\'s struct table for this type is self-overlapping and wrong; this layout is taken from the bytes.)',
+	fields: {
+		mu32SlotCount: u32(),
+		mu32ParameterCount: u32(),
+		mu32OutputParamCount: u32(),
+		featureSchemaHashes: { kind: 'list', item: u32(), makeEmpty: () => 0 },
+	},
+	fieldMetadata: {
+		mu32SlotCount: { label: 'Slot count', description: 'Always 0 in retail; which of the wiki\'s three remaining counts sits at this offset is unverifiable.', readOnly: true },
+		mu32ParameterCount: { label: 'Parameter count', description: 'Always 0 in retail; meaning unverified.', readOnly: true },
+		mu32OutputParamCount: { label: 'Output param count', description: 'Always 0 in retail; meaning unverified.', readOnly: true },
+		featureSchemaHashes: { label: 'Feature schema hashes', description: 'Sound hashes of the FeatureSchema entities this voice class chains together (e.g. PlayerVoice + Panning + Pause).' },
+	},
+};
+
+const RegistryVoiceSpec: RecordSchema = {
+	name: 'RegistryVoiceSpec',
+	description: 'VoiceSpec payload — a concrete voice the engine can allocate: its schema, channel layout, type, and the submix/master voices it sends into. The on-disk send count is re-derived from the list on write.',
+	fields: {
+		mpVoiceSchema: u32(),
+		mu8ProcessingStage: u8(),
+		mu8ChannelCount: u8(),
+		mu8VoiceType: {
+			kind: 'enum',
+			storage: 'u8',
+			values: [
+				{ value: 0, label: 'Player', description: 'E_PLAYER_VOICE — plays content.' },
+				{ value: 1, label: 'Submix', description: 'E_SUBMIX_VOICE — mixes other voices.' },
+				{ value: 2, label: 'Master', description: 'E_MASTER_VOICE — the output bus.' },
+			],
+		},
+		sendHashes: { kind: 'list', item: u32(), makeEmpty: () => 0 },
+	},
+	fieldMetadata: {
+		mpVoiceSchema: { label: 'Voice schema hash', description: 'Name hash of the VoiceSchema entity describing this voice\'s DSP chain — possibly defined in a different registry (CSIS voice regs reference schemas from their entity regs).' },
+		mu8ProcessingStage: { label: 'Processing stage', description: 'Bitmask-looking values in retail (0x00, 0x01, 0x3E, 0x3F, 0x7F, 0xBF, 0xF0); meaning unknown.' },
+		mu8ChannelCount: { label: 'Channel count', description: '1 mono, 2 stereo, 4 quad, 6 = 5.1 (the values seen in retail).' },
+		mu8VoiceType: { label: 'Voice type' },
+		sendHashes: { label: 'Send hashes', description: 'Sound hashes of the voices this one feeds (submixes / the master voice).' },
+	},
+};
+
+const RegistryAemsVoiceCsis: RecordSchema = {
+	name: 'RegistryAemsVoiceCsis',
+	description: 'AemsVoiceCsisClass payload (undocumented on the wiki) — binds a CSIS voice class to its AEMS bank content via an inline class label. The entity name is soundHash(\'AEMS_\' + label) in every retail instance and is re-derived when the label is edited.',
+	fields: {
+		mUnknown08: u32(),
+		mUnknown0C: u16(),
+		mUnknown10: u32(),
+		mUnknown14: u32(),
+		label: str(),
+		_padTail: rawBytes(),
+	},
+	fieldMetadata: {
+		mUnknown08: { label: 'Unknown +0x8', description: 'Small varying value (6–28 in retail); meaning unknown.' },
+		mUnknown0C: { label: 'Unknown +0xC', description: '2 in every retail instance; meaning unknown.', readOnly: true },
+		mUnknown10: { label: 'Unknown +0x10', description: 'Shared by all AemsVoiceCsisClass entities in the same registry — likely an AEMS bank id.' },
+		mUnknown14: { label: 'Unknown +0x14', description: 'Distinct per entity; meaning unknown.' },
+		label: { label: 'Class label', description: 'Inline CSIS class name (e.g. \'Skids\', \'class_horns\'). Editing it re-derives the entity name hash as soundHash(\'AEMS_\' + label); add the AEMS_-prefixed name to the string pool to keep tree labels readable.' },
+		_padTail: {
+			label: 'pad tail',
+			description: 'Uninitialised 0–3 alignment bytes after the NUL (0xCD allocator fill in retail); preserved verbatim, recomputed when the label length changes.',
+			hidden: true,
+		},
+	},
+	label: (value, index) => {
+		const label = (value as { label?: string }).label;
+		return `#${index ?? 0} · ${label ?? '?'}`;
+	},
+};
+
 const RegistryEntity: RecordSchema = {
 	name: 'RegistryEntity',
 	description: 'One registry entry: a name hash plus a typed payload. Exactly one payload field is populated, matching the type — ContentClass entities have none. The hash-table slot is re-derived from the name on write, so renaming is safe.',
@@ -243,6 +354,10 @@ const RegistryEntity: RecordSchema = {
 		parameterSchema: record('RegistryParameterSchema'),
 		featureSchema: record('RegistryFeatureSchema'),
 		rwacFeature: record('RegistryRwacFeature'),
+		contentSpec: record('RegistryContentSpec'),
+		voiceSchema: record('RegistryVoiceSchema'),
+		voiceSpec: record('RegistryVoiceSpec'),
+		aemsVoiceCsis: record('RegistryAemsVoiceCsis'),
 		_unknownPayload: rawBytes(),
 	},
 	fieldMetadata: {
@@ -262,17 +377,32 @@ const RegistryEntity: RecordSchema = {
 		parameterSchema: { label: 'Parameter schema', description: 'Populated only on ParameterSchema entities.' },
 		featureSchema: { label: 'Feature schema', description: 'Populated only on FeatureSchema entities.' },
 		rwacFeature: { label: 'RWAC feature', description: 'Populated only on GenericRwacFeatureImplementation entities.' },
+		contentSpec: { label: 'Content spec', description: 'Populated only on ContentSpec entities.' },
+		voiceSchema: { label: 'Voice schema', description: 'Populated only on VoiceSchema entities.' },
+		voiceSpec: { label: 'Voice spec', description: 'Populated only on VoiceSpec entities.' },
+		aemsVoiceCsis: { label: 'AEMS CSIS class', description: 'Populated only on AemsVoiceCsisClass entities. Editing its label re-derives this entity\'s name hash.' },
 		_unknownPayload: {
 			label: 'Unknown payload',
-			description: 'Verbatim payload bytes for entity types this build does not decode (ContentSpec, VoiceSchema, VoiceSpec, …); preserved for byte-exact round-trip.',
+			description: 'Verbatim payload bytes for entity types this build does not decode; preserved for byte-exact round-trip. All nine retail type names decode, so this only appears on modded data.',
 			hidden: true,
 		},
 	},
 	propertyGroups: [
 		{ title: 'Identity', properties: ['mName', 'mTypeName'] },
-		{ title: 'Payload', properties: ['mpContentClass', 'parameterSchema', 'featureSchema', 'rwacFeature'] },
+		{ title: 'Payload', properties: ['mpContentClass', 'parameterSchema', 'featureSchema', 'rwacFeature', 'contentSpec', 'voiceSchema', 'voiceSpec', 'aemsVoiceCsis'] },
 	],
 	label: (value, index, ctx) => entityLabel(value, index ?? 0, ctx.root),
+	// Retail invariant (12/12 instances): an AemsVoiceCsisClass entity is
+	// registered under soundHash('AEMS_' + label), so a label edit must move
+	// the entity's hash-table identity with it.
+	derive: (prev, next) => {
+		const prevLabel = (prev.aemsVoiceCsis as { label?: string } | null)?.label;
+		const nextLabel = (next.aemsVoiceCsis as { label?: string } | null)?.label;
+		if (nextLabel != null && nextLabel !== prevLabel) {
+			return { mName: soundHash('AEMS_' + nextLabel) };
+		}
+		return {};
+	},
 };
 
 const ParsedRegistry: RecordSchema = {
@@ -330,6 +460,10 @@ const registry: SchemaRegistry = {
 	RegistryParameterSchema,
 	RegistryFeatureSchema,
 	RegistryRwacFeature,
+	RegistryContentSpec,
+	RegistryVoiceSchema,
+	RegistryVoiceSpec,
+	RegistryAemsVoiceCsis,
 	RwacDspBlock,
 	RwacParamBinding,
 	RwacSlotBinding,

--- a/src/lib/schema/resources/snapshotData.test.ts
+++ b/src/lib/schema/resources/snapshotData.test.ts
@@ -1,0 +1,147 @@
+// Schema coverage tests for snapshotDataResourceSchema.
+//
+// Coverage fixture: example/SOUND/NICOTINEASSETMAIN.BUNDLE (the surround
+// SnapshotData is byte-identical, so one fixture covers both). Mirrors
+// staticSoundMap.test.ts: parse the model and walk it against the schema
+// asserting record references resolve, walkResource visits cleanly, no
+// parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseSnapshotData, type ParsedSnapshotData } from '../../core/snapshotData';
+
+import { snapshotDataResourceSchema } from './snapshotData';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const BUNDLE_FIXTURE = path.resolve(REPO_ROOT, 'example/SOUND/NICOTINEASSETMAIN.BUNDLE');
+const SNAPSHOT_TYPE_ID = 0xa029;
+
+function loadModel(fixturePath: string): ParsedSnapshotData {
+	const fileBytes = fs.readFileSync(fixturePath);
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === SNAPSHOT_TYPE_ID)!;
+	return parseSnapshotData(extractResourceRaw(buffer.buffer, bundle, resource), ctx.littleEndian);
+}
+
+const model = loadModel(BUNDLE_FIXTURE);
+
+describe('snapshotDataResourceSchema coverage', () => {
+	it('fixture parses with non-trivial content', () => {
+		expect(model.channels.length).toBeGreaterThan(0);
+		expect(model.snapshots.length).toBeGreaterThan(0);
+	});
+
+	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+		const missing: string[] = [];
+		for (const [recordName, rec] of Object.entries(snapshotDataResourceSchema.registry)) {
+			for (const [fieldName, field] of Object.entries(rec.fields)) {
+				checkField(field, `${recordName}.${fieldName}`, missing);
+			}
+		}
+		if (missing.length > 0) {
+			throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+		}
+		function checkField(f: FieldSchema, where: string, out: string[]) {
+			if (f.kind === 'record') {
+				if (!snapshotDataResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+				return;
+			}
+			if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+		}
+	});
+
+	it('walkResource visits every parsed field without throwing', () => {
+		let recordCount = 0;
+		let fieldCount = 0;
+		walkResource(snapshotDataResourceSchema, model, (_p, _v, field, rec) => {
+			if (rec) recordCount++;
+			if (field) fieldCount++;
+		});
+		expect(recordCount).toBeGreaterThan(0);
+		expect(fieldCount).toBeGreaterThan(0);
+	});
+
+	it('no parsed record has fields absent from the schema', () => {
+		const missing: string[] = [];
+		walkResource(snapshotDataResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const declared = new Set(Object.keys(rec.fields));
+			for (const key of Object.keys(value as Record<string, unknown>)) {
+				if (!declared.has(key)) {
+					missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+
+	it('every schema field is represented in the parsed data', () => {
+		const missing: string[] = [];
+		walkResource(snapshotDataResourceSchema, model, (p, value, _field, rec) => {
+			if (!rec) return;
+			if (value == null || typeof value !== 'object') return;
+			const obj = value as Record<string, unknown>;
+			for (const fieldName of Object.keys(rec.fields)) {
+				if (!(fieldName in obj)) {
+					missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+				}
+			}
+		});
+		if (missing.length > 0) {
+			throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+		}
+	});
+});
+
+describe('snapshotData path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(snapshotDataResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedSnapshotData');
+	});
+
+	it('resolves channels[0] as a read-only-keyed SnapshotChannel', () => {
+		const loc = resolveSchemaAtPath(snapshotDataResourceSchema, ['channels', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('SnapshotChannel');
+		expect(loc!.record?.fieldMetadata?.mixChId?.readOnly).toBe(true);
+	});
+
+	it('resolves snapshots[0].entries[0].value as f32', () => {
+		const loc = resolveSchemaAtPath(snapshotDataResourceSchema, ['snapshots', 0, 'entries', 0, 'value']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('f32');
+	});
+
+	it('resolves snapshots[0].entries[0].control as u32', () => {
+		const loc = resolveSchemaAtPath(snapshotDataResourceSchema, ['snapshots', 0, 'entries', 0, 'control']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('u32');
+	});
+
+	it('channel and snapshot lists are locked (cross-indexed on disk)', () => {
+		for (const fieldPath of [['channels'], ['snapshots']] as const) {
+			const loc = resolveSchemaAtPath(snapshotDataResourceSchema, [...fieldPath]);
+			expect(loc).not.toBeNull();
+			if (loc!.field?.kind === 'list') {
+				expect(loc!.field.addable, fieldPath.join('.')).toBe(false);
+				expect(loc!.field.removable, fieldPath.join('.')).toBe(false);
+			} else {
+				throw new Error(`${fieldPath.join('.')} is not a list`);
+			}
+		}
+	});
+});

--- a/src/lib/schema/resources/snapshotData.ts
+++ b/src/lib/schema/resources/snapshotData.ts
@@ -1,0 +1,156 @@
+// Hand-written schema for ParsedSnapshotData (resource type 0xA029).
+//
+// Mirrors the types in `src/lib/core/snapshotData.ts`. Keep these in
+// lockstep with the parser/writer — any field added there needs a matching
+// entry here, or the schema walker reports it as drift.
+//
+// Domain: snapshots are mixer presets for the companion Nicotine map
+// (0xA024) in the same bundle. Each channel record names a Nicotine MASTER
+// mix channel by its exact MIXCHID word; each snapshot carries one
+// (control, value) datum per channel. Channels and snapshots are
+// cross-indexed on disk (snapshot s × channel c), so both lists are locked:
+// adding a channel would require adding a datum to all 17 snapshots, an op
+// steward doesn't have yet.
+
+import type { FieldSchema, RecordSchema, ResourceSchema, SchemaRegistry } from '../types';
+import { hex8 } from './nicotine';
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const f32 = (): FieldSchema => ({ kind: 'f32' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+
+const fixedRecordList = (
+	type: string,
+	itemLabel?: (item: unknown, index: number) => string,
+): FieldSchema => ({
+	kind: 'list',
+	item: record(type),
+	addable: false,
+	removable: false,
+	itemLabel: itemLabel ? (item, index) => itemLabel(item, index) : undefined,
+});
+
+function channelLabel(value: unknown, index: number | null): string {
+	const ch = value as { mixChId?: number; channelId?: number } | null;
+	return `#${index ?? 0} · ${hex8(ch?.mixChId)} · hash ${hex8(ch?.channelId)}`;
+}
+
+function entryLabel(value: unknown, index: number | null): string {
+	try {
+		const e = value as { control?: number; value?: number } | null;
+		const val = typeof e?.value === 'number' ? e.value.toFixed(3) : '?';
+		return `ch ${index ?? 0} · ctl ${e?.control ?? '?'} · ${val}`;
+	} catch {
+		return `#${index ?? 0}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const SnapshotChannel: RecordSchema = {
+	name: 'SnapshotChannel',
+	description: 'One mixer channel under snapshot control. References a master mix channel of the companion Nicotine map by its exact MIXCHID word (verified across both retail bundles).',
+	fields: {
+		mixChId: u32(),
+		channelId: u32(),
+	},
+	fieldMetadata: {
+		mixChId: {
+			label: 'Mix channel ID',
+			description: 'Packed master-mix MIXCHID from the companion Nicotine map (top two bits always set; 0xC0-prefixed in retail). The link to the mixer — changing it detaches every snapshot datum for this channel.',
+			readOnly: true,
+		},
+		channelId: {
+			label: 'Channel hash',
+			description: 'Hash-like 32-bit id (not a CgsID; source name unknown). Appears nowhere in the Nicotine map — informational, not the link.',
+			readOnly: true,
+		},
+	},
+	label: channelLabel,
+};
+
+const SnapshotEntry: RecordSchema = {
+	name: 'SnapshotEntry',
+	description: 'One channel\'s datum within a snapshot. Entry i drives channels[i].',
+	fields: {
+		control: u32(),
+		value: f32(),
+	},
+	fieldMetadata: {
+		control: {
+			label: 'Control word',
+			description: 'Packed word: the low i16 lane is consistent with a level in hundredths of a dB (0xD8F0 = -10000 = -100.00 dB floor), the high lane is 0 or 1. Retail range 0..130658.',
+		},
+		value: {
+			label: 'Value',
+			description: 'Unknown float — the wiki suggests volume. Retail range 0..5.6, typically ~0.25.',
+		},
+	},
+	label: entryLabel,
+};
+
+const Snapshot: RecordSchema = {
+	name: 'Snapshot',
+	description: 'One mixer preset: a (control, value) datum for every channel, in channel-list order.',
+	fields: {
+		entries: fixedRecordList('SnapshotEntry', (item, index) => entryLabel(item, index)),
+	},
+	fieldMetadata: {
+		entries: {
+			label: 'Channel data',
+			description: 'One entry per channel — entry i corresponds to channels[i]. The on-disk array is sized snapshots × channels, so the length is locked.',
+		},
+	},
+	label: (_value, index) => `Snapshot #${index ?? 0}`,
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedSnapshotData: RecordSchema = {
+	name: 'ParsedSnapshotData',
+	description: 'Root record for the Snapshot Data resource (0xA029): mixer-channel snapshots for the companion Nicotine map. Both retail resources are byte-identical (17 snapshots × 72 channels) — stereo/surround differences live in the Nicotine maps.',
+	fields: {
+		channels: fixedRecordList('SnapshotChannel', (item, index) => channelLabel(item, index)),
+		snapshots: fixedRecordList('Snapshot'),
+		_pad08: u32(),
+		_pad0C: u32(),
+	},
+	fieldMetadata: {
+		channels: {
+			label: 'Channels',
+			description: 'The master mix channels under snapshot control, each named by its Nicotine MIXCHID. Order is load-bearing: snapshot entries index this list by position.',
+		},
+		snapshots: {
+			label: 'Snapshots',
+			description: 'Mixer presets the game crossfades between. Each carries one datum per channel.',
+		},
+		_pad08: { label: 'maiPad[0]', description: '1 in retail (wiki: "mixer state?"); preserved verbatim.', hidden: true },
+		_pad0C: { label: 'maiPad[1]', description: '0x12345678 in retail; preserved verbatim.', hidden: true },
+	},
+	propertyGroups: [
+		{ title: 'Channels', properties: ['channels'] },
+		{ title: 'Snapshots', properties: ['snapshots'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedSnapshotData,
+	SnapshotChannel,
+	Snapshot,
+	SnapshotEntry,
+};
+
+export const snapshotDataResourceSchema: ResourceSchema = {
+	key: 'snapshotData',
+	name: 'Snapshot Data',
+	rootType: 'ParsedSnapshotData',
+	registry,
+};

--- a/src/lib/schema/resources/splicer.test.ts
+++ b/src/lib/schema/resources/splicer.test.ts
@@ -1,0 +1,192 @@
+// Schema coverage tests for splicerResourceSchema.
+//
+// Coverage fixtures: BIKESOUNDS (smallest retail splicer, mono samples) and
+// PRESENTATIONASSET (largest splice count, stereo samples, zero-ref splices
+// — including splice 0). The same schema must cover both shapes.
+//
+// Mirrors staticSoundMap.test.ts: parse each model and walk it against the
+// schema asserting record references resolve, walkResource visits cleanly,
+// no parser/schema field drift in either direction, and representative deep
+// paths resolve with the expected field kinds.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle } from '../../core/bundle';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
+import { parseSplicer, type ParsedSplicer } from '../../core/splicer';
+
+import { splicerResourceSchema, sampleLabel } from './splicer';
+import { resolveSchemaAtPath, walkResource, formatPath } from '../walk';
+import type { FieldSchema, ListFieldSchema } from '../types';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const SPLICER_TYPE_ID = 0xa025;
+
+function loadModel(bundleFile: string): ParsedSplicer {
+	const fileBytes = fs.readFileSync(path.resolve(REPO_ROOT, bundleFile));
+	const buffer = new Uint8Array(fileBytes.byteLength);
+	buffer.set(fileBytes);
+	const bundle = parseBundle(buffer.buffer, { strict: false });
+	const ctx = resourceCtxFromBundle(bundle);
+	const resource = bundle.resources.find((r) => r.resourceTypeId === SPLICER_TYPE_ID)!;
+	return parseSplicer(extractResourceRaw(buffer.buffer, bundle, resource), ctx.littleEndian);
+}
+
+const fixtures = [
+	['BikeSounds', loadModel('example/SOUND/SPLICER/BIKESOUNDS.BUNDLE')],
+	['PresentationAsset', loadModel('example/SOUND/SPLICER/PRESENTATIONASSET.BUNDLE')],
+] as const;
+
+for (const [label, model] of fixtures) {
+	describe(`splicerResourceSchema coverage — ${label}`, () => {
+		it('fixture parses with non-trivial content', () => {
+			expect(model.splices.length).toBeGreaterThan(0);
+			expect(model.samples.length).toBeGreaterThan(0);
+		});
+
+		it('every record type referenced by a `record` or `list<record>` field is registered', () => {
+			const missing: string[] = [];
+			for (const [recordName, rec] of Object.entries(splicerResourceSchema.registry)) {
+				for (const [fieldName, field] of Object.entries(rec.fields)) {
+					checkField(field, `${recordName}.${fieldName}`, missing);
+				}
+			}
+			if (missing.length > 0) {
+				throw new Error(`Unknown record types referenced:\n  ${missing.join('\n  ')}`);
+			}
+			function checkField(f: FieldSchema, where: string, out: string[]) {
+				if (f.kind === 'record') {
+					if (!splicerResourceSchema.registry[f.type]) out.push(`${where} -> "${f.type}"`);
+					return;
+				}
+				if (f.kind === 'list') checkField(f.item, `${where}[]`, out);
+			}
+		});
+
+		it('walkResource visits every parsed field without throwing', () => {
+			let recordCount = 0;
+			let fieldCount = 0;
+			walkResource(splicerResourceSchema, model, (_p, _v, field, rec) => {
+				if (rec) recordCount++;
+				if (field) fieldCount++;
+			});
+			expect(recordCount).toBeGreaterThan(0);
+			expect(fieldCount).toBeGreaterThan(0);
+		});
+
+		it('no parsed record has fields absent from the schema', () => {
+			const missing: string[] = [];
+			walkResource(splicerResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const declared = new Set(Object.keys(rec.fields));
+				for (const key of Object.keys(value as Record<string, unknown>)) {
+					if (!declared.has(key)) {
+						missing.push(`${formatPath(p)}.${key}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema is missing fields present in parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+
+		it('every schema field is represented in the parsed data', () => {
+			const missing: string[] = [];
+			walkResource(splicerResourceSchema, model, (p, value, _field, rec) => {
+				if (!rec) return;
+				if (value == null || typeof value !== 'object') return;
+				const obj = value as Record<string, unknown>;
+				for (const fieldName of Object.keys(rec.fields)) {
+					if (!(fieldName in obj)) {
+						missing.push(`${formatPath(p)}.${fieldName}  (record "${rec.name}")`);
+					}
+				}
+			});
+			if (missing.length > 0) {
+				throw new Error(`Schema declares fields missing from parsed data:\n  ${missing.join('\n  ')}`);
+			}
+		});
+	});
+}
+
+describe('splicer path resolution', () => {
+	it('resolves the root', () => {
+		const loc = resolveSchemaAtPath(splicerResourceSchema, []);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('ParsedSplicer');
+	});
+
+	it('resolves splices[0] as a SpliceData', () => {
+		const loc = resolveSchemaAtPath(splicerResourceSchema, ['splices', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('SpliceData');
+	});
+
+	it('resolves splices[0].sampleRefs[0] as a SpliceSampleRef', () => {
+		const loc = resolveSchemaAtPath(splicerResourceSchema, ['splices', 0, 'sampleRefs', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.record?.name).toBe('SpliceSampleRef');
+	});
+
+	it('resolves splices[0].sampleRefs[0].Pitch as f32', () => {
+		const loc = resolveSchemaAtPath(splicerResourceSchema, ['splices', 0, 'sampleRefs', 0, 'Pitch']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('f32');
+	});
+
+	it('resolves splices[0].SpliceIndex as read-only u16', () => {
+		const loc = resolveSchemaAtPath(splicerResourceSchema, ['splices', 0, 'SpliceIndex']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('u16');
+		const rec = splicerResourceSchema.registry.SpliceData;
+		expect(rec.fieldMetadata?.SpliceIndex?.readOnly).toBe(true);
+	});
+
+	it('resolves samples[0] as a custom (rawBytes) leaf', () => {
+		const loc = resolveSchemaAtPath(splicerResourceSchema, ['samples', 0]);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('custom');
+	});
+});
+
+describe('splicer labels and list affordances', () => {
+	const model = fixtures[0][1];
+
+	it('sample labels decode the embedded EA-XAS header', () => {
+		// BIKESOUNDS sample 0: 21161 samples @ 48 kHz mono, 5979 bytes.
+		expect(sampleLabel(model.samples[0], 0)).toBe('#0 · 0.44 s · mono · 5979 B');
+		// Garbage-tolerant: too-short blobs fall back to the byte count.
+		expect(sampleLabel(new Uint8Array(4), 3)).toBe('#3 · 4 B');
+		expect(sampleLabel(undefined, 5)).toBe('#5');
+	});
+
+	it('splice and ref labels survive null-ish values', () => {
+		const spliceList = splicerResourceSchema.registry.ParsedSplicer.fields.splices as ListFieldSchema;
+		expect(spliceList.itemLabel!(model.splices[0], 0, { root: model, resource: splicerResourceSchema })).toContain('2 refs');
+		expect(spliceList.itemLabel!(null, 7, { root: model, resource: splicerResourceSchema })).toBe('#7');
+		const refList = splicerResourceSchema.registry.SpliceData.fields.sampleRefs as ListFieldSchema;
+		expect(refList.itemLabel!(model.splices[0].sampleRefs[0], 0, { root: model, resource: splicerResourceSchema })).toContain('sample 7');
+	});
+
+	it('sampleRefs.makeEmpty produces a record matching the schema exactly (drift guard)', () => {
+		const refList = splicerResourceSchema.registry.SpliceData.fields.sampleRefs as ListFieldSchema;
+		const empty = refList.makeEmpty!({ root: model, resource: splicerResourceSchema }) as Record<string, unknown>;
+		const declared = Object.keys(splicerResourceSchema.registry.SpliceSampleRef.fields).sort();
+		expect(Object.keys(empty).sort()).toEqual(declared);
+		// Defaults the writer accepts: in-range sample, audible duration.
+		expect(empty.SampleIndex).toBe(0);
+		expect(empty.Duration).toBe(1);
+	});
+
+	it('the samples list is fixed (no add/remove) and splices are remove-only', () => {
+		const samplesList = splicerResourceSchema.registry.ParsedSplicer.fields.samples as ListFieldSchema;
+		expect(samplesList.addable).toBe(false);
+		expect(samplesList.removable).toBe(false);
+		const splicesList = splicerResourceSchema.registry.ParsedSplicer.fields.splices as ListFieldSchema;
+		expect(splicesList.addable).toBe(false);
+		expect(splicesList.removable).toBe(true);
+	});
+});

--- a/src/lib/schema/resources/splicer.ts
+++ b/src/lib/schema/resources/splicer.ts
@@ -1,0 +1,314 @@
+// Hand-written schema for ParsedSplicer (resource type 0xA025).
+//
+// Mirrors the types in `src/lib/core/splicer.ts`. Keep these in lockstep
+// with the parser/writer — any field added to the parser needs a matching
+// entry here, or the schema walker reports it as drift.
+//
+// Domain: a splicer is a self-contained bank of triggered sounds. Each
+// *splice* is one playable event built from *sample refs* — playback
+// instructions pointing into the table of audio samples embedded at the
+// tail of the same resource (48 kHz EA-XAS streams; no external wave
+// references). Game events bind to splices by hardcoded order, which is why
+// SpliceIndex is read-only and the samples list is fixed: removing or
+// reordering either silently rebinds every event behind it.
+//
+// Units (validated against all six retail fixtures): volumes are LINEAR
+// amplitude multipliers (retail authors them on the 2^(n/6) ladder — about
+// 1 dB per step, 6 dB per doubling). Pitches are frequency RATIOS (retail
+// uses 2^(n/12) — semitone steps). All timing fields are seconds.
+
+import type {
+	FieldSchema,
+	RecordSchema,
+	ResourceSchema,
+	SchemaRegistry,
+} from '../types';
+import { splicerSampleInfo, type SpliceSampleRef } from '@/lib/core/splicer';
+
+// ---------------------------------------------------------------------------
+// Local helpers (mirroring staticSoundMap.ts)
+// ---------------------------------------------------------------------------
+
+const f32 = (opts?: { min?: number; max?: number }): FieldSchema => ({ kind: 'f32', ...opts });
+const u8 = (): FieldSchema => ({ kind: 'u8' });
+const i8 = (): FieldSchema => ({ kind: 'i8' });
+const u16 = (): FieldSchema => ({ kind: 'u16' });
+const u32 = (): FieldSchema => ({ kind: 'u32' });
+const record = (type: string): FieldSchema => ({ kind: 'record', type });
+const rawBytes = (): FieldSchema => ({ kind: 'custom', component: 'rawBytes' });
+
+// ---------------------------------------------------------------------------
+// Tree-label helpers
+// ---------------------------------------------------------------------------
+
+function spliceLabel(value: unknown, index: number): string {
+	try {
+		if (!value || typeof value !== 'object') return `#${index}`;
+		const s = value as { Volume?: number; sampleRefs?: unknown[] };
+		const n = s.sampleRefs?.length ?? 0;
+		const vol = s.Volume != null ? `vol ×${s.Volume.toFixed(2)}` : '';
+		return `#${index} · ${n} ref${n === 1 ? '' : 's'}${vol ? ` · ${vol}` : ''}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+function sampleRefLabel(value: unknown, index: number): string {
+	try {
+		if (!value || typeof value !== 'object') return `#${index}`;
+		const r = value as Partial<SpliceSampleRef>;
+		const dur = r.Duration != null ? ` · ${r.Duration.toFixed(2)} s` : '';
+		const pitch = r.Pitch != null && r.Pitch !== 1 ? ` · pitch ×${r.Pitch.toFixed(2)}` : '';
+		return `#${index} · sample ${r.SampleIndex ?? '?'}${dur}${pitch}`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+export function sampleLabel(value: unknown, index: number): string {
+	try {
+		if (!(value instanceof Uint8Array)) return `#${index}`;
+		const info = splicerSampleInfo(value);
+		if (!info) return `#${index} · ${value.byteLength} B`;
+		return `#${index} · ${info.seconds.toFixed(2)} s · ${info.channels === 1 ? 'mono' : 'stereo'} · ${value.byteLength} B`;
+	} catch {
+		return `#${index}`;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+const SpliceSampleRefRecord: RecordSchema = {
+	name: 'SpliceSampleRef',
+	description: 'One playback instruction inside a splice: which embedded sample to play and how — volume, pitch, delay, duration, fades, and per-trigger randomisation.',
+	fields: {
+		SampleIndex: u16(),
+		Volume: f32({ min: 0 }),
+		Pitch: f32({ min: 0 }),
+		Offset: f32({ min: 0 }),
+		Az: f32(),
+		Duration: f32({ min: 0 }),
+		FadeIn: f32({ min: 0 }),
+		FadeOut: f32({ min: 0 }),
+		RND_Vol: f32(),
+		RND_Pitch: f32(),
+		Priority: u8(),
+		eSpliceType: i8(),
+		eRollOffType: u8(),
+		_pad03: u8(),
+		_pad2A: u16(),
+	},
+	fieldMetadata: {
+		SampleIndex: {
+			label: 'Sample',
+			description: 'Index into the splicer\'s embedded sample list. The writer rejects out-of-range values.',
+		},
+		Volume: {
+			label: 'Volume',
+			description: 'Linear amplitude multiplier (1 = as recorded). Retail authors on the 2^(n/6) ladder (≈1 dB steps); observed 0.0039–2.',
+		},
+		Pitch: {
+			label: 'Pitch',
+			description: 'Frequency ratio (1 = original; 2^(n/12) = n semitones). Retail observed 0.0014–2.',
+		},
+		Offset: {
+			label: 'Delay',
+			description: 'Seconds between the splice trigger and this sample starting. Retail observed 0–8.75.',
+		},
+		Az: {
+			label: 'Azimuth',
+			description: 'Wiki: "typically 0 or -127". Retail values run -127..121 (collision/presentation banks use ±35–61) — looks like degrees with -127 as a sentinel, unverified.',
+		},
+		Duration: {
+			label: 'Duration',
+			description: 'Seconds of the sample to play. Always > 0 in retail (0.0001–15 observed).',
+		},
+		FadeIn: {
+			label: 'Fade in',
+			description: 'Fade-in length in seconds (0 = hard start).',
+		},
+		FadeOut: {
+			label: 'Fade out',
+			description: 'Fade-out length in seconds (0 = hard stop).',
+		},
+		RND_Vol: {
+			label: 'Random volume',
+			description: 'Per-trigger volume randomisation bound (1 = none). Retail observed 0.5–1.2.',
+		},
+		RND_Pitch: {
+			label: 'Random pitch',
+			description: 'Per-trigger pitch randomisation offset (0 = none). Retail observed -0.41..0.79.',
+		},
+		Priority: {
+			label: 'Priority',
+			description: 'Always 0 in retail; runtime meaning unverified.',
+			readOnly: true,
+		},
+		eSpliceType: {
+			label: 'Splice type',
+			description: 'Undocumented enum — 0 in every known instance (the values are absent from the debug data).',
+			readOnly: true,
+		},
+		eRollOffType: {
+			label: 'Roll-off type',
+			description: 'Undocumented enum — 0 in every known instance.',
+			readOnly: true,
+		},
+		_pad03: {
+			label: 'pad +0x03',
+			description: 'Pad byte (0 in retail); preserved verbatim.',
+			hidden: true,
+		},
+		_pad2A: {
+			label: 'pad +0x2A',
+			description: 'Pad u16 (0 in retail); preserved verbatim.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Sample', properties: ['SampleIndex', 'Volume', 'Pitch'] },
+		{ title: 'Timing', properties: ['Offset', 'Duration', 'FadeIn', 'FadeOut'] },
+		{ title: 'Variation', properties: ['RND_Vol', 'RND_Pitch', 'Az', 'Priority', 'eSpliceType', 'eRollOffType'] },
+	],
+	label: (value, index) => sampleRefLabel(value, index ?? 0),
+};
+
+const SpliceDataRecord: RecordSchema = {
+	name: 'SpliceData',
+	description: 'One playable sound event. Game code triggers splices by their hardcoded order in this resource, so position is load-bearing. The refs play together (each with its own delay) when the splice fires.',
+	fields: {
+		Volume: f32({ min: 0 }),
+		RND_Pitch: f32(),
+		RND_Vol: f32(),
+		sampleRefs: {
+			kind: 'list',
+			item: record('SpliceSampleRef'),
+			addable: true,
+			removable: true,
+			makeEmpty: () => ({
+				SampleIndex: 0,
+				eSpliceType: 0,
+				_pad03: 0,
+				Volume: 1,
+				Pitch: 1,
+				Offset: 0,
+				Az: 0,
+				Duration: 1,
+				FadeIn: 0,
+				FadeOut: 0,
+				RND_Vol: 1,
+				RND_Pitch: 0,
+				Priority: 0,
+				eRollOffType: 0,
+				_pad2A: 0,
+			} satisfies SpliceSampleRef),
+			itemLabel: (item, index) => sampleRefLabel(item, index),
+		},
+		SpliceIndex: u16(),
+		NameHash: u32(),
+		eSpliceType: i8(),
+	},
+	fieldMetadata: {
+		Volume: {
+			label: 'Volume',
+			description: 'Linear amplitude multiplier for the whole splice, on top of each ref\'s own volume. Retail observed 0.22–10.08 (the 2^(n/6) ladder: ≈1 dB per step).',
+		},
+		RND_Pitch: {
+			label: 'Random pitch',
+			description: 'Splice-level pitch randomisation (0 in every retail splice).',
+		},
+		RND_Vol: {
+			label: 'Random volume',
+			description: 'Splice-level volume randomisation bound (1 in every retail splice).',
+		},
+		sampleRefs: {
+			label: 'Sample refs',
+			description: 'Playback instructions fired together when this splice triggers. Count is stored as a u8 — the writer rejects more than 255.',
+		},
+		SpliceIndex: {
+			label: 'Splice index',
+			description: 'Rank in the shared on-disk SampleRef array. Equals the splice\'s position in every retail resource; must stay unique. Read-only — the refs are nested here, so the rank only matters for byte layout.',
+			readOnly: true,
+		},
+		NameHash: {
+			label: 'Name hash',
+			description: 'Always 0 in retail (the wiki marks it "Always null"). Preserved verbatim.',
+			readOnly: true,
+		},
+		eSpliceType: {
+			label: 'Splice type',
+			description: 'Undocumented enum — 0 in every known instance.',
+			readOnly: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Playback', properties: ['Volume', 'RND_Vol', 'RND_Pitch', 'sampleRefs'] },
+		{ title: 'Identity', properties: ['SpliceIndex', 'NameHash', 'eSpliceType'] },
+	],
+	label: (value, index) => spliceLabel(value, index ?? 0),
+};
+
+// ---------------------------------------------------------------------------
+// Root + registry export
+// ---------------------------------------------------------------------------
+
+const ParsedSplicerRecord: RecordSchema = {
+	name: 'ParsedSplicer',
+	description: 'Root record for the Splicer resource (0xA025): a self-contained bank of triggered sounds with the audio sample data embedded at the tail. Nothing here references other resources.',
+	fields: {
+		splices: {
+			kind: 'list',
+			item: record('SpliceData'),
+			// Adding a splice needs a fresh unique SpliceIndex; removal is safe
+			// for the bytes but rebinds the hardcoded game-event order — allowed,
+			// with the warning carried on the field description.
+			addable: false,
+			removable: true,
+			itemLabel: (item, index) => spliceLabel(item, index),
+		},
+		samples: {
+			kind: 'list',
+			item: rawBytes(),
+			// Fixed: SampleIndex refs address this list by position, and steward
+			// has no audio-import pipeline to author new EA-XAS streams.
+			addable: false,
+			removable: false,
+			itemLabel: (item, index) => sampleLabel(item, index),
+		},
+		_wrapperPad: rawBytes(),
+	},
+	fieldMetadata: {
+		splices: {
+			label: 'Splices',
+			description: 'Playable sound events in trigger order. Game events bind to splices by hardcoded position — removing one rebinds every splice behind it.',
+		},
+		samples: {
+			label: 'Samples',
+			description: 'Embedded audio streams (48 kHz EA-XAS, mono or stereo), addressed by each ref\'s Sample index. Opaque bytes — steward preserves them verbatim.',
+		},
+		_wrapperPad: {
+			label: 'Wrapper pad',
+			description: 'BinaryFile header pad bytes 0x8–0xF (zero in retail). Preserved for byte-exact round-trip.',
+			hidden: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Splices', properties: ['splices'] },
+		{ title: 'Samples', properties: ['samples'] },
+	],
+};
+
+const registry: SchemaRegistry = {
+	ParsedSplicer: ParsedSplicerRecord,
+	SpliceData: SpliceDataRecord,
+	SpliceSampleRef: SpliceSampleRefRecord,
+};
+
+export const splicerResourceSchema: ResourceSchema = {
+	key: 'splicer',
+	name: 'Splicer',
+	rootType: 'ParsedSplicer',
+	registry,
+};


### PR DESCRIPTION
## What

Seven more resource types by six parallel workflow agents — five spec groups plus, for the first time, an **exclusive-edit extension agent** that finished what batch 2 started. Coverage: **56/114**, and the Sound category goes from one type to eight. Branched from post-#120 main; born mergeable.

| Spec | Type | Scale |
|---|---|---|
| GenericRwacWaveContent | 0xA020 | **all 37** GLOBALWAVES waves |
| AemsBank | 0xA022 | all 23 AEMS banks (read: partial — x86 module + SND10 bank opaque) |
| Csis | 0xA023 | all 10 class systems |
| Splicer | 0xA025 | all 6 bundles (767 splices, 582 embedded samples) |
| Nicotine | 0xA024 | both mixer maps |
| SnapshotData | 0xA029 | both snapshot sets |
| FlaptFile | 0x10020 | the 1.3 MB HUD resource (read/write: partial — in-place patch writer) |

**Registry (0xA000) entity extension:** with SOUNDENTITY.BUNDLE and CSIS.BUNDLE as fixtures, ContentSpec (×115), VoiceSchema (×26), and VoiceSpec (×28) all decode — **nothing is left verbatim** — plus a NEW wiki-undocumented entity type `~AemsVoiceCsisClass~` whose name derives as `soundHash('AEMS_' + label)` (wired as a derive hook). CSIS.BUNDLE's 30 registries (10 effect groups × Entity/Voice/Factory) sweep byte-exact.

## Data findings (all pinned in tests)

- **Waves**: a BIG-endian bit-packed header inside the little-endian wrapper; the wiki's chunk-size convention is wrong (size includes the chunk header); multi-chunk waves exist ONLY for loops, with the chunk boundary landing exactly on the loop start sample; every retail wave is EALayer3.
- **AEMS/Csis**: the wiki's ClassDesc stride is wrong (0xC, not 0x10); `SystemDesc.crc` is derived — `(Σ entry crcs) & 0x7FFF`, re-derived on write; a cross-resource sweep proves all 27 bank interface references resolve to retail Csis classes; `nummodules` is not "always 1".
- **Splicer**: the wave-reference question has a clean answer — audio is **embedded** (internal TOC of EA-XAS blobs), no external refs at all; volumes live on the 2^(n/6) ladder (~1 dB steps), pitches on 2^(n/12) semitones.
- **Nicotine**: stereo and surround differ in exactly **16 words** (master attenuation only); snapshot channels match the companion map's master MIXCHIDs 72/72; mixData is centi-dB i16 lanes with a constant −100 dB floor.
- **FlaptFile**: every pointer is payload-absolute (even inside the undecoded timeline region), so the writer patches fixed-width fields in place over a verbatim payload — frame time, vertices, font colours, and texture retargets are editable today; the trigger table contains the EasyDrive wiring the wiki speculates about.

## Tests

Full suite: **3,570 passing** (+421). Zero integration failures. The only 3 failures are the long-standing missing-prototype-fixture cases.

Specs: https://burnout.wiki/wiki/Generic_Rwac_Wave_Content · https://burnout.wiki/wiki/AEMS_Bank · https://burnout.wiki/wiki/CSIS · https://burnout.wiki/wiki/Splicer · https://burnout.wiki/wiki/Nicotine · https://burnout.wiki/wiki/Snapshot_Data · https://burnout.wiki/wiki/Flapt_File · https://burnout.wiki/wiki/Registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)