### PR TITLE
fix(bundle): stop inflating raw resource blocks that start with a zlib magic

### DIFF
--- a/src/components/schema-editor/viewports/propGeometryDecode.ts
+++ b/src/components/schema-editor/viewports/propGeometryDecode.ts
@@ -29,7 +29,7 @@
 import * as THREE from 'three';
 import type { ParsedBundle, ResourceEntry } from '@/lib/core/types';
 import { getImportsByPtrOffset } from '@/lib/core/bundle';
-import { extractResourceSize, isCompressed, decompressData } from '@/lib/core/resourceManager';
+import { extractResourceSize, isResourceBlockCompressed, decompressData } from '@/lib/core/resourceManager';
 import {
 	parsePropGraphicsList,
 	PROP_GRAPHICS_LIST_TYPE_ID,
@@ -73,7 +73,7 @@ function extractBlock0(buffer: ArrayBuffer, bundle: ParsedBundle, entry: Resourc
 	const start = (bundle.header.resourceDataOffsets[0] + entry.diskOffsets[0]) >>> 0;
 	if (start + size > buffer.byteLength) return null;
 	let bytes: Uint8Array = new Uint8Array(buffer, start, size);
-	if (isCompressed(bytes)) bytes = decompressData(bytes) as Uint8Array;
+	if (isResourceBlockCompressed(entry, 0, bytes)) bytes = decompressData(bytes) as Uint8Array;
 	return bytes;
 }
 

--- a/src/components/schema-editor/viewports/renderableDecodedContext.tsx
+++ b/src/components/schema-editor/viewports/renderableDecodedContext.tsx
@@ -49,7 +49,7 @@ import {
 	type RawLocator,
 } from '@/lib/core/graphicsSpec';
 import { getImportsByPtrOffset, getImportIds, parseBundle } from '@/lib/core/bundle';
-import { extractResourceSize, isCompressed, decompressData } from '@/lib/core/resourceManager';
+import { extractResourceSize, isResourceBlockCompressed, decompressData } from '@/lib/core/resourceManager';
 import { u64ToBigInt } from '@/lib/core/u64';
 import {
 	resolveMaterialTextures,
@@ -131,7 +131,7 @@ function decodeOneRenderable(
 			}
 			const start = (bundle.header.resourceDataOffsets[0] + entry.diskOffsets[0]) >>> 0;
 			let bytes: Uint8Array = new Uint8Array(buffer, start, size);
-			if (isCompressed(bytes)) bytes = decompressData(bytes) as Uint8Array;
+			if (isResourceBlockCompressed(entry, 0, bytes)) bytes = decompressData(bytes) as Uint8Array;
 			let parsed: ParsedVertexDescriptor | null = null;
 			try {
 				parsed = parseVertexDescriptor(bytes);

--- a/src/components/schema-editor/viewports/trackGeometryDecode.ts
+++ b/src/components/schema-editor/viewports/trackGeometryDecode.ts
@@ -39,7 +39,7 @@ import {
 	type ParsedVertexDescriptor,
 	type RenderableMesh,
 } from '@/lib/core/renderable';
-import { extractResourceSize, isCompressed, decompressData } from '@/lib/core/resourceManager';
+import { extractResourceSize, isResourceBlockCompressed, decompressData } from '@/lib/core/resourceManager';
 import { u64ToBigInt } from '@/lib/core/u64';
 import { parseInstanceList, INSTANCE_LIST_TYPE_ID } from '@/lib/core/instanceList';
 
@@ -119,7 +119,7 @@ function decodeRenderableGeometries(
 			}
 			const start = (bundle.header.resourceDataOffsets[0] + entry.diskOffsets[0]) >>> 0;
 			let bytes: Uint8Array = new Uint8Array(buffer, start, size);
-			if (isCompressed(bytes)) bytes = decompressData(bytes) as Uint8Array;
+			if (isResourceBlockCompressed(entry, 0, bytes)) bytes = decompressData(bytes) as Uint8Array;
 			let parsed: ParsedVertexDescriptor | null = null;
 			try {
 				parsed = parseVertexDescriptor(bytes);
@@ -229,7 +229,7 @@ export function decodeTrackGeometry(
 		if (size <= 0) return empty;
 		const start = (bundle.header.resourceDataOffsets[0] + ilEntry.diskOffsets[0]) >>> 0;
 		let bytes: Uint8Array = new Uint8Array(buffer, start, size);
-		if (isCompressed(bytes)) bytes = decompressData(bytes) as Uint8Array;
+		if (isResourceBlockCompressed(ilEntry, 0, bytes)) bytes = decompressData(bytes) as Uint8Array;
 		il = parseInstanceList(bytes);
 	} catch {
 		return empty;

--- a/src/lib/core/__tests__/staticSoundMap.test.ts
+++ b/src/lib/core/__tests__/staticSoundMap.test.ts
@@ -389,11 +389,11 @@ describe('rebucket retail sweep (example/TRK_UNIT*_GR.BNDL)', () => {
 		? fs.readdirSync(exampleDir).filter((f) => /^TRK_UNIT\d+_GR\.BNDL$/.test(f)).sort()
 		: [];
 
-	// TRK_UNIT192_GR.BNDL fails at the BUNDLE level ('invalid stored block
-	// lengths' during decompression) — a pre-existing envelope issue unrelated
-	// to StaticSoundMap, so the sweep tolerates bundle-parse failures but
-	// reports them, pinning that only this one exists.
-	const KNOWN_UNPARSEABLE_BUNDLES = ['TRK_UNIT192_GR.BNDL'];
+	// Every retail TRK bundle parses. TRK_UNIT192 once failed here because its
+	// raw PropGraphicsList payload starts with a coincidental zlib magic and the
+	// envelope used to trust the byte sniff — keep the unparseable channel so a
+	// regression is reported by name instead of as a silent count drop.
+	const KNOWN_UNPARSEABLE_BUNDLES: string[] = [];
 
 	it.skipIf(trkBundles.length === 0)(
 		'write(rebucket(parse(raw))) is byte-identical to raw for every retail StaticSoundMap',
@@ -428,8 +428,8 @@ describe('rebucket retail sweep (example/TRK_UNIT*_GR.BNDL)', () => {
 			}
 			expect(unparseable).toEqual(KNOWN_UNPARSEABLE_BUNDLES);
 			expect(failures).toEqual([]);
-			// 427 parseable bundles x 2 maps each.
-			expect(checked).toBe(854);
+			// 428 bundles x 2 maps each.
+			expect(checked).toBe(856);
 		},
 		600_000,
 	);

--- a/src/lib/core/bundle/__tests__/rawBlockZlibSniff.test.ts
+++ b/src/lib/core/bundle/__tests__/rawBlockZlibSniff.test.ts
@@ -1,0 +1,138 @@
+// A raw (stored-uncompressed) resource block may begin with a coincidental
+// zlib magic — 0x78 0x01 is also the little-endian u32 0x178, a perfectly
+// plausible struct offset. The envelope's disk-vs-uncompressed size pair is
+// the authoritative compression signal: equal sizes mean stored raw, and the
+// bytes must never be inflated no matter what they start with.
+//
+// Retail TRK_UNIT192_GR.BNDL is the live case: its PropGraphicsList (0x10010)
+// payload starts 0x78 0x01 and used to abort the whole bundle parse with
+// "invalid stored block lengths" from zlib.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as pako from 'pako';
+
+import { parseBundle } from '..';
+import {
+	parseImportEntries,
+	createEmptyResourceEntry,
+	getResourceImportSlice,
+} from '../bundleEntry';
+import {
+	isResourceBlockCompressed,
+	packSizeAndAlignment,
+} from '../../resourceManager';
+import { extractResourceRaw } from '../../registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+const FIXTURE = path.resolve(REPO_ROOT, 'example/TRK_UNIT192_GR.BNDL');
+const PROP_GRAPHICS_LIST_TYPE_ID = 0x10010;
+
+describe('isResourceBlockCompressed', () => {
+	const zlibLooking = new Uint8Array([0x78, 0x01, 0x00, 0x00, 0xc0, 0x00]);
+
+	it('treats equal disk/uncompressed sizes as raw even when bytes sniff as zlib', () => {
+		const entry = createEmptyResourceEntry();
+		entry.sizeAndAlignmentOnDisk[0] = packSizeAndAlignment(zlibLooking.length, 1);
+		entry.uncompressedSizeAndAlignment[0] = packSizeAndAlignment(zlibLooking.length, 1);
+		expect(isResourceBlockCompressed(entry, 0, zlibLooking)).toBe(false);
+	});
+
+	it('treats differing sizes with a zlib magic as compressed', () => {
+		const raw = new Uint8Array(64).fill(7);
+		const compressed = pako.deflate(raw);
+		const entry = createEmptyResourceEntry();
+		entry.sizeAndAlignmentOnDisk[0] = packSizeAndAlignment(compressed.length, 1);
+		entry.uncompressedSizeAndAlignment[0] = packSizeAndAlignment(raw.length, 16);
+		expect(isResourceBlockCompressed(entry, 0, compressed)).toBe(true);
+	});
+
+	it('does not trust differing sizes alone when the bytes are not zlib', () => {
+		const bytes = new Uint8Array([0x12, 0x34, 0x56, 0x78]);
+		const entry = createEmptyResourceEntry();
+		entry.sizeAndAlignmentOnDisk[0] = packSizeAndAlignment(bytes.length, 1);
+		entry.uncompressedSizeAndAlignment[0] = packSizeAndAlignment(128, 16);
+		expect(isResourceBlockCompressed(entry, 0, bytes)).toBe(false);
+	});
+});
+
+describe('parseImportEntries on a raw block with a coincidental zlib magic', () => {
+	// 0x30-byte raw payload: leading "0x78 0x01" struct data, import table at
+	// 0x20 with one entry { id 0xAABBCCDD00112233, ptrOffset 0x10 }.
+	function makePayload(): Uint8Array {
+		const payload = new Uint8Array(0x30);
+		const dv = new DataView(payload.buffer);
+		dv.setUint32(0x00, 0x178, true);
+		dv.setUint32(0x20, 0x00112233, true);
+		dv.setUint32(0x24, 0xaabbccdd, true);
+		dv.setUint32(0x28, 0x10, true);
+		return payload;
+	}
+
+	function makeEntry(diskSize: number, uncompSize: number) {
+		const entry = createEmptyResourceEntry();
+		entry.sizeAndAlignmentOnDisk[0] = packSizeAndAlignment(diskSize, 1);
+		entry.uncompressedSizeAndAlignment[0] = packSizeAndAlignment(uncompSize, 16);
+		entry.importOffset = 0x20;
+		entry.importCount = 1;
+		return entry;
+	}
+
+	it('reads the import table from the raw bytes without inflating', () => {
+		const payload = makePayload();
+		const entry = makeEntry(payload.length, payload.length);
+		const imports = parseImportEntries(
+			payload.buffer,
+			[entry],
+			{ resourceDataOffsets: [0, 0, 0] },
+		);
+		expect(imports).toEqual([
+			{ resourceId: { low: 0x00112233, high: 0xaabbccdd }, offset: 0x10, padding: 0 },
+		]);
+	});
+
+	it('still inflates a genuinely compressed block before reading its table', () => {
+		const payload = makePayload();
+		const compressed = pako.deflate(payload);
+		const entry = makeEntry(compressed.length, payload.length);
+		const compressedBuffer = compressed.buffer.slice(
+			compressed.byteOffset,
+			compressed.byteOffset + compressed.byteLength,
+		) as ArrayBuffer;
+		const imports = parseImportEntries(
+			compressedBuffer,
+			[entry],
+			{ resourceDataOffsets: [0, 0, 0] },
+		);
+		expect(imports).toEqual([
+			{ resourceId: { low: 0x00112233, high: 0xaabbccdd }, offset: 0x10, padding: 0 },
+		]);
+	});
+});
+
+describe.skipIf(!fs.existsSync(FIXTURE))('TRK_UNIT192_GR.BNDL (raw PropGraphicsList starting 0x78 0x01)', () => {
+	const buf = fs.existsSync(FIXTURE) ? fs.readFileSync(FIXTURE) : Buffer.alloc(0);
+	const buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+
+	it('parses the whole bundle', () => {
+		const bundle = parseBundle(buffer);
+		expect(bundle.resources.length).toBe(346);
+	});
+
+	it('extracts the PropGraphicsList raw, un-inflated, with its import table intact', () => {
+		const bundle = parseBundle(buffer);
+		const index = bundle.resources.findIndex((r) => r.resourceTypeId === PROP_GRAPHICS_LIST_TYPE_ID);
+		expect(index).toBeGreaterThanOrEqual(0);
+		const resource = bundle.resources[index];
+
+		const raw = extractResourceRaw(buffer, bundle, resource);
+		expect(raw.byteLength).toBe(832);
+		expect([raw[0], raw[1]]).toEqual([0x78, 0x01]);
+
+		// 28 imports at payload-relative 0x180 — exactly the raw payload tail.
+		const slice = getResourceImportSlice(bundle.imports, bundle.resources, index);
+		expect(slice?.length).toBe(28);
+		expect(resource.importOffset + resource.importCount * 16).toBe(raw.byteLength);
+	});
+});

--- a/src/lib/core/bundle/bundle1.ts
+++ b/src/lib/core/bundle/bundle1.ts
@@ -34,6 +34,7 @@ import {
   extractResourceSize,
   extractAlignment,
   isCompressed,
+  isResourceBlockCompressed,
   decompressData,
   compressData,
 } from '../resourceManager';
@@ -917,7 +918,7 @@ export function bnd2ToBnd1Shape(
     let resourceCompressed = false;
     if (size0 > 0 && absOff + 2 <= originalBuffer.byteLength) {
       const probe = new Uint8Array(originalBuffer, absOff, Math.min(2, size0));
-      resourceCompressed = isCompressed(probe);
+      resourceCompressed = isResourceBlockCompressed(r, 0, probe);
     }
     if (resourceCompressed) numCompressed++;
 
@@ -1189,7 +1190,7 @@ export function reencodeResourceChunksForTarget(
     const rel = r.diskOffsets[0] >>> 0;
     const absOff = (base + rel) >>> 0;
     const sourceChunk = new Uint8Array(originalBuffer, absOff, sizeOnDisk);
-    const wasCompressed = isCompressed(sourceChunk);
+    const wasCompressed = isResourceBlockCompressed(r, 0, sourceChunk);
     const decoded = wasCompressed ? decompressData(sourceChunk) : sourceChunk;
 
     let outBytes: Uint8Array;

--- a/src/lib/core/bundle/bundleEntry.ts
+++ b/src/lib/core/bundle/bundleEntry.ts
@@ -176,7 +176,12 @@ export function parseImportEntries(
       continue;
     }
     let bytes = new Uint8Array(buffer, start, size);
-    if (isCompressedLocal(bytes)) bytes = decompressLocal(bytes);
+    // Equal disk/uncompressed sizes mean the block is stored raw; raw payloads
+    // can start with a valid zlib magic by coincidence (retail TRK_UNIT192's
+    // PropGraphicsList begins 0x78 0x01 — the u32 0x178), so the magic sniff
+    // alone must never trigger decompression.
+    const uncompSize = extractResourceSizeLocal(resource.uncompressedSizeAndAlignment[0]);
+    if (size !== uncompSize && isCompressedLocal(bytes)) bytes = decompressLocal(bytes);
 
     const importOff = resource.importOffset >>> 0;
     if (importOff + resource.importCount * 16 > bytes.byteLength) {

--- a/src/lib/core/bundle/index.ts
+++ b/src/lib/core/bundle/index.ts
@@ -41,7 +41,7 @@ import { parsePlayerCarColours } from '../playerCarColors';
 import { RESOURCE_TYPES } from '../../resourceTypes';
 import { parseIceTakeDictionary } from '../iceTakeDictionary';
 import { parseTriggerData } from '../triggerData';
-import { extractResourceSize, extractAlignment, packSizeAndAlignment, isCompressed, compressData } from '../resourceManager';
+import { extractResourceSize, extractAlignment, packSizeAndAlignment, isResourceBlockCompressed, compressData } from '../resourceManager';
 import { parseChallengeList } from '../challengeList';
 import { parseStreetData } from '../streetData';
 import { registry, getHandlerByTypeId, resourceCtxFromBundle } from '../registry';
@@ -219,7 +219,7 @@ export function writeBundleFresh(
       const rel = resource.diskOffsets[bi] >>> 0;
       const start = (base + rel) >>> 0;
       const rawOriginal = new Uint8Array(originalBuffer, start, size);
-      const wasCompressed = isCompressed(rawOriginal);
+      const wasCompressed = isResourceBlockCompressed(resource, bi, rawOriginal);
       const align = extractAlignment(resource.sizeAndAlignmentOnDisk[bi]);
       const uncompAlign = extractAlignment(resource.uncompressedSizeAndAlignment[bi]);
 

--- a/src/lib/core/graphicsSpec.ts
+++ b/src/lib/core/graphicsSpec.ts
@@ -14,7 +14,7 @@
 // resolves the Model → Renderable chain via the bundle's resource list.
 
 import type { ParsedBundle, ResourceEntry } from './types';
-import { extractResourceSize, isCompressed, decompressData } from './resourceManager';
+import { extractResourceSize, isResourceBlockCompressed, decompressData } from './resourceManager';
 import { u64ToBigInt } from './u64';
 import { BundleError } from './errors';
 import { getImportIds } from './bundle';
@@ -100,7 +100,7 @@ export function getGraphicsSpecHeader(
 		throw new BundleError('GraphicsSpec block 0 runs past end of file', 'PARSE_ERROR');
 	}
 	let bytes: Uint8Array = new Uint8Array(buffer, start, size);
-	if (isCompressed(bytes)) bytes = decompressData(bytes) as Uint8Array;
+	if (isResourceBlockCompressed(resource, 0, bytes)) bytes = decompressData(bytes) as Uint8Array;
 	return bytes;
 }
 
@@ -291,7 +291,7 @@ function getModelHeader(
 	const rel = resource.diskOffsets[0] >>> 0;
 	const start = (base + rel) >>> 0;
 	let bytes: Uint8Array = new Uint8Array(buffer, start, size);
-	if (isCompressed(bytes)) bytes = decompressData(bytes) as Uint8Array;
+	if (isResourceBlockCompressed(resource, 0, bytes)) bytes = decompressData(bytes) as Uint8Array;
 	return bytes;
 }
 

--- a/src/lib/core/registry/extract.ts
+++ b/src/lib/core/registry/extract.ts
@@ -3,7 +3,7 @@
 // offset math and zlib handling only live in one place.
 
 import type { ParsedBundle, ResourceEntry } from '../types';
-import { extractResourceData, isCompressed, decompressData } from '../resourceManager';
+import { extractResourceDataWithBlock, isResourceBlockCompressed, decompressData } from '../resourceManager';
 import { BundleError } from '../errors';
 
 /**
@@ -21,13 +21,13 @@ export function extractResourceRaw(
 	bundle: ParsedBundle,
 	resource: ResourceEntry,
 ): Uint8Array {
-	const raw = extractResourceData(buffer, bundle, resource);
+	const { data: raw, blockIndex } = extractResourceDataWithBlock(buffer, bundle, resource);
 	if (raw.byteLength === 0) {
 		throw new BundleError(
 			`Resource 0x${resource.resourceTypeId.toString(16)} has no populated data block`,
 			'RESOURCE_EMPTY',
 		);
 	}
-	if (isCompressed(raw)) return decompressData(raw);
+	if (isResourceBlockCompressed(resource, blockIndex, raw)) return decompressData(raw);
 	return raw;
 }

--- a/src/lib/core/renderable.ts
+++ b/src/lib/core/renderable.ts
@@ -17,7 +17,7 @@
 // bundle-level parseImportEntries() data.
 
 import type { ParsedBundle, ResourceEntry } from './types';
-import { extractResourceSize, isCompressed, decompressData } from './resourceManager';
+import { extractResourceSize, isResourceBlockCompressed, decompressData } from './resourceManager';
 import { u64ToBigInt } from './u64';
 import { BundleError } from './errors';
 
@@ -222,7 +222,7 @@ export function getRenderableBlocks(
 		const start = (base + rel) >>> 0;
 		if (start + size > buffer.byteLength) return null;
 		let bytes: Uint8Array = new Uint8Array(buffer, start, size);
-		if (isCompressed(bytes)) bytes = decompressData(bytes) as Uint8Array;
+		if (isResourceBlockCompressed(resource, i, bytes)) bytes = decompressData(bytes) as Uint8Array;
 		return bytes;
 	};
 

--- a/src/lib/core/resourceManager.ts
+++ b/src/lib/core/resourceManager.ts
@@ -98,6 +98,20 @@ export function extractResourceData(
   bundle: ParsedBundle,
   resource: ResourceEntry,
 ): Uint8Array {
+  return extractResourceDataWithBlock(buffer, bundle, resource).data;
+}
+
+/**
+ * Same as {@link extractResourceData} but also reports WHICH memory block the
+ * bytes came from, so callers can run the per-block compression check
+ * ({@link isResourceBlockCompressed}) against the matching entry fields.
+ * blockIndex is -1 when no block had usable data.
+ */
+export function extractResourceDataWithBlock(
+  buffer: ArrayBuffer,
+  bundle: ParsedBundle,
+  resource: ResourceEntry,
+): { data: Uint8Array; blockIndex: number } {
   for (let i = 0; i < 3; i++) {
     const size = extractResourceSize(resource.sizeAndAlignmentOnDisk[i]);
     if (size <= 0) continue;
@@ -105,10 +119,10 @@ export function extractResourceData(
     const rel = resource.diskOffsets[i] >>> 0;
     const start = (base + rel) >>> 0;
     if (start + size <= buffer.byteLength) {
-      return new Uint8Array(buffer, start, size);
+      return { data: new Uint8Array(buffer, start, size), blockIndex: i };
     }
   }
-  return new Uint8Array();
+  return { data: new Uint8Array(), blockIndex: -1 };
 }
 
 /**
@@ -135,7 +149,7 @@ export function getResourceBlocks(
     const start = (base + rel) >>> 0;
     if (start + size > buffer.byteLength) continue;
     let bytes: Uint8Array = new Uint8Array(buffer, start, size);
-    if (isCompressed(bytes)) bytes = decompressData(bytes) as Uint8Array;
+    if (isResourceBlockCompressed(resource, i, bytes)) bytes = decompressData(bytes) as Uint8Array;
     blocks[i] = bytes;
   }
   return blocks;
@@ -171,10 +185,38 @@ export function packSizeAndAlignment(size: number, alignment: number): number {
 // ============================================================================
 
 /**
- * Detects if data is compressed (zlib format)
+ * Detects if data LOOKS like a zlib stream (magic-byte sniff).
+ *
+ * Sniffing alone is not authoritative: raw resource payloads can start with a
+ * valid zlib magic by coincidence (0x78 0x01 is also the little-endian u32
+ * 0x178 — a perfectly plausible struct offset; retail TRK_UNIT192 has exactly
+ * such a PropGraphicsList). Whenever the ResourceEntry is available, use
+ * {@link isResourceBlockCompressed} instead, which consults the envelope's
+ * disk-vs-uncompressed size pair before trusting the sniff.
  */
 export function isCompressed(data: Uint8Array): boolean {
-  return data.length >= 2 && data[0] === 0x78;
+  // zlib magic: CMF 0x78 followed by a standard-level FLG byte.
+  if (data.length < 2 || data[0] !== 0x78) return false;
+  return data[1] === 0x01 || data[1] === 0x9C || data[1] === 0xDA || data[1] === 0x5E;
+}
+
+/**
+ * Authoritative per-block compression check for a resource's memory block.
+ *
+ * BND2 entries carry both the on-disk and the in-memory (uncompressed) size
+ * per block. Equal sizes mean the block is stored raw — the bytes must NOT be
+ * inflated even if they happen to start with a zlib magic. Different sizes
+ * mean a compressed block, with the sniff kept as a sanity guard.
+ */
+export function isResourceBlockCompressed(
+  resource: ResourceEntry,
+  blockIndex: number,
+  bytes: Uint8Array,
+): boolean {
+  const diskSize = extractResourceSize(resource.sizeAndAlignmentOnDisk[blockIndex]);
+  const uncompressedSize = extractResourceSize(resource.uncompressedSizeAndAlignment[blockIndex]);
+  if (diskSize === uncompressedSize) return false;
+  return isCompressed(bytes);
 }
 
 /**
@@ -225,8 +267,8 @@ export function compressData(data: Uint8Array, level: number = 6): Uint8Array {
  * Gets resource data with automatic decompression
  */
 export function getResourceData(context: ResourceContext): ResourceData {
-  const rawData = extractResourceData(context.buffer, context.bundle, context.resource);
-  const compressed = isCompressed(rawData);
+  const { data: rawData, blockIndex } = extractResourceDataWithBlock(context.buffer, context.bundle, context.resource);
+  const compressed = blockIndex >= 0 && isResourceBlockCompressed(context.resource, blockIndex, rawData);
   const data = compressed ? decompressData(rawData) : rawData;
 
   return {
@@ -362,8 +404,8 @@ export function calculateBundleStats(bundle: ParsedBundle, buffer: ArrayBuffer):
     stats.resourceTypes[resource.resourceTypeId] = (stats.resourceTypes[resource.resourceTypeId] || 0) + 1;
 
     // Check if compressed
-    const data = extractResourceData(buffer, bundle, resource);
-    if (isCompressed(data)) {
+    const { data, blockIndex } = extractResourceDataWithBlock(buffer, bundle, resource);
+    if (blockIndex >= 0 && isResourceBlockCompressed(resource, blockIndex, data)) {
       stats.compressedResources++;
       stats.compressedSize += data.length;
     }

--- a/src/pages/ResourceInspectorPage.tsx
+++ b/src/pages/ResourceInspectorPage.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useFirstLoadedBundle } from '@/context/WorkspaceContext';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { getResourceData, extractResourceSize, isCompressed, decompressData } from '@/lib/core/resourceManager';
+import { getResourceData, extractResourceSize, isResourceBlockCompressed, decompressData } from '@/lib/core/resourceManager';
 import { getResourceType } from '@/lib/resourceTypes';
 import { RESOURCE_TYPE_IDS } from '@/lib/core/types';
 import { ResourceInspectorView } from '@/components/hexviewer/ResourceInspectorView';
@@ -21,7 +21,7 @@ const ResourceInspectorPage = () => {
     const res = resourceIndex ? loadedBundle.resources[Number(resourceIndex)] : undefined;
     if (!res) return null;
 
-    let bytes: Uint8Array | null = null;
+    let data: Uint8Array | null = null;
     const bi = blockIndexParam != null ? Number(blockIndexParam) : undefined;
     if (typeof bi === 'number' && !Number.isNaN(bi)) {
       const base = loadedBundle.header.resourceDataOffsets[bi] >>> 0;
@@ -31,13 +31,14 @@ const ResourceInspectorPage = () => {
       const size = extractResourceSize(packed);
       if (start < originalArrayBuffer.byteLength && size > 0) {
         const max = Math.min(size, originalArrayBuffer.byteLength - start);
-        bytes = new Uint8Array(originalArrayBuffer, start, max);
+        const bytes = new Uint8Array(originalArrayBuffer, start, max);
+        data = isResourceBlockCompressed(res, bi, bytes) ? decompressData(bytes) : bytes;
       }
     }
-    if (!bytes) {
-      bytes = getResourceData({ bundle: loadedBundle, resource: res, buffer: originalArrayBuffer }).data;
+    if (!data) {
+      // getResourceData already returns decompressed bytes.
+      data = getResourceData({ bundle: loadedBundle, resource: res, buffer: originalArrayBuffer }).data;
     }
-    const data = isCompressed(bytes) ? decompressData(bytes) : bytes;
     const typeLabel = getResourceType(res.resourceTypeId).name;
     const overlays: { name: string; start: number; end: number; color: string }[] = [];
     if (res.resourceTypeId === RESOURCE_TYPE_IDS.VEHICLE_LIST) {


### PR DESCRIPTION
## Problem

`example/TRK_UNIT192_GR.BNDL` was the only retail TRK bundle (of 428) whose `parseBundle` threw — `invalid stored block lengths` during zlib decompression, even with `{ strict: false }`. The gold sweep in `staticSoundMap.test.ts` had to pin it as known-unparseable.

## Root cause

The file is fine (the `example/` copy is hash-identical to the Steam original). The real finding:

- **All retail TRK bundles are stored uncompressed** — header flags are `0xe` (COMPRESSED bit unset) and every resource block has `diskSize == uncompressedSize`.
- The parser decided compressed-vs-raw by **sniffing for the zlib magic byte alone**.
- TRK_UNIT192's PropGraphicsList (type `0x10010`, 832 bytes) is the one resource in the corpus whose raw payload begins `78 01` — just the little-endian u32 `0x178`, a struct offset — so `parseImportEntries` inflated raw bytes and zlib aborted the whole bundle parse.

Confirming evidence: that entry's import table (`28 entries @ 0x180`) ends at exactly byte 832 — the tail of the **raw** payload.

## Fix

The envelope is the authoritative signal: equal disk/uncompressed sizes mean stored raw — never inflate, no matter what the bytes look like.

- New `isResourceBlockCompressed(resource, blockIndex, bytes)` in `resourceManager.ts`: `diskSize !== uncompressedSize && zlibSniff(bytes)`.
- Threaded through every decision site that has the `ResourceEntry`: `parseImportEntries` (the crash site; local copy due to the import cycle), `extractResourceRaw`, `getResourceData` / `getResourceBlocks`, `writeBundleFresh`'s `wasCompressed` (which would otherwise re-compress edits to an uncompressed bundle), the BND2-shaped paths in `bundle1.ts`, `renderable.ts`, `graphicsSpec.ts`, the viewport decoders, and `ResourceInspectorPage` (which was also re-sniffing already-decompressed bytes).
- The byte sniff itself (`isCompressed`) now checks the zlib FLG byte too, but remains advisory-only.

## Tests

- New `src/lib/core/bundle/__tests__/rawBlockZlibSniff.test.ts`: synthetic raw-block-with-coincidental-magic and genuinely-compressed cases for the helper and `parseImportEntries`, plus fixture-gated pins on TRK_UNIT192 (parses, 346 resources, PropGraphicsList extracts raw with its 28 imports intact).
- `staticSoundMap.test.ts` gold sweep pin updated: `unparseable === []`, 856/856 maps (428 bundles × 2) byte-exact through rebucket — TRK_UNIT192's two maps included.
- Full suite: 3,691 passing. The only failures are the pre-existing `AI v6.DAT` missing-fixture ENOENTs, reproduced identically without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)