### PR TITLE
feat(props): writable Prop Graphics List + editable cell grid

### DIFF
--- a/docs/prop-graphics-list-spec.md
+++ b/docs/prop-graphics-list-spec.md
@@ -37,8 +37,14 @@ PropGraphicsList (0x10010)
   ├─ props:  PropGraphics[muNumberOfPropModels]       // at 0x20, 0x0C (12) bytes each
   ├─ <align16 pad>
   ├─ parts:  PropPartGraphics[muNumberOfPropPartModels]// at align16(propEnd), 0x0C (12) bytes each
-  └─ _tail:  <align16 pad> + inline BND2 import table  // importCount × 16 bytes, to end of payload
+  └─ <align16 pad> + inline BND2 import table          // importCount × 16 bytes, to end of payload
 ```
+
+The import table is **modelled** (each entry's resource id becomes the owning
+record's `mpModelId`) and **rebuilt** by the writer from the record counts, so it
+is not carried verbatim — see "Parsed model shape" and "Round-trip / writer
+strategy" below. The on-disk field notes that follow describe the disk format; the
+"how it's modelled" column says what the parser/writer do with each field.
 
 `mpaPropGraphics` and `mpaPropPartGraphics` are absolute byte offsets into the
 payload; both are **rigid** (always `0x20` and `align16(0x20 + nProps*0x0C)`) so on
@@ -54,7 +60,7 @@ PC LE only**. Console (BE) and 64-bit are out of scope.
 
 | Offset | Size | Type | Name | Notes |
 |--------|------|------|------|-------|
-| 0x00 | 4 | u32 | `muSizeInBytes` | **stored field; does NOT consistently equal a derivable offset** — part-array end when parts exist (may be unaligned), `align16(prop-array end)` when no parts, `0x20` when empty. Preserve **verbatim**. |
+| 0x00 | 4 | u32 | `muSizeInBytes` | the **structural end**: part-array end when parts exist (may be unaligned), `align16(prop-array end)` when only props, `0x20` when empty. **Derived** — recomputed on write; the parser asserts the stored value matches (proven across all 428 fixtures). |
 | 0x04 | 4 | u32 | `muZoneNumber` | PVS zone / track-unit id (editable) |
 | 0x08 | 4 | u32 | `muNumberOfPropModels` | count of stored `PropGraphics` records = `props.length` (recomputed on write) |
 | 0x0C | 1 | u8 | `muNumberOfPropPartModels` | count of stored `PropPartGraphics` records = `parts.length`. **u8 in a 4-byte slot** (u8 + 3 zero pad). Recomputed on write. |
@@ -68,8 +74,8 @@ PC LE only**. Console (BE) and 64-bit are out of scope.
 | Offset | Size | Type | Name | Notes |
 |--------|------|------|------|-------|
 | 0x00 | 4 | u32 | `muTypeId` | prop type index (into [`prop-types.md`](prop-types.md)) |
-| 0x04 | 4 | `Model*` | `mpPropModel` | **`0x0` on disk** — a BND2 **import** (see below); the body mesh. Resolved via `getImportsByPtrOffset` keyed by this field's byte offset. Preserved verbatim. |
-| 0x08 | 4 | `PropPartGraphics*` | `mpParts` | resource-relative **internal pointer** to this prop's first part record; **`0` (NULL) when the prop has no parts**. Preserved verbatim. |
+| 0x04 | 4 | `Model*` | `mpPropModel` | **`0x0` on disk** — a BND2 **import** (see below); the body mesh. Modelled as the editable `mpModelId` (bigint); the writer emits 0 here and rebuilds the import-table entry from `mpModelId`. |
+| 0x08 | 4 | `PropPartGraphics*` | `mpParts` | resource-relative **internal pointer** to this prop's first part record; **`0` (NULL) when the prop has no parts**. Modelled as `firstPartIndex` (the part-array index) and recomputed on write. |
 
 ### `PropPartGraphics` — 12 bytes (`0x0C`) — at `align16(0x20 + nProps*0x0C)`
 
@@ -77,7 +83,7 @@ PC LE only**. Console (BE) and 64-bit are out of scope.
 |--------|------|------|------|-------|
 | 0x00 | 4 | u32 | `muTypeId` | owning prop's type id |
 | 0x04 | 4 | u32 | `muPartId` | part index within the prop |
-| 0x08 | 4 | `Model*` | `mpPropModel` | **`0x0` on disk** — a BND2 **import**; the part's mesh. Resolved via `getImportsByPtrOffset`. Preserved verbatim. |
+| 0x08 | 4 | `Model*` | `mpPropModel` | **`0x0` on disk** — a BND2 **import**; the part's mesh. Modelled as the editable `mpModelId` (bigint); the writer emits 0 here and rebuilds the import-table entry from `mpModelId`. |
 
 ## Model imports (`mpPropModel`) and the `mpParts` internal pointer
 
@@ -92,18 +98,24 @@ record's field offset (`0x20 + i*0x0C + 0x04` for prop `i`; `mpaPropPartGraphics
 j*0x0C + 0x08` for part `j`) to get the Model's `resourceId`. The Model resource may
 live in another bundle (shared/neighbour-chunk models are imported but not local).
 
+On read, the parser resolves each `mpModelId` from this table by field offset; on
+write it rebuilds the table from the per-record `mpModelId`s (see below).
+
 `mpParts` is **not** an import — it is an **internal, resource-relative pointer** to
 the prop's first `PropPartGraphics` record. Because parts are grouped contiguously
 by owning prop, a prop with parts points at its first one; a prop with **no** parts
 stores `mpParts == 0` (NULL). The parser never dereferences `mpParts` to read the
 structure (the part array is located via the recomputed `mpaPropPartGraphics`); it
-is preserved verbatim purely for byte-exactness.
+is modelled as `firstPartIndex` (the part-array index it points at) and recomputed
+on write as `mpaPropPartGraphics + firstPartIndex*0x0C`, so it survives the part
+array relocating after a prop add/remove.
 
-> The parser **never needs the import table** to decode the structure — the layout
-> is fully determined by the two counts. It captures the table verbatim in `_tail`
-> so the round-trip stays byte-exact and every Model import stays valid.
+> The parser **needs** the import table to recover each record's `mpModelId`, but
+> the structural layout is fully determined by the two counts. The writer rebuilds
+> the table from the model, so the round-trip stays byte-exact and adds/removes of
+> props re-establish every Model import.
 
-## Inline import table (the BND2 import section, captured in `_tail`)
+## Inline import table (the BND2 import section)
 
 After the last structural array, the payload is padded to a 16-byte boundary and
 then carries the resource's **inline BND2 import table**:
@@ -119,17 +131,21 @@ then carries the resource's **inline BND2 import table**:
   layout is u32 low, u32 high, u32 offset, u32 padding, all little-endian.)
 - `payload length == align16(muSizeInBytes) + importCount*16`.
 
-The whole region (align pad + import table) is captured as `_tail` and re-emitted
-**verbatim**. This is why **field edits round-trip** but **adding/removing props or
-parts is out of scope**: changing the counts shifts every `mpPropModel` field
-offset, which would invalidate the captured table's `fieldOffset` values.
+The table is **modelled** (each entry's resource id becomes the owning record's
+`mpModelId`) and **rebuilt** by the writer in canonical order — props then parts by
+ascending field offset, each entry `{ u64 resourceId, u32 fieldOffset, u32 0 }`.
+Because the table is reconstructed from the record counts rather than carried
+verbatim, **both field edits and add/remove of props/parts round-trip**: changing
+the counts shifts every `mpPropModel` field offset, and the writer simply emits the
+new offsets. The bundle envelope's `importOffset`/`importCount` are recomputed on
+export via the handler's `importTable()` hook.
 
 ## Real-fixture findings (verified 2026-06-09)
 
 Decoded against two real bundle-embedded resources via the CLI/registry extract path:
 
-| fixture | zone | raw bytes | nProps | nParts | `muSizeInBytes` | `mpaPropPartGraphics` | importCount | import-table bytes | `_tail` bytes |
-|---------|-----:|----------:|-------:|-------:|----------------:|----------------------:|------------:|-------------------:|--------------:|
+| fixture | zone | raw bytes | nProps | nParts | `muSizeInBytes` | `mpaPropPartGraphics` | importCount | import-table bytes | pad+table bytes |
+|---------|-----:|----------:|-------:|-------:|----------------:|----------------------:|------------:|-------------------:|----------------:|
 | `TRK_UNIT9_GR.BNDL` | 9 | 1776 | 10 | 52 | 784 | `0xA0` (160) | 62 | 992 | 992 |
 | `TRK_UNIT10_GR.BNDL` | 10 | 1616 | 9 | 47 | 708 | `0x90` (144) | 56 | 896 | 908 |
 
@@ -138,18 +154,18 @@ Arithmetic check (self-consistent, confirms the invariants):
 ```
 TRK9 : mpaPropPartGraphics = align16(0x20 + 10*0x0C) = align16(0x98) = 0xA0  ✓
        importCount = 10+52 = 62 ; 62*16 = 992 ; align16(784)=784 ; 784+992 = 1776 = rawLen  ✓
-       muSizeInBytes 784 is already 16-aligned, so _tail = 0 pad + 992 table = 992.
+       muSizeInBytes 784 is already 16-aligned, so the region = 0 pad + 992 table = 992.
 TRK10: mpaPropPartGraphics = align16(0x20 + 9*0x0C) = align16(0x8C) = 0x90  ✓
        importCount =  9+47 = 56 ; 56*16 = 896 ; align16(708)=720 ; 720+896 = 1616 = rawLen  ✓
        muSizeInBytes 708 is the unaligned part-array end; importOffset rounds it to 720, so
-       _tail = 12 pad (708→720) + 896 table = 908 (the parser captures pad+table, not just the table).
+       the import-table region = 12 pad (708→720) + 896 table = 908.
 ```
 
-> **`_tail` ≠ import-table bytes when `muSizeInBytes` is unaligned.** `_tail` is everything
-> from the last array end to EOF, i.e. the align-pad **plus** the import table. When
-> `muSizeInBytes` is already 16-aligned (TRK9) the pad is empty and the two coincide; when it
-> is unaligned (TRK10) `_tail` is larger by the pad width. The writer re-emits `_tail` verbatim,
-> so it reproduces both regions in one shot.
+> **The pad+table region ≠ the import-table bytes when `muSizeInBytes` is unaligned.**
+> The region from the last array end to EOF is the align-pad **plus** the import table.
+> When `muSizeInBytes` is already 16-aligned (TRK9) the pad is empty and the two coincide;
+> when it is unaligned (TRK10) the region is larger by the pad width. The writer regenerates
+> the pad as zero and rebuilds the table from the model, reproducing both regions exactly.
 
 **Corpus distribution** (sweep of all `TRK_UNIT*_GR.BNDL` in `example/`):
 
@@ -160,9 +176,11 @@ TRK10: mpaPropPartGraphics = align16(0x20 + 9*0x0C) = align16(0x8C) = 0x90  ✓
 
 **Byte-exact sweep result:** every PropGraphicsList that reaches the parser
 round-trips `writePropGraphicsList(parsePropGraphicsList(raw))` **byte-for-byte**
-(426/426 byte-exact pass, 0 fail). The parser/writer in
-[`src/lib/core/propGraphicsList.ts`](../src/lib/core/propGraphicsList.ts) needs no
-changes.
+across all 428 fixtures (256 populated + 172 empty, 0 fail) — including the
+model-driven rebuild of the import table. The parser/writer in
+[`src/lib/core/propGraphicsList.ts`](../src/lib/core/propGraphicsList.ts) were
+rewritten for this (model `mpModelId`/`firstPartIndex`, derive `muSizeInBytes`,
+rebuild the table); the byte-exactness above is what proves that rewrite safe.
 
 **Confirmed invariants (all 254 populated resources, zero violations):**
 
@@ -186,56 +204,73 @@ is a parser bug.
 
 ## Parsed model shape
 
+The catalogue is **fully editable**: Model references are modelled as per-record
+resource ids, and props/parts can be added or removed. The writer rebuilds the
+inline import table and every derived offset from the model, so nothing is carried
+verbatim except what the corpus sweep proved is reconstructable.
+
 ```ts
 type PropGraphics = {
-  muTypeId: number;    // u32 — prop type index (into prop-types)
-  mpPropModel: number; // u32 — Model* import, 0 on disk; resolved by field offset. Verbatim.
-  mpParts: number;     // u32 — internal pointer to first part (0 = no parts). Verbatim.
+  muTypeId: number;            // u32 — prop type index (into prop-types)
+  mpModelId: bigint;           // Model resource id (the BND2 import); 0n = none/unresolved. Editable.
+  firstPartIndex: number | null; // index into parts[] of this prop's first part; null = no parts
 };
 
 type PropPartGraphics = {
   muTypeId: number;    // u32 — owning prop's type id
   muPartId: number;    // u32 — part index within the prop
-  mpPropModel: number; // u32 — Model* import, 0 on disk; resolved by field offset. Verbatim.
+  mpModelId: bigint;   // Model resource id (the BND2 import). Editable.
 };
 
 type ParsedPropGraphicsList = {
   muZoneNumber: number;     // u32 — PVS zone / track-unit id (editable)
-  muSizeInBytes: number;    // u32 — stored size; not a derivable offset (preserved verbatim, readOnly)
   props: PropGraphics[];
   parts: PropPartGraphics[];
-  _tail: Uint8Array;        // align16 pad + inline import table, end-of-arrays..EOF (verbatim)
 };
 ```
 
 `muNumberOfPropModels` / `muNumberOfPropPartModels` are **not** stored on the model
 (they equal `props.length` / `parts.length`); the writer emits the array lengths.
-`mpaPropGraphics` / `mpaPropPartGraphics` are recomputed from those lengths.
+`mpaPropGraphics` / `mpaPropPartGraphics` and `muSizeInBytes` (the structural end)
+are recomputed from those lengths. `mpPropModel` (0 on disk) is rebuilt as a 0
+pointer + an import-table entry carrying `mpModelId`. `mpParts` is rebuilt from
+`firstPartIndex` (`null → 0`, else `mpaPropPartGraphics + firstPartIndex*0x0C`), so
+it stays valid when the part array relocates after a prop add/remove.
 
 ## Round-trip / writer strategy
 
 Byte-exact (`byteRoundTrip`) is achievable — the layout is rigid. Writer:
 
-1. **Header (32 bytes):** `muSizeInBytes` (**verbatim** — not a derivable offset);
+1. **Header (32 bytes):** `muSizeInBytes` = derived structural end;
    `muZoneNumber`; `muNumberOfPropModels = props.length`; `muNumberOfPropPartModels
    = parts.length & 0xff` (u8) + 3 pad; `mpaPropGraphics = props.length ? 0x20 : 0`;
    `mpaPropPartGraphics = parts.length ? align16(0x20 + nProps*0x0C) : 0`; zero-pad
    up to `0x20`.
-2. **PropGraphics:** for each, `muTypeId`; `mpPropModel` (**verbatim**, `0` on
-   disk); `mpParts` (**verbatim** internal pointer).
+2. **PropGraphics:** for each, `muTypeId`; `mpPropModel = 0` (the id is emitted into
+   the import table below); `mpParts` recomputed from `firstPartIndex`.
 3. **align16 pad → PropPartGraphics:** zero-pad to `mpaPropPartGraphics`, then for
-   each part `muTypeId`; `muPartId`; `mpPropModel` (**verbatim**, `0`).
-4. **`_tail`:** append verbatim (align pad + inline import table) → reproduces the
-   exact length and keeps every Model import valid.
+   each part `muTypeId`; `muPartId`; `mpPropModel = 0`. Then zero-pad up to the
+   structural end (a no-parts list has an align pad after the prop array).
+4. **align16 pad → import table:** for each prop, then each part, emit
+   `{ u64 mpModelId, u32 fieldOffset, u32 0 }` → reproduces the exact length and
+   re-establishes every Model import.
 
-This mirrors the [`propInstanceData`](prop-instance-data-spec.md) / `zoneList`
-precedent (recompute pointers + counts, preserve verbatim stored-size and pad for
-byte-exactness). Because the inline import table is keyed by `mpPropModel` field
-offsets, **field edits** (zone id, a prop/part `muTypeId`, `muPartId`) round-trip,
-but **adding or removing props/parts is OUT of scope** — it would shift those field
-offsets and invalidate the captured table. `muSizeInBytes` is preserved verbatim
-with no validation against the recomputed layout, so it would be stale after a
-structural mutation (which is why such mutations are blocked).
+This mirrors the [`environmentTimeLine`](../src/lib/core/environmentSettings.ts)
+precedent (model the inline import-table ids per record; recompute pointers,
+counts, structural size, and the table from the array lengths on write). Because
+the table is **rebuilt** rather than carried verbatim, both **field edits** AND
+**adding/removing props or parts** round-trip byte-exact (verified across all 256
+populated fixtures). When the prop/part count changes, the bundle envelope's
+`importOffset`/`importCount` follow via the handler's `importTable()` hook on
+export, exactly like EnvironmentTimeLine and ParticleDescriptionCollection.
+
+The corpus sweep that justified the rebuild (all 256 populated + 172 empty
+fixtures, zero violations): `muSizeInBytes` always equals the derived structural
+end; the import table is ordered props-then-parts by ascending field offset; every
+import-entry padding word and inter-array/align pad is zero; `mpParts` is always an
+aligned index into the part array; and the payload length is always exactly
+`align16(structuralEnd) + (nProps+nParts)*16`. The parser asserts each of these and
+fails loud on any unexpected layout.
 
 ## Editor / resourcespec notes
 
@@ -243,15 +278,17 @@ structural mutation (which is why such mutations are blocked).
 - `muTypeId` (on both record types) → enum dropdown sourced from `PROP_TYPES` (same
   table as [`prop-instance-data-spec.md`](prop-instance-data-spec.md)); `muPartId`
   is a plain integer.
-- `mpPropModel` is `readOnly` in the editor — it is `0` on disk and the real Model
-  id is resolved from the import table at display/render time via
-  `getImportsByPtrOffset(bundle.imports, bundle.resources, resourceIndex)`, keyed by
-  the record's field offset. Surface the resolved Model `resourceId` in the tree
-  label so artists can see which mesh a prop/part maps to.
-- `mpParts`, `muSizeInBytes`, and `_tail` are `readOnly`/`hidden` round-trip-only
-  fields (`mpaPropGraphics`/`mpaPropPartGraphics` are derived and never modelled).
-- Tree labels: prop → `#i · <propTypeName> · model <resourceId> · parts <n>`; part →
-  `#j · part <muPartId> of <propTypeName> · model <resourceId>`.
-- Adding/removing props or parts must be disabled (`addable`/`removable` off) until
-  a future slice rebuilds the inline import table from scratch.
+- `mpModelId` is an **editable** `bigint` resource id (`{ kind: 'bigint', bytes: 8,
+  hex: true }`) — the Model the runtime spawns. On disk it is a `0` pointer + an
+  import-table entry; the writer rebuilds that entry from `mpModelId`. Prop Models
+  usually live in `GLOBALPROPS.BIN`.
+- `firstPartIndex` is a `hidden`/`readOnly` round-trip-only field (the modelled form
+  of `mpParts`); `muSizeInBytes`, `mpaPropGraphics`, `mpaPropPartGraphics` are
+  derived and never modelled.
+- Tree labels: prop → `#i · <propTypeName> · model <resourceId>`; part →
+  `#j · <propTypeName> · part <muPartId> · model <resourceId>`.
+- **Adding/removing props and parts is supported** (`addable`/`removable` on, with a
+  `makeEmpty` that seeds `mpModelId = 0n`). The main workflow is cataloguing a
+  newly-placed prop type: add a prop row, set its type + Model id. The bundle
+  envelope's import metadata is recomputed on export via the `importTable()` hook.
 ```

--- a/src/components/schema-editor/viewports/PropCellGridOverlay.tsx
+++ b/src/components/schema-editor/viewports/PropCellGridOverlay.tsx
@@ -1,0 +1,240 @@
+// PropCellGridOverlay — WorldViewport overlay drawing the prop streaming grid.
+//
+// Prop instances are partitioned into 100 m × 100 m cells (see propCellGrid.ts);
+// a cell's id is its (x, z) grid index, derived from world position via
+// (pos + 5000) / 100. This overlay superimposes that grid on the world — the
+// prop analogue of TrafficData's PVS grid (PvsGridOverlay) — so the user can
+// read a prop's cell id off the map and confirm a PropCell's muX/muZ is right.
+//
+// What it draws (over the bounding region of this zone's populated cells):
+//   - thin border lines for every cell in the region,
+//   - a tinted fill + an id label on each POPULATED cell (one that owns props),
+//   - a bright outline on the selected instance's containing cell and on the
+//     selected cell.
+// Clicking a populated cell selects it (['cells', i]); a checkbox in the chrome
+// HTML slot toggles the whole grid (on by default), mirroring the PVS grid.
+
+import { useCallback, useMemo, useState } from 'react';
+import { Html } from '@react-three/drei';
+import { type ThreeEvent } from '@react-three/fiber';
+import * as THREE from 'three';
+import type { ParsedPropInstanceData, PropCell } from '@/lib/core/propInstanceData';
+import { PROP_CELL_SIZE, propCellId, propCellRect } from '@/lib/core/propCellGrid';
+import { useDisposeOnDepsChange } from '@/hooks/useDisposeOnDepsChange';
+import type { NodePath } from '@/lib/schema/walk';
+import type { WorldOverlayComponent } from './WorldViewport.types';
+import { useWorldViewportHtmlSlot } from './WorldViewport';
+import { SELECTION_THEME, isDragRelease } from './selection';
+
+// Sits just above the grid Y to avoid z-fighting between the fill and borders.
+const FILL_DY = 0;
+const BORDER_DY = 0.3;
+const OUTLINE_DY = 0.6;
+
+const gridFillMat = new THREE.MeshBasicMaterial({
+	color: 0x33ddaa, transparent: true, opacity: 0.16, side: THREE.DoubleSide, depthWrite: false,
+});
+const gridBorderMat = new THREE.LineBasicMaterial({
+	color: 0xffffff, transparent: true, opacity: 0.18, depthWrite: false,
+});
+const selectedCellMat = new THREE.LineBasicMaterial({
+	color: 0xffaa33, transparent: true, opacity: 0.95, depthTest: false,
+});
+const instanceCellMat = new THREE.LineBasicMaterial({
+	color: '#' + SELECTION_THEME.primary.getHexString(), transparent: true, opacity: 0.9, depthTest: false,
+});
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+/** Mean world Y of the placed props, so the flat grid floats near them rather
+ *  than at sea level (Paradise terrain spans a wide altitude range). */
+export function gridPlaneY(data: ParsedPropInstanceData): number {
+	const n = data.instances.length;
+	if (n === 0) return 0;
+	let sum = 0;
+	for (const inst of data.instances) sum += inst.mWorldTransform[13] ?? 0;
+	return sum / n;
+}
+
+/** Inclusive (minX, maxX, minZ, maxZ) cell-index bounds of the populated cells,
+ *  padded by one cell for context. Null when there are no cells. */
+export function cellRegionBounds(cells: PropCell[]): { minX: number; maxX: number; minZ: number; maxZ: number } | null {
+	if (cells.length === 0) return null;
+	let minX = Infinity, maxX = -Infinity, minZ = Infinity, maxZ = -Infinity;
+	for (const c of cells) {
+		if (c.muX < minX) minX = c.muX;
+		if (c.muX > maxX) maxX = c.muX;
+		if (c.muZ < minZ) minZ = c.muZ;
+		if (c.muZ > maxZ) maxZ = c.muZ;
+	}
+	return { minX: minX - 1, maxX: maxX + 1, minZ: minZ - 1, maxZ: maxZ + 1 };
+}
+
+/** A unit-cell rectangle outline as 4 line segments (8 vertices) at height y. */
+function cellOutlinePositions(muX: number, muZ: number, y: number): Float32Array {
+	const r = propCellRect(muX, muZ);
+	return new Float32Array([
+		r.x0, y, r.z0, r.x1, y, r.z0,
+		r.x1, y, r.z0, r.x1, y, r.z1,
+		r.x1, y, r.z1, r.x0, y, r.z1,
+		r.x0, y, r.z1, r.x0, y, r.z0,
+	]);
+}
+
+// ---------------------------------------------------------------------------
+// Geometry builders
+// ---------------------------------------------------------------------------
+
+function buildBorderGeometry(bounds: { minX: number; maxX: number; minZ: number; maxZ: number }, y: number): THREE.BufferGeometry {
+	const { minX, maxX, minZ, maxZ } = bounds;
+	const x0 = minX * PROP_CELL_SIZE - 5000;
+	const z0 = minZ * PROP_CELL_SIZE - 5000;
+	const nx = maxX - minX + 1;
+	const nz = maxZ - minZ + 1;
+	const segs: number[] = [];
+	for (let i = 0; i <= nx; i++) {
+		const x = x0 + i * PROP_CELL_SIZE;
+		segs.push(x, y, z0, x, y, z0 + nz * PROP_CELL_SIZE);
+	}
+	for (let j = 0; j <= nz; j++) {
+		const z = z0 + j * PROP_CELL_SIZE;
+		segs.push(x0, y, z, x0 + nx * PROP_CELL_SIZE, y, z);
+	}
+	const geo = new THREE.BufferGeometry();
+	geo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(segs), 3));
+	return geo;
+}
+
+function buildFillGeometry(cells: PropCell[], y: number): THREE.BufferGeometry {
+	const pos = new Float32Array(cells.length * 6 * 3);
+	let p = 0;
+	for (const c of cells) {
+		const r = propCellRect(c.muX, c.muZ);
+		const verts: [number, number][] = [
+			[r.x0, r.z0], [r.x1, r.z0], [r.x1, r.z1],
+			[r.x0, r.z0], [r.x1, r.z1], [r.x0, r.z1],
+		];
+		for (const [vx, vz] of verts) { pos[p++] = vx; pos[p++] = y; pos[p++] = vz; }
+	}
+	const geo = new THREE.BufferGeometry();
+	geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+	geo.computeBoundingSphere();
+	return geo;
+}
+
+// ---------------------------------------------------------------------------
+// Overlay
+// ---------------------------------------------------------------------------
+
+export const PropCellGridOverlay: WorldOverlayComponent<ParsedPropInstanceData> = ({
+	data, selectedPath, onSelect, isActive = true,
+}) => {
+	const cells = data?.cells ?? [];
+	const [show, setShow] = useState(true);
+
+	const y = useMemo(() => gridPlaneY(data), [data]);
+	const bounds = useMemo(() => cellRegionBounds(cells), [cells]);
+	const borderGeo = useMemo(() => (bounds ? buildBorderGeometry(bounds, y + BORDER_DY) : null), [bounds, y]);
+	const fillGeo = useMemo(() => (cells.length ? buildFillGeometry(cells, y + FILL_DY) : null), [cells, y]);
+	// These geometries are passed to R3F by reference (not declarative children),
+	// so R3F won't auto-dispose them — free the old GPU buffers when the memo
+	// re-runs. The two outline geometries below churn on every selection change.
+	useDisposeOnDepsChange(() => borderGeo?.dispose(), [borderGeo]);
+	useDisposeOnDepsChange(() => fillGeo?.dispose(), [fillGeo]);
+
+	// Selected cell (a ['cells', i] selection) and the selected instance's
+	// containing cell (a ['instances', i] selection → computed from position).
+	const selectedCellOutline = useMemo(() => {
+		if (selectedPath[0] !== 'cells' || typeof selectedPath[1] !== 'number') return null;
+		const c = cells[selectedPath[1]];
+		if (!c) return null;
+		const geo = new THREE.BufferGeometry();
+		geo.setAttribute('position', new THREE.BufferAttribute(cellOutlinePositions(c.muX, c.muZ, y + OUTLINE_DY), 3));
+		return geo;
+	}, [cells, selectedPath, y]);
+	useDisposeOnDepsChange(() => selectedCellOutline?.dispose(), [selectedCellOutline]);
+
+	const instanceCellOutline = useMemo(() => {
+		if (selectedPath[0] !== 'instances' || typeof selectedPath[1] !== 'number') return null;
+		const inst = data.instances[selectedPath[1]];
+		if (!inst) return null;
+		const { muX, muZ } = propCellId(inst.mWorldTransform[12] ?? 0, inst.mWorldTransform[14] ?? 0);
+		const geo = new THREE.BufferGeometry();
+		geo.setAttribute('position', new THREE.BufferAttribute(cellOutlinePositions(muX, muZ, y + OUTLINE_DY + 0.1), 3));
+		return geo;
+	}, [data, selectedPath, y]);
+	useDisposeOnDepsChange(() => instanceCellOutline?.dispose(), [instanceCellOutline]);
+
+	// Click a populated cell → select it. Convert the world hit point to a cell
+	// id, then find the matching cell (cells are keyed by their (muX, muZ)).
+	const onClick = useCallback((e: ThreeEvent<MouseEvent>) => {
+		e.stopPropagation();
+		if (isDragRelease(e.nativeEvent.clientX, e.nativeEvent.clientY)) return;
+		const { muX, muZ } = propCellId(e.point.x, e.point.z);
+		const idx = cells.findIndex((c) => c.muX === muX && c.muZ === muZ);
+		if (idx >= 0) onSelect(['cells', idx] as NodePath);
+	}, [cells, onSelect]);
+
+	// Toggle checkbox in the chrome HTML slot — only while this overlay owns the
+	// active selection, so sibling overlays don't stack toggles (issue #24).
+	const htmlNode = useMemo(
+		() =>
+			bounds ? (
+				<label
+					style={{
+						position: 'absolute', top: 8, right: 8,
+						background: 'rgba(0,0,0,0.7)', color: '#cdd', padding: '4px 8px',
+						borderRadius: 4, fontSize: 11, fontFamily: 'monospace',
+						display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer',
+						userSelect: 'none', pointerEvents: 'auto',
+					}}
+				>
+					<input type="checkbox" checked={show} onChange={(ev) => setShow(ev.target.checked)} style={{ margin: 0 }} />
+					Prop cell grid ({cells.length} cell{cells.length === 1 ? '' : 's'})
+				</label>
+			) : null,
+		[bounds, show, cells.length],
+	);
+	useWorldViewportHtmlSlot(isActive ? htmlNode : null);
+
+	if (!bounds || !show) return null;
+
+	return (
+		<>
+			{fillGeo && (
+				<mesh geometry={fillGeo} material={gridFillMat} renderOrder={1} onClick={onClick} />
+			)}
+			{borderGeo && (
+				<lineSegments geometry={borderGeo} material={gridBorderMat} renderOrder={2} raycast={() => undefined as unknown as void} />
+			)}
+			{instanceCellOutline && (
+				<lineSegments geometry={instanceCellOutline} material={instanceCellMat} renderOrder={6} />
+			)}
+			{selectedCellOutline && (
+				<lineSegments geometry={selectedCellOutline} material={selectedCellMat} renderOrder={7} />
+			)}
+			{/* Cell-id labels on populated cells. Prop zones are spatially local, so
+			    the count stays small (a handful per track unit). */}
+			{cells.map((c, i) => {
+				const r = propCellRect(c.muX, c.muZ);
+				return (
+					<Html
+						key={`${c.muX}:${c.muZ}:${i}`}
+						position={[(r.x0 + r.x1) / 2, y + OUTLINE_DY, (r.z0 + r.z1) / 2]}
+						center
+						style={{ pointerEvents: 'none' }}
+					>
+						<div style={{
+							background: 'rgba(0,0,0,0.6)', color: '#9fe', padding: '1px 4px',
+							borderRadius: 3, fontSize: 9, whiteSpace: 'nowrap', fontFamily: 'monospace',
+						}}>
+							{c.muX}, {c.muZ}
+						</div>
+					</Html>
+				);
+			})}
+		</>
+	);
+};

--- a/src/components/schema-editor/viewports/PropInstanceDataOverlay.tsx
+++ b/src/components/schema-editor/viewports/PropInstanceDataOverlay.tsx
@@ -22,6 +22,7 @@ import { useThree, type ThreeEvent } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { ParsedPropInstanceData, PropInstance } from '@/lib/core/propInstanceData';
 import { propTypeLabel } from '@/lib/core/propTypes';
+import { propCellId } from '@/lib/core/propCellGrid';
 import { useUpdateInstancedMesh } from '@/lib/three/scene/useUpdateInstancedMesh';
 import { useFlyCameraToTarget } from '@/lib/three/scene/useFlyCameraToTarget';
 import type { NodePath } from '@/lib/schema/walk';
@@ -118,6 +119,7 @@ export function SelectedPropDecor({
 }) {
 	const matrix = useMemo(() => propInstanceMatrix(inst, new THREE.Matrix4()), [inst]);
 	const [x, y, z] = propInstancePosition(inst);
+	const cell = propCellId(x, z);
 	return (
 		<>
 			<lineSegments geometry={outline ?? MARKER_EDGES_GEO} material={MARKER_EDGES_MAT} matrixAutoUpdate={false} matrix={matrix} />
@@ -130,7 +132,7 @@ export function SelectedPropDecor({
 					borderRadius: 4, fontSize: 10, whiteSpace: 'nowrap', fontFamily: 'monospace',
 					transform: 'translateY(-22px)',
 				}}>
-					#{index} {propTypeLabel(inst.typeId)} | id {inst.muInstanceID}
+					#{index} {propTypeLabel(inst.typeId)} | id {inst.muInstanceID} | cell ({cell.muX}, {cell.muZ})
 				</div>
 			</Html>
 		</>

--- a/src/components/schema-editor/viewports/__tests__/PropCellGridOverlay.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/PropCellGridOverlay.test.ts
@@ -1,0 +1,45 @@
+// Spec coverage for the PropCellGridOverlay pure helpers — the geometry math
+// that turns a prop zone's cells into a grid region + plane height. The React
+// rendering itself is exercised in the browser; these pin the math.
+
+import { describe, it, expect } from 'vitest';
+import { gridPlaneY, cellRegionBounds } from '../PropCellGridOverlay';
+import type { ParsedPropInstanceData, PropCell, PropInstance } from '@/lib/core/propInstanceData';
+
+function inst(y: number): PropInstance {
+	const m = new Array(16).fill(0);
+	m[13] = y; m[15] = 1;
+	return {
+		mWorldTransform: m, typeId: 0, flags: 0, muInstanceID: 0,
+		muAlternativeType: 0xffff, mn8RotSpeed: 0, mn8MaxAngle: 0, mn8MinAngle: 0,
+		_pad4D: [0, 0, 0],
+	};
+}
+
+function cell(muX: number, muZ: number): PropCell {
+	return { muX, muZ, muStartIndex: 0, muCount: 0, muNumberOfRespawnDifferent: 0, muNumberOfDontRespawn: 0 };
+}
+
+function pid(instances: PropInstance[], cells: PropCell[]): ParsedPropInstanceData {
+	return { muZoneId: 0, muSizeInBytes: 0, muNumberOfInstances: instances.length, instances, cells, _trailingPad: new Uint8Array(0) };
+}
+
+describe('gridPlaneY', () => {
+	it('averages the instance Y so the grid floats near the props', () => {
+		expect(gridPlaneY(pid([inst(10), inst(20), inst(30)], []))).toBe(20);
+	});
+	it('is 0 for an empty zone', () => {
+		expect(gridPlaneY(pid([], []))).toBe(0);
+	});
+});
+
+describe('cellRegionBounds', () => {
+	it('returns the populated-cell extent padded by one cell', () => {
+		expect(cellRegionBounds([cell(36, 30), cell(40, 33), cell(38, 31)])).toEqual({
+			minX: 35, maxX: 41, minZ: 29, maxZ: 34,
+		});
+	});
+	it('is null when there are no cells', () => {
+		expect(cellRegionBounds([])).toBeNull();
+	});
+});

--- a/src/components/schema-editor/viewports/propGeometryDecode.ts
+++ b/src/components/schema-editor/viewports/propGeometryDecode.ts
@@ -28,7 +28,6 @@
 
 import * as THREE from 'three';
 import type { ParsedBundle, ResourceEntry } from '@/lib/core/types';
-import { getImportsByPtrOffset } from '@/lib/core/bundle';
 import { extractResourceSize, isResourceBlockCompressed, decompressData } from '@/lib/core/resourceManager';
 import {
 	parsePropGraphicsList,
@@ -39,11 +38,6 @@ import type { ParsedVertexDescriptor } from '@/lib/core/renderable';
 import { findResourceById } from '@/lib/core/renderable';
 import { MODEL_TYPE_ID } from '@/lib/core/model';
 import { decodeModelGeometries, instanceTransformToMatrix4 } from './trackGeometryDecode';
-
-// PropGraphics array begins at 0x20; each record is 0x0C with mpPropModel at +4.
-const PROP_GRAPHICS_OFFSET = 0x20;
-const PROP_RECORD_SIZE = 0x0c;
-const PROP_MODEL_FIELD = 0x04;
 
 /** A bundle paired with its raw bytes — prop Models often live in a companion
  *  bundle (GLOBALPROPS.BIN), so resolution searches these after the local one. */
@@ -86,6 +80,10 @@ function extractBlock0(buffer: ArrayBuffer, bundle: ParsedBundle, entry: Resourc
  * Returns an empty map when the bundle has no PropGraphicsList. Throws are
  * swallowed (a malformed catalogue just yields no prop meshes — the boxes
  * remain), since this feeds a best-effort viewport, never an edit path.
+ *
+ * The parsed model carries each prop's Model id directly (mpModelId, decoded
+ * from the resource's inline import table), so no separate import-table lookup
+ * is needed. A 0n id means "unresolved" — skip it so the box fallback shows.
  */
 export function buildPropTypeModelMap(bundle: ParsedBundle, buffer: ArrayBuffer): Map<number, bigint> {
 	const map = new Map<number, bigint>();
@@ -95,12 +93,9 @@ export function buildPropTypeModelMap(bundle: ParsedBundle, buffer: ArrayBuffer)
 		const raw = extractBlock0(buffer, bundle, entry);
 		if (!raw) return map;
 		const pgl = parsePropGraphicsList(raw);
-		const index = bundle.resources.indexOf(entry);
-		const imports = getImportsByPtrOffset(bundle.imports, bundle.resources, index);
-		pgl.props.forEach((prop, i) => {
-			const id = imports.get(PROP_GRAPHICS_OFFSET + i * PROP_RECORD_SIZE + PROP_MODEL_FIELD);
-			if (id != null) map.set(prop.muTypeId, id);
-		});
+		for (const prop of pgl.props) {
+			if (prop.mpModelId !== 0n) map.set(prop.muTypeId, prop.mpModelId);
+		}
 	} catch {
 		return map;
 	}

--- a/src/components/workspace/WorldViewportComposition.tsx
+++ b/src/components/workspace/WorldViewportComposition.tsx
@@ -50,6 +50,7 @@ import { useWorkspace } from '@/context/WorkspaceContext';
 import { WorldViewport } from '@/components/schema-editor/viewports/WorldViewport';
 import { TrackGeometry } from '@/components/schema-editor/viewports/TrackGeometry';
 import { PropGeometry } from '@/components/schema-editor/viewports/PropGeometry';
+import { PropCellGridOverlay } from '@/components/schema-editor/viewports/PropCellGridOverlay';
 import { PolygonSoupListOverlay } from '@/components/schema-editor/viewports/PolygonSoupListOverlay';
 import { INSTANCE_LIST_TYPE_ID } from '@/lib/core/instanceList';
 import { PROP_GRAPHICS_LIST_TYPE_ID } from '@/lib/core/propGraphicsList';
@@ -261,6 +262,40 @@ function WorldViewportCompositionInner({
 		[bundles, allSources, isVisible, selection, select],
 	);
 
+	// Prop cell grid: one <PropCellGridOverlay> per visible bundle that carries a
+	// PropInstanceData (whether or not it also has a PropGraphicsList, so it shows
+	// for both the real-mesh and box-fallback prop paths). It superimposes the
+	// 100 m streaming grid + cell-id labels so the user can read/verify a prop's
+	// cell. Its chrome toggle only registers when propInstanceData is the active
+	// selection, so it doesn't fight sibling overlays for the HTML slot.
+	const cellGridChildren = useMemo(
+		() =>
+			bundles
+				.filter(
+					(b) =>
+						isVisible({ bundleId: b.id }) &&
+						isVisible({ bundleId: b.id, resourceKey: 'propInstanceData', index: 0 }) &&
+						(b.parsedResourcesAll.get('propInstanceData')?.[0] ?? null) != null,
+				)
+				.map((b) => {
+					const pid = b.parsedResourcesAll.get('propInstanceData')![0] as ParsedPropInstanceData;
+					const isSelected =
+						selection?.bundleId === b.id && selection.resourceKey === 'propInstanceData';
+					return (
+						<PropCellGridOverlay
+							key={`cellgrid::${b.id}`}
+							data={pid}
+							selectedPath={isSelected ? selection!.path : EMPTY_PATH}
+							onSelect={(path) =>
+								select({ bundleId: b.id, resourceKey: 'propInstanceData', index: 0, path })
+							}
+							isActive={isSelected}
+						/>
+					);
+				}),
+		[bundles, isVisible, selection, select],
+	);
+
 	// Stable per-(bundleId, key, index) callback factories. We can't memoise
 	// each one with useCallback (the descriptor list is dynamic), but a
 	// single useCallback over the closure-captured Workspace methods means
@@ -350,6 +385,7 @@ function WorldViewportCompositionInner({
 		<WorldViewport>
 			{trackChildren}
 			{propChildren}
+			{cellGridChildren}
 			{children}
 		</WorldViewport>
 	);

--- a/src/lib/core/__tests__/propCellGrid.test.ts
+++ b/src/lib/core/__tests__/propCellGrid.test.ts
@@ -1,0 +1,41 @@
+// Coverage for the prop cell-grid math (propCellGrid.ts). The worked example
+// is the one the user verified by hand against the map textures:
+//   -1400 ≤ x < -1300 and -2000 ≤ z < -1900  →  cell (muX=36, muZ=30).
+
+import { describe, it, expect } from 'vitest';
+import {
+	PROP_CELL_SIZE,
+	PROP_GRID_ORIGIN,
+	propCellIndex,
+	propCellId,
+	propCellMin,
+	propCellRect,
+} from '../propCellGrid';
+
+describe('propCellGrid', () => {
+	it('maps the user-verified worked example', () => {
+		expect(propCellId(-1400, -2000)).toEqual({ muX: 36, muZ: 30 });
+		// Anywhere inside the half-open cell resolves to the same id.
+		expect(propCellId(-1301, -1901)).toEqual({ muX: 36, muZ: 30 });
+	});
+
+	it('puts the grid origin at index 0 and is half-open at the upper edge', () => {
+		expect(propCellIndex(PROP_GRID_ORIGIN)).toBe(0);
+		expect(propCellIndex(PROP_GRID_ORIGIN + PROP_CELL_SIZE - 0.001)).toBe(0);
+		expect(propCellIndex(PROP_GRID_ORIGIN + PROP_CELL_SIZE)).toBe(1);
+	});
+
+	it('handles the world centre and positive coordinates', () => {
+		expect(propCellId(0, 0)).toEqual({ muX: 50, muZ: 50 });
+		expect(propCellId(4999, 4999)).toEqual({ muX: 99, muZ: 99 });
+	});
+
+	it('round-trips id → world rect → id', () => {
+		const { muX, muZ } = propCellId(2025.59, -1292.24); // gold instance[10]
+		const rect = propCellRect(muX, muZ);
+		expect(rect.x0).toBe(propCellMin(muX));
+		expect(rect.x1 - rect.x0).toBe(PROP_CELL_SIZE);
+		// The rect's lower corner sits in the same cell.
+		expect(propCellId(rect.x0, rect.z0)).toEqual({ muX, muZ });
+	});
+});

--- a/src/lib/core/__tests__/propGraphicsList.test.ts
+++ b/src/lib/core/__tests__/propGraphicsList.test.ts
@@ -1,10 +1,16 @@
 // Coverage for parsePropGraphicsList / writePropGraphicsList (resource 0x10010).
 //
-// Two layers:
+// The catalogue is now fully editable — Model references are modelled as
+// per-record resource ids (mpModelId), and props/parts can be added/removed.
+// The writer rebuilds the inline import table + all derived offsets, so these
+// tests cover field edits AND structural mutations, byte-exact round-trip, and
+// the layout guards.
+//
+// Layers:
 //  - Synthesised payloads (always run): an empty list (null pointers) and a
-//    small populated list — machine-independent, pinned on every box.
+//    populated list with a canonical inline import table.
 //  - A gold check against the real example/TRK_UNIT9_GR.BNDL bundle, skipped
-//    when that untracked binary is absent (same convention as registry.test.ts).
+//    when that untracked binary is absent.
 
 import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
@@ -13,6 +19,7 @@ import * as path from 'node:path';
 import {
 	parsePropGraphicsList,
 	writePropGraphicsList,
+	propGraphicsListImportTable,
 	type ParsedPropGraphicsList,
 } from '../propGraphicsList';
 import { parseBundle } from '../bundle';
@@ -46,8 +53,6 @@ describe('PropGraphicsList empty list (null pointers)', () => {
 		expect(model.props.length).toBe(0);
 		expect(model.parts.length).toBe(0);
 		expect(model.muZoneNumber).toBe(7);
-		expect(model.muSizeInBytes).toBe(0x20);
-		expect(model._tail.byteLength).toBe(0);
 	});
 
 	it('round-trips byte-for-byte (re-emits null pointers, not 0x20)', () => {
@@ -58,52 +63,62 @@ describe('PropGraphicsList empty list (null pointers)', () => {
 	});
 });
 
-// --- Synthesised: a small populated list with a non-zero import-table tail ---
+// --- Synthesised: a populated list with a canonical inline import table ---
+
+// 2 props + 3 parts. propEnd = 0x20 + 2*0x0C = 0x38, partsStart = align16(0x38)
+// = 0x40, partEnd = 0x40 + 3*0x0C = 0x64 (= muSizeInBytes), importOffset =
+// align16(0x64) = 0x70, total = 0x70 + 5*16 = 0xC0.
+const PROP0_MODEL = 0x1A2B3C4D5E6Fn; // exercises the u64 high dword
+const PROP1_MODEL = 0x222n;
+const PART_MODELS = [0x333n, 0x444n, 0x555n];
+
+function buildBytes(): Uint8Array {
+	const total = 0xc0;
+	const bytes = new Uint8Array(total);
+	const dv = new DataView(bytes.buffer);
+	dv.setUint32(0x00, 0x64, true);         // muSizeInBytes = part-array end
+	dv.setUint32(0x04, 55, true);           // muZoneNumber
+	dv.setUint32(0x08, 2, true);            // props
+	dv.setUint8(0x0c, 3);                   // parts (u8)
+	dv.setUint32(0x10, 0x20, true);         // mpaPropGraphics
+	dv.setUint32(0x14, 0x40, true);         // mpaPropPartGraphics
+	// props (mpPropModel slots stay 0; mpParts points prop0 at part index 0)
+	dv.setUint32(0x20, 0xaa, true); dv.setUint32(0x28, 0x40, true); // prop0: type, mpParts
+	dv.setUint32(0x2c, 0xbb, true); dv.setUint32(0x34, 0, true);    // prop1: type, mpParts=0 (no parts)
+	// parts (at 0x40): {type, partId, mpPropModel=0}
+	dv.setUint32(0x40, 0xaa, true); dv.setUint32(0x44, 0, true);
+	dv.setUint32(0x4c, 0xaa, true); dv.setUint32(0x50, 1, true);
+	dv.setUint32(0x58, 0xbb, true); dv.setUint32(0x5c, 0, true);
+	// import table at 0x70 — props then parts, each {u64 id, u32 fieldOffset, u32 0}
+	const entries: [bigint, number][] = [
+		[PROP0_MODEL, 0x24], // prop0 mpPropModel field = 0x20 + 0*0x0C + 4
+		[PROP1_MODEL, 0x30], // prop1 mpPropModel field = 0x20 + 1*0x0C + 4
+		[PART_MODELS[0], 0x48], // part0 mpPropModel field = 0x40 + 0*0x0C + 8
+		[PART_MODELS[1], 0x54], // part1
+		[PART_MODELS[2], 0x60], // part2
+	];
+	entries.forEach(([id, off], i) => {
+		const p = 0x70 + i * 16;
+		dv.setUint32(p + 0, Number(id & 0xffffffffn), true);
+		dv.setUint32(p + 4, Number(id >> 32n), true);
+		dv.setUint32(p + 8, off, true);
+	});
+	return bytes;
+}
 
 describe('PropGraphicsList populated round-trip (synthesised)', () => {
-	// 2 props + 3 parts. mpaPropGraphics = 0x20, propEnd = 0x20 + 2*0x0C = 0x38,
-	// mpaPropPartGraphics = align16(0x38) = 0x40, partEnd = 0x40 + 3*0x0C = 0x64.
-	// Then an align pad to 0x70 + a fake import table of 5 entries × 16 = 80 bytes.
-	function buildBytes(): Uint8Array {
-		const partEnd = 0x40 + 3 * 0x0c; // 0x64
-		const importOffset = (partEnd + 15) & ~15; // 0x70
-		const importCount = 2 + 3;
-		const total = importOffset + importCount * 16; // 0x70 + 80 = 0xC0
-		const bytes = new Uint8Array(total);
-		const dv = new DataView(bytes.buffer);
-		dv.setUint32(0x00, partEnd, true);      // muSizeInBytes = part-array end
-		dv.setUint32(0x04, 55, true);           // muZoneNumber
-		dv.setUint32(0x08, 2, true);            // props
-		dv.setUint8(0x0c, 3);                   // parts (u8)
-		dv.setUint32(0x10, 0x20, true);         // mpaPropGraphics
-		dv.setUint32(0x14, 0x40, true);         // mpaPropPartGraphics
-		// props
-		dv.setUint32(0x20, 0xaa, true); dv.setUint32(0x24, 0, true); dv.setUint32(0x28, 0x40, true);
-		dv.setUint32(0x2c, 0xbb, true); dv.setUint32(0x30, 0, true); dv.setUint32(0x34, 0x40, true);
-		// parts (at 0x40)
-		dv.setUint32(0x40, 0xaa, true); dv.setUint32(0x44, 0, true); dv.setUint32(0x48, 0, true);
-		dv.setUint32(0x4c, 0xaa, true); dv.setUint32(0x50, 1, true); dv.setUint32(0x54, 0, true);
-		dv.setUint32(0x58, 0xbb, true); dv.setUint32(0x5c, 0, true); dv.setUint32(0x60, 0, true);
-		// fake import table (non-zero) so the tail capture is exercised
-		for (let i = 0; i < importCount; i++) {
-			dv.setUint32(importOffset + i * 16 + 0, 0x1000 + i, true); // resourceId low
-			dv.setUint32(importOffset + i * 16 + 8, 0x24 + i * 4, true); // field offset
-		}
-		return bytes;
-	}
-
-	it('decodes the structure and captures the non-zero tail', () => {
+	it('decodes the structure, Model ids, and part index', () => {
 		const model = parsePropGraphicsList(buildBytes());
 		expect(model.muZoneNumber).toBe(55);
 		expect(model.props.length).toBe(2);
 		expect(model.parts.length).toBe(3);
 		expect(model.props[0].muTypeId).toBe(0xaa);
-		expect(model.props[0].mpParts).toBe(0x40);
+		expect(model.props[0].mpModelId).toBe(PROP0_MODEL);
+		expect(model.props[0].firstPartIndex).toBe(0);
+		expect(model.props[1].mpModelId).toBe(PROP1_MODEL);
+		expect(model.props[1].firstPartIndex).toBeNull();
 		expect(model.parts[1].muPartId).toBe(1);
-		// tail = align pad (0x64→0x70) + 5×16 import table = 12 + 80 = 92 bytes.
-		expect(model._tail.byteLength).toBe(0xc0 - 0x64);
-		// and it is genuinely non-zero (the inline import table).
-		expect(model._tail.some((b) => b !== 0)).toBe(true);
+		expect(model.parts.map((p) => p.mpModelId)).toEqual(PART_MODELS);
 	});
 
 	it('round-trips byte-for-byte', () => {
@@ -113,24 +128,64 @@ describe('PropGraphicsList populated round-trip (synthesised)', () => {
 		expect(bytesEqual(rewritten, original)).toBe(true);
 	});
 
-	it('survives a muZoneNumber / prop-type edit', () => {
+	it('survives a muZoneNumber / prop-type / Model-id edit', () => {
 		const model = parsePropGraphicsList(buildBytes());
 		const edited: ParsedPropGraphicsList = {
 			...model,
 			muZoneNumber: 999,
-			props: model.props.map((p, i) => (i === 0 ? { ...p, muTypeId: 0x321 } : p)),
+			props: model.props.map((p, i) => (i === 0 ? { ...p, muTypeId: 0x321, mpModelId: 0x99n } : p)),
 		};
 		const re = parsePropGraphicsList(writePropGraphicsList(edited));
 		expect(re.muZoneNumber).toBe(999);
 		expect(re.props[0].muTypeId).toBe(0x321);
-		// the import-pointer fields and the tail are untouched.
-		expect(re.props[0].mpParts).toBe(0x40);
-		expect(bytesEqual(re._tail, model._tail)).toBe(true);
+		expect(re.props[0].mpModelId).toBe(0x99n);
+		// The part index and the other prop are untouched.
+		expect(re.props[0].firstPartIndex).toBe(0);
+		expect(re.props[1].mpModelId).toBe(PROP1_MODEL);
+	});
+
+	it('grows by one PropGraphics + one import entry when a prop is added', () => {
+		const original = buildBytes();
+		const model = parsePropGraphicsList(original);
+		const added: ParsedPropGraphicsList = {
+			...model,
+			props: [...model.props, { muTypeId: 0x77, mpModelId: 0xABCDn, firstPartIndex: null }],
+		};
+		const written = writePropGraphicsList(added);
+		// One more prop record (0x0C) shifts everything; adding a prop crosses an
+		// align16 boundary here (3 props → partsStart 0x50), and one import entry
+		// (16 bytes) is appended.
+		const re = parsePropGraphicsList(written);
+		expect(re.props.length).toBe(3);
+		expect(re.props[2].muTypeId).toBe(0x77);
+		expect(re.props[2].mpModelId).toBe(0xABCDn);
+		// Existing entries survive the relocation: prop0 still owns part index 0,
+		// and every part Model id is intact.
+		expect(re.props[0].mpModelId).toBe(PROP0_MODEL);
+		expect(re.props[0].firstPartIndex).toBe(0);
+		expect(re.parts.map((p) => p.mpModelId)).toEqual(PART_MODELS);
+		// The import-table hook reports the rebuilt table (props+parts = 6 entries)
+		// at the relocated offset: 3 props → propEnd 0x44, partsStart 0x50, partEnd
+		// 0x74 (= muSizeInBytes), importOffset = align16(0x74) = 0x80.
+		const table = propGraphicsListImportTable(written);
+		expect(table.count).toBe(6);
+		expect(table.offset).toBe(0x80);
+	});
+
+	it('shrinks when a prop is removed', () => {
+		const model = parsePropGraphicsList(buildBytes());
+		// Remove the partless prop1 so no part orphaning is involved.
+		const removed: ParsedPropGraphicsList = { ...model, props: [model.props[0]] };
+		const re = parsePropGraphicsList(writePropGraphicsList(removed));
+		expect(re.props.length).toBe(1);
+		expect(re.props[0].mpModelId).toBe(PROP0_MODEL);
+		expect(re.parts.map((p) => p.mpModelId)).toEqual(PART_MODELS);
+		expect(propGraphicsListImportTable(writePropGraphicsList(removed)).count).toBe(4);
 	});
 });
 
-// --- Defensive guards (the writer regenerates pads as zero; reject layouts that
-//     would make that silently lossy, and reject a u8-overflowing part count) ---
+// --- Defensive guards (the writer regenerates pads as zero / derives the
+//     length, so reject layouts that would make that silently lossy) ---
 
 describe('PropGraphicsList layout guards', () => {
 	it('throws on a non-zero header pad [0x18,0x20)', () => {
@@ -140,29 +195,22 @@ describe('PropGraphicsList layout guards', () => {
 		expect(() => parsePropGraphicsList(bytes)).toThrow(/header pad/);
 	});
 
-	it('throws on a non-zero inter-array pad between the prop and part arrays', () => {
-		// 1 prop (propEnd 0x2C) + 1 part (partsStart align16(0x2C)=0x30): the gap
-		// [0x2C,0x30) is regenerated as zero, so a non-zero byte there must fail.
-		const importOffset = 0x30 + 1 * 0x0c; // partEnd; aligned already
-		const total = importOffset + 2 * 16;  // 1 prop + 1 part imports
-		const bytes = new Uint8Array(total);
-		const dv = new DataView(bytes.buffer);
-		dv.setUint32(0x00, importOffset, true); // muSizeInBytes
-		dv.setUint32(0x08, 1, true);            // 1 prop
-		dv.setUint8(0x0c, 1);                   // 1 part
-		dv.setUint32(0x10, 0x20, true);         // mpaPropGraphics
-		dv.setUint32(0x14, 0x30, true);         // mpaPropPartGraphics
-		bytes[0x2c] = 0x99;                     // poison the inter-array gap
-		expect(() => parsePropGraphicsList(bytes)).toThrow(/inter-array pad/);
+	it('throws when muSizeInBytes disagrees with the derived structural end', () => {
+		const bytes = buildBytes();
+		new DataView(bytes.buffer).setUint32(0x00, 0x999, true); // wrong muSizeInBytes
+		expect(() => parsePropGraphicsList(bytes)).toThrow(/structural end/);
+	});
+
+	it('throws when the payload length disagrees with the derived layout', () => {
+		const short = buildBytes().slice(0, 0xbf); // drop the last byte
+		expect(() => parsePropGraphicsList(short)).toThrow(/expected 0x/);
 	});
 
 	it('throws rather than truncate when a model carries more than 255 parts', () => {
 		const model: ParsedPropGraphicsList = {
 			muZoneNumber: 1,
-			muSizeInBytes: 0,
-			props: [{ muTypeId: 1, mpPropModel: 0, mpParts: 0 }],
-			parts: Array.from({ length: 300 }, (_, i) => ({ muTypeId: 1, muPartId: i, mpPropModel: 0 })),
-			_tail: new Uint8Array(0),
+			props: [{ muTypeId: 1, mpModelId: 0n, firstPartIndex: 0 }],
+			parts: Array.from({ length: 300 }, (_, i) => ({ muTypeId: 1, muPartId: i, mpModelId: 0n })),
 		};
 		expect(() => writePropGraphicsList(model)).toThrow(/exceeds the u8/);
 	});
@@ -187,17 +235,16 @@ describeTrk9('PropGraphicsList gold (example/TRK_UNIT9_GR.BNDL)', () => {
 
 	it('decodes the header', () => {
 		expect(model.muZoneNumber).toBe(9);
-		expect(model.muSizeInBytes).toBe(784);
 		expect(model.props.length).toBe(10);
 		expect(model.parts.length).toBe(52);
 	});
 
-	it('decodes the first props (Model* are 0 on disk; mpParts is an internal pointer)', () => {
+	it('decodes the first props (Model ids from the import table; mpParts → part index)', () => {
 		expect(model.props[0].muTypeId).toBe(0x28);
-		expect(model.props[0].mpPropModel).toBe(0);
-		expect(model.props[0].mpParts).toBe(0xa0);
+		expect(model.props[0].mpModelId).toBe(0x12f7700an); // verified Model id for type 0x28
+		expect(model.props[0].firstPartIndex).toBe(0);       // mpParts 0xA0 = partsStart + 0
 		expect(model.props[2].muTypeId).toBe(0x06);
-		expect(model.props[2].mpParts).toBe(0xd0);
+		expect(model.props[2].firstPartIndex).toBe(4);       // mpParts 0xD0 = 0xA0 + 4*0x0C
 	});
 
 	it('decodes the first parts (grouped by owning prop type)', () => {
@@ -207,7 +254,7 @@ describeTrk9('PropGraphicsList gold (example/TRK_UNIT9_GR.BNDL)', () => {
 		expect(model.parts[1].muPartId).toBe(1);
 		expect(model.parts[4].muTypeId).toBe(0x06);
 		expect(model.parts[4].muPartId).toBe(0);
-		expect(model.parts.every((p) => p.mpPropModel === 0)).toBe(true);
+		expect(model.parts.every((p) => typeof p.mpModelId === 'bigint')).toBe(true);
 	});
 
 	it('round-trips byte-for-byte', () => {
@@ -220,5 +267,10 @@ describeTrk9('PropGraphicsList gold (example/TRK_UNIT9_GR.BNDL)', () => {
 		const write1 = writePropGraphicsList(parsePropGraphicsList(raw));
 		const write2 = writePropGraphicsList(parsePropGraphicsList(write1));
 		expect(bytesEqual(write1, write2)).toBe(true);
+	});
+
+	it('import-table hook matches the real envelope (props + parts)', () => {
+		const table = propGraphicsListImportTable(raw);
+		expect(table.count).toBe(model.props.length + model.parts.length); // 62
 	});
 });

--- a/src/lib/core/__tests__/propInstanceData.test.ts
+++ b/src/lib/core/__tests__/propInstanceData.test.ts
@@ -97,6 +97,28 @@ describe('PropInstanceData gold file (example/BE_9F_C7_93.dat)', () => {
 	});
 });
 
+// The cell partition (muStartIndex / muCount) is editable, not derived: some
+// external tools — and the "add new instances" workflow — need to set it by
+// hand. The writer must therefore emit whatever the model carries, even values
+// that disagree with the running-sum a derive-on-write writer would compute.
+describe('PropInstanceData cell partition is written verbatim (editable)', () => {
+	const bytes = loadGold();
+
+	it('preserves a hand-edited muStartIndex / muCount instead of recomputing', () => {
+		const model = parsePropInstanceData(bytes);
+		// Poison cell[0] with a partition that is NOT the running sum a derive-on-
+		// write writer would produce (cell[0] always starts at 0 in a valid file).
+		const cells = model.cells.map((c) => ({ ...c }));
+		cells[0] = { ...cells[0], muStartIndex: 123, muCount: 7 };
+		const re = parsePropInstanceData(writePropInstanceData({ ...model, cells }));
+		expect(re.cells[0].muStartIndex).toBe(123);
+		expect(re.cells[0].muCount).toBe(7);
+		// Other cells are untouched and survive unchanged.
+		expect(re.cells[1].muStartIndex).toBe(model.cells[1].muStartIndex);
+		expect(re.cells[1].muCount).toBe(model.cells[1].muCount);
+	});
+});
+
 // ~40% of track units (172/427 in example/) ship an *empty* prop zone: no
 // props, no cells, with maInstances and maCells stored as null (0) rather than
 // the populated-layout 0x20. The parser must accept this all-zero shape instead

--- a/src/lib/core/bundle/__tests__/propGraphicsListExport.test.ts
+++ b/src/lib/core/bundle/__tests__/propGraphicsListExport.test.ts
@@ -1,0 +1,80 @@
+// End-to-end coverage for the editable PropGraphicsList (0x10010): adding a prop
+// entry in the editor and exporting the bundle must produce a valid bundle whose
+// inline import table — and the envelope's importOffset/importCount — grow with
+// the new Model reference. This is the real "catalogue a newly-placed prop type"
+// workflow, exercised through writeBundleFresh's importTable() hook.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parseBundle, writeBundleFresh } from '../index';
+import { getImportsByPtrOffset } from '../bundleEntry';
+import { extractResourceRaw, resourceCtxFromBundle } from '../../registry/index';
+import {
+	parsePropGraphicsList,
+	PROP_GRAPHICS_LIST_TYPE_ID,
+	type ParsedPropGraphicsList,
+} from '../../propGraphicsList';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+const TRK9 = 'example/TRK_UNIT9_GR.BNDL';
+
+function loadBundle(name: string): ArrayBuffer {
+	const raw = fs.readFileSync(path.resolve(REPO_ROOT, name));
+	const bytes = new Uint8Array(raw.byteLength);
+	bytes.set(raw);
+	return bytes.buffer as ArrayBuffer;
+}
+
+const NEW_TYPE = 0xfe;
+const NEW_MODEL = 0xDEADBEEFCAFEn;
+
+const hasTrk9 = fs.existsSync(path.resolve(REPO_ROOT, TRK9));
+const describeTrk9 = hasTrk9 ? describe : describe.skip;
+
+describeTrk9('add a PropGraphics entry and export (example/TRK_UNIT9_GR.BNDL)', () => {
+	it('grows the import table + envelope metadata and wires the new Model id', () => {
+		const original = loadBundle(TRK9);
+		const bundle = parseBundle(original);
+		const ctx = resourceCtxFromBundle(bundle);
+		const entry = bundle.resources.find((r) => r.resourceTypeId === PROP_GRAPHICS_LIST_TYPE_ID)!;
+		const model = parsePropGraphicsList(extractResourceRaw(original, bundle, entry), ctx.littleEndian);
+		const beforeImports = entry.importCount; // 62 = 10 props + 52 parts
+
+		const mutated: ParsedPropGraphicsList = {
+			...model,
+			props: [...model.props, { muTypeId: NEW_TYPE, mpModelId: NEW_MODEL, firstPartIndex: null }],
+		};
+		const repacked = writeBundleFresh(bundle, original, {
+			overrides: { resources: { [PROP_GRAPHICS_LIST_TYPE_ID]: mutated } },
+		});
+
+		const reparsed = parseBundle(repacked);
+		const reIdx = reparsed.resources.findIndex((r) => r.resourceTypeId === PROP_GRAPHICS_LIST_TYPE_ID);
+		const reEntry = reparsed.resources[reIdx];
+		const payload = extractResourceRaw(repacked, reparsed, reEntry);
+		const reModel = parsePropGraphicsList(payload, ctx.littleEndian);
+
+		// The new prop survived round-trip.
+		expect(reModel.props.length).toBe(model.props.length + 1);
+		const added = reModel.props[reModel.props.length - 1];
+		expect(added.muTypeId).toBe(NEW_TYPE);
+		expect(added.mpModelId).toBe(NEW_MODEL);
+
+		// Envelope import metadata grew by one and points at the rebuilt tail table.
+		expect(reEntry.importCount).toBe(beforeImports + 1);
+		expect(reEntry.importOffset).toBe(payload.byteLength - reEntry.importCount * 16);
+
+		// The new Model id is resolvable through the bundle import index at the new
+		// prop's mpPropModel field offset (0x20 + propIndex*0x0C + 0x04).
+		const newPropIndex = reModel.props.length - 1;
+		const fieldOffset = 0x20 + newPropIndex * 0x0c + 0x04;
+		const imports = getImportsByPtrOffset(reparsed.imports, reparsed.resources, reIdx);
+		expect(imports.get(fieldOffset)).toBe(NEW_MODEL);
+
+		// Existing prop Model ids are still resolvable (table fully rebuilt).
+		const firstFieldOffset = 0x20 + 0x04;
+		expect(imports.get(firstFieldOffset)).toBe(model.props[0].mpModelId);
+	});
+});

--- a/src/lib/core/propCellGrid.ts
+++ b/src/lib/core/propCellGrid.ts
@@ -1,0 +1,52 @@
+// Prop cell grid — the coarse XZ streaming grid that PropInstanceData (0x10011)
+// partitions its instances into.
+//
+// Domain: prop instances are divided into 100 m × 100 m cells. A cell's id is
+// its (x, z) grid index. The runtime derives the id from the instance's world
+// position, but the editor must be able to compute and verify it too — some
+// external tools require setting PropCell.muX / muZ by hand, and the cell-grid
+// overlay needs cell↔world geometry.
+//
+// The mapping is `index = floor((pos + 5000) / 100)`, i.e. world coordinate
+// -5000 maps to grid index 0. Worked example: for -1400 ≤ x < -1300 and
+// -2000 ≤ z < -1900 the cell id is (muX=36, muZ=30). The reference map textures
+// Criterion shipped are imperfectly scaled, so this formula — not the texture —
+// is authoritative.
+//
+// Pure (no THREE / no React) so it can be unit-tested in node and shared by the
+// schema labels and the 3D overlay alike.
+
+/** Cell edge length in world metres. */
+export const PROP_CELL_SIZE = 100;
+
+/** World coordinate that maps to grid index 0 (both axes). */
+export const PROP_GRID_ORIGIN = -5000;
+
+/** Number of cells along each axis for the canonical ±5000 world (10000 / 100). */
+export const PROP_GRID_AXIS_CELLS = 100;
+
+export type PropCellId = { muX: number; muZ: number };
+
+/** World axis coordinate → grid index along that axis: floor((pos + 5000) / 100). */
+export function propCellIndex(pos: number): number {
+	return Math.floor((pos - PROP_GRID_ORIGIN) / PROP_CELL_SIZE);
+}
+
+/** World (x, z) → cell id (muX, muZ). y is irrelevant — the grid is on the ground plane. */
+export function propCellId(x: number, z: number): PropCellId {
+	return { muX: propCellIndex(x), muZ: propCellIndex(z) };
+}
+
+/** Lowest world coordinate owned by the cell at this grid index along an axis. */
+export function propCellMin(index: number): number {
+	return index * PROP_CELL_SIZE + PROP_GRID_ORIGIN;
+}
+
+export type PropCellRect = { x0: number; z0: number; x1: number; z1: number };
+
+/** World-space XZ rectangle a cell (muX, muZ) covers. */
+export function propCellRect(muX: number, muZ: number): PropCellRect {
+	const x0 = propCellMin(muX);
+	const z0 = propCellMin(muZ);
+	return { x0, z0, x1: x0 + PROP_CELL_SIZE, z1: z0 + PROP_CELL_SIZE };
+}

--- a/src/lib/core/propGraphicsList.ts
+++ b/src/lib/core/propGraphicsList.ts
@@ -11,34 +11,35 @@
 //    first part.
 //
 // The Model references are BND2 imports: on disk every mpPropModel pointer is 0,
-// and the real resource id lives in the bundle's INLINE import table (stored at
-// the tail of this resource's own payload). Imports are keyed by the byte offset
-// of the pointer field, so the renderer resolves them with getImportsByPtrOffset
-// — exactly like InstanceList's mpModel. The parser never needs the import table
-// to read the structure; it preserves it verbatim for byte-exact round-trip.
+// and the real resource id lives in the resource's INLINE import table (stored
+// at the tail of this resource's own payload). Each import entry is keyed by the
+// byte offset of the pointer field it fills. We MODEL those ids (mpModelId per
+// record) rather than carrying the table verbatim, so the catalogue is fully
+// editable: a new prop instance whose type isn't catalogued yet needs a new
+// PropGraphics entry mapping its type → a Model, which means adding both a record
+// and its import. The writer rebuilds the whole table from the model.
 //
 // Scope: 32-bit PC, little-endian. The wiki documents a 64-bit (Paradise
 // Remastered) layout too; like propInstanceData / instanceList / streetData we
 // implement 32-bit PC LE only.
 //
-// Round-trip strategy (byte-exact, grounded by sweeping all 427 PGL resources in
-// example/):
+// Round-trip strategy (byte-exact, grounded by sweeping all 256 populated PGL
+// resources in example/ — every invariant below holds with zero violations):
 //  - Layout is rigid: header(0x20) → PropGraphics[nProps] (0x0C each, at 0x20) →
 //    align16 pad → PropPartGraphics[nParts] (0x0C each) → align16 pad → inline
-//    import table (importCount*16) to end of payload. mpaPropGraphics is always
-//    0x20 and mpaPropPartGraphics is always align16(0x20 + nProps*0x0C), so both
-//    are recomputed from the counts on write (null/0 when their array is empty).
-//  - muSizeInBytes is a stored field that does NOT consistently equal a derivable
-//    offset (it is the part-array end when there are parts, but align16(prop-array
-//    end) when there are none), so it is preserved verbatim, mirroring
-//    propInstanceData.
-//  - mpPropModel (always 0) and mpParts (an internal resource-relative pointer)
-//    are preserved verbatim per record.
-//  - Everything from the end of the last array to the end of the payload (the
-//    align pad + the inline import table) is captured as _tail and re-emitted
-//    verbatim. This keeps every Model import valid as long as the prop/part
-//    counts are unchanged — so field edits round-trip, but adding/removing props
-//    or parts (which would shift the import-table field offsets) is out of scope.
+//    import table (importCount*16) to end of payload. Every offset/pointer/count
+//    is recomputed from nProps/nParts, so add/remove of props or parts is safe.
+//  - muSizeInBytes is the "structural end": part-array end when parts exist,
+//    align16(prop-array end) when only props, 0x20 when empty. It is DERIVED
+//    (not stored on the model) — the sweep proved the stored value always equals
+//    this formula. importOffset = align16(muSizeInBytes).
+//  - mpPropModel is 0 on disk; the real Model id is mpModelId, written into the
+//    rebuilt import table (one entry per prop, one per part), keyed by field
+//    offset. importCount == nProps + nParts.
+//  - mpParts is an internal resource-relative pointer to a prop's first part. We
+//    model it as firstPartIndex (the part-array INDEX it points at), so it stays
+//    valid when the part array relocates after a prop add/remove — on write it
+//    becomes mpaPropPartGraphics + firstPartIndex*0x0C (or 0 for a partless prop).
 
 import { BinReader, BinWriter } from './binTools';
 
@@ -48,34 +49,27 @@ import { BinReader, BinWriter } from './binTools';
 
 export type PropGraphics = {
 	muTypeId: number;    // u32 — prop type index (into the prop-types table)
-	// Model* import — 0 on disk; real id resolved from the import table by this
-	// field's byte offset. Preserved verbatim for round-trip.
-	mpPropModel: number; // u32
-	// Resource-relative pointer to this prop's first PropPartGraphics (0 when the
-	// prop has no parts). An internal pointer, preserved verbatim.
-	mpParts: number;     // u32
+	// Model resource id (64-bit) the runtime spawns for this prop's body mesh.
+	// Stored on disk as a 0 pointer + a BND2 import; editable here, rebuilt into
+	// the import table on write. 0n means "no model / unresolved".
+	mpModelId: bigint;
+	// Index into `parts` of this prop's first PropPartGraphics, or null when the
+	// prop has no parts. Replaces the raw resource-relative mpParts pointer so it
+	// survives the part array relocating when props are added/removed.
+	firstPartIndex: number | null;
 };
 
 export type PropPartGraphics = {
 	muTypeId: number;    // u32 — owning prop's type id (always little endian per wiki)
 	muPartId: number;    // u32 — part index within the prop
-	// Model* import — 0 on disk; resolved from the import table. Verbatim.
-	mpPropModel: number; // u32
+	// Model resource id for this part's mesh — same import mechanism as PropGraphics.
+	mpModelId: bigint;
 };
 
 export type ParsedPropGraphicsList = {
 	muZoneNumber: number; // PVS zone / track-unit id (editable)
-	// Stored size field; does NOT consistently equal any derivable offset (it is
-	// the part-array end with parts, align16(prop-array end) without). Preserved
-	// verbatim so the writer reproduces the header byte-for-byte.
-	muSizeInBytes: number;
 	props: PropGraphics[];
 	parts: PropPartGraphics[];
-	// Bytes from the end of the last array to the end of the payload: an align16
-	// pad followed by the inline BND2 import table (one entry per prop + per part).
-	// Re-emitted verbatim — reproduces the exact length and keeps every Model
-	// import valid (the table is keyed by field offset).
-	_tail: Uint8Array;
 };
 
 // =============================================================================
@@ -89,8 +83,26 @@ const HEADER_SIZE = 0x20;            // header fields end at 0x18, padded to 0x2
 const PROP_GRAPHICS_OFFSET = 0x20;   // mpaPropGraphics is always 0x20 when populated
 const PROP_RECORD_SIZE = 0x0c;       // PropGraphics
 const PART_RECORD_SIZE = 0x0c;       // PropPartGraphics
+const PROP_MODEL_FIELD = 0x04;       // mpPropModel within a PropGraphics record
+const PART_MODEL_FIELD = 0x08;       // mpPropModel within a PropPartGraphics record
+const IMPORT_ENTRY_SIZE = 0x10;      // { u64 resourceId, u32 fieldOffset, u32 pad }
 
 const align16 = (x: number): number => (x + 15) & ~15;
+
+// Layout offsets derived purely from the two record counts. Single source of
+// truth for parser, writer, and the import-table hook.
+function layout(nProps: number, nParts: number) {
+	const propGraphicsEnd = PROP_GRAPHICS_OFFSET + nProps * PROP_RECORD_SIZE;
+	const partsStart = align16(propGraphicsEnd);
+	// "structural end" — what muSizeInBytes stores (proven by corpus sweep).
+	const structuralEnd =
+		nParts > 0 ? partsStart + nParts * PART_RECORD_SIZE
+			: nProps > 0 ? align16(propGraphicsEnd)
+				: HEADER_SIZE;
+	const importOffset = align16(structuralEnd);
+	const total = importOffset + (nProps + nParts) * IMPORT_ENTRY_SIZE;
+	return { propGraphicsEnd, partsStart, structuralEnd, importOffset, total };
+}
 
 // =============================================================================
 // Reader
@@ -109,30 +121,52 @@ export function parsePropGraphicsList(raw: Uint8Array, littleEndian = true): Par
 	const mpaPropPartGraphics = r.readU32();
 	// 0x18..0x20 is zero pad up to where PropGraphics begins (mpaPropGraphics).
 
+	const { propGraphicsEnd, partsStart, structuralEnd, importOffset, total } =
+		layout(muNumberOfPropModels, muNumberOfPropPartModels);
+
 	// The layout is rigid; bail loudly if a populated fixture violates it rather
 	// than silently producing a model that won't round-trip. Empty lists store
 	// null (0) pointers, so only validate a pointer when its array is present.
-	const propGraphicsEnd = PROP_GRAPHICS_OFFSET + muNumberOfPropModels * PROP_RECORD_SIZE;
-	const partsStart = align16(propGraphicsEnd);
 	if (muNumberOfPropModels > 0 && mpaPropGraphics !== PROP_GRAPHICS_OFFSET) {
 		throw new Error(`PropGraphicsList: mpaPropGraphics is 0x${mpaPropGraphics.toString(16)}, expected 0x20 (rigid layout)`);
 	}
 	if (muNumberOfPropPartModels > 0 && mpaPropPartGraphics !== partsStart) {
 		throw new Error(`PropGraphicsList: mpaPropPartGraphics is 0x${mpaPropPartGraphics.toString(16)}, expected 0x${partsStart.toString(16)} for ${muNumberOfPropModels} props`);
 	}
-
-	// The header pad [0x18,0x20) and the align16 inter-array gap are regenerated
-	// as zero by the writer (not captured on the model), so a non-zero byte in
-	// either region would silently break the byte-exact round-trip. Both are zero
-	// in every fixture — assert it and fail loud, like the pointer checks above,
-	// rather than drop data on some unexpected layout.
-	for (let i = 0x18; i < HEADER_SIZE && i < raw.byteLength; i++) {
-		if (raw[i] !== 0) throw new Error(`PropGraphicsList: non-zero header pad at 0x${i.toString(16)} — layout not as expected`);
+	// muSizeInBytes always equals the structural end across the whole corpus; a
+	// mismatch means an unexpected layout we don't know how to rebuild — fail loud.
+	if (muSizeInBytes !== structuralEnd) {
+		throw new Error(`PropGraphicsList: muSizeInBytes 0x${muSizeInBytes.toString(16)} != derived structural end 0x${structuralEnd.toString(16)} (nProps=${muNumberOfPropModels} nParts=${muNumberOfPropPartModels})`);
 	}
-	if (muNumberOfPropPartModels > 0) {
-		for (let i = propGraphicsEnd; i < partsStart; i++) {
-			if (raw[i] !== 0) throw new Error(`PropGraphicsList: non-zero inter-array pad at 0x${i.toString(16)} — layout not as expected`);
+	// The payload must be exactly the derived length: header + arrays + pads +
+	// (nProps+nParts) import entries. The writer rebuilds to this length, so any
+	// extra/missing trailing bytes would break the byte-exact round-trip.
+	if (raw.byteLength !== total) {
+		throw new Error(`PropGraphicsList: payload is 0x${raw.byteLength.toString(16)} bytes, expected 0x${total.toString(16)} for ${muNumberOfPropModels} props + ${muNumberOfPropPartModels} parts`);
+	}
+
+	// The header pad [0x18,0x20), the align16 inter-array gap, and the align16 gap
+	// before the import table are all regenerated as zero by the writer (not
+	// captured on the model), so a non-zero byte in any of them would silently
+	// break the byte-exact round-trip. All are zero in every fixture — assert it.
+	const assertZeroRange = (from: number, to: number, what: string) => {
+		for (let i = from; i < to && i < raw.byteLength; i++) {
+			if (raw[i] !== 0) throw new Error(`PropGraphicsList: non-zero ${what} at 0x${i.toString(16)} — layout not as expected`);
 		}
+	};
+	assertZeroRange(0x18, HEADER_SIZE, 'header pad');
+	if (muNumberOfPropPartModels > 0) assertZeroRange(propGraphicsEnd, partsStart, 'inter-array pad');
+	assertZeroRange(structuralEnd, importOffset, 'import-table align pad');
+
+	// --- Inline import table (field offset → Model resource id) ---
+	const importById = new Map<number, bigint>();
+	r.position = importOffset;
+	for (let i = 0; i < muNumberOfPropModels + muNumberOfPropPartModels; i++) {
+		const resourceId = r.readU64();
+		const fieldOffset = r.readU32();
+		const pad = r.readU32();
+		if (pad !== 0) throw new Error(`PropGraphicsList: non-zero import-entry padding ${pad} — layout not as expected`);
+		importById.set(fieldOffset, resourceId);
 	}
 
 	// --- PropGraphics (12 bytes each, at 0x20) ---
@@ -140,33 +174,36 @@ export function parsePropGraphicsList(raw: Uint8Array, littleEndian = true): Par
 	r.position = PROP_GRAPHICS_OFFSET;
 	for (let i = 0; i < muNumberOfPropModels; i++) {
 		const muTypeId = r.readU32();
-		const mpPropModel = r.readU32();
+		r.readU32();                     // mpPropModel — 0 on disk, ignored (id is in the import table)
 		const mpParts = r.readU32();
-		props.push({ muTypeId, mpPropModel, mpParts });
+		const fieldOffset = PROP_GRAPHICS_OFFSET + i * PROP_RECORD_SIZE + PROP_MODEL_FIELD;
+		const mpModelId = importById.get(fieldOffset) ?? 0n;
+		// mpParts is an aligned offset into the part array (proven by the sweep) —
+		// store it as a part index so it survives the array relocating on edit.
+		let firstPartIndex: number | null = null;
+		if (mpParts !== 0) {
+			const rel = mpParts - partsStart;
+			if (rel < 0 || rel % PART_RECORD_SIZE !== 0 || rel / PART_RECORD_SIZE >= muNumberOfPropPartModels) {
+				throw new Error(`PropGraphicsList: prop[${i}] mpParts 0x${mpParts.toString(16)} is not an aligned index into the ${muNumberOfPropPartModels}-part array`);
+			}
+			firstPartIndex = rel / PART_RECORD_SIZE;
+		}
+		props.push({ muTypeId, mpModelId, firstPartIndex });
 	}
 
 	// --- PropPartGraphics (12 bytes each, at align16(propGraphicsEnd)) ---
 	const parts: PropPartGraphics[] = [];
 	r.position = partsStart;
-	for (let i = 0; i < muNumberOfPropPartModels; i++) {
+	for (let j = 0; j < muNumberOfPropPartModels; j++) {
 		const muTypeId = r.readU32();
 		const muPartId = r.readU32();
-		const mpPropModel = r.readU32();
-		parts.push({ muTypeId, muPartId, mpPropModel });
+		r.readU32();                     // mpPropModel — 0 on disk, ignored
+		const fieldOffset = partsStart + j * PART_RECORD_SIZE + PART_MODEL_FIELD;
+		const mpModelId = importById.get(fieldOffset) ?? 0n;
+		parts.push({ muTypeId, muPartId, mpModelId });
 	}
 
-	// --- Tail (align pad + inline import table) — captured verbatim. ---
-	const structuralEnd =
-		muNumberOfPropPartModels > 0
-			? partsStart + muNumberOfPropPartModels * PART_RECORD_SIZE
-			: muNumberOfPropModels > 0
-				? propGraphicsEnd
-				: HEADER_SIZE;
-	const _tail = structuralEnd < raw.byteLength
-		? raw.slice(structuralEnd, raw.byteLength)
-		: new Uint8Array(0);
-
-	return { muZoneNumber, muSizeInBytes, props, parts, _tail };
+	return { muZoneNumber, props, parts };
 }
 
 // =============================================================================
@@ -180,29 +217,22 @@ export function writePropGraphicsList(model: ParsedPropGraphicsList, littleEndia
 
 	// muNumberOfPropPartModels is a u8 on disk; refuse to silently truncate a
 	// model carrying >255 parts into a desynced count. Real fixtures top out at
-	// 82 parts — this only guards out-of-scope bulk edits that add parts.
+	// 82 parts.
 	if (nParts > 0xff) {
 		throw new Error(`PropGraphicsList: ${nParts} parts exceeds the u8 muNumberOfPropPartModels field (max 255)`);
 	}
 
-	// Layout offsets recomputed from the counts — never trust stored values.
-	const propGraphicsEnd = PROP_GRAPHICS_OFFSET + nProps * PROP_RECORD_SIZE;
-	const partsStart = align16(propGraphicsEnd);
-	const structuralEnd =
-		nParts > 0 ? partsStart + nParts * PART_RECORD_SIZE
-			: nProps > 0 ? propGraphicsEnd
-				: HEADER_SIZE;
-	const totalSize = structuralEnd + model._tail.byteLength;
+	const { partsStart, structuralEnd, importOffset, total } = layout(nProps, nParts);
 
 	// Stored pointers are null (0) when their array is empty — reproduces the
 	// all-zero header an empty list ships, keeping the round-trip byte-exact.
 	const mpaPropGraphics = nProps > 0 ? PROP_GRAPHICS_OFFSET : 0;
 	const mpaPropPartGraphics = nParts > 0 ? partsStart : 0;
 
-	const w = new BinWriter(totalSize, littleEndian);
+	const w = new BinWriter(total, littleEndian);
 
 	// --- Header (32 bytes) ---
-	w.writeU32(model.muSizeInBytes);             // verbatim — not a derivable offset
+	w.writeU32(structuralEnd);                   // muSizeInBytes — derived structural end
 	w.writeU32(model.muZoneNumber);
 	w.writeU32(nProps);
 	w.writeU8(nParts & 0xff);
@@ -214,9 +244,14 @@ export function writePropGraphicsList(model: ParsedPropGraphicsList, littleEndia
 
 	// --- PropGraphics (12 bytes each) ---
 	for (const p of props) {
+		const idx = p.firstPartIndex;
+		if (idx != null && (idx < 0 || idx >= nParts)) {
+			throw new Error(`PropGraphicsList writer: firstPartIndex ${idx} out of range for ${nParts} parts`);
+		}
+		const mpParts = idx == null ? 0 : partsStart + idx * PART_RECORD_SIZE;
 		w.writeU32(p.muTypeId);
-		w.writeU32(p.mpPropModel);                // verbatim, 0 on disk
-		w.writeU32(p.mpParts);                     // verbatim internal pointer
+		w.writeU32(0);                            // mpPropModel — 0 on disk, id lives in the import table
+		w.writeU32(mpParts);                      // recomputed internal pointer
 	}
 
 	// --- align16 pad → PropPartGraphics (12 bytes each) ---
@@ -225,13 +260,45 @@ export function writePropGraphicsList(model: ParsedPropGraphicsList, littleEndia
 		for (const q of parts) {
 			w.writeU32(q.muTypeId);
 			w.writeU32(q.muPartId);
-			w.writeU32(q.mpPropModel);             // verbatim, 0 on disk
+			w.writeU32(0);                        // mpPropModel — 0 on disk
 		}
 	}
-	if (w.offset !== structuralEnd) throw new Error(`PropGraphicsList writer: tail offset mismatch ${w.offset} vs ${structuralEnd}`);
+	// Pad up to the structural end. With parts this is already the part-array end
+	// (no-op); with only props the structural end is align16(prop-array end), so
+	// there's an align pad after the last prop record to fill here.
+	while (w.offset < structuralEnd) w.writeU8(0);
+	if (w.offset !== structuralEnd) throw new Error(`PropGraphicsList writer: structural-end offset mismatch ${w.offset} vs ${structuralEnd}`);
 
-	// --- Tail (align pad + inline import table) — verbatim. ---
-	if (model._tail.byteLength > 0) w.writeBytes(model._tail);
+	// --- align16 pad → inline import table (one entry per prop, then per part) ---
+	while (w.offset < importOffset) w.writeU8(0);
+	props.forEach((p, i) => {
+		w.writeU64(p.mpModelId);
+		w.writeU32(PROP_GRAPHICS_OFFSET + i * PROP_RECORD_SIZE + PROP_MODEL_FIELD);
+		w.writeU32(0);
+	});
+	parts.forEach((q, j) => {
+		w.writeU64(q.mpModelId);
+		w.writeU32(partsStart + j * PART_RECORD_SIZE + PART_MODEL_FIELD);
+		w.writeU32(0);
+	});
+	if (w.offset !== total) throw new Error(`PropGraphicsList writer: end offset mismatch ${w.offset} vs ${total}`);
 
 	return w.bytes;
+}
+
+// =============================================================================
+// Import-table hook (for the bundle envelope on export)
+// =============================================================================
+
+// Where the rewritten payload's inline import table sits and how many entries it
+// has. The bundle writer calls this so ResourceEntry.importOffset/importCount
+// follow a count-changing edit (add/remove of props or parts). muSizeInBytes in
+// the payload header is the structural end the writer emitted, so the table
+// starts at align16 of it; count is nProps + nParts.
+export function propGraphicsListImportTable(payload: Uint8Array, littleEndian = true): { offset: number; count: number } {
+	const dv = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
+	const muSizeInBytes = dv.getUint32(0x00, littleEndian);
+	const nProps = dv.getUint32(0x08, littleEndian);
+	const nParts = dv.getUint8(0x0c);
+	return { offset: align16(muSizeInBytes), count: nProps + nParts };
 }

--- a/src/lib/core/propInstanceData.ts
+++ b/src/lib/core/propInstanceData.ts
@@ -31,8 +31,13 @@
 //    preserved verbatim on the model so the writer reproduces them exactly.
 //  - The exact original byte length is reproduced by capturing the trailing zero
 //    pad (end-of-cells → end-of-buffer) as _trailingPad and re-emitting it.
-//  - Per-cell muStartIndex / muCount are derived from the partition (cells own a
-//    contiguous run of instances) and recomputed on write.
+//  - Per-cell muStartIndex / muCount describe the partition (each cell owns the
+//    contiguous run [muStartIndex, muStartIndex+muCount) of the instance array).
+//    They are written VERBATIM, not recomputed: some external tools (and the
+//    "add new instances" workflow) need to set the partition by hand, so the
+//    editor exposes both fields and the writer trusts the model. For a
+//    well-formed file muStartIndex is the running sum of prior muCount, so an
+//    untouched resource still round-trips byte-exact.
 
 import { BinReader, BinWriter } from './binTools';
 import { PROP_TYPE_ID_MASK, PROP_TYPE_ID_BITS } from './propTypes';
@@ -71,8 +76,12 @@ export type PropInstance = {
 export type PropCell = {
 	muX: number;                        // PropCellId.muX — grid coord
 	muZ: number;                        // PropCellId.muZ — grid coord
-	muStartIndex: number;               // derived: running sum of prior muCount
-	muCount: number;                    // derived: instances owned by this cell
+	// First instance index this cell owns, and how many it owns. The partition
+	// is editable (see the round-trip note in the file header) — both are
+	// written verbatim. For a well-formed file muStartIndex equals the running
+	// sum of prior cells' muCount.
+	muStartIndex: number;               // u16
+	muCount: number;                    // u16
 	muNumberOfRespawnDifferent: number; // u16, ordered first within the cell
 	muNumberOfDontRespawn: number;      // u16, ordered after the respawn-different ones
 };
@@ -247,19 +256,17 @@ export function writePropInstanceData(model: ParsedPropInstanceData, littleEndia
 	}
 	if (w.offset !== instancesEnd) throw new Error(`PropInstanceData writer: cells offset mismatch ${w.offset} vs ${instancesEnd}`);
 
-	// --- Cells (12 bytes each) — muStartIndex / muCount derived from the
-	// partition: each cell consumes the next muCount instances contiguously. We
-	// recompute muStartIndex as the running sum of the cells' muCount so the
-	// partition stays self-consistent after edits.
-	let runningStart = 0;
+	// --- Cells (12 bytes each) — muStartIndex / muCount written VERBATIM so the
+	// editor can set the partition by hand (e.g. after adding instances). The
+	// caller owns keeping it self-consistent; for an untouched file the stored
+	// muStartIndex already equals the running sum, so this stays byte-exact.
 	for (const cell of cells) {
 		w.writeU16(cell.muX);
 		w.writeU16(cell.muZ);
-		w.writeU16(runningStart);
+		w.writeU16(cell.muStartIndex);
 		w.writeU16(cell.muCount);
 		w.writeU16(cell.muNumberOfRespawnDifferent);
 		w.writeU16(cell.muNumberOfDontRespawn);
-		runningStart += cell.muCount;
 	}
 	if (w.offset !== cellsEnd) throw new Error(`PropInstanceData writer: trailing-pad offset mismatch ${w.offset} vs ${cellsEnd}`);
 

--- a/src/lib/core/registry/handlers/propGraphicsList.ts
+++ b/src/lib/core/registry/handlers/propGraphicsList.ts
@@ -8,6 +8,7 @@
 import {
 	parsePropGraphicsList,
 	writePropGraphicsList,
+	propGraphicsListImportTable,
 	PROP_GRAPHICS_LIST_TYPE_ID,
 	type ParsedPropGraphicsList,
 } from '../../propGraphicsList';
@@ -18,6 +19,8 @@ import type { ResourceHandler } from '../handler';
 const STRESS_PROP_TYPE = 0x123;
 // A part id distinct from the low sequential ids parts carry on disk.
 const STRESS_PART_ID = 0x77;
+// A Model resource id marker for the import-table edit/add scenarios.
+const STRESS_MODEL_ID = 0xCAFEF00DBABEn;
 
 export const propGraphicsListHandler: ResourceHandler<ParsedPropGraphicsList> = {
 	typeId: PROP_GRAPHICS_LIST_TYPE_ID,
@@ -27,12 +30,18 @@ export const propGraphicsListHandler: ResourceHandler<ParsedPropGraphicsList> = 
 	category: 'Data',
 	caps: { read: true, write: true },
 	wikiUrl: 'https://burnout.wiki/wiki/Prop_Graphics_List',
+	notes: 'Model references live in the resource\'s inline import table — one entry per prop + per part. Adding/removing entries resizes the table; the bundle envelope recomputes its import metadata via importTable() on export.',
 
 	parseRaw(raw, ctx) {
 		return parsePropGraphicsList(raw, ctx.littleEndian);
 	},
 	writeRaw(model, ctx) {
 		return writePropGraphicsList(model, ctx.littleEndian);
+	},
+	importTable(payload, ctx) {
+		// One import per prop + per part, after the structural arrays. Read the
+		// header counts the writer emitted (muSizeInBytes is the structural end).
+		return propGraphicsListImportTable(payload, ctx.littleEndian);
 	},
 	describe(model) {
 		return `zone ${model.muZoneNumber}, props ${model.props.length}, parts ${model.parts.length}`;
@@ -76,7 +85,7 @@ export const propGraphicsListHandler: ResourceHandler<ParsedPropGraphicsList> = 
 		},
 		{
 			name: 'edit-prop-type',
-			description: 'set props[0].muTypeId to a marker and verify it survives without perturbing the import pointers',
+			description: 'set props[0].muTypeId to a marker and verify it survives without perturbing the Model id / parts pointer',
 			mutate: (m) => {
 				const props = m.props.slice();
 				props[0] = { ...props[0], muTypeId: STRESS_PROP_TYPE };
@@ -87,13 +96,29 @@ export const propGraphicsListHandler: ResourceHandler<ParsedPropGraphicsList> = 
 				if (after.props[0].muTypeId !== STRESS_PROP_TYPE) {
 					problems.push(`props[0].muTypeId = ${after.props[0].muTypeId}, expected ${STRESS_PROP_TYPE}`);
 				}
-				// mpPropModel (0 on disk) and mpParts must be untouched — they share
-				// the record and are preserved verbatim.
-				if (after.props[0].mpPropModel !== before.props[0].mpPropModel) {
-					problems.push(`props[0].mpPropModel changed to ${after.props[0].mpPropModel}`);
+				// The Model id and the parts pointer share the record and must be
+				// preserved when only the type changes.
+				if (after.props[0].mpModelId !== before.props[0].mpModelId) {
+					problems.push(`props[0].mpModelId changed to 0x${after.props[0].mpModelId.toString(16)}`);
 				}
-				if (after.props[0].mpParts !== before.props[0].mpParts) {
-					problems.push(`props[0].mpParts changed to ${after.props[0].mpParts}`);
+				if (after.props[0].firstPartIndex !== before.props[0].firstPartIndex) {
+					problems.push(`props[0].firstPartIndex changed to ${after.props[0].firstPartIndex}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-prop-model-id',
+			description: 'set props[0].mpModelId to a marker resource id and verify the rebuilt import table preserves it',
+			mutate: (m) => {
+				const props = m.props.slice();
+				props[0] = { ...props[0], mpModelId: STRESS_MODEL_ID };
+				return { ...m, props };
+			},
+			verify: (_before, after) => {
+				const problems: string[] = [];
+				if (after.props[0].mpModelId !== STRESS_MODEL_ID) {
+					problems.push(`props[0].mpModelId = 0x${after.props[0].mpModelId.toString(16)}, expected 0x${STRESS_MODEL_ID.toString(16)}`);
 				}
 				return problems;
 			},
@@ -116,8 +141,65 @@ export const propGraphicsListHandler: ResourceHandler<ParsedPropGraphicsList> = 
 				if (after.parts[0].muPartId !== STRESS_PART_ID) {
 					problems.push(`parts[0].muPartId = ${after.parts[0].muPartId}, expected ${STRESS_PART_ID}`);
 				}
-				if (after.parts[0].mpPropModel !== before.parts[0].mpPropModel) {
-					problems.push(`parts[0].mpPropModel changed to ${after.parts[0].mpPropModel}`);
+				if (after.parts[0].mpModelId !== before.parts[0].mpModelId) {
+					problems.push(`parts[0].mpModelId changed to 0x${after.parts[0].mpModelId.toString(16)}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'add-prop-entry',
+			description: 'append a new partless PropGraphics (a prop type that was not catalogued) with a Model id, and verify the new entry + rebuilt import table survive while existing entries are untouched',
+			mutate: (m) => {
+				const props = [
+					...m.props,
+					{ muTypeId: STRESS_PROP_TYPE, mpModelId: STRESS_MODEL_ID, firstPartIndex: null },
+				];
+				return { ...m, props };
+			},
+			// The runner passes (afterMutate, afterReparse): both already carry the
+			// appended prop, so they must AGREE.
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.props.length !== afterMutate.props.length) {
+					problems.push(`prop count ${afterReparse.props.length} != ${afterMutate.props.length}`);
+				}
+				const added = afterReparse.props[afterReparse.props.length - 1];
+				if (added.muTypeId !== STRESS_PROP_TYPE) problems.push(`added muTypeId = ${added.muTypeId}`);
+				if (added.mpModelId !== STRESS_MODEL_ID) problems.push(`added mpModelId = 0x${added.mpModelId.toString(16)}`);
+				if (added.firstPartIndex !== null) problems.push(`added firstPartIndex = ${added.firstPartIndex}, expected null`);
+				// Adding a prop shifts the part array; existing part Model ids and
+				// the parts-pointer indices must survive the relocation intact.
+				if (afterReparse.parts.length !== afterMutate.parts.length) {
+					problems.push(`part count changed to ${afterReparse.parts.length}`);
+				}
+				for (let i = 0; i < afterMutate.parts.length; i++) {
+					if (afterReparse.parts[i].mpModelId !== afterMutate.parts[i].mpModelId) {
+						problems.push(`parts[${i}].mpModelId drifted after add`);
+						break;
+					}
+				}
+				if (afterMutate.props[0].firstPartIndex !== afterReparse.props[0].firstPartIndex) {
+					problems.push(`props[0].firstPartIndex drifted after add`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'remove-last-prop-entry',
+			description: 'drop the final PropGraphics entry and verify the count shrinks and the import table is rebuilt for the remaining entries',
+			mutate: (m) => ({ ...m, props: m.props.slice(0, -1) }),
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (afterReparse.props.length !== afterMutate.props.length) {
+					problems.push(`prop count ${afterReparse.props.length} != ${afterMutate.props.length}`);
+				}
+				// Surviving props keep their Model ids.
+				for (let i = 0; i < afterMutate.props.length; i++) {
+					if (afterReparse.props[i].mpModelId !== afterMutate.props[i].mpModelId) {
+						problems.push(`props[${i}].mpModelId drifted after remove`);
+						break;
+					}
 				}
 				return problems;
 			},

--- a/src/lib/core/registry/handlers/propInstanceData.ts
+++ b/src/lib/core/registry/handlers/propInstanceData.ts
@@ -202,6 +202,27 @@ export const propInstanceDataHandler: ResourceHandler<ParsedPropInstanceData> = 
 			},
 		},
 		{
+			name: 'edit-cell-partition-verbatim',
+			description: 'set the first cell muStartIndex / muCount to markers that disagree with the running sum and verify the writer keeps them verbatim (the partition is editable, not derived)',
+			mutate: (m) => {
+				if (m.cells.length === 0) return m;
+				const cells = m.cells.slice();
+				cells[0] = { ...cells[0], muStartIndex: 4321, muCount: 9 };
+				return { ...m, cells };
+			},
+			verify: (_before, after) => {
+				const problems: string[] = [];
+				if (after.cells.length === 0) return problems;
+				if (after.cells[0].muStartIndex !== 4321) {
+					problems.push(`cell[0].muStartIndex = ${after.cells[0].muStartIndex}, expected 4321 (verbatim)`);
+				}
+				if (after.cells[0].muCount !== 9) {
+					problems.push(`cell[0].muCount = ${after.cells[0].muCount}, expected 9 (verbatim)`);
+				}
+				return problems;
+			},
+		},
+		{
 			name: 'append-instance-to-last-cell',
 			description: 'clone instances[last], push it, and increment the last cell muCount; verify the new instance and recomputed partition survive',
 			mutate: (m) => {

--- a/src/lib/schema/resources/propGraphicsList.test.ts
+++ b/src/lib/schema/resources/propGraphicsList.test.ts
@@ -155,10 +155,16 @@ describe('propGraphicsList path resolution', () => {
 		expect(loc!.record?.name).toBe('PropGraphics');
 	});
 
-	it('resolves props[0].muTypeId as u32', () => {
+	it('resolves props[0].muTypeId as an enum (prop-types vocabulary)', () => {
 		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['props', 0, 'muTypeId']);
 		expect(loc).not.toBeNull();
-		expect(loc!.field?.kind).toBe('u32');
+		expect(loc!.field?.kind).toBe('enum');
+	});
+
+	it('resolves props[0].mpModelId as an editable bigint resource id', () => {
+		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['props', 0, 'mpModelId']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('bigint');
 	});
 
 	it('resolves parts[0] as a PropPartGraphics', () => {
@@ -173,6 +179,27 @@ describe('propGraphicsList path resolution', () => {
 		expect(loc!.field?.kind).toBe('u32');
 	});
 
+	it('resolves parts[0].mpModelId as an editable bigint resource id', () => {
+		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['parts', 0, 'mpModelId']);
+		expect(loc).not.toBeNull();
+		expect(loc!.field?.kind).toBe('bigint');
+	});
+
+	it('exposes props as an addable list but locks parts (firstPartIndex linkage is internal)', () => {
+		const props = propGraphicsListResourceSchema.registry.ParsedPropGraphicsList.fields.props;
+		const parts = propGraphicsListResourceSchema.registry.ParsedPropGraphicsList.fields.parts;
+		if (props.kind !== 'list' || parts.kind !== 'list') throw new Error('expected lists');
+		expect(props.addable).toBe(true);
+		expect(props.removable).toBe(true);
+		// Parts can't be added/removed (only their fields edited) — see schema note.
+		expect(parts.addable).toBe(false);
+		expect(parts.removable).toBe(false);
+		// makeEmpty supplies a default Model id so a new prop row is valid immediately.
+		const empty = props.makeEmpty!({ root: {}, resource: propGraphicsListResourceSchema }) as { mpModelId: bigint; firstPartIndex: number | null };
+		expect(empty.mpModelId).toBe(0n);
+		expect(empty.firstPartIndex).toBeNull();
+	});
+
 	it('resolves muZoneNumber as u32', () => {
 		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['muZoneNumber']);
 		expect(loc).not.toBeNull();
@@ -185,22 +212,27 @@ describe('propGraphicsList path resolution', () => {
 // ---------------------------------------------------------------------------
 
 describeFixture('propGraphicsList tree labels', () => {
-	it('prop label includes the index and hex type id', () => {
-		// props[0] in TRK_UNIT9 has type id 0x28.
+	it('prop label includes the index, prop name, and Model id', () => {
+		// props[0] in TRK_UNIT9 has type id 0x28 and Model 0x12F7700A.
 		const prop = model.props[0];
 		const field = propGraphicsListResourceSchema.registry.ParsedPropGraphicsList.fields.props;
 		if (field.kind !== 'list') throw new Error('expected list');
 		const labelFn = field.itemLabel as (v: unknown, i: number) => string;
-		expect(labelFn(prop, 0)).toBe('#0 · type 0x28');
+		const label = labelFn(prop, 0);
+		expect(label.startsWith('#0 · ')).toBe(true);
+		expect(label).toContain('model 0x12F7700A');
 	});
 
-	it('part label includes the index, hex type id, and part number', () => {
+	it('part label includes the index, part number, and Model id', () => {
 		// parts[1] in TRK_UNIT9 is type 0x28, part 1.
 		const part = model.parts[1];
 		const field = propGraphicsListResourceSchema.registry.ParsedPropGraphicsList.fields.parts;
 		if (field.kind !== 'list') throw new Error('expected list');
 		const labelFn = field.itemLabel as (v: unknown, i: number) => string;
-		expect(labelFn(part, 1)).toBe('#1 · type 0x28 · part 1');
+		const label = labelFn(part, 1);
+		expect(label.startsWith('#1 · ')).toBe(true);
+		expect(label).toContain('part 1');
+		expect(label).toContain('model 0x');
 	});
 
 	it('PropGraphics.label callback returns a non-empty string', () => {
@@ -226,13 +258,14 @@ describeFixture('propGraphicsList getAtPath', () => {
 		expect(Number.isFinite(id)).toBe(true);
 	});
 
-	it('reads props[0].mpPropModel as a number (0 on disk)', () => {
-		const mpModel = getAtPath(model, ['props', 0, 'mpPropModel']);
-		expect(mpModel).toBe(0);
+	it('reads props[0].mpModelId as a bigint Model resource id', () => {
+		const id = getAtPath(model, ['props', 0, 'mpModelId']);
+		expect(typeof id).toBe('bigint');
+		expect(id).toBe(0x12f7700an);
 	});
 
-	it('reads a part Model pointer as 0 on disk', () => {
-		const mpModel = getAtPath(model, ['parts', 0, 'mpPropModel']);
-		expect(mpModel).toBe(0);
+	it('reads a part Model id as a bigint', () => {
+		const id = getAtPath(model, ['parts', 0, 'mpModelId']);
+		expect(typeof id).toBe('bigint');
 	});
 });

--- a/src/lib/schema/resources/propGraphicsList.ts
+++ b/src/lib/schema/resources/propGraphicsList.ts
@@ -9,11 +9,12 @@
 // resource(s) the runtime spawns for it. Two parallel arrays: one PropGraphics
 // per whole prop (its body Model) and one PropPartGraphics per destructible
 // sub-piece (e.g. a billboard panel that breaks off), grouped contiguously by
-// owning prop. The Model references are BND2 imports — every mpPropModel is 0 on
-// disk; the real resource id is resolved at render time from the inline import
-// table by the field's byte offset (same pattern as InstanceList's mpModel).
-// That import table lives in `_tail`, so adding/removing props or parts (which
-// would shift the table's field offsets) is out of scope; field edits are fine.
+// owning prop. The Model references are BND2 imports — modelled here as the
+// editable `mpModelId` (the on-disk pointer is 0; the real id lives in the
+// resource's inline import table, which the writer rebuilds). Entries are
+// addable/removable: a prop instance whose type isn't catalogued needs a new
+// PropGraphics row mapping type → Model. The bundle envelope's import metadata
+// follows a count change via the handler's importTable() hook.
 
 import type {
 	FieldSchema,
@@ -22,33 +23,36 @@ import type {
 	SchemaContext,
 	SchemaRegistry,
 } from '../types';
+import { PROP_TYPES, propTypeLabel } from '@/lib/core/propTypes';
 
 // ---------------------------------------------------------------------------
-// Local helpers (mirroring instanceList.ts)
+// Local helpers (mirroring environmentTimeLine.ts)
 // ---------------------------------------------------------------------------
 
 const u32 = (): FieldSchema => ({ kind: 'u32' });
+const resourceId = (): FieldSchema => ({ kind: 'bigint', bytes: 8, hex: true });
 const record = (type: string): FieldSchema => ({ kind: 'record', type });
-// Raw byte buffer used for round-trip-only preservation fields. The default
-// form renderer hides custom fields without a registered component, which is
-// fine — users shouldn't edit these directly.
-const rawBytes = (): FieldSchema => ({ kind: 'custom', component: 'rawBytes' });
+
+// typeId enum sourced from the 247-entry prop-types table (same vocabulary as
+// PropInstanceData), so the dropdown shows human prop names.
+const PROP_TYPE_VALUES = PROP_TYPES.map((p) => ({ value: p.index, label: p.name }));
+const propTypeEnum = (): FieldSchema => ({ kind: 'enum', storage: 'u32', values: PROP_TYPE_VALUES });
 
 const recordList = (
 	type: string,
+	makeEmpty: (ctx: SchemaContext) => unknown,
 	itemLabel?: (item: unknown, index: number, ctx: SchemaContext) => string,
+	addable = true,
 ): FieldSchema => ({
 	kind: 'list',
 	item: record(type),
-	// Add/remove is out of scope: a prop/part count change shifts the inline
-	// import table's field offsets, breaking every Model reference. Keep the
-	// arrays fixed-length so the inspector only exposes field edits.
-	addable: false,
-	removable: false,
+	addable,
+	removable: addable,
+	makeEmpty,
 	itemLabel,
 });
 
-const hex = (n: number | undefined): string =>
+const hex = (n: number | bigint | undefined): string =>
 	n != null ? `0x${n.toString(16).toUpperCase()}` : '?';
 
 // ---------------------------------------------------------------------------
@@ -58,8 +62,9 @@ const hex = (n: number | undefined): string =>
 function propLabel(prop: unknown, index: number): string {
 	try {
 		if (!prop || typeof prop !== 'object') return `#${index}`;
-		const p = prop as { muTypeId?: number };
-		return `#${index} · type ${hex(p.muTypeId)}`;
+		const p = prop as { muTypeId?: number; mpModelId?: bigint };
+		const name = p.muTypeId != null ? propTypeLabel(p.muTypeId) : '?';
+		return `#${index} · ${name} · model ${hex(p.mpModelId)}`;
 	} catch {
 		return `#${index}`;
 	}
@@ -68,8 +73,9 @@ function propLabel(prop: unknown, index: number): string {
 function partLabel(part: unknown, index: number): string {
 	try {
 		if (!part || typeof part !== 'object') return `#${index}`;
-		const p = part as { muTypeId?: number; muPartId?: number };
-		return `#${index} · type ${hex(p.muTypeId)} · part ${p.muPartId ?? '?'}`;
+		const p = part as { muTypeId?: number; muPartId?: number; mpModelId?: bigint };
+		const name = p.muTypeId != null ? propTypeLabel(p.muTypeId) : '?';
+		return `#${index} · ${name} · part ${p.muPartId ?? '?'} · model ${hex(p.mpModelId)}`;
 	} catch {
 		return `#${index}`;
 	}
@@ -81,59 +87,60 @@ function partLabel(part: unknown, index: number): string {
 
 const PropGraphics: RecordSchema = {
 	name: 'PropGraphics',
-	description: 'One whole prop — its type id plus a (locally-zero) import pointer to the body Model the runtime spawns, and an internal pointer to the prop\'s first destructible part.',
+	description: 'One whole prop — its type plus the Model resource the runtime spawns for the body mesh. The Model is a BND2 import (the on-disk pointer is 0); edit it via the Model id.',
 	fields: {
-		muTypeId: u32(),
-		mpPropModel: u32(),
-		mpParts: u32(),
+		muTypeId: propTypeEnum(),
+		mpModelId: resourceId(),
+		// Internal pointer (mpParts) modelled as a part-array index; null = the
+		// prop has no destructible parts. Round-trip-only — hidden.
+		firstPartIndex: { kind: 'i32' },
 	},
 	fieldMetadata: {
 		muTypeId: {
 			label: 'Prop type',
-			description: 'Prop TYPE index (into the prop-types table). Identifies which prop placed in this track unit this Model catalogue entry is for.',
+			description: 'Which prop this Model catalogue entry is for — an index into the 247-entry prop-types table (same vocabulary as PropInstanceData).',
 		},
-		mpPropModel: {
-			label: 'Model pointer',
-			description: 'Import pointer to the body Model this prop spawns. Always 0 on disk — the real Model id is a BND2 import resolved at render time by the field offset, not stored in the payload. Preserved verbatim.',
-			readOnly: true,
+		mpModelId: {
+			label: 'Model',
+			description: 'Resource id of the Model (0x2A) the runtime spawns for this prop. Stored as a BND2 import (the on-disk pointer is 0 until load); the writer rebuilds the import table from this id, so it is freely editable. Prop Models usually live in GLOBALPROPS.BIN.',
 		},
-		mpParts: {
-			label: 'Parts pointer',
-			description: 'Internal resource-relative pointer to this prop\'s first PropPartGraphics (0 when the prop has no parts). Parts are grouped contiguously by owning prop; preserved verbatim.',
+		firstPartIndex: {
+			label: 'First part index',
+			description: 'Internal pointer to this prop\'s first destructible part (an index into the parts array; absent when the prop has none). Recomputed into a resource-relative offset on write; users shouldn\'t edit it.',
+			hidden: true,
 			readOnly: true,
 		},
 	},
 	propertyGroups: [
-		{ title: 'Identity', properties: ['muTypeId', 'mpPropModel', 'mpParts'] },
+		{ title: 'Identity', properties: ['muTypeId', 'mpModelId'] },
 	],
 	label: (value, index) => propLabel(value, index ?? 0),
 };
 
 const PropPartGraphics: RecordSchema = {
 	name: 'PropPartGraphics',
-	description: 'One destructible sub-piece of a prop (e.g. a billboard panel that breaks off) — the owning prop\'s type id, the part index within that prop, and a (locally-zero) import pointer to the part\'s Model.',
+	description: 'One destructible sub-piece of a prop (e.g. a billboard panel that breaks off) — the owning prop\'s type, the part index within that prop, and the Model the runtime spawns for it.',
 	fields: {
-		muTypeId: u32(),
+		muTypeId: propTypeEnum(),
 		muPartId: u32(),
-		mpPropModel: u32(),
+		mpModelId: resourceId(),
 	},
 	fieldMetadata: {
 		muTypeId: {
 			label: 'Prop type',
-			description: 'The owning prop\'s TYPE index. Parts are grouped contiguously by this value, matching the PropGraphics entry they belong to.',
+			description: 'The owning prop\'s type. Parts are grouped contiguously by this value, matching the PropGraphics entry they belong to.',
 		},
 		muPartId: {
 			label: 'Part ID',
-			description: 'Index of this part within its owning prop (0, 1, 2, …). Identifies which destructible sub-piece this Model entry drives.',
+			description: 'Index of this part within its owning prop (0, 1, 2, …).',
 		},
-		mpPropModel: {
-			label: 'Model pointer',
-			description: 'Import pointer to this part\'s Model. Always 0 on disk — the real Model id is a BND2 import resolved at render time by the field offset. Preserved verbatim.',
-			readOnly: true,
+		mpModelId: {
+			label: 'Model',
+			description: 'Resource id of the Model (0x2A) for this destructible part. Same import mechanism as a whole prop — the writer rebuilds the import table from this id.',
 		},
 	},
 	propertyGroups: [
-		{ title: 'Identity', properties: ['muTypeId', 'muPartId', 'mpPropModel'] },
+		{ title: 'Identity', properties: ['muTypeId', 'muPartId', 'mpModelId'] },
 	],
 	label: (value, index) => partLabel(value, index ?? 0),
 };
@@ -144,40 +151,34 @@ const PropPartGraphics: RecordSchema = {
 
 const ParsedPropGraphicsList: RecordSchema = {
 	name: 'ParsedPropGraphicsList',
-	description: 'Root record for the PropGraphicsList resource (0x10010). Maps every prop TYPE placed in one track unit to its Model(s): a props array (one body Model per prop) plus a parts array (one Model per destructible sub-piece).',
+	description: 'Root record for the PropGraphicsList resource (0x10010). Maps every prop TYPE placed in one track unit to its Model(s): a props array (one body Model per prop) plus a parts array (one Model per destructible sub-piece). Add a prop entry to catalogue a newly-placed prop type.',
 	fields: {
 		muZoneNumber: u32(),
-		muSizeInBytes: u32(),
-		props: recordList('PropGraphics', propLabel),
-		parts: recordList('PropPartGraphics', partLabel),
-		_tail: rawBytes(),
+		props: recordList('PropGraphics', () => ({ muTypeId: 0, mpModelId: 0n, firstPartIndex: null }), propLabel),
+		// Parts are field-editable but NOT addable/removable: a prop's link to its
+		// parts is the internal firstPartIndex pointer (hidden, not user-settable),
+		// so adding a part can't be wired to a prop, and removing/inserting one
+		// would shift the part indices that surviving props point at — silently
+		// re-owning the wrong parts. Edit a prop's parts by editing existing rows;
+		// structural part changes belong in the Blender exporter.
+		parts: recordList('PropPartGraphics', () => ({ muTypeId: 0, muPartId: 0, mpModelId: 0n }), partLabel, false),
 	},
 	fieldMetadata: {
 		muZoneNumber: {
 			label: 'Zone number',
 			description: 'PVS zone / track-unit id this prop catalogue belongs to (e.g. 9). Editable.',
 		},
-		muSizeInBytes: {
-			label: 'Size in bytes',
-			description: 'Internal stored size field. Does NOT consistently equal a derivable offset (it is the part-array end when parts exist, but align16(prop-array end) when there are none); preserved verbatim so the writer reproduces the header byte-for-byte.',
-			readOnly: true,
-		},
 		props: {
 			label: 'Props',
-			description: 'One entry per whole prop type in this track unit, mapping it to its body Model. Fixed-length: adding/removing entries would shift the inline import table\'s field offsets and break every Model reference.',
+			description: 'One entry per whole prop type in this track unit, mapping it to its body Model. Add an entry (type + Model id) to catalogue a prop type you have newly placed via PropInstanceData; the import table is rebuilt on export.',
 		},
 		parts: {
 			label: 'Parts',
-			description: 'One entry per destructible prop sub-piece, mapping it to its Model. Grouped contiguously by owning prop. Fixed-length for the same import-offset reason as props.',
-		},
-		_tail: {
-			label: 'Tail',
-			description: 'Bytes from the end of the last array to the end of the payload: an align16 pad followed by the inline BND2 import table (one entry per prop + per part). Re-emitted verbatim to reproduce the exact length and keep every Model import valid; users shouldn\'t edit this.',
-			hidden: true,
+			description: 'One entry per destructible prop sub-piece, mapping it to its Model. Grouped contiguously by owning prop. Fields are editable, but rows can\'t be added/removed here — a part\'s owning-prop link is an internal pointer the UI doesn\'t expose, so structural changes would mis-assign ownership.',
 		},
 	},
 	propertyGroups: [
-		{ title: 'Header', properties: ['muZoneNumber', 'muSizeInBytes'] },
+		{ title: 'Header', properties: ['muZoneNumber'] },
 		{ title: 'Props', properties: ['props'] },
 		{ title: 'Parts', properties: ['parts'] },
 	],

--- a/src/lib/schema/resources/propInstanceData.ts
+++ b/src/lib/schema/resources/propInstanceData.ts
@@ -25,6 +25,7 @@ import type {
 } from '../types';
 import { PROP_INSTANCE_FLAGS } from '@/lib/core/propInstanceData';
 import { PROP_ALT_TYPE_NONE, PROP_TYPES, propTypeLabel } from '@/lib/core/propTypes';
+import { propCellId } from '@/lib/core/propCellGrid';
 
 // ---------------------------------------------------------------------------
 // Local helpers (mirroring zoneList.ts)
@@ -93,7 +94,12 @@ function instanceLabel(inst: unknown, index: number): string {
 		const t = i.mWorldTransform;
 		const x = t && t[12] != null ? t[12].toFixed(0) : '?';
 		const z = t && t[14] != null ? t[14].toFixed(0) : '?';
-		return `#${index} · ${name} · id ${id} · (${x}, ${z})`;
+		// Cell id derived from the world position — lets the user see which cell a
+		// prop falls into (and spot when its owning PropCell.muX/muZ is wrong).
+		const cell = t && t[12] != null && t[14] != null
+			? (() => { const c = propCellId(t[12], t[14]); return ` · cell (${c.muX}, ${c.muZ})`; })()
+			: '';
+		return `#${index} · ${name} · id ${id} · (${x}, ${z})${cell}`;
 	} catch {
 		return `#${index}`;
 	}
@@ -181,7 +187,7 @@ const PropInstance: RecordSchema = {
 
 const PropCell: RecordSchema = {
 	name: 'PropCell',
-	description: 'A coarse XZ grid cell owning a contiguous run of instances. Cells partition the instance array; muStartIndex/muCount are derived from that partition and recomputed on write.',
+	description: 'A coarse XZ grid cell owning a contiguous run of instances. Cells partition the instance array; muStartIndex/muCount are editable so the partition can be set by hand (e.g. after adding instances) and are written verbatim.',
 	fields: {
 		muX: u16(),
 		muZ: u16(),
@@ -203,13 +209,11 @@ const PropCell: RecordSchema = {
 		},
 		muStartIndex: {
 			label: 'Start index',
-			description: 'First instance index this cell owns. Derived: the running sum of prior cells\' counts. Recomputed on write.',
-			readOnly: true,
+			description: 'First instance index this cell owns. Normally the running sum of prior cells\' counts, but editable: some tools require setting the partition by hand (e.g. after adding instances). Written verbatim.',
 		},
 		muCount: {
 			label: 'Count',
-			description: 'Number of instances in this cell. Derived from the partition; recomputed on write.',
-			readOnly: true,
+			description: 'Number of instances in this cell (the cell owns [Start index, Start index + Count)). Editable so added instances can be assigned to a cell. Written verbatim.',
 		},
 	},
 	propertyGroups: [
@@ -255,7 +259,7 @@ const ParsedPropInstanceData: RecordSchema = {
 		},
 		cells: {
 			label: 'Cells',
-			description: 'The coarse XZ grid partition over the instance array. Each cell owns a contiguous run; muStartIndex/muCount are recomputed from the partition on write.',
+			description: 'The coarse XZ grid partition over the instance array. Each cell owns a contiguous run [Start index, Start index + Count); both fields are editable and written verbatim so the partition can be repaired after adding instances.',
 		},
 		_trailingPad: {
 			label: 'Trailing pad',


### PR DESCRIPTION
Implements four community-requested prop-editor changes for editing prop placement outside the Blender exporter.

## Changes

**1. Prop Graphics List (`0x10010`) is now writable, incl. adding prop entries.**
The inline import table is no longer carried as an opaque `_tail` — it's **modelled** per record (`mpModelId: bigint`) plus a part-array index (`firstPartIndex`) and **rebuilt** on write, with `muSizeInBytes` and all offsets derived. Props are addable/removable, so a prop type newly placed via PropInstanceData can be catalogued to its Model. An `importTable()` handler hook keeps the bundle envelope's `importOffset`/`importCount` correct on export (same mechanism as EnvironmentTimeLine / Font). Parts stay field-editable only — a part's owning-prop link is an internal pointer the UI doesn't expose, so add/remove would mis-assign ownership.

**2. PropInstanceData (`0x10011`) cell `Start index` / `Count` are manually editable.**
Written verbatim instead of recomputed, so newly-added instances can be assigned to a cell.

**3. Every instance shows its cell.**
New pure `propCellGrid` helper (`cellId = floor((pos + 5000) / 100)`); the cell appears in the instance tree label and the 3D selection label.

**4. Cell Grid overlay.**
Toggleable 100 m grid (modelled on the traffic PVS grid): tinted populated cells with `(x, z)` id labels, highlights for the selected instance's cell and the selected cell, click-to-select. Mounted per-bundle in `WorldViewportComposition`.

## Verification
- **Byte-exact round-trip across all 428 `TRK_UNIT*_GR.BNDL` fixtures** (256 populated + 172 empty) with the rewritten PGL parser/writer.
- Full suite green (the only failures are pre-existing `ENOENT` on an untracked AI fixture, unrelated); adds prop add→export end-to-end, cell-grid, and partition coverage.
- `tsc` clean on all touched files.
- An adversarial multi-agent review of the diff was run; its confirmed findings are fixed in this branch (parts locked to field-edits, a tautological test assertion replaced, overlay GPU geometries disposed, stale spec narrative purged).

Spec doc (`docs/prop-graphics-list-spec.md`) updated to reflect the modelled/rebuilt import table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
