### PR TITLE
feat(props): cell-grid show-all + click-coords, and a move/rotate gizmo with marquee

### DIFF
--- a/src/components/schema-editor/viewports/PropCellGridOverlay.tsx
+++ b/src/components/schema-editor/viewports/PropCellGridOverlay.tsx
@@ -6,20 +6,24 @@
 // prop analogue of TrafficData's PVS grid (PvsGridOverlay) — so the user can
 // read a prop's cell id off the map and confirm a PropCell's muX/muZ is right.
 //
-// What it draws (over the bounding region of this zone's populated cells):
-//   - thin border lines for every cell in the region,
-//   - a tinted fill + an id label on each POPULATED cell (one that owns props),
-//   - a bright outline on the selected instance's containing cell and on the
-//     selected cell.
-// Clicking a populated cell selects it (['cells', i]); a checkbox in the chrome
-// HTML slot toggles the whole grid (on by default), mirroring the PVS grid.
+// Two modes (chrome HTML-slot checkboxes, only while propInstanceData is the
+// active selection so sibling overlays don't fight for the slot):
+//   - default: the grid spans the bounding region of this zone's populated cells.
+//   - "show all cells": the full 100×100 world grid, so the user can read off
+//     the cell id anywhere — even where no props are placed yet.
+// What it draws: thin cell borders over the active region, a tinted fill + id
+// label on each POPULATED cell, a bright outline on the selected instance's
+// containing cell and on the selected cell. A transparent picking plane over the
+// region turns a click into a cell id — the clicked cell is pinned with its
+// (x, z) label (and selected if it's a populated PropCell), so the user never
+// has to hand-calculate a coordinate.
 
 import { useCallback, useMemo, useState } from 'react';
 import { Html } from '@react-three/drei';
 import { type ThreeEvent } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { ParsedPropInstanceData, PropCell } from '@/lib/core/propInstanceData';
-import { PROP_CELL_SIZE, propCellId, propCellRect } from '@/lib/core/propCellGrid';
+import { PROP_CELL_SIZE, PROP_GRID_AXIS_CELLS, propCellId, propCellRect } from '@/lib/core/propCellGrid';
 import { useDisposeOnDepsChange } from '@/hooks/useDisposeOnDepsChange';
 import type { NodePath } from '@/lib/schema/walk';
 import type { WorldOverlayComponent } from './WorldViewport.types';
@@ -43,6 +47,14 @@ const selectedCellMat = new THREE.LineBasicMaterial({
 const instanceCellMat = new THREE.LineBasicMaterial({
 	color: '#' + SELECTION_THEME.primary.getHexString(), transparent: true, opacity: 0.9, depthTest: false,
 });
+const pinnedCellMat = new THREE.LineBasicMaterial({
+	color: 0x66ffff, transparent: true, opacity: 0.95, depthTest: false,
+});
+// Invisible-but-pickable plane catching clicks over the whole grid region — the
+// same trick TrafficData's PickingPlane uses. opacity 0 keeps it from drawing.
+const pickPlaneMat = new THREE.MeshBasicMaterial({ transparent: true, opacity: 0, depthWrite: false, side: THREE.DoubleSide });
+
+export type CellBounds = { minX: number; maxX: number; minZ: number; maxZ: number };
 
 // ---------------------------------------------------------------------------
 // Pure helpers (exported for tests)
@@ -60,7 +72,7 @@ export function gridPlaneY(data: ParsedPropInstanceData): number {
 
 /** Inclusive (minX, maxX, minZ, maxZ) cell-index bounds of the populated cells,
  *  padded by one cell for context. Null when there are no cells. */
-export function cellRegionBounds(cells: PropCell[]): { minX: number; maxX: number; minZ: number; maxZ: number } | null {
+export function cellRegionBounds(cells: PropCell[]): CellBounds | null {
 	if (cells.length === 0) return null;
 	let minX = Infinity, maxX = -Infinity, minZ = Infinity, maxZ = -Infinity;
 	for (const c of cells) {
@@ -70,6 +82,21 @@ export function cellRegionBounds(cells: PropCell[]): { minX: number; maxX: numbe
 		if (c.muZ > maxZ) maxZ = c.muZ;
 	}
 	return { minX: minX - 1, maxX: maxX + 1, minZ: minZ - 1, maxZ: maxZ + 1 };
+}
+
+/** The full world grid: every cell of the canonical ±5000 / 100 m grid. Used by
+ *  the "show all cells" mode so the user can read off a coordinate anywhere. */
+export function fullGridBounds(): CellBounds {
+	return { minX: 0, maxX: PROP_GRID_AXIS_CELLS - 1, minZ: 0, maxZ: PROP_GRID_AXIS_CELLS - 1 };
+}
+
+/** World-space XZ rectangle (+ centre/size) a cell-index region covers. */
+export function regionWorldRect(b: CellBounds): { x0: number; z0: number; x1: number; z1: number; cx: number; cz: number; width: number; depth: number } {
+	const x0 = b.minX * PROP_CELL_SIZE - 5000;
+	const z0 = b.minZ * PROP_CELL_SIZE - 5000;
+	const x1 = (b.maxX + 1) * PROP_CELL_SIZE - 5000;
+	const z1 = (b.maxZ + 1) * PROP_CELL_SIZE - 5000;
+	return { x0, z0, x1, z1, cx: (x0 + x1) / 2, cz: (z0 + z1) / 2, width: x1 - x0, depth: z1 - z0 };
 }
 
 /** A unit-cell rectangle outline as 4 line segments (8 vertices) at height y. */
@@ -87,12 +114,10 @@ function cellOutlinePositions(muX: number, muZ: number, y: number): Float32Array
 // Geometry builders
 // ---------------------------------------------------------------------------
 
-function buildBorderGeometry(bounds: { minX: number; maxX: number; minZ: number; maxZ: number }, y: number): THREE.BufferGeometry {
-	const { minX, maxX, minZ, maxZ } = bounds;
-	const x0 = minX * PROP_CELL_SIZE - 5000;
-	const z0 = minZ * PROP_CELL_SIZE - 5000;
-	const nx = maxX - minX + 1;
-	const nz = maxZ - minZ + 1;
+function buildBorderGeometry(bounds: CellBounds, y: number): THREE.BufferGeometry {
+	const { x0, z0 } = regionWorldRect(bounds);
+	const nx = bounds.maxX - bounds.minX + 1;
+	const nz = bounds.maxZ - bounds.minZ + 1;
 	const segs: number[] = [];
 	for (let i = 0; i <= nx; i++) {
 		const x = x0 + i * PROP_CELL_SIZE;
@@ -133,14 +158,25 @@ export const PropCellGridOverlay: WorldOverlayComponent<ParsedPropInstanceData> 
 }) => {
 	const cells = data?.cells ?? [];
 	const [show, setShow] = useState(true);
+	const [showAll, setShowAll] = useState(false);
+	// The last cell the user clicked — pinned with its (x, z) so they don't have
+	// to hand-calculate the coordinate. Independent of the inspector selection.
+	const [pinned, setPinned] = useState<{ muX: number; muZ: number } | null>(null);
 
 	const y = useMemo(() => gridPlaneY(data), [data]);
-	const bounds = useMemo(() => cellRegionBounds(cells), [cells]);
-	const borderGeo = useMemo(() => (bounds ? buildBorderGeometry(bounds, y + BORDER_DY) : null), [bounds, y]);
+	const populatedBounds = useMemo(() => cellRegionBounds(cells), [cells]);
+	// "Show all" expands the grid to the whole world; otherwise it hugs the
+	// populated cells. Null only when neither mode has anything to draw.
+	const region = useMemo(
+		() => (showAll ? fullGridBounds() : populatedBounds),
+		[showAll, populatedBounds],
+	);
+
+	const borderGeo = useMemo(() => (region ? buildBorderGeometry(region, y + BORDER_DY) : null), [region, y]);
 	const fillGeo = useMemo(() => (cells.length ? buildFillGeometry(cells, y + FILL_DY) : null), [cells, y]);
 	// These geometries are passed to R3F by reference (not declarative children),
 	// so R3F won't auto-dispose them — free the old GPU buffers when the memo
-	// re-runs. The two outline geometries below churn on every selection change.
+	// re-runs. The outline geometries below churn on every selection/click.
 	useDisposeOnDepsChange(() => borderGeo?.dispose(), [borderGeo]);
 	useDisposeOnDepsChange(() => fillGeo?.dispose(), [fillGeo]);
 
@@ -167,44 +203,78 @@ export const PropCellGridOverlay: WorldOverlayComponent<ParsedPropInstanceData> 
 	}, [data, selectedPath, y]);
 	useDisposeOnDepsChange(() => instanceCellOutline?.dispose(), [instanceCellOutline]);
 
-	// Click a populated cell → select it. Convert the world hit point to a cell
-	// id, then find the matching cell (cells are keyed by their (muX, muZ)).
-	const onClick = useCallback((e: ThreeEvent<MouseEvent>) => {
+	const pinnedOutline = useMemo(() => {
+		if (!pinned) return null;
+		const geo = new THREE.BufferGeometry();
+		geo.setAttribute('position', new THREE.BufferAttribute(cellOutlinePositions(pinned.muX, pinned.muZ, y + OUTLINE_DY + 0.2), 3));
+		return geo;
+	}, [pinned, y]);
+	useDisposeOnDepsChange(() => pinnedOutline?.dispose(), [pinnedOutline]);
+
+	// Click anywhere on the grid → pin that cell's (x, z). If it's a populated
+	// PropCell, also select it so the inspector tracks. Convert the world hit
+	// point to a cell id via the shared formula.
+	const onPick = useCallback((e: ThreeEvent<MouseEvent>) => {
 		e.stopPropagation();
 		if (isDragRelease(e.nativeEvent.clientX, e.nativeEvent.clientY)) return;
 		const { muX, muZ } = propCellId(e.point.x, e.point.z);
+		setPinned({ muX, muZ });
 		const idx = cells.findIndex((c) => c.muX === muX && c.muZ === muZ);
 		if (idx >= 0) onSelect(['cells', idx] as NodePath);
 	}, [cells, onSelect]);
 
-	// Toggle checkbox in the chrome HTML slot — only while this overlay owns the
+	// Two checkboxes in the chrome HTML slot — only while this overlay owns the
 	// active selection, so sibling overlays don't stack toggles (issue #24).
 	const htmlNode = useMemo(
-		() =>
-			bounds ? (
-				<label
-					style={{
-						position: 'absolute', top: 8, right: 8,
-						background: 'rgba(0,0,0,0.7)', color: '#cdd', padding: '4px 8px',
-						borderRadius: 4, fontSize: 11, fontFamily: 'monospace',
-						display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer',
-						userSelect: 'none', pointerEvents: 'auto',
-					}}
-				>
+		() => (
+			<div
+				style={{
+					position: 'absolute', top: 8, right: 8,
+					background: 'rgba(0,0,0,0.7)', color: '#cdd', padding: '6px 8px',
+					borderRadius: 4, fontSize: 11, fontFamily: 'monospace',
+					display: 'flex', flexDirection: 'column', gap: 4,
+					userSelect: 'none', pointerEvents: 'auto',
+				}}
+			>
+				<label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
 					<input type="checkbox" checked={show} onChange={(ev) => setShow(ev.target.checked)} style={{ margin: 0 }} />
 					Prop cell grid ({cells.length} cell{cells.length === 1 ? '' : 's'})
 				</label>
-			) : null,
-		[bounds, show, cells.length],
+				<label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: show ? 'pointer' : 'default', opacity: show ? 1 : 0.5 }}>
+					<input type="checkbox" checked={showAll} disabled={!show} onChange={(ev) => setShowAll(ev.target.checked)} style={{ margin: 0 }} />
+					Show all cells
+				</label>
+				{pinned && (
+					<div style={{ color: '#9ff', borderTop: '1px solid rgba(255,255,255,0.15)', paddingTop: 4 }}>
+						cell ({pinned.muX}, {pinned.muZ})
+					</div>
+				)}
+			</div>
+		),
+		[show, showAll, cells.length, pinned],
 	);
 	useWorldViewportHtmlSlot(isActive ? htmlNode : null);
 
-	if (!bounds || !show) return null;
+	if (!show || !region) return null;
+
+	const rect = regionWorldRect(region);
 
 	return (
 		<>
+			{/* Transparent picking plane over the whole region — turns any click
+			    into a cell id (works on empty cells too, the whole point of
+			    "show all"). Drawn first/below so the visible grid sits on top. */}
+			<mesh
+				position={[rect.cx, y, rect.cz]}
+				rotation={[-Math.PI / 2, 0, 0]}
+				material={pickPlaneMat}
+				onClick={onPick}
+				renderOrder={0}
+			>
+				<planeGeometry args={[rect.width, rect.depth]} />
+			</mesh>
 			{fillGeo && (
-				<mesh geometry={fillGeo} material={gridFillMat} renderOrder={1} onClick={onClick} />
+				<mesh geometry={fillGeo} material={gridFillMat} renderOrder={1} raycast={() => undefined as unknown as void} />
 			)}
 			{borderGeo && (
 				<lineSegments geometry={borderGeo} material={gridBorderMat} renderOrder={2} raycast={() => undefined as unknown as void} />
@@ -215,8 +285,25 @@ export const PropCellGridOverlay: WorldOverlayComponent<ParsedPropInstanceData> 
 			{selectedCellOutline && (
 				<lineSegments geometry={selectedCellOutline} material={selectedCellMat} renderOrder={7} />
 			)}
+			{pinnedOutline && (
+				<lineSegments geometry={pinnedOutline} material={pinnedCellMat} renderOrder={8} />
+			)}
+			{/* The clicked cell's coordinate, pinned in the world at that cell. */}
+			{pinned && (() => {
+				const r = propCellRect(pinned.muX, pinned.muZ);
+				return (
+					<Html position={[(r.x0 + r.x1) / 2, y + OUTLINE_DY + 0.3, (r.z0 + r.z1) / 2]} center style={{ pointerEvents: 'none' }}>
+						<div style={{
+							background: 'rgba(0,40,40,0.85)', color: '#9ff', padding: '2px 6px',
+							borderRadius: 3, fontSize: 11, whiteSpace: 'nowrap', fontFamily: 'monospace', fontWeight: 'bold',
+						}}>
+							{pinned.muX}, {pinned.muZ}
+						</div>
+					</Html>
+				);
+			})()}
 			{/* Cell-id labels on populated cells. Prop zones are spatially local, so
-			    the count stays small (a handful per track unit). */}
+			    the count stays small (a handful per track unit) even in show-all. */}
 			{cells.map((c, i) => {
 				const r = propCellRect(c.muX, c.muZ);
 				return (

--- a/src/components/schema-editor/viewports/PropCellGridOverlay.tsx
+++ b/src/components/schema-editor/viewports/PropCellGridOverlay.tsx
@@ -54,6 +54,12 @@ const pinnedCellMat = new THREE.LineBasicMaterial({
 // same trick TrafficData's PickingPlane uses. opacity 0 keeps it from drawing.
 const pickPlaneMat = new THREE.MeshBasicMaterial({ transparent: true, opacity: 0, depthWrite: false, side: THREE.DoubleSide });
 
+// A click within this XZ radius (m²) of a placed prop is treated as "meant for
+// the prop", so the picking plane lets it fall through to prop selection instead
+// of pinning a cell — TrafficData's PickingPlane has the same open-space guard
+// (findNearestRung). Coordinate-pinning is for empty ground / empty cells.
+const PROP_PICK_SNAP_SQ = 5 * 5;
+
 export type CellBounds = { minX: number; maxX: number; minZ: number; maxZ: number };
 
 // ---------------------------------------------------------------------------
@@ -215,13 +221,22 @@ export const PropCellGridOverlay: WorldOverlayComponent<ParsedPropInstanceData> 
 	// PropCell, also select it so the inspector tracks. Convert the world hit
 	// point to a cell id via the shared formula.
 	const onPick = useCallback((e: ThreeEvent<MouseEvent>) => {
-		e.stopPropagation();
 		if (isDragRelease(e.nativeEvent.clientX, e.nativeEvent.clientY)) return;
-		const { muX, muZ } = propCellId(e.point.x, e.point.z);
+		const px = e.point.x, pz = e.point.z;
+		// Don't swallow clicks meant for a placed prop: if the hit is within a
+		// prop's footprint, fall through (NO stopPropagation) so the prop overlay's
+		// own onClick selects the instance. Pinning is for open ground / empty cells.
+		for (const inst of data.instances) {
+			const dx = (inst.mWorldTransform[12] ?? 0) - px;
+			const dz = (inst.mWorldTransform[14] ?? 0) - pz;
+			if (dx * dx + dz * dz <= PROP_PICK_SNAP_SQ) return;
+		}
+		e.stopPropagation();
+		const { muX, muZ } = propCellId(px, pz);
 		setPinned({ muX, muZ });
 		const idx = cells.findIndex((c) => c.muX === muX && c.muZ === muZ);
 		if (idx >= 0) onSelect(['cells', idx] as NodePath);
-	}, [cells, onSelect]);
+	}, [cells, data.instances, onSelect]);
 
 	// Two checkboxes in the chrome HTML slot — only while this overlay owns the
 	// active selection, so sibling overlays don't stack toggles (issue #24).
@@ -263,16 +278,20 @@ export const PropCellGridOverlay: WorldOverlayComponent<ParsedPropInstanceData> 
 		<>
 			{/* Transparent picking plane over the whole region — turns any click
 			    into a cell id (works on empty cells too, the whole point of
-			    "show all"). Drawn first/below so the visible grid sits on top. */}
-			<mesh
-				position={[rect.cx, y, rect.cz]}
-				rotation={[-Math.PI / 2, 0, 0]}
-				material={pickPlaneMat}
-				onClick={onPick}
-				renderOrder={0}
-			>
-				<planeGeometry args={[rect.width, rect.depth]} />
-			</mesh>
+			    "show all"). Only the ACTIVE bundle's plane is interactive, so
+			    background bundles' grids never hijack a click; the near-prop guard
+			    in onPick keeps real props selectable. Drawn below the visible grid. */}
+			{isActive && (
+				<mesh
+					position={[rect.cx, y, rect.cz]}
+					rotation={[-Math.PI / 2, 0, 0]}
+					material={pickPlaneMat}
+					onClick={onPick}
+					renderOrder={0}
+				>
+					<planeGeometry args={[rect.width, rect.depth]} />
+				</mesh>
+			)}
 			{fillGeo && (
 				<mesh geometry={fillGeo} material={gridFillMat} renderOrder={1} raycast={() => undefined as unknown as void} />
 			)}

--- a/src/components/schema-editor/viewports/PropTransformOverlay.tsx
+++ b/src/components/schema-editor/viewports/PropTransformOverlay.tsx
@@ -31,6 +31,7 @@ import { BulkTransformGizmo } from '@/components/common/three/BulkTransformGizmo
 import { CameraBridge, type CameraBridgeData } from '@/components/common/three/CameraBridge';
 import { MarqueeSelector } from '@/components/common/three/MarqueeSelector';
 import { type BulkTransformDelta, isIdentityDelta } from '@/hooks/useBulkTransformDrag';
+import { useDisposeOnDepsChange } from '@/hooks/useDisposeOnDepsChange';
 import type { NodePath } from '@/lib/schema/walk';
 import type { WorldOverlayComponent } from './WorldViewport.types';
 import { useWorldViewportHtmlSlot } from './WorldViewport';
@@ -112,10 +113,10 @@ export const PropTransformOverlay: WorldOverlayComponent<ParsedPropInstanceData>
 	const livePivot = useMemo(() => propInstancesPivot(data, targets), [data, targets]);
 
 	const outlineGeo = useMemo(() => buildTargetOutline(data, targets), [data, targets]);
-	// Built imperatively + handed to R3F by reference, so dispose on change.
-	const prevOutline = useRef<THREE.BufferGeometry | null>(null);
-	if (prevOutline.current && prevOutline.current !== outlineGeo) prevOutline.current.dispose();
-	prevOutline.current = outlineGeo;
+	// Built imperatively + handed to R3F by reference, so R3F won't auto-dispose
+	// it — free the prior geometry on change AND on unmount (the hook's effect
+	// cleanup covers both), matching PropCellGridOverlay / PropGeometry.
+	useDisposeOnDepsChange(() => outlineGeo?.dispose(), [outlineGeo]);
 
 	const handleMarquee = useCallback((frustum: THREE.Frustum, mode: 'add' | 'remove') => {
 		const pt = new THREE.Vector3();

--- a/src/components/schema-editor/viewports/PropTransformOverlay.tsx
+++ b/src/components/schema-editor/viewports/PropTransformOverlay.tsx
@@ -1,0 +1,212 @@
+// PropTransformOverlay — move/rotate gizmo + marquee multi-select for prop
+// instances, the prop analogue of TrafficData's static-vehicle gizmo.
+//
+// A prop's pose is a full Matrix44Affine (mWorldTransform), so the gizmo offers
+// all three translate arrows AND all three rotate rings (TRANSFORM_AXES_FULL_3D).
+// The gizmo anchors at the median pivot of the transform set, which is the union
+// of:
+//   - the inspector-selected instance (selectedPath ['instances', i]), and
+//   - any instances box-selected with the marquee (press B, drag; alt = remove).
+//
+// The marquee set is VIEWPORT-LOCAL state (a Set of instance indices) — it isn't
+// wired into the WorkspaceHierarchy tree / bulk panel the way TrafficData's is.
+// That keeps this self-contained; the in-viewport interaction (box-select, then
+// drag the gizmo to move/rotate the whole set) is identical. The selected set is
+// outlined so the user can see what will move.
+//
+// Edits flow through propInstanceDataOps (translate then rotate, rotate-around-
+// pivot premultiply) and out via onChange. One gesture = one onChange = one undo
+// entry (commit on pointer release; the live drag only moves the gizmo).
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import type { ParsedPropInstanceData } from '@/lib/core/propInstanceData';
+import {
+	propInstancesPivot,
+	translatePropInstances,
+	rotatePropInstances,
+} from '@/lib/core/propInstanceDataOps';
+import { TRANSFORM_AXES_FULL_3D } from '@/lib/core/transformAxes';
+import { BulkTransformGizmo } from '@/components/common/three/BulkTransformGizmo';
+import { CameraBridge, type CameraBridgeData } from '@/components/common/three/CameraBridge';
+import { MarqueeSelector } from '@/components/common/three/MarqueeSelector';
+import { type BulkTransformDelta, isIdentityDelta } from '@/hooks/useBulkTransformDrag';
+import type { NodePath } from '@/lib/schema/walk';
+import type { WorldOverlayComponent } from './WorldViewport.types';
+import { useWorldViewportHtmlSlot } from './WorldViewport';
+import { SELECTION_THEME } from './selection';
+
+// Half-extent of the per-target selection outline box (world metres). Roughly
+// the prop marker footprint so the outline reads as "this prop is in the set".
+const OUTLINE_HALF = 2.5;
+
+const targetOutlineMat = new THREE.LineBasicMaterial({
+	color: '#' + SELECTION_THEME.primary.getHexString(),
+	transparent: true, opacity: 0.85, depthTest: false,
+});
+
+// 12 edges of a unit cube (±1) as 24 endpoints — translated/scaled per target.
+const CUBE_EDGES: ReadonlyArray<readonly [number, number, number]> = [
+	[-1, -1, -1], [1, -1, -1], [1, -1, -1], [1, -1, 1], [1, -1, 1], [-1, -1, 1], [-1, -1, 1], [-1, -1, -1],
+	[-1, 1, -1], [1, 1, -1], [1, 1, -1], [1, 1, 1], [1, 1, 1], [-1, 1, 1], [-1, 1, 1], [-1, 1, -1],
+	[-1, -1, -1], [-1, 1, -1], [1, -1, -1], [1, 1, -1], [1, -1, 1], [1, 1, 1], [-1, -1, 1], [-1, 1, 1],
+];
+
+/** Box-edge outlines around every instance in `indices`. Null when empty. */
+export function buildTargetOutline(data: ParsedPropInstanceData, indices: readonly number[]): THREE.BufferGeometry | null {
+	if (indices.length === 0) return null;
+	const pos = new Float32Array(indices.length * CUBE_EDGES.length * 3);
+	let p = 0;
+	for (const i of indices) {
+		const inst = data.instances[i];
+		if (!inst) continue;
+		const cx = inst.mWorldTransform[12] ?? 0;
+		const cy = inst.mWorldTransform[13] ?? 0;
+		const cz = inst.mWorldTransform[14] ?? 0;
+		for (const e of CUBE_EDGES) {
+			pos[p++] = cx + e[0] * OUTLINE_HALF;
+			pos[p++] = cy + e[1] * OUTLINE_HALF;
+			pos[p++] = cz + e[2] * OUTLINE_HALF;
+		}
+	}
+	const geo = new THREE.BufferGeometry();
+	geo.setAttribute('position', new THREE.BufferAttribute(pos.subarray(0, p), 3));
+	return geo;
+}
+
+/** The instance index a NodePath selects, or -1. Exported for tests. */
+export function selectedInstanceIndex(path: NodePath, count: number): number {
+	if (path[0] !== 'instances' || typeof path[1] !== 'number') return -1;
+	return path[1] >= 0 && path[1] < count ? path[1] : -1;
+}
+
+type Props = {
+	data: ParsedPropInstanceData;
+	selectedPath: NodePath;
+	onSelect: (path: NodePath) => void;
+	onChange?: (next: ParsedPropInstanceData) => void;
+	isActive?: boolean;
+};
+
+export const PropTransformOverlay: WorldOverlayComponent<ParsedPropInstanceData> = ({
+	data, selectedPath, onChange, isActive = true,
+}: Props) => {
+	const instances = data?.instances ?? [];
+	const count = instances.length;
+	const [marquee, setMarquee] = useState<ReadonlySet<number>>(() => new Set());
+	const [dragDelta, setDragDelta] = useState<BulkTransformDelta | null>(null);
+	const cameraBridge = useRef<CameraBridgeData | null>(null);
+	// Snapshot the pivot at gesture start so a rotate doesn't drift as the
+	// translate part of the same gesture moves the median (mirrors TrafficData).
+	const pivotRef = useRef<{ x: number; y: number; z: number } | null>(null);
+
+	// Transform set = inspector selection ∪ marqueed indices, clamped to range.
+	const targets = useMemo(() => {
+		const set = new Set<number>();
+		for (const i of marquee) if (i >= 0 && i < count) set.add(i);
+		const sel = selectedInstanceIndex(selectedPath, count);
+		if (sel >= 0) set.add(sel);
+		return [...set].sort((a, b) => a - b);
+	}, [marquee, selectedPath, count]);
+
+	const livePivot = useMemo(() => propInstancesPivot(data, targets), [data, targets]);
+
+	const outlineGeo = useMemo(() => buildTargetOutline(data, targets), [data, targets]);
+	// Built imperatively + handed to R3F by reference, so dispose on change.
+	const prevOutline = useRef<THREE.BufferGeometry | null>(null);
+	if (prevOutline.current && prevOutline.current !== outlineGeo) prevOutline.current.dispose();
+	prevOutline.current = outlineGeo;
+
+	const handleMarquee = useCallback((frustum: THREE.Frustum, mode: 'add' | 'remove') => {
+		const pt = new THREE.Vector3();
+		const hits: number[] = [];
+		for (let i = 0; i < count; i++) {
+			const t = instances[i].mWorldTransform;
+			pt.set(t[12] ?? 0, t[13] ?? 0, t[14] ?? 0);
+			if (frustum.containsPoint(pt)) hits.push(i);
+		}
+		if (hits.length === 0) return;
+		setMarquee((prev) => {
+			const next = new Set(prev);
+			for (const i of hits) { if (mode === 'remove') next.delete(i); else next.add(i); }
+			return next;
+		});
+	}, [instances, count]);
+
+	const gizmoPosition = useMemo<[number, number, number] | null>(() => {
+		const pivot = pivotRef.current ?? livePivot;
+		if (!pivot) return null;
+		return [
+			pivot.x + (dragDelta?.translate.x ?? 0),
+			pivot.y + (dragDelta?.translate.y ?? 0),
+			pivot.z + (dragDelta?.translate.z ?? 0),
+		];
+	}, [livePivot, dragDelta]);
+
+	const handleTransform = useCallback((delta: BulkTransformDelta) => {
+		if (!pivotRef.current && livePivot) pivotRef.current = livePivot;
+		setDragDelta(delta);
+	}, [livePivot]);
+
+	const handleCommit = useCallback((delta: BulkTransformDelta) => {
+		setDragDelta(null);
+		const pivot = pivotRef.current;
+		pivotRef.current = null;
+		if (!onChange || targets.length === 0 || isIdentityDelta(delta)) return;
+		let next = data;
+		if (delta.translate.x !== 0 || delta.translate.y !== 0 || delta.translate.z !== 0) {
+			next = translatePropInstances(next, targets, delta.translate);
+		}
+		const hasRotate = delta.rotate.x !== 0 || delta.rotate.y !== 0 || delta.rotate.z !== 0;
+		if (hasRotate && pivot) {
+			// Rotate applies after translate, so the pivot rides the translate delta.
+			const rotatedPivot = {
+				x: pivot.x + delta.translate.x,
+				y: pivot.y + delta.translate.y,
+				z: pivot.z + delta.translate.z,
+			};
+			next = rotatePropInstances(next, targets, rotatedPivot, delta.rotate);
+		}
+		if (next !== data) onChange(next);
+	}, [data, onChange, targets]);
+
+	const handleCancel = useCallback(() => {
+		setDragDelta(null);
+		pivotRef.current = null;
+	}, []);
+
+	// Marquee DOM rides the chrome HTML slot, only while this PID is the active
+	// selection so it doesn't fight sibling overlays for the slot (issue #24).
+	const htmlNode = useMemo(
+		() => (
+			<MarqueeSelector
+				bridge={cameraBridge}
+				far={50000}
+				onMarquee={handleMarquee}
+				hintIdle="press B to box-select props"
+			/>
+		),
+		[handleMarquee],
+	);
+	useWorldViewportHtmlSlot(isActive ? htmlNode : null);
+
+	if (!isActive) return null;
+
+	return (
+		<>
+			{outlineGeo && (
+				<lineSegments geometry={outlineGeo} material={targetOutlineMat} renderOrder={9} raycast={() => undefined as unknown as void} />
+			)}
+			{onChange && gizmoPosition && (
+				<BulkTransformGizmo
+					position={gizmoPosition}
+					axes={TRANSFORM_AXES_FULL_3D}
+					onTransform={handleTransform}
+					onCommit={handleCommit}
+					onCancel={handleCancel}
+				/>
+			)}
+			<CameraBridge bridge={cameraBridge} />
+		</>
+	);
+};

--- a/src/components/schema-editor/viewports/__tests__/PropCellGridOverlay.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/PropCellGridOverlay.test.ts
@@ -3,7 +3,8 @@
 // rendering itself is exercised in the browser; these pin the math.
 
 import { describe, it, expect } from 'vitest';
-import { gridPlaneY, cellRegionBounds } from '../PropCellGridOverlay';
+import { gridPlaneY, cellRegionBounds, fullGridBounds, regionWorldRect } from '../PropCellGridOverlay';
+import { PROP_GRID_AXIS_CELLS, propCellId } from '@/lib/core/propCellGrid';
 import type { ParsedPropInstanceData, PropCell, PropInstance } from '@/lib/core/propInstanceData';
 
 function inst(y: number): PropInstance {
@@ -41,5 +42,32 @@ describe('cellRegionBounds', () => {
 	});
 	it('is null when there are no cells', () => {
 		expect(cellRegionBounds([])).toBeNull();
+	});
+});
+
+describe('fullGridBounds (show-all mode)', () => {
+	it('spans the whole canonical grid', () => {
+		expect(fullGridBounds()).toEqual({ minX: 0, maxX: PROP_GRID_AXIS_CELLS - 1, minZ: 0, maxZ: PROP_GRID_AXIS_CELLS - 1 });
+	});
+});
+
+describe('regionWorldRect', () => {
+	it('maps a single-cell region to that cell\'s world rect', () => {
+		const r = regionWorldRect({ minX: 36, maxX: 36, minZ: 30, maxZ: 30 });
+		// cell 36 → x in [-1400, -1300); cell 30 → z in [-2000, -1900).
+		expect(r).toMatchObject({ x0: -1400, x1: -1300, z0: -2000, z1: -1900, cx: -1350, cz: -1950, width: 100, depth: 100 });
+	});
+
+	it('covers the full world in show-all', () => {
+		const r = regionWorldRect(fullGridBounds());
+		expect(r).toMatchObject({ x0: -5000, z0: -5000, x1: 5000, z1: 5000, width: 10000, depth: 10000 });
+	});
+
+	it('a click anywhere in the region resolves to a cell inside it (picking-plane contract)', () => {
+		const r = regionWorldRect(fullGridBounds());
+		// The picking plane spans [x0,x1]×[z0,z1]; a hit at world (cx,cz) → centre cell.
+		const { muX, muZ } = propCellId(r.cx, r.cz);
+		expect(muX).toBe(50);
+		expect(muZ).toBe(50);
 	});
 });

--- a/src/components/schema-editor/viewports/__tests__/PropTransformOverlay.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/PropTransformOverlay.test.ts
@@ -1,0 +1,57 @@
+// Spec coverage for the PropTransformOverlay pure helpers — the bits the gizmo
+// React layer relies on. The drag/gizmo interaction is exercised in the browser;
+// these pin the selection-resolution + outline geometry.
+
+import { describe, it, expect } from 'vitest';
+import { buildTargetOutline, selectedInstanceIndex } from '../PropTransformOverlay';
+import type { ParsedPropInstanceData, PropInstance } from '@/lib/core/propInstanceData';
+
+function instAt(x: number, y: number, z: number): PropInstance {
+	const m = new Array(16).fill(0);
+	m[12] = x; m[13] = y; m[14] = z; m[15] = 1;
+	return {
+		mWorldTransform: m, typeId: 0, flags: 0, muInstanceID: 0,
+		muAlternativeType: 0xffff, mn8RotSpeed: 0, mn8MaxAngle: 0, mn8MinAngle: 0,
+		_pad4D: [0, 0, 0],
+	};
+}
+
+function pid(instances: PropInstance[]): ParsedPropInstanceData {
+	return { muZoneId: 0, muSizeInBytes: 0, muNumberOfInstances: instances.length, instances, cells: [], _trailingPad: new Uint8Array(0) };
+}
+
+describe('selectedInstanceIndex', () => {
+	it('reads the instance index from an instances path, clamped to range', () => {
+		expect(selectedInstanceIndex(['instances', 2], 5)).toBe(2);
+		expect(selectedInstanceIndex(['instances', 9], 5)).toBe(-1);
+		expect(selectedInstanceIndex(['instances', 2, 'mWorldTransform'], 5)).toBe(2);
+	});
+	it('is -1 for a non-instance path', () => {
+		expect(selectedInstanceIndex(['cells', 0], 5)).toBe(-1);
+		expect(selectedInstanceIndex([], 5)).toBe(-1);
+	});
+});
+
+describe('buildTargetOutline', () => {
+	it('is null when nothing is selected', () => {
+		expect(buildTargetOutline(pid([instAt(0, 0, 0)]), [])).toBeNull();
+	});
+	it('emits one cube wireframe (24 edge endpoints) per target, centred on the prop', () => {
+		const data = pid([instAt(100, 0, -50), instAt(0, 0, 0)]);
+		const geo = buildTargetOutline(data, [0])!;
+		const pos = geo.getAttribute('position');
+		expect(pos.count).toBe(24); // 12 edges × 2 endpoints
+		// Every vertex sits within the half-extent box around (100, 0, -50).
+		for (let i = 0; i < pos.count; i++) {
+			expect(Math.abs(pos.getX(i) - 100)).toBeLessThanOrEqual(2.5 + 1e-6);
+			expect(Math.abs(pos.getZ(i) - -50)).toBeLessThanOrEqual(2.5 + 1e-6);
+		}
+		geo.dispose();
+	});
+	it('scales the vertex count with the number of targets', () => {
+		const data = pid([instAt(0, 0, 0), instAt(10, 0, 0), instAt(20, 0, 0)]);
+		const geo = buildTargetOutline(data, [0, 1, 2])!;
+		expect(geo.getAttribute('position').count).toBe(24 * 3);
+		geo.dispose();
+	});
+});

--- a/src/components/workspace/WorldViewportComposition.tsx
+++ b/src/components/workspace/WorldViewportComposition.tsx
@@ -51,6 +51,7 @@ import { WorldViewport } from '@/components/schema-editor/viewports/WorldViewpor
 import { TrackGeometry } from '@/components/schema-editor/viewports/TrackGeometry';
 import { PropGeometry } from '@/components/schema-editor/viewports/PropGeometry';
 import { PropCellGridOverlay } from '@/components/schema-editor/viewports/PropCellGridOverlay';
+import { PropTransformOverlay } from '@/components/schema-editor/viewports/PropTransformOverlay';
 import { PolygonSoupListOverlay } from '@/components/schema-editor/viewports/PolygonSoupListOverlay';
 import { INSTANCE_LIST_TYPE_ID } from '@/lib/core/instanceList';
 import { PROP_GRAPHICS_LIST_TYPE_ID } from '@/lib/core/propGraphicsList';
@@ -296,6 +297,41 @@ function WorldViewportCompositionInner({
 		[bundles, isVisible, selection, select],
 	);
 
+	// Prop transform gizmo + marquee: one <PropTransformOverlay> per visible
+	// bundle with a PropInstanceData (box or mesh path alike). It owns the
+	// move/rotate gizmo and box-select, editing instance transforms via
+	// setResourceAt. Mounted alongside the cell grid (separate concern); its
+	// HTML-slot marquee only registers while propInstanceData is the active
+	// selection.
+	const propTransformChildren = useMemo(
+		() =>
+			bundles
+				.filter(
+					(b) =>
+						isVisible({ bundleId: b.id }) &&
+						isVisible({ bundleId: b.id, resourceKey: 'propInstanceData', index: 0 }) &&
+						(b.parsedResourcesAll.get('propInstanceData')?.[0] ?? null) != null,
+				)
+				.map((b) => {
+					const pid = b.parsedResourcesAll.get('propInstanceData')![0] as ParsedPropInstanceData;
+					const isSelected =
+						selection?.bundleId === b.id && selection.resourceKey === 'propInstanceData';
+					return (
+						<PropTransformOverlay
+							key={`proptransform::${b.id}`}
+							data={pid}
+							selectedPath={isSelected ? selection!.path : EMPTY_PATH}
+							onSelect={(path) =>
+								select({ bundleId: b.id, resourceKey: 'propInstanceData', index: 0, path })
+							}
+							onChange={(next) => setResourceAt(b.id, 'propInstanceData', 0, next)}
+							isActive={isSelected}
+						/>
+					);
+				}),
+		[bundles, isVisible, selection, select, setResourceAt],
+	);
+
 	// Stable per-(bundleId, key, index) callback factories. We can't memoise
 	// each one with useCallback (the descriptor list is dynamic), but a
 	// single useCallback over the closure-captured Workspace methods means
@@ -386,6 +422,7 @@ function WorldViewportCompositionInner({
 			{trackChildren}
 			{propChildren}
 			{cellGridChildren}
+			{propTransformChildren}
 			{children}
 		</WorldViewport>
 	);

--- a/src/lib/core/__tests__/propInstanceDataOps.test.ts
+++ b/src/lib/core/__tests__/propInstanceDataOps.test.ts
@@ -1,0 +1,97 @@
+// Coverage for the prop-instance rigid transform ops (propInstanceDataOps.ts) —
+// the math behind the WorldViewport gizmo. Pure, so fully unit-tested here.
+
+import { describe, it, expect } from 'vitest';
+import {
+	translatePropInstance,
+	rotatePropInstance,
+	translatePropInstances,
+	rotatePropInstances,
+	propInstancesPivot,
+} from '../propInstanceDataOps';
+import type { ParsedPropInstanceData, PropInstance } from '../propInstanceData';
+
+// Identity Matrix44Affine with translation at [12,13,14] and pad slots 0 (the
+// on-disk shape) — [15] is 0, not 1, mirroring a real placed prop.
+function instAt(x: number, y: number, z: number): PropInstance {
+	const m = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 0];
+	return {
+		mWorldTransform: m, typeId: 0, flags: 0, muInstanceID: 0,
+		muAlternativeType: 0xffff, mn8RotSpeed: 0, mn8MaxAngle: 0, mn8MinAngle: 0,
+		_pad4D: [0, 0, 0],
+	};
+}
+
+function pid(instances: PropInstance[]): ParsedPropInstanceData {
+	return { muZoneId: 0, muSizeInBytes: 0, muNumberOfInstances: instances.length, instances, cells: [], _trailingPad: new Uint8Array(0) };
+}
+
+describe('translatePropInstance', () => {
+	it('shifts only the translation column', () => {
+		const out = translatePropInstance(instAt(10, 20, 30), { x: 1, y: 2, z: 3 });
+		expect(out.mWorldTransform[12]).toBe(11);
+		expect(out.mWorldTransform[13]).toBe(22);
+		expect(out.mWorldTransform[14]).toBe(33);
+		// rotation portion + pad untouched
+		expect(out.mWorldTransform.slice(0, 12)).toEqual([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0]);
+	});
+	it('returns the same reference on a zero offset (byte-exact no-op)', () => {
+		const inst = instAt(1, 2, 3);
+		expect(translatePropInstance(inst, { x: 0, y: 0, z: 0 })).toBe(inst);
+	});
+});
+
+describe('rotatePropInstance', () => {
+	it('orbits the position around a remote pivot (180° about Y)', () => {
+		// (10,0,0) rotated 180° about Y around origin → (-10,0,0).
+		const out = rotatePropInstance(instAt(10, 0, 0), { x: 0, y: 0, z: 0 }, { x: 0, y: Math.PI, z: 0 });
+		expect(out.mWorldTransform[12]).toBeCloseTo(-10, 5);
+		expect(out.mWorldTransform[13]).toBeCloseTo(0, 5);
+		expect(out.mWorldTransform[14]).toBeCloseTo(0, 5);
+	});
+	it('keeps position fixed when the pivot is the prop itself', () => {
+		const out = rotatePropInstance(instAt(10, 5, -3), { x: 10, y: 5, z: -3 }, { x: 0, y: Math.PI / 2, z: 0 });
+		expect(out.mWorldTransform[12]).toBeCloseTo(10, 5);
+		expect(out.mWorldTransform[13]).toBeCloseTo(5, 5);
+		expect(out.mWorldTransform[14]).toBeCloseTo(-3, 5);
+	});
+	it('writes pad slots [3],[7],[11],[15] back to 0 (byte-exact layout)', () => {
+		const out = rotatePropInstance(instAt(1, 2, 3), { x: 0, y: 0, z: 0 }, { x: 0.1, y: 0.2, z: 0.3 });
+		for (const i of [3, 7, 11, 15]) expect(out.mWorldTransform[i]).toBe(0);
+	});
+	it('returns the same reference on an identity delta', () => {
+		const inst = instAt(1, 2, 3);
+		expect(rotatePropInstance(inst, { x: 5, y: 5, z: 5 }, { x: 0, y: 0, z: 0 })).toBe(inst);
+	});
+});
+
+describe('set-scoped ops', () => {
+	it('translates only the addressed instances and leaves the rest by reference', () => {
+		const data = pid([instAt(0, 0, 0), instAt(10, 0, 0), instAt(20, 0, 0)]);
+		const out = translatePropInstances(data, [0, 2], { x: 5, y: 0, z: 0 });
+		expect(out.instances[0].mWorldTransform[12]).toBe(5);
+		expect(out.instances[2].mWorldTransform[12]).toBe(25);
+		expect(out.instances[1]).toBe(data.instances[1]); // untouched, same ref
+	});
+	it('returns the same model reference on an empty index set', () => {
+		const data = pid([instAt(0, 0, 0)]);
+		expect(translatePropInstances(data, [], { x: 5, y: 0, z: 0 })).toBe(data);
+		expect(rotatePropInstances(data, [], { x: 0, y: 0, z: 0 }, { x: 0, y: 1, z: 0 })).toBe(data);
+	});
+	it('ignores out-of-range / duplicate indices', () => {
+		const data = pid([instAt(0, 0, 0), instAt(10, 0, 0)]);
+		const out = translatePropInstances(data, [1, 1, 9, -1], { x: 5, y: 0, z: 0 });
+		expect(out.instances[1].mWorldTransform[12]).toBe(15);
+		expect(out.instances[0]).toBe(data.instances[0]);
+	});
+});
+
+describe('propInstancesPivot', () => {
+	it('is the per-axis median of the addressed positions', () => {
+		const data = pid([instAt(0, 0, 0), instAt(10, 4, 100), instAt(20, 8, -100)]);
+		expect(propInstancesPivot(data, [0, 1, 2])).toEqual({ x: 10, y: 4, z: 0 });
+	});
+	it('is null for an empty set', () => {
+		expect(propInstancesPivot(pid([instAt(0, 0, 0)]), [])).toBeNull();
+	});
+});

--- a/src/lib/core/propInstanceDataOps.ts
+++ b/src/lib/core/propInstanceDataOps.ts
@@ -1,0 +1,143 @@
+// Prop-instance rigid transform ops — translate / rotate a set of placed props
+// by editing their `mWorldTransform` (a Matrix44Affine, 16 f32s). Powers the
+// WorldViewport transform gizmo + marquee multi-select, mirroring the
+// static-traffic-vehicle ops (staticVehicleMatrix44.ts) — props are likewise a
+// full 4×4 pose, so they get all three rotate axes.
+//
+// Matrix layout (load-bearing). Criterion's Matrix44Affine stores the
+// translation column at elements [12],[13],[14] with the pad slots
+// [3],[7],[11],[15] = 0 on disk. That is column-major from three.js's view, so
+// `THREE.Matrix4.fromArray` maps it 1:1 (same as the prop renderer's
+// `propInstanceMatrix`). We patch the bottom row to [0,0,0,1] before the
+// homogeneous multiply, then write [3],[7],[11],[15] back to 0 so a placed
+// prop's bytes round-trip exactly (the writer emits 16 f32s linearly).
+//
+// Rotate-around-pivot rule (same as the static vehicle / trigger-box gizmos):
+//   M' = T(P) · R(delta) · T(-P) · M     (pre-multiply)
+// which orbits the prop's position around the pivot AND composes the rotation
+// delta into its facing. Euler order 'XYZ', matching every other WorldViewport
+// gizmo so a future mixed Selection composes consistently.
+//
+// No-op contract: an identity gesture (zero translate / zero rotate) or an empty
+// index set returns the SAME `ParsedPropInstanceData` reference, so the BND2
+// byte-for-byte writeback survives a touch-free gizmo gesture.
+
+import * as THREE from 'three';
+import type { ParsedPropInstanceData, PropInstance } from './propInstanceData';
+
+export const PROP_DELTA_EULER_ORDER: THREE.EulerOrder = 'XYZ';
+
+type Vec3 = { x: number; y: number; z: number };
+
+// --- Matrix44Affine ↔ THREE.Matrix4 ----------------------------------------
+
+function readMatrix(mWorldTransform: readonly number[]): THREE.Matrix4 {
+	const m = new THREE.Matrix4().fromArray(mWorldTransform);
+	const e = m.elements;
+	e[3] = 0; e[7] = 0; e[11] = 0; e[15] = 1;
+	return m;
+}
+
+function writeMatrix(mat: THREE.Matrix4): number[] {
+	const arr = mat.toArray();
+	arr[3] = 0; arr[7] = 0; arr[11] = 0; arr[15] = 0;
+	return arr;
+}
+
+// --- Single-instance ops (exported for tests) -------------------------------
+
+/** Translate one instance's transform by `(dx, dy, dz)`. Returns the input
+ *  reference verbatim on a zero offset. */
+export function translatePropInstance(inst: PropInstance, offset: Vec3): PropInstance {
+	if (offset.x === 0 && offset.y === 0 && offset.z === 0) return inst;
+	const next = inst.mWorldTransform.slice();
+	next[12] = (next[12] ?? 0) + offset.x;
+	next[13] = (next[13] ?? 0) + offset.y;
+	next[14] = (next[14] ?? 0) + offset.z;
+	return { ...inst, mWorldTransform: next };
+}
+
+/** Rotate one instance's transform around `pivot` by the delta Euler. Returns
+ *  the input reference verbatim on an identity delta. */
+export function rotatePropInstance(inst: PropInstance, pivot: Vec3, deltaEuler: Vec3): PropInstance {
+	if (deltaEuler.x === 0 && deltaEuler.y === 0 && deltaEuler.z === 0) return inst;
+	const M = readMatrix(inst.mWorldTransform);
+	const R = new THREE.Matrix4().makeRotationFromEuler(
+		new THREE.Euler(deltaEuler.x, deltaEuler.y, deltaEuler.z, PROP_DELTA_EULER_ORDER),
+	);
+	// composed = T(P) · R · T(-P), then M' = composed · M (see file header).
+	M.premultiply(new THREE.Matrix4().makeTranslation(-pivot.x, -pivot.y, -pivot.z));
+	M.premultiply(R);
+	M.premultiply(new THREE.Matrix4().makeTranslation(pivot.x, pivot.y, pivot.z));
+	return { ...inst, mWorldTransform: writeMatrix(M) };
+}
+
+// --- Set-scoped ops over ParsedPropInstanceData -----------------------------
+
+function uniqueValidIndices(data: ParsedPropInstanceData, indices: Iterable<number>): number[] {
+	const n = data.instances.length;
+	const out = new Set<number>();
+	for (const i of indices) if (Number.isInteger(i) && i >= 0 && i < n) out.add(i);
+	return [...out];
+}
+
+/** Translate every instance in `indices` by `offset`. Returns the input model
+ *  reference on a zero offset, empty set, or when no instance actually moved. */
+export function translatePropInstances(
+	data: ParsedPropInstanceData,
+	indices: Iterable<number>,
+	offset: Vec3,
+): ParsedPropInstanceData {
+	if (offset.x === 0 && offset.y === 0 && offset.z === 0) return data;
+	const targets = new Set(uniqueValidIndices(data, indices));
+	if (targets.size === 0) return data;
+	let changed = false;
+	const instances = data.instances.map((inst, i) => {
+		if (!targets.has(i)) return inst;
+		const next = translatePropInstance(inst, offset);
+		if (next !== inst) changed = true;
+		return next;
+	});
+	return changed ? { ...data, instances } : data;
+}
+
+/** Rotate every instance in `indices` around `pivot` by the delta Euler.
+ *  Returns the input model reference on an identity delta / empty set. */
+export function rotatePropInstances(
+	data: ParsedPropInstanceData,
+	indices: Iterable<number>,
+	pivot: Vec3,
+	deltaEuler: Vec3,
+): ParsedPropInstanceData {
+	if (deltaEuler.x === 0 && deltaEuler.y === 0 && deltaEuler.z === 0) return data;
+	const targets = new Set(uniqueValidIndices(data, indices));
+	if (targets.size === 0) return data;
+	let changed = false;
+	const instances = data.instances.map((inst, i) => {
+		if (!targets.has(i)) return inst;
+		const next = rotatePropInstance(inst, pivot, deltaEuler);
+		if (next !== inst) changed = true;
+		return next;
+	});
+	return changed ? { ...data, instances } : data;
+}
+
+function median(values: number[]): number {
+	const s = [...values].sort((a, b) => a - b);
+	const mid = s.length >> 1;
+	return s.length % 2 === 0 ? (s[mid - 1] + s[mid]) / 2 : s[mid];
+}
+
+/** Median world position of the addressed instances — the gizmo pivot. Null for
+ *  an empty / fully out-of-range set. Median (not mean) so one far outlier
+ *  doesn't drag the pivot off the cluster, matching trafficDataSelectionPivot. */
+export function propInstancesPivot(data: ParsedPropInstanceData, indices: Iterable<number>): Vec3 | null {
+	const targets = uniqueValidIndices(data, indices);
+	if (targets.length === 0) return null;
+	const xs: number[] = [], ys: number[] = [], zs: number[] = [];
+	for (const i of targets) {
+		const t = data.instances[i].mWorldTransform;
+		xs.push(t[12] ?? 0); ys.push(t[13] ?? 0); zs.push(t[14] ?? 0);
+	}
+	return { x: median(xs), y: median(ys), z: median(zs) };
+}


### PR DESCRIPTION
Follow-up to #124 implementing the community's three requests on the prop editor.

## 1 · Cell grid: "show all cells" + click-to-read coordinates
- **Show all cells** toggle: draws the full 100×100 world grid (not just the populated-cell region), so a cell id can be read anywhere — even where no props are placed yet.
- **Click any cell → its (x, z)**: a transparent picking plane over the grid turns a click into a cell id, pinned in-world and in the chrome. No more hand-calculating with `(pos + 5000) / 100`. Clicking a populated cell still selects its PropCell.
- Per-cell labels stay limited to populated cells, so show-all is just border lines + the picking plane (no 10k-label explosion).

## 2 · Move/rotate transform gizmo + marquee multi-select
Props are placed via a full Matrix44 transform, so — like TrafficData's static vehicles — they now get an in-viewport gizmo instead of numeric-only editing.
- `propInstanceDataOps.ts` — pure translate/rotate of a set of instance transforms (rotate-around-pivot premultiply `T(P)·R·T(-P)`, `XYZ` Euler), median pivot, reference-identity on a no-op so untouched props stay byte-exact.
- `PropTransformOverlay.tsx` — `BulkTransformGizmo` (all 3 translate + 3 rotate axes) anchored at the median pivot, plus `MarqueeSelector` box-select (press **B**, drag; **alt** = remove). The transform set is the inspector selection ∪ the marqueed instances, outlined so the user sees what will move. One gesture = one undo entry (commit on release).
- Mounted per visible PropInstanceData bundle in `WorldViewportComposition`, wiring `onChange → setResourceAt`.

> The marquee set is **viewport-local** (not yet wired into the hierarchy tree / bulk panel the way TrafficData's is). The in-viewport interaction is identical; the cross-component bulk integration is a separable follow-up.

## Verification
- 61 prop tests pass (transform ops, cell-grid + overlay helpers, composition); full `tsc` clean (0 new errors).
- All new modules + the composition transform/import cleanly through Vite (real import-graph resolution).
- ⚠️ The interactive 3D drag (gizmo / marquee) could **not** be exercised in-browser here — the preview window runs hidden, which starves `requestAnimationFrame` so the WebGL canvas won't render. The transform math is unit-tested with explicit rotation assertions; please give the gizmo a spin locally and shout if anything feels off.

Two commits: one for the cell-grid items, one for the gizmo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
