### PR TITLE
feat(props): editable Prop Graphics parts (add/remove), nested under their prop

### DIFF
--- a/docs/prop-graphics-list-spec.md
+++ b/docs/prop-graphics-list-spec.md
@@ -75,7 +75,7 @@ PC LE only**. Console (BE) and 64-bit are out of scope.
 |--------|------|------|------|-------|
 | 0x00 | 4 | u32 | `muTypeId` | prop type index (into [`prop-types.md`](prop-types.md)) |
 | 0x04 | 4 | `Model*` | `mpPropModel` | **`0x0` on disk** — a BND2 **import** (see below); the body mesh. Modelled as the editable `mpModelId` (bigint); the writer emits 0 here and rebuilds the import-table entry from `mpModelId`. |
-| 0x08 | 4 | `PropPartGraphics*` | `mpParts` | resource-relative **internal pointer** to this prop's first part record; **`0` (NULL) when the prop has no parts**. Modelled as `firstPartIndex` (the part-array index) and recomputed on write. |
+| 0x08 | 4 | `PropPartGraphics*` | `mpParts` | resource-relative **internal pointer** to this prop's first part record; leftover/garbage when the prop has no parts. Derived on write for a prop that owns parts; preserved verbatim (`_mpPartsRaw`) for a partless prop. |
 
 ### `PropPartGraphics` — 12 bytes (`0x0C`) — at `align16(0x20 + nProps*0x0C)`
 
@@ -102,13 +102,15 @@ On read, the parser resolves each `mpModelId` from this table by field offset; o
 write it rebuilds the table from the per-record `mpModelId`s (see below).
 
 `mpParts` is **not** an import — it is an **internal, resource-relative pointer** to
-the prop's first `PropPartGraphics` record. Because parts are grouped contiguously
-by owning prop, a prop with parts points at its first one; a prop with **no** parts
-stores `mpParts == 0` (NULL). The parser never dereferences `mpParts` to read the
-structure (the part array is located via the recomputed `mpaPropPartGraphics`); it
-is modelled as `firstPartIndex` (the part-array index it points at) and recomputed
-on write as `mpaPropPartGraphics + firstPartIndex*0x0C`, so it survives the part
-array relocating after a prop add/remove.
+the prop's first `PropPartGraphics` record. Parts are grouped contiguously by
+owning prop (the prop with the matching `muTypeId`), so a prop with parts points at
+its run's first record. A prop with **no** parts carries a leftover/garbage `mpParts`
+the runtime never dereferences (nonzero in most fixtures — 2951 of them — and `0` in
+the rest). The parser never follows `mpParts` to read the structure (the part array
+is located via the recomputed `mpaPropPartGraphics` and grouped by `muTypeId`); the
+writer derives `mpParts` for a prop that owns parts (the byte offset of its run) and
+re-emits `_mpPartsRaw` verbatim for a partless prop — so it survives the part array
+relocating after a prop add/remove.
 
 > The parser **needs** the import table to recover each record's `mpModelId`, but
 > the structural layout is fully determined by the two counts. The writer rebuilds
@@ -179,8 +181,9 @@ round-trips `writePropGraphicsList(parsePropGraphicsList(raw))` **byte-for-byte*
 across all 428 fixtures (256 populated + 172 empty, 0 fail) — including the
 model-driven rebuild of the import table. The parser/writer in
 [`src/lib/core/propGraphicsList.ts`](../src/lib/core/propGraphicsList.ts) were
-rewritten for this (model `mpModelId`/`firstPartIndex`, derive `muSizeInBytes`,
-rebuild the table); the byte-exactness above is what proves that rewrite safe.
+rewritten for this (model `mpModelId` per record, nest parts under their owning
+prop, derive `muSizeInBytes`/`mpParts`, rebuild the table); the byte-exactness above
+is what proves that rewrite safe.
 
 **Confirmed invariants (all 254 populated resources, zero violations):**
 
@@ -191,8 +194,10 @@ rebuild the table); the byte-exactness above is what proves that rewrite safe.
    mpaPropPartGraphics)` are **all zero** in every fixture.
 5. Every `mpPropModel` field is `0` on disk; the real id lives in the inline import
    table, keyed by the field offset.
-6. A prop with no parts stores `mpParts == 0` (NULL) — it does **not** reuse a
-   neighbour's pointer or the part-array-end value.
+6. Parts are grouped contiguously by `muTypeId`; the prop with the matching type
+   owns that run (no two parts-owning props share a type; every run matches a prop;
+   runs are in prop order). A prop with no parts carries a leftover/garbage `mpParts`
+   (nonzero in 2951 fixtures, `0` in 610) the runtime never dereferences.
 
 **Extractor false-positives (not PGL bugs):** `TRK_UNIT158_GR.BNDL` throws a
 spurious "incorrect header check" zlib error inside the bundle extractor's
@@ -205,37 +210,48 @@ is a parser bug.
 ## Parsed model shape
 
 The catalogue is **fully editable**: Model references are modelled as per-record
-resource ids, and props/parts can be added or removed. The writer rebuilds the
-inline import table and every derived offset from the model, so nothing is carried
-verbatim except what the corpus sweep proved is reconstructable.
+resource ids, and props **and parts** can be added or removed. The writer rebuilds
+the inline import table and every derived offset from the model, so nothing is
+carried verbatim except what the corpus sweep proved is reconstructable.
+
+**Parts nest under their owning prop.** The on-disk part array is flat and grouped
+contiguously by `muTypeId`; the prop with the matching type owns that run (verified
+across all 234 PGLs-with-parts: contiguous-by-type, single-owner, every run matches
+a prop, runs in prop order). So the model nests each prop's parts under it rather
+than carrying a flat array + a pointer — ownership is then structural and can't
+desync on edit. `mpParts` is derived on write for a prop that owns parts; for a
+**partless** prop it's leftover/garbage the runtime never dereferences, preserved
+verbatim as `_mpPartsRaw` so the round-trip stays byte-exact.
 
 ```ts
-type PropGraphics = {
-  muTypeId: number;            // u32 — prop type index (into prop-types)
-  mpModelId: bigint;           // Model resource id (the BND2 import); 0n = none/unresolved. Editable.
-  firstPartIndex: number | null; // index into parts[] of this prop's first part; null = no parts
+type PropPartGraphics = {
+  muPartId: number;   // u32 — part index within the owning prop
+  mpModelId: bigint;  // Model resource id (the BND2 import). Editable.
+  // On disk the part ALSO stores muTypeId == the owning prop's type id; it isn't
+  // modelled — the part is nested under its prop, so the writer re-emits the prop's.
 };
 
-type PropPartGraphics = {
-  muTypeId: number;    // u32 — owning prop's type id
-  muPartId: number;    // u32 — part index within the prop
-  mpModelId: bigint;   // Model resource id (the BND2 import). Editable.
+type PropGraphics = {
+  muTypeId: number;          // u32 — prop type index (into prop-types)
+  mpModelId: bigint;         // Model resource id (the BND2 import); 0n = none/unresolved. Editable.
+  parts: PropPartGraphics[]; // this prop's destructible parts (owned by type; empty = partless)
+  _mpPartsRaw: number;       // raw on-disk mpParts — derived on write for owners, preserved verbatim for partless props
 };
 
 type ParsedPropGraphicsList = {
-  muZoneNumber: number;     // u32 — PVS zone / track-unit id (editable)
-  props: PropGraphics[];
-  parts: PropPartGraphics[];
+  muZoneNumber: number;      // u32 — PVS zone / track-unit id (editable)
+  props: PropGraphics[];     // each prop carries its own parts; there is no top-level parts array
 };
 ```
 
 `muNumberOfPropModels` / `muNumberOfPropPartModels` are **not** stored on the model
-(they equal `props.length` / `parts.length`); the writer emits the array lengths.
-`mpaPropGraphics` / `mpaPropPartGraphics` and `muSizeInBytes` (the structural end)
-are recomputed from those lengths. `mpPropModel` (0 on disk) is rebuilt as a 0
-pointer + an import-table entry carrying `mpModelId`. `mpParts` is rebuilt from
-`firstPartIndex` (`null → 0`, else `mpaPropPartGraphics + firstPartIndex*0x0C`), so
-it stays valid when the part array relocates after a prop add/remove.
+(they equal `props.length` / `sum(props[].parts.length)`); the writer emits those
+counts. `mpaPropGraphics` / `mpaPropPartGraphics` and `muSizeInBytes` (the structural
+end) are recomputed. `mpPropModel` (0 on disk) is rebuilt as a 0 pointer + an
+import-table entry carrying `mpModelId`. `mpParts` is the byte offset of a prop's
+first part run (derived from the running part offset) for owners, else `_mpPartsRaw`
+verbatim. The writer rejects two props of the same type where one owns parts (parts
+are owned by type, so that shape can't round-trip).
 
 ## Round-trip / writer strategy
 
@@ -247,10 +263,12 @@ Byte-exact (`byteRoundTrip`) is achievable — the layout is rigid. Writer:
    `mpaPropPartGraphics = parts.length ? align16(0x20 + nProps*0x0C) : 0`; zero-pad
    up to `0x20`.
 2. **PropGraphics:** for each, `muTypeId`; `mpPropModel = 0` (the id is emitted into
-   the import table below); `mpParts` recomputed from `firstPartIndex`.
-3. **align16 pad → PropPartGraphics:** zero-pad to `mpaPropPartGraphics`, then for
-   each part `muTypeId`; `muPartId`; `mpPropModel = 0`. Then zero-pad up to the
-   structural end (a no-parts list has an align pad after the prop array).
+   the import table below); `mpParts` = the byte offset of this prop's part run
+   (running part offset) when it owns parts, else `_mpPartsRaw` verbatim.
+3. **align16 pad → PropPartGraphics:** zero-pad to `mpaPropPartGraphics`, then flatten
+   parts in prop order — for each prop, for each of its parts: the owning prop's
+   `muTypeId`; `muPartId`; `mpPropModel = 0`. Then zero-pad up to the structural end
+   (a no-parts list has an align pad after the prop array).
 4. **align16 pad → import table:** for each prop, then each part, emit
    `{ u64 mpModelId, u32 fieldOffset, u32 0 }` → reproduces the exact length and
    re-establishes every Model import.
@@ -275,16 +293,17 @@ fails loud on any unexpected layout.
 ## Editor / resourcespec notes
 
 - `muZoneNumber` is the only freely-editable header field.
-- `muTypeId` (on both record types) → enum dropdown sourced from `PROP_TYPES` (same
-  table as [`prop-instance-data-spec.md`](prop-instance-data-spec.md)); `muPartId`
-  is a plain integer.
-- `mpModelId` is an **editable** `bigint` resource id (`{ kind: 'bigint', bytes: 8,
-  hex: true }`) — the Model the runtime spawns. On disk it is a `0` pointer + an
-  import-table entry; the writer rebuilds that entry from `mpModelId`. Prop Models
-  usually live in `GLOBALPROPS.BIN`.
-- `firstPartIndex` is a `hidden`/`readOnly` round-trip-only field (the modelled form
-  of `mpParts`); `muSizeInBytes`, `mpaPropGraphics`, `mpaPropPartGraphics` are
-  derived and never modelled.
+- A prop's `muTypeId` → enum dropdown sourced from `PROP_TYPES` (same table as
+  [`prop-instance-data-spec.md`](prop-instance-data-spec.md)). Parts are nested under
+  their prop and take the prop's type, so a part exposes only `muPartId` (a plain
+  integer) + `mpModelId`. Props and parts are both **addable/removable**.
+- `mpModelId` (on props and parts) is an **editable** `bigint` resource id
+  (`{ kind: 'bigint', bytes: 8, hex: true }`) — the Model the runtime spawns. On
+  disk it is a `0` pointer + an import-table entry; the writer rebuilds that entry
+  from `mpModelId`. Prop Models usually live in `GLOBALPROPS.BIN`.
+- `_mpPartsRaw` is a `hidden`/`readOnly` round-trip-only field (the raw `mpParts`,
+  preserved verbatim for partless props); `muSizeInBytes`, `mpaPropGraphics`,
+  `mpaPropPartGraphics` are derived and never modelled.
 - Tree labels: prop → `#i · <propTypeName> · model <resourceId>`; part →
   `#j · <propTypeName> · part <muPartId> · model <resourceId>`.
 - **Adding/removing props and parts is supported** (`addable`/`removable` on, with a

--- a/docs/prop-graphics-list-spec.md
+++ b/docs/prop-graphics-list-spec.md
@@ -63,7 +63,7 @@ PC LE only**. Console (BE) and 64-bit are out of scope.
 | 0x00 | 4 | u32 | `muSizeInBytes` | the **structural end**: part-array end when parts exist (may be unaligned), `align16(prop-array end)` when only props, `0x20` when empty. **Derived** — recomputed on write; the parser asserts the stored value matches (proven across all 428 fixtures). |
 | 0x04 | 4 | u32 | `muZoneNumber` | PVS zone / track-unit id (editable) |
 | 0x08 | 4 | u32 | `muNumberOfPropModels` | count of stored `PropGraphics` records = `props.length` (recomputed on write) |
-| 0x0C | 1 | u8 | `muNumberOfPropPartModels` | count of stored `PropPartGraphics` records = `parts.length`. **u8 in a 4-byte slot** (u8 + 3 zero pad). Recomputed on write. |
+| 0x0C | 4 | u32 | `muNumberOfPropPartModels` | count of stored `PropPartGraphics` records = total parts across all props. **Full u32** (an earlier reading as a u8+3-pad was wrong; byte-identical for the corpus since the max is 82, so the high 3 bytes are 0). Recomputed on write. |
 | 0x0D | 3 | — | padding | zero |
 | 0x10 | 4 | `PropGraphics*` | `mpaPropGraphics` | abs offset to prop array; **always `0x20`** when populated, `0` when empty. **Recomputed.** |
 | 0x14 | 4 | `PropPartGraphics*` | `mpaPropPartGraphics` | abs offset to part array; **always `align16(0x20 + nProps*0x0C)`** when parts exist, `0` otherwise. **Recomputed.** |
@@ -259,7 +259,7 @@ Byte-exact (`byteRoundTrip`) is achievable — the layout is rigid. Writer:
 
 1. **Header (32 bytes):** `muSizeInBytes` = derived structural end;
    `muZoneNumber`; `muNumberOfPropModels = props.length`; `muNumberOfPropPartModels
-   = parts.length & 0xff` (u8) + 3 pad; `mpaPropGraphics = props.length ? 0x20 : 0`;
+   = total parts` (u32); `mpaPropGraphics = props.length ? 0x20 : 0`;
    `mpaPropPartGraphics = parts.length ? align16(0x20 + nProps*0x0C) : 0`; zero-pad
    up to `0x20`.
 2. **PropGraphics:** for each, `muTypeId`; `mpPropModel = 0` (the id is emitted into

--- a/src/lib/core/__tests__/propGraphicsList.test.ts
+++ b/src/lib/core/__tests__/propGraphicsList.test.ts
@@ -65,7 +65,7 @@ function buildRaw(zone: number, props: PropSpec[], parts: PartSpec[]): Uint8Arra
 	dv.setUint32(0x00, structuralEnd, true);
 	dv.setUint32(0x04, zone, true);
 	dv.setUint32(0x08, nProps, true);
-	dv.setUint8(0x0c, nParts & 0xff);
+	dv.setUint32(0x0c, nParts, true); // muNumberOfPropPartModels is a full u32 on disk
 	dv.setUint32(0x10, nProps > 0 ? 0x20 : 0, true);
 	dv.setUint32(0x14, nParts > 0 ? partsStart : 0, true);
 
@@ -407,15 +407,20 @@ describe('PropGraphicsList — guards', () => {
 		expect(re.props.map((p) => p.mpModelId)).toEqual([0x1n, 0x2n]);
 	});
 
-	it('throws rather than truncate when a model carries more than 255 parts', () => {
+	it('round-trips a model with more than 255 parts (muNumberOfPropPartModels is a u32, not a u8)', () => {
+		// The part-count field is a full u32 on disk — so a model with
+		// >255 parts must round-trip, not throw a u8-overflow.
 		const model: ParsedPropGraphicsList = {
 			muZoneNumber: 1,
 			props: [{
 				muTypeId: 1, mpModelId: 0n, _mpPartsRaw: 0,
-				parts: Array.from({ length: 300 }, (_, i) => ({ muPartId: i, mpModelId: 0n })),
+				parts: Array.from({ length: 300 }, (_, i) => ({ muPartId: i, mpModelId: BigInt(i) })),
 			}],
 		};
-		expect(() => writePropGraphicsList(model)).toThrow(/exceeds the u8/);
+		const re = parsePropGraphicsList(writePropGraphicsList(model));
+		expect(re.props[0].parts.length).toBe(300);
+		expect(re.props[0].parts[299].muPartId).toBe(299);
+		expect(re.props[0].parts[299].mpModelId).toBe(299n);
 	});
 });
 

--- a/src/lib/core/__tests__/propGraphicsList.test.ts
+++ b/src/lib/core/__tests__/propGraphicsList.test.ts
@@ -353,6 +353,20 @@ describe('PropGraphicsList — guards', () => {
 		expect(() => parsePropGraphicsList(raw)).toThrow(/no owning prop/);
 	});
 
+	it('throws when part runs are not in prop order (would round-trip to different bytes)', () => {
+		// props [0xBB, 0xAA] but on-disk part runs [0xAA-run, 0xBB-run]: contiguous,
+		// single-owner, no orphans — but the run order disagrees with the prop order,
+		// which the writer (flatten-in-prop-order) can't reproduce byte-exactly.
+		const raw = buildRaw(1, [
+			{ typeId: 0xBB, model: 0x2n, mpParts: 0 },
+			{ typeId: 0xAA, model: 0x1n, mpParts: 0 },
+		], [
+			{ typeId: 0xAA, partId: 0, model: 0xA0n },
+			{ typeId: 0xBB, partId: 0, model: 0xB0n },
+		]);
+		expect(() => parsePropGraphicsList(raw)).toThrow(/not in prop order/);
+	});
+
 	it('throws on a non-zero header pad', () => {
 		const raw = buildRaw(1, [{ typeId: 1, model: 0n, mpParts: 0 }], []);
 		raw[0x1c] = 0xab;

--- a/src/lib/core/__tests__/propGraphicsList.test.ts
+++ b/src/lib/core/__tests__/propGraphicsList.test.ts
@@ -1,16 +1,11 @@
 // Coverage for parsePropGraphicsList / writePropGraphicsList (resource 0x10010).
 //
-// The catalogue is now fully editable — Model references are modelled as
-// per-record resource ids (mpModelId), and props/parts can be added/removed.
-// The writer rebuilds the inline import table + all derived offsets, so these
-// tests cover field edits AND structural mutations, byte-exact round-trip, and
-// the layout guards.
-//
-// Layers:
-//  - Synthesised payloads (always run): an empty list (null pointers) and a
-//    populated list with a canonical inline import table.
-//  - A gold check against the real example/TRK_UNIT9_GR.BNDL bundle, skipped
-//    when that untracked binary is absent.
+// The catalogue is fully editable: props AND their nested parts can be added,
+// removed, and re-pointed; Model references are modelled as per-record resource
+// ids and the writer rebuilds the inline import table. Parts are nested under
+// their owning prop (grouped by muTypeId on disk). These tests cover the model
+// shape, byte-exact round-trip, add/remove of props + parts, partless-prop
+// garbage preservation, the layout guards, and the real TRK9 gold fixture.
 
 import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
@@ -29,194 +24,390 @@ const REPO_ROOT = path.resolve(__dirname, '../../../..');
 const TRK9_PATH = path.resolve(REPO_ROOT, 'example/TRK_UNIT9_GR.BNDL');
 const PROP_GRAPHICS_LIST = 0x10010;
 
+const align16 = (x: number) => (x + 15) & ~15;
+
 function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
 	if (a.byteLength !== b.byteLength) return false;
 	for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
 	return true;
 }
 
-// --- Synthesised: empty list (172/427 track units ship this all-zero shape) ---
+function totalParts(m: ParsedPropGraphicsList): number {
+	return m.props.reduce((n, p) => n + p.parts.length, 0);
+}
 
-describe('PropGraphicsList empty list (null pointers)', () => {
-	function emptyBytes(zone: number): Uint8Array {
-		// 32-byte header only: muSizeInBytes = 0x20, both array pointers null.
-		const bytes = new Uint8Array(0x20);
-		const dv = new DataView(bytes.buffer);
-		dv.setUint32(0x00, 0x20, true); // muSizeInBytes
-		dv.setUint32(0x04, zone, true); // muZoneNumber
-		// counts + pointers stay zero.
-		return bytes;
-	}
+// ---------------------------------------------------------------------------
+// Raw-bytes builder — lays out a canonical PGL payload (header → props → pad →
+// parts → pad → import table) so the parser/writer can be exercised on exact
+// byte shapes. The import table is props-then-parts in array order, matching
+// the writer, so a well-formed build round-trips byte-exact.
+// ---------------------------------------------------------------------------
 
-	it('parses zero props/parts with null pointers', () => {
-		const model = parsePropGraphicsList(emptyBytes(7));
-		expect(model.props.length).toBe(0);
-		expect(model.parts.length).toBe(0);
-		expect(model.muZoneNumber).toBe(7);
-	});
+type PropSpec = { typeId: number; model: bigint; mpParts: number };
+type PartSpec = { typeId: number; partId: number; model: bigint };
 
-	it('round-trips byte-for-byte (re-emits null pointers, not 0x20)', () => {
-		const original = emptyBytes(7);
-		const rewritten = writePropGraphicsList(parsePropGraphicsList(original));
-		expect(rewritten.byteLength).toBe(original.byteLength);
-		expect(bytesEqual(rewritten, original)).toBe(true);
-	});
-});
+function buildRaw(zone: number, props: PropSpec[], parts: PartSpec[]): Uint8Array {
+	const nProps = props.length;
+	const nParts = parts.length;
+	const propEnd = 0x20 + nProps * 0x0c;
+	const partsStart = align16(propEnd);
+	const structuralEnd = nParts > 0 ? partsStart + nParts * 0x0c : nProps > 0 ? align16(propEnd) : 0x20;
+	const importOffset = align16(structuralEnd);
+	const total = importOffset + (nProps + nParts) * 16;
 
-// --- Synthesised: a populated list with a canonical inline import table ---
-
-// 2 props + 3 parts. propEnd = 0x20 + 2*0x0C = 0x38, partsStart = align16(0x38)
-// = 0x40, partEnd = 0x40 + 3*0x0C = 0x64 (= muSizeInBytes), importOffset =
-// align16(0x64) = 0x70, total = 0x70 + 5*16 = 0xC0.
-const PROP0_MODEL = 0x1A2B3C4D5E6Fn; // exercises the u64 high dword
-const PROP1_MODEL = 0x222n;
-const PART_MODELS = [0x333n, 0x444n, 0x555n];
-
-function buildBytes(): Uint8Array {
-	const total = 0xc0;
 	const bytes = new Uint8Array(total);
 	const dv = new DataView(bytes.buffer);
-	dv.setUint32(0x00, 0x64, true);         // muSizeInBytes = part-array end
-	dv.setUint32(0x04, 55, true);           // muZoneNumber
-	dv.setUint32(0x08, 2, true);            // props
-	dv.setUint8(0x0c, 3);                   // parts (u8)
-	dv.setUint32(0x10, 0x20, true);         // mpaPropGraphics
-	dv.setUint32(0x14, 0x40, true);         // mpaPropPartGraphics
-	// props (mpPropModel slots stay 0; mpParts points prop0 at part index 0)
-	dv.setUint32(0x20, 0xaa, true); dv.setUint32(0x28, 0x40, true); // prop0: type, mpParts
-	dv.setUint32(0x2c, 0xbb, true); dv.setUint32(0x34, 0, true);    // prop1: type, mpParts=0 (no parts)
-	// parts (at 0x40): {type, partId, mpPropModel=0}
-	dv.setUint32(0x40, 0xaa, true); dv.setUint32(0x44, 0, true);
-	dv.setUint32(0x4c, 0xaa, true); dv.setUint32(0x50, 1, true);
-	dv.setUint32(0x58, 0xbb, true); dv.setUint32(0x5c, 0, true);
-	// import table at 0x70 — props then parts, each {u64 id, u32 fieldOffset, u32 0}
-	const entries: [bigint, number][] = [
-		[PROP0_MODEL, 0x24], // prop0 mpPropModel field = 0x20 + 0*0x0C + 4
-		[PROP1_MODEL, 0x30], // prop1 mpPropModel field = 0x20 + 1*0x0C + 4
-		[PART_MODELS[0], 0x48], // part0 mpPropModel field = 0x40 + 0*0x0C + 8
-		[PART_MODELS[1], 0x54], // part1
-		[PART_MODELS[2], 0x60], // part2
-	];
-	entries.forEach(([id, off], i) => {
-		const p = 0x70 + i * 16;
-		dv.setUint32(p + 0, Number(id & 0xffffffffn), true);
-		dv.setUint32(p + 4, Number(id >> 32n), true);
-		dv.setUint32(p + 8, off, true);
+	const setU64 = (off: number, v: bigint) => {
+		dv.setUint32(off, Number(v & 0xffffffffn), true);
+		dv.setUint32(off + 4, Number(v >> 32n), true);
+	};
+
+	dv.setUint32(0x00, structuralEnd, true);
+	dv.setUint32(0x04, zone, true);
+	dv.setUint32(0x08, nProps, true);
+	dv.setUint8(0x0c, nParts & 0xff);
+	dv.setUint32(0x10, nProps > 0 ? 0x20 : 0, true);
+	dv.setUint32(0x14, nParts > 0 ? partsStart : 0, true);
+
+	props.forEach((p, i) => {
+		const o = 0x20 + i * 0x0c;
+		dv.setUint32(o, p.typeId, true);
+		dv.setUint32(o + 4, 0, true);          // mpPropModel — 0 on disk
+		dv.setUint32(o + 8, p.mpParts, true);
+	});
+	parts.forEach((p, j) => {
+		const o = partsStart + j * 0x0c;
+		dv.setUint32(o, p.typeId, true);
+		dv.setUint32(o + 4, p.partId, true);
+		dv.setUint32(o + 8, 0, true);          // mpPropModel — 0 on disk
+	});
+
+	// Import table: props first (field offset of each mpPropModel), then parts.
+	let e = importOffset;
+	props.forEach((p, i) => {
+		setU64(e, p.model);
+		dv.setUint32(e + 8, 0x20 + i * 0x0c + 0x04, true);
+		e += 16;
+	});
+	parts.forEach((p, j) => {
+		setU64(e, p.model);
+		dv.setUint32(e + 8, partsStart + j * 0x0c + 0x08, true);
+		e += 16;
 	});
 	return bytes;
 }
 
-describe('PropGraphicsList populated round-trip (synthesised)', () => {
-	it('decodes the structure, Model ids, and part index', () => {
-		const model = parsePropGraphicsList(buildBytes());
-		expect(model.muZoneNumber).toBe(55);
-		expect(model.props.length).toBe(2);
-		expect(model.parts.length).toBe(3);
-		expect(model.props[0].muTypeId).toBe(0xaa);
-		expect(model.props[0].mpModelId).toBe(PROP0_MODEL);
-		expect(model.props[0].firstPartIndex).toBe(0);
-		expect(model.props[1].mpModelId).toBe(PROP1_MODEL);
-		expect(model.props[1].firstPartIndex).toBeNull();
-		expect(model.parts[1].muPartId).toBe(1);
-		expect(model.parts.map((p) => p.mpModelId)).toEqual(PART_MODELS);
-	});
+// ---------------------------------------------------------------------------
+// Empty list (172/427 track units)
+// ---------------------------------------------------------------------------
 
-	it('round-trips byte-for-byte', () => {
-		const original = buildBytes();
-		const rewritten = writePropGraphicsList(parsePropGraphicsList(original));
-		expect(rewritten.byteLength).toBe(original.byteLength);
-		expect(bytesEqual(rewritten, original)).toBe(true);
-	});
-
-	it('survives a muZoneNumber / prop-type / Model-id edit', () => {
-		const model = parsePropGraphicsList(buildBytes());
-		const edited: ParsedPropGraphicsList = {
-			...model,
-			muZoneNumber: 999,
-			props: model.props.map((p, i) => (i === 0 ? { ...p, muTypeId: 0x321, mpModelId: 0x99n } : p)),
-		};
-		const re = parsePropGraphicsList(writePropGraphicsList(edited));
-		expect(re.muZoneNumber).toBe(999);
-		expect(re.props[0].muTypeId).toBe(0x321);
-		expect(re.props[0].mpModelId).toBe(0x99n);
-		// The part index and the other prop are untouched.
-		expect(re.props[0].firstPartIndex).toBe(0);
-		expect(re.props[1].mpModelId).toBe(PROP1_MODEL);
-	});
-
-	it('grows by one PropGraphics + one import entry when a prop is added', () => {
-		const original = buildBytes();
-		const model = parsePropGraphicsList(original);
-		const added: ParsedPropGraphicsList = {
-			...model,
-			props: [...model.props, { muTypeId: 0x77, mpModelId: 0xABCDn, firstPartIndex: null }],
-		};
-		const written = writePropGraphicsList(added);
-		// One more prop record (0x0C) shifts everything; adding a prop crosses an
-		// align16 boundary here (3 props → partsStart 0x50), and one import entry
-		// (16 bytes) is appended.
-		const re = parsePropGraphicsList(written);
-		expect(re.props.length).toBe(3);
-		expect(re.props[2].muTypeId).toBe(0x77);
-		expect(re.props[2].mpModelId).toBe(0xABCDn);
-		// Existing entries survive the relocation: prop0 still owns part index 0,
-		// and every part Model id is intact.
-		expect(re.props[0].mpModelId).toBe(PROP0_MODEL);
-		expect(re.props[0].firstPartIndex).toBe(0);
-		expect(re.parts.map((p) => p.mpModelId)).toEqual(PART_MODELS);
-		// The import-table hook reports the rebuilt table (props+parts = 6 entries)
-		// at the relocated offset: 3 props → propEnd 0x44, partsStart 0x50, partEnd
-		// 0x74 (= muSizeInBytes), importOffset = align16(0x74) = 0x80.
-		const table = propGraphicsListImportTable(written);
-		expect(table.count).toBe(6);
-		expect(table.offset).toBe(0x80);
-	});
-
-	it('shrinks when a prop is removed', () => {
-		const model = parsePropGraphicsList(buildBytes());
-		// Remove the partless prop1 so no part orphaning is involved.
-		const removed: ParsedPropGraphicsList = { ...model, props: [model.props[0]] };
-		const re = parsePropGraphicsList(writePropGraphicsList(removed));
-		expect(re.props.length).toBe(1);
-		expect(re.props[0].mpModelId).toBe(PROP0_MODEL);
-		expect(re.parts.map((p) => p.mpModelId)).toEqual(PART_MODELS);
-		expect(propGraphicsListImportTable(writePropGraphicsList(removed)).count).toBe(4);
+describe('PropGraphicsList — empty list', () => {
+	it('parses zero props with null pointers and round-trips byte-for-byte', () => {
+		const raw = buildRaw(7, [], []);
+		expect(raw.byteLength).toBe(0x20);
+		const model = parsePropGraphicsList(raw);
+		expect(model.props.length).toBe(0);
+		expect(model.muZoneNumber).toBe(7);
+		expect(bytesEqual(writePropGraphicsList(model), raw)).toBe(true);
 	});
 });
 
-// --- Defensive guards (the writer regenerates pads as zero / derives the
-//     length, so reject layouts that would make that silently lossy) ---
+// ---------------------------------------------------------------------------
+// Props only (no parts) — incl. the unaligned-prop-count align pad
+// ---------------------------------------------------------------------------
 
-describe('PropGraphicsList layout guards', () => {
-	it('throws on a non-zero header pad [0x18,0x20)', () => {
-		const bytes = new Uint8Array(0x20);
-		new DataView(bytes.buffer).setUint32(0x00, 0x20, true); // muSizeInBytes
-		bytes[0x1c] = 0xab; // poison a header-pad byte
-		expect(() => parsePropGraphicsList(bytes)).toThrow(/header pad/);
+describe('PropGraphicsList — props only (no parts)', () => {
+	it('nests no parts and preserves each prop Model id', () => {
+		const raw = buildRaw(9, [
+			{ typeId: 0x10, model: 0x111n, mpParts: 0 },
+			{ typeId: 0x20, model: 0x222n, mpParts: 0 },
+		], []);
+		const model = parsePropGraphicsList(raw);
+		expect(model.props.map((p) => p.parts.length)).toEqual([0, 0]);
+		expect(model.props.map((p) => p.mpModelId)).toEqual([0x111n, 0x222n]);
+		expect(bytesEqual(writePropGraphicsList(model), raw)).toBe(true);
+	});
+
+	it('round-trips a prop count whose array end is NOT 16-aligned (1 prop → pad to 0x30)', () => {
+		// 1 prop: propEnd 0x2C, structuralEnd align16 → 0x30. Regression for the
+		// writer dropping the props→structuralEnd align pad when there are no parts.
+		const raw = buildRaw(3, [{ typeId: 5, model: 0xAAn, mpParts: 0 }], []);
+		expect(raw.byteLength).toBe(0x30 + 1 * 16);
+		const model = parsePropGraphicsList(raw);
+		expect(bytesEqual(writePropGraphicsList(model), raw)).toBe(true);
+	});
+
+	it('preserves a partless prop\'s leftover (garbage) mpParts pointer verbatim', () => {
+		// Two props, no parts. Second prop carries a non-zero "garbage" mpParts the
+		// runtime never dereferences; it must round-trip byte-exact.
+		const raw = buildRaw(1, [
+			{ typeId: 0x10, model: 0x1n, mpParts: 0 },
+			{ typeId: 0x20, model: 0x2n, mpParts: 0x999 },
+		], []);
+		const model = parsePropGraphicsList(raw);
+		expect(model.props[1]._mpPartsRaw).toBe(0x999);
+		expect(bytesEqual(writePropGraphicsList(model), raw)).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Populated with nested parts (synth) — the core of the new model
+// ---------------------------------------------------------------------------
+
+// 3 props: prop0 (0xAA) owns 2 parts, prop1 (0xCC) is partless w/ garbage mpParts,
+// prop2 (0xBB) owns 1 part. propEnd 0x44, partsStart 0x50.
+const SYNTH_PROPS: PropSpec[] = [
+	{ typeId: 0xAA, model: 0x1A2B3C4D5E6Fn, mpParts: 0x50 },
+	{ typeId: 0xCC, model: 0xCCCn, mpParts: 0x50 }, // partless, garbage pointer
+	{ typeId: 0xBB, model: 0xBBBn, mpParts: 0x68 },
+];
+const SYNTH_PARTS: PartSpec[] = [
+	{ typeId: 0xAA, partId: 0, model: 0xA00n },
+	{ typeId: 0xAA, partId: 1, model: 0xA11n },
+	{ typeId: 0xBB, partId: 0, model: 0xB00n },
+];
+
+describe('PropGraphicsList — nested parts (synth)', () => {
+	const raw = buildRaw(42, SYNTH_PROPS, SYNTH_PARTS);
+	const model = parsePropGraphicsList(raw);
+
+	it('groups parts under their owning prop by type id', () => {
+		expect(model.props.map((p) => p.parts.length)).toEqual([2, 0, 1]);
+		expect(model.props[0].parts.map((p) => p.muPartId)).toEqual([0, 1]);
+		expect(model.props[0].parts.map((p) => p.mpModelId)).toEqual([0xA00n, 0xA11n]);
+		expect(model.props[2].parts[0].mpModelId).toBe(0xB00n);
+	});
+
+	it('preserves the partless middle prop\'s garbage pointer', () => {
+		expect(model.props[1].parts.length).toBe(0);
+		expect(model.props[1]._mpPartsRaw).toBe(0x50);
+	});
+
+	it('round-trips byte-for-byte and is idempotent', () => {
+		const w1 = writePropGraphicsList(model);
+		expect(bytesEqual(w1, raw)).toBe(true);
+		const w2 = writePropGraphicsList(parsePropGraphicsList(w1));
+		expect(bytesEqual(w2, w1)).toBe(true);
+	});
+
+	it('reports the rebuilt import table (props + parts) via the hook', () => {
+		const table = propGraphicsListImportTable(writePropGraphicsList(model));
+		expect(table.count).toBe(3 + 3);
+		expect(table.offset).toBe(align16(SYNTH_PROPS.length * 0 + 0x50 + 3 * 0x0c)); // align16(structuralEnd 0x74) = 0x80
+		expect(table.offset).toBe(0x80);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Field edits survive round-trip
+// ---------------------------------------------------------------------------
+
+describe('PropGraphicsList — field edits', () => {
+	const base = () => parsePropGraphicsList(buildRaw(42, SYNTH_PROPS, SYNTH_PARTS));
+
+	it('edits a prop Model id', () => {
+		const m = base();
+		m.props[0] = { ...m.props[0], mpModelId: 0xFEEDn };
+		const re = parsePropGraphicsList(writePropGraphicsList(m));
+		expect(re.props[0].mpModelId).toBe(0xFEEDn);
+		expect(re.props[0].parts.length).toBe(2); // parts untouched
+	});
+
+	it('edits a part muPartId + Model id', () => {
+		const m = base();
+		m.props[0] = { ...m.props[0], parts: m.props[0].parts.slice() };
+		m.props[0].parts[1] = { muPartId: 0x55, mpModelId: 0x9999n };
+		const re = parsePropGraphicsList(writePropGraphicsList(m));
+		expect(re.props[0].parts[1].muPartId).toBe(0x55);
+		expect(re.props[0].parts[1].mpModelId).toBe(0x9999n);
+	});
+
+	it('edits a prop type and its part run follows the new type', () => {
+		const m = base();
+		m.props[0] = { ...m.props[0], muTypeId: 0x7F };
+		const re = parsePropGraphicsList(writePropGraphicsList(m));
+		expect(re.props[0].muTypeId).toBe(0x7F);
+		expect(re.props[0].parts.length).toBe(2); // re-grouped under the new type
+		expect(re.props[0].parts.map((p) => p.mpModelId)).toEqual([0xA00n, 0xA11n]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Add / remove parts (the requested feature)
+// ---------------------------------------------------------------------------
+
+describe('PropGraphicsList — add / remove parts', () => {
+	const base = () => parsePropGraphicsList(buildRaw(42, SYNTH_PROPS, SYNTH_PARTS));
+
+	it('appends a part to a prop that already owns parts', () => {
+		const m = base();
+		m.props[0] = { ...m.props[0], parts: [...m.props[0].parts, { muPartId: 2, mpModelId: 0xA22n }] };
+		const re = parsePropGraphicsList(writePropGraphicsList(m));
+		expect(totalParts(re)).toBe(4);
+		expect(re.props[0].parts.map((p) => p.muPartId)).toEqual([0, 1, 2]);
+		expect(re.props[0].parts[2].mpModelId).toBe(0xA22n);
+		// Other props' parts intact.
+		expect(re.props[2].parts[0].mpModelId).toBe(0xB00n);
+	});
+
+	it('gives a previously-partless prop its first part (mpParts becomes derived)', () => {
+		const m = base();
+		m.props[1] = { ...m.props[1], parts: [{ muPartId: 0, mpModelId: 0xC00n }] };
+		const re = parsePropGraphicsList(writePropGraphicsList(m));
+		expect(totalParts(re)).toBe(4);
+		expect(re.props[1].parts.length).toBe(1);
+		expect(re.props[1].parts[0].mpModelId).toBe(0xC00n);
+		// The other runs still resolve to the right props.
+		expect(re.props[0].parts.length).toBe(2);
+		expect(re.props[2].parts.length).toBe(1);
+	});
+
+	it('removes a part from a prop', () => {
+		const m = base();
+		m.props[0] = { ...m.props[0], parts: m.props[0].parts.slice(0, 1) };
+		const re = parsePropGraphicsList(writePropGraphicsList(m));
+		expect(totalParts(re)).toBe(2);
+		expect(re.props[0].parts.map((p) => p.muPartId)).toEqual([0]);
+		expect(re.props[2].parts[0].mpModelId).toBe(0xB00n); // unaffected
+	});
+
+	it('removes every part from a prop (it becomes partless)', () => {
+		const m = base();
+		m.props[2] = { ...m.props[2], parts: [] };
+		const re = parsePropGraphicsList(writePropGraphicsList(m));
+		expect(totalParts(re)).toBe(2);
+		expect(re.props[2].parts.length).toBe(0);
+	});
+
+	it('reflects an added part in the import-table hook count', () => {
+		const m = base();
+		m.props[2] = { ...m.props[2], parts: [...m.props[2].parts, { muPartId: 1, mpModelId: 0xB11n }] };
+		const written = writePropGraphicsList(m);
+		expect(propGraphicsListImportTable(written).count).toBe(3 + 4); // 3 props + 4 parts
+		expect(parsePropGraphicsList(written).props[2].parts.length).toBe(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Add / remove props
+// ---------------------------------------------------------------------------
+
+describe('PropGraphicsList — add / remove props', () => {
+	const base = () => parsePropGraphicsList(buildRaw(42, SYNTH_PROPS, SYNTH_PARTS));
+
+	it('appends a new partless prop', () => {
+		const m = base();
+		m.props = [...m.props, { muTypeId: 0x77, mpModelId: 0xABCDn, parts: [], _mpPartsRaw: 0 }];
+		const re = parsePropGraphicsList(writePropGraphicsList(m));
+		expect(re.props.length).toBe(4);
+		expect(re.props[3].muTypeId).toBe(0x77);
+		expect(re.props[3].mpModelId).toBe(0xABCDn);
+		expect(re.props[3].parts.length).toBe(0);
+		// Existing parts survive the part-array relocation.
+		expect(re.props[0].parts.map((p) => p.mpModelId)).toEqual([0xA00n, 0xA11n]);
+	});
+
+	it('removes the last prop', () => {
+		const m = base();
+		m.props = m.props.slice(0, -1); // drops prop2 (and its part)
+		const re = parsePropGraphicsList(writePropGraphicsList(m));
+		expect(re.props.length).toBe(2);
+		expect(totalParts(re)).toBe(2); // only prop0's 2 parts remain
+		expect(re.props[0].parts.length).toBe(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Layout guards (fail loud on shapes the model can't represent)
+// ---------------------------------------------------------------------------
+
+describe('PropGraphicsList — guards', () => {
+	it('throws when a type id\'s parts are not contiguous', () => {
+		const raw = buildRaw(1, [
+			{ typeId: 0xAA, model: 0x1n, mpParts: 0x30 },
+			{ typeId: 0xBB, model: 0x2n, mpParts: 0x3c },
+		], [
+			{ typeId: 0xAA, partId: 0, model: 0xA0n },
+			{ typeId: 0xBB, partId: 0, model: 0xB0n },
+			{ typeId: 0xAA, partId: 1, model: 0xA1n }, // 0xAA reappears
+		]);
+		expect(() => parsePropGraphicsList(raw)).toThrow(/not contiguous/);
+	});
+
+	it('throws when two props share a type id that owns parts', () => {
+		const raw = buildRaw(1, [
+			{ typeId: 0xAA, model: 0x1n, mpParts: 0x30 },
+			{ typeId: 0xAA, model: 0x2n, mpParts: 0x30 },
+		], [
+			{ typeId: 0xAA, partId: 0, model: 0xA0n },
+		]);
+		expect(() => parsePropGraphicsList(raw)).toThrow(/share type/);
+	});
+
+	it('throws when a part run has no owning prop', () => {
+		const raw = buildRaw(1, [
+			{ typeId: 0xAA, model: 0x1n, mpParts: 0 },
+		], [
+			{ typeId: 0xBB, partId: 0, model: 0xB0n }, // no prop of type 0xBB
+		]);
+		expect(() => parsePropGraphicsList(raw)).toThrow(/no owning prop/);
+	});
+
+	it('throws on a non-zero header pad', () => {
+		const raw = buildRaw(1, [{ typeId: 1, model: 0n, mpParts: 0 }], []);
+		raw[0x1c] = 0xab;
+		expect(() => parsePropGraphicsList(raw)).toThrow(/header pad/);
 	});
 
 	it('throws when muSizeInBytes disagrees with the derived structural end', () => {
-		const bytes = buildBytes();
-		new DataView(bytes.buffer).setUint32(0x00, 0x999, true); // wrong muSizeInBytes
-		expect(() => parsePropGraphicsList(bytes)).toThrow(/structural end/);
+		const raw = buildRaw(42, SYNTH_PROPS, SYNTH_PARTS);
+		new DataView(raw.buffer).setUint32(0x00, 0x999, true);
+		expect(() => parsePropGraphicsList(raw)).toThrow(/structural end/);
 	});
 
 	it('throws when the payload length disagrees with the derived layout', () => {
-		const short = buildBytes().slice(0, 0xbf); // drop the last byte
-		expect(() => parsePropGraphicsList(short)).toThrow(/expected 0x/);
+		const raw = buildRaw(42, SYNTH_PROPS, SYNTH_PARTS).slice(0, -1);
+		expect(() => parsePropGraphicsList(raw)).toThrow(/expected 0x/);
+	});
+
+	it('throws on write when two props share a type and one owns parts (can\'t round-trip)', () => {
+		const model: ParsedPropGraphicsList = {
+			muZoneNumber: 1,
+			props: [
+				{ muTypeId: 0xAA, mpModelId: 0n, _mpPartsRaw: 0, parts: [] },
+				{ muTypeId: 0xAA, mpModelId: 0n, _mpPartsRaw: 0, parts: [{ muPartId: 0, mpModelId: 0n }] },
+			],
+		};
+		expect(() => writePropGraphicsList(model)).toThrow(/more than one prop and owns parts/);
+	});
+
+	it('allows duplicate prop types when NEITHER owns parts (partless dups are fine)', () => {
+		const model: ParsedPropGraphicsList = {
+			muZoneNumber: 1,
+			props: [
+				{ muTypeId: 0xAA, mpModelId: 0x1n, _mpPartsRaw: 0, parts: [] },
+				{ muTypeId: 0xAA, mpModelId: 0x2n, _mpPartsRaw: 0, parts: [] },
+			],
+		};
+		const re = parsePropGraphicsList(writePropGraphicsList(model));
+		expect(re.props.map((p) => p.mpModelId)).toEqual([0x1n, 0x2n]);
 	});
 
 	it('throws rather than truncate when a model carries more than 255 parts', () => {
 		const model: ParsedPropGraphicsList = {
 			muZoneNumber: 1,
-			props: [{ muTypeId: 1, mpModelId: 0n, firstPartIndex: 0 }],
-			parts: Array.from({ length: 300 }, (_, i) => ({ muTypeId: 1, muPartId: i, mpModelId: 0n })),
+			props: [{
+				muTypeId: 1, mpModelId: 0n, _mpPartsRaw: 0,
+				parts: Array.from({ length: 300 }, (_, i) => ({ muPartId: i, mpModelId: 0n })),
+			}],
 		};
 		expect(() => writePropGraphicsList(model)).toThrow(/exceeds the u8/);
 	});
 });
 
-// --- Gold: the real TRK_UNIT9_GR.BNDL bundle (skipped when the binary is absent) ---
+// ---------------------------------------------------------------------------
+// Gold: the real TRK_UNIT9_GR.BNDL bundle (skipped when the binary is absent)
+// ---------------------------------------------------------------------------
 
 const hasTrk9 = fs.existsSync(TRK9_PATH);
 const describeTrk9 = hasTrk9 ? describe : describe.skip;
@@ -233,44 +424,36 @@ describeTrk9('PropGraphicsList gold (example/TRK_UNIT9_GR.BNDL)', () => {
 	const raw = loadRaw();
 	const model = parsePropGraphicsList(raw);
 
-	it('decodes the header', () => {
+	it('decodes the header + counts', () => {
 		expect(model.muZoneNumber).toBe(9);
 		expect(model.props.length).toBe(10);
-		expect(model.parts.length).toBe(52);
+		expect(totalParts(model)).toBe(52);
 	});
 
-	it('decodes the first props (Model ids from the import table; mpParts → part index)', () => {
+	it('nests the first prop\'s parts (type 0x28, Model 0x12F7700A, parts 0,1,…)', () => {
 		expect(model.props[0].muTypeId).toBe(0x28);
-		expect(model.props[0].mpModelId).toBe(0x12f7700an); // verified Model id for type 0x28
-		expect(model.props[0].firstPartIndex).toBe(0);       // mpParts 0xA0 = partsStart + 0
-		expect(model.props[2].muTypeId).toBe(0x06);
-		expect(model.props[2].firstPartIndex).toBe(4);       // mpParts 0xD0 = 0xA0 + 4*0x0C
+		expect(model.props[0].mpModelId).toBe(0x12f7700an);
+		expect(model.props[0].parts.length).toBeGreaterThanOrEqual(2);
+		expect(model.props[0].parts[0].muPartId).toBe(0);
+		expect(model.props[0].parts[1].muPartId).toBe(1);
+		expect(model.props[0].parts.every((p) => typeof p.mpModelId === 'bigint')).toBe(true);
 	});
 
-	it('decodes the first parts (grouped by owning prop type)', () => {
-		expect(model.parts[0].muTypeId).toBe(0x28);
-		expect(model.parts[0].muPartId).toBe(0);
-		expect(model.parts[1].muTypeId).toBe(0x28);
-		expect(model.parts[1].muPartId).toBe(1);
-		expect(model.parts[4].muTypeId).toBe(0x06);
-		expect(model.parts[4].muPartId).toBe(0);
-		expect(model.parts.every((p) => typeof p.mpModelId === 'bigint')).toBe(true);
+	it('nests the type-0x06 prop\'s parts', () => {
+		const prop = model.props.find((p) => p.muTypeId === 0x06)!;
+		expect(prop).toBeTruthy();
+		expect(prop.parts.length).toBeGreaterThanOrEqual(1);
+		expect(prop.parts[0].muPartId).toBe(0);
 	});
 
-	it('round-trips byte-for-byte', () => {
-		const rewritten = writePropGraphicsList(model);
-		expect(rewritten.byteLength).toBe(raw.byteLength);
-		expect(bytesEqual(rewritten, raw)).toBe(true);
+	it('round-trips byte-for-byte and is idempotent', () => {
+		const w1 = writePropGraphicsList(model);
+		expect(bytesEqual(w1, raw)).toBe(true);
+		const w2 = writePropGraphicsList(parsePropGraphicsList(w1));
+		expect(bytesEqual(w2, w1)).toBe(true);
 	});
 
-	it('writer is idempotent', () => {
-		const write1 = writePropGraphicsList(parsePropGraphicsList(raw));
-		const write2 = writePropGraphicsList(parsePropGraphicsList(write1));
-		expect(bytesEqual(write1, write2)).toBe(true);
-	});
-
-	it('import-table hook matches the real envelope (props + parts)', () => {
-		const table = propGraphicsListImportTable(raw);
-		expect(table.count).toBe(model.props.length + model.parts.length); // 62
+	it('import-table hook matches the real envelope (props + parts = 62)', () => {
+		expect(propGraphicsListImportTable(raw).count).toBe(model.props.length + totalParts(model));
 	});
 });

--- a/src/lib/core/bundle/__tests__/propGraphicsListExport.test.ts
+++ b/src/lib/core/bundle/__tests__/propGraphicsListExport.test.ts
@@ -29,6 +29,7 @@ function loadBundle(name: string): ArrayBuffer {
 
 const NEW_TYPE = 0xfe;
 const NEW_MODEL = 0xDEADBEEFCAFEn;
+const NEW_PART_MODEL = 0xABCDEF012345n;
 
 const hasTrk9 = fs.existsSync(path.resolve(REPO_ROOT, TRK9));
 const describeTrk9 = hasTrk9 ? describe : describe.skip;
@@ -44,7 +45,7 @@ describeTrk9('add a PropGraphics entry and export (example/TRK_UNIT9_GR.BNDL)', 
 
 		const mutated: ParsedPropGraphicsList = {
 			...model,
-			props: [...model.props, { muTypeId: NEW_TYPE, mpModelId: NEW_MODEL, firstPartIndex: null }],
+			props: [...model.props, { muTypeId: NEW_TYPE, mpModelId: NEW_MODEL, parts: [], _mpPartsRaw: 0 }],
 		};
 		const repacked = writeBundleFresh(bundle, original, {
 			overrides: { resources: { [PROP_GRAPHICS_LIST_TYPE_ID]: mutated } },
@@ -76,5 +77,45 @@ describeTrk9('add a PropGraphics entry and export (example/TRK_UNIT9_GR.BNDL)', 
 		// Existing prop Model ids are still resolvable (table fully rebuilt).
 		const firstFieldOffset = 0x20 + 0x04;
 		expect(imports.get(firstFieldOffset)).toBe(model.props[0].mpModelId);
+	});
+
+	it('adds a PART to a prop and exports it with a wired-up Model id', () => {
+		const original = loadBundle(TRK9);
+		const bundle = parseBundle(original);
+		const ctx = resourceCtxFromBundle(bundle);
+		const entry = bundle.resources.find((r) => r.resourceTypeId === PROP_GRAPHICS_LIST_TYPE_ID)!;
+		const model = parsePropGraphicsList(extractResourceRaw(original, bundle, entry), ctx.littleEndian);
+		const beforeImports = entry.importCount;
+		const beforeParts = model.props.reduce((n, p) => n + p.parts.length, 0);
+
+		// Append a part to the first prop that already owns parts (extends its run).
+		const targetIdx = model.props.findIndex((p) => p.parts.length > 0);
+		expect(targetIdx).toBeGreaterThanOrEqual(0);
+		const props = model.props.map((p) => ({ ...p, parts: p.parts.slice() }));
+		props[targetIdx].parts.push({ muPartId: 99, mpModelId: NEW_PART_MODEL });
+		const mutated: ParsedPropGraphicsList = { ...model, props };
+
+		const repacked = writeBundleFresh(bundle, original, {
+			overrides: { resources: { [PROP_GRAPHICS_LIST_TYPE_ID]: mutated } },
+		});
+
+		const reparsed = parseBundle(repacked);
+		const reIdx = reparsed.resources.findIndex((r) => r.resourceTypeId === PROP_GRAPHICS_LIST_TYPE_ID);
+		const reEntry = reparsed.resources[reIdx];
+		const payload = extractResourceRaw(repacked, reparsed, reEntry);
+		const reModel = parsePropGraphicsList(payload, ctx.littleEndian);
+
+		// One more part overall, on the same prop, with the new Model id.
+		expect(reModel.props.reduce((n, p) => n + p.parts.length, 0)).toBe(beforeParts + 1);
+		const added = reModel.props[targetIdx].parts.find((p) => p.muPartId === 99);
+		expect(added?.mpModelId).toBe(NEW_PART_MODEL);
+
+		// Envelope import metadata grew by one (one Model import per part).
+		expect(reEntry.importCount).toBe(beforeImports + 1);
+		expect(reEntry.importOffset).toBe(payload.byteLength - reEntry.importCount * 16);
+
+		// The new part's Model id is resolvable through the bundle import index.
+		const imports = getImportsByPtrOffset(reparsed.imports, reparsed.resources, reIdx);
+		expect([...imports.values()]).toContain(NEW_PART_MODEL);
 	});
 });

--- a/src/lib/core/propGraphicsList.ts
+++ b/src/lib/core/propGraphicsList.ts
@@ -194,6 +194,7 @@ export function parsePropGraphicsList(raw: Uint8Array, littleEndian = true): Par
 	// after a different one), since the nested model + writer rely on it.
 	r.position = partsStart;
 	const partsByType = new Map<number, PropPartGraphics[]>();
+	const runStartByType = new Map<number, number>();   // first part-array index of each type's run
 	const closedTypes = new Set<number>();
 	let prevType: number | null = null;
 	for (let j = 0; j < muNumberOfPropPartModels; j++) {
@@ -208,6 +209,7 @@ export function parsePropGraphicsList(raw: Uint8Array, littleEndian = true): Par
 			if (prevType !== null) closedTypes.add(prevType);
 			prevType = muTypeId;
 			partsByType.set(muTypeId, []);
+			runStartByType.set(muTypeId, j);
 		}
 		partsByType.get(muTypeId)!.push({ muPartId, mpModelId });
 	}
@@ -231,6 +233,20 @@ export function parsePropGraphicsList(raw: Uint8Array, littleEndian = true): Par
 	if (claimed.size !== partsByType.size) {
 		const orphan = [...partsByType.keys()].find((t) => !claimed.has(t));
 		throw new Error(`PropGraphicsList: part run for type 0x${(orphan ?? 0).toString(16)} has no owning prop — unexpected layout`);
+	}
+
+	// Part runs must appear in PROP order — the writer flattens parts by iterating
+	// props in order, so an out-of-order on-disk run layout would round-trip to
+	// DIFFERENT bytes (silently). Verified across the corpus; fail loud here rather
+	// than write back a reordered payload, keeping the parser's loud-fail contract.
+	let lastRunStart = -1;
+	for (const p of props) {
+		if (p.parts.length === 0) continue;
+		const runStart = runStartByType.get(p.muTypeId)!;
+		if (runStart <= lastRunStart) {
+			throw new Error(`PropGraphicsList: part runs are not in prop order (type 0x${p.muTypeId.toString(16)} run starts at ${runStart}, after ${lastRunStart}) — unexpected layout`);
+		}
+		lastRunStart = runStart;
 	}
 
 	return { muZoneNumber, props };

--- a/src/lib/core/propGraphicsList.ts
+++ b/src/lib/core/propGraphicsList.ts
@@ -3,43 +3,45 @@
 //
 // A PropGraphicsList is the per-track-unit catalogue that maps every prop TYPE
 // placed in that unit (see PropInstanceData / 0x10011) to the Model resource(s)
-// the runtime spawns for it. It carries two parallel arrays:
+// the runtime spawns for it. It carries two parallel on-disk arrays:
 //  - PropGraphics:     one entry per whole prop  → its Model (the body mesh).
 //  - PropPartGraphics: one entry per prop PART   → its Model (a destructible
-//    sub-piece, e.g. a billboard panel that breaks off). Parts are grouped
-//    contiguously by owning prop; a PropGraphics.mpParts points at the prop's
-//    first part.
+//    sub-piece, e.g. a billboard panel that breaks off).
+//
+// PART OWNERSHIP (load-bearing, grounded by sweeping all 234 PGLs-with-parts):
+// parts are grouped CONTIGUOUSLY by muTypeId, and the prop whose muTypeId matches
+// owns that whole run. No two parts-owning props ever share a typeId, every part
+// run matches a prop, and the runs appear in prop-array order. So the relationship
+// is unambiguous BY TYPE. We therefore MODEL parts NESTED under their owning prop
+// (PropGraphics.parts) rather than as a flat array + a pointer — adding/removing a
+// part is then an edit to one prop's list, and ownership can never desync. The
+// flat on-disk array is purely a writer detail (flatten props' parts in prop order).
+//
+// The old PropGraphics.mpParts pointer is DERIVED on write (a prop with parts →
+// the byte offset of its run's first part). On disk, partless props carry a
+// LEFTOVER/garbage mpParts the runtime never dereferences (2951 of them in the
+// corpus, 610 null); we preserve it verbatim as _mpPartsRaw so the round-trip
+// stays byte-exact.
 //
 // The Model references are BND2 imports: on disk every mpPropModel pointer is 0,
-// and the real resource id lives in the resource's INLINE import table (stored
-// at the tail of this resource's own payload). Each import entry is keyed by the
-// byte offset of the pointer field it fills. We MODEL those ids (mpModelId per
-// record) rather than carrying the table verbatim, so the catalogue is fully
-// editable: a new prop instance whose type isn't catalogued yet needs a new
-// PropGraphics entry mapping its type → a Model, which means adding both a record
-// and its import. The writer rebuilds the whole table from the model.
+// and the real resource id lives in the resource's INLINE import table (at the
+// tail of the payload), keyed by the field's byte offset. We MODEL those ids
+// (mpModelId per record) and the writer rebuilds the whole table — so a prop's
+// (or part's) Model, and the set of props/parts itself, are all freely editable.
 //
 // Scope: 32-bit PC, little-endian. The wiki documents a 64-bit (Paradise
 // Remastered) layout too; like propInstanceData / instanceList / streetData we
 // implement 32-bit PC LE only.
 //
-// Round-trip strategy (byte-exact, grounded by sweeping all 256 populated PGL
-// resources in example/ — every invariant below holds with zero violations):
+// Round-trip strategy (byte-exact, grounded by sweeping all 256 populated PGLs):
 //  - Layout is rigid: header(0x20) → PropGraphics[nProps] (0x0C each, at 0x20) →
 //    align16 pad → PropPartGraphics[nParts] (0x0C each) → align16 pad → inline
 //    import table (importCount*16) to end of payload. Every offset/pointer/count
 //    is recomputed from nProps/nParts, so add/remove of props or parts is safe.
 //  - muSizeInBytes is the "structural end": part-array end when parts exist,
-//    align16(prop-array end) when only props, 0x20 when empty. It is DERIVED
-//    (not stored on the model) — the sweep proved the stored value always equals
-//    this formula. importOffset = align16(muSizeInBytes).
-//  - mpPropModel is 0 on disk; the real Model id is mpModelId, written into the
-//    rebuilt import table (one entry per prop, one per part), keyed by field
-//    offset. importCount == nProps + nParts.
-//  - mpParts is an internal resource-relative pointer to a prop's first part. We
-//    model it as firstPartIndex (the part-array INDEX it points at), so it stays
-//    valid when the part array relocates after a prop add/remove — on write it
-//    becomes mpaPropPartGraphics + firstPartIndex*0x0C (or 0 for a partless prop).
+//    align16(prop-array end) when only props, 0x20 when empty. DERIVED.
+//  - mpPropModel is 0 on disk; the real Model id is mpModelId. importCount ==
+//    nProps + nParts (one per prop + one per part).
 
 import { BinReader, BinWriter } from './binTools';
 
@@ -47,29 +49,33 @@ import { BinReader, BinWriter } from './binTools';
 // Types
 // =============================================================================
 
+export type PropPartGraphics = {
+	muPartId: number;    // u32 — part index within the owning prop
+	// Model resource id for this part's mesh (BND2 import; 0 on disk). Editable.
+	mpModelId: bigint;
+	// NOTE: the on-disk part also stores muTypeId == the owning prop's muTypeId.
+	// It isn't modelled here — the part is nested under its prop, so the writer
+	// re-emits the prop's muTypeId. That makes a new part trivially well-formed.
+};
+
 export type PropGraphics = {
 	muTypeId: number;    // u32 — prop type index (into the prop-types table)
 	// Model resource id (64-bit) the runtime spawns for this prop's body mesh.
-	// Stored on disk as a 0 pointer + a BND2 import; editable here, rebuilt into
-	// the import table on write. 0n means "no model / unresolved".
+	// BND2 import (0 on disk); editable, rebuilt into the import table on write.
 	mpModelId: bigint;
-	// Index into `parts` of this prop's first PropPartGraphics, or null when the
-	// prop has no parts. Replaces the raw resource-relative mpParts pointer so it
-	// survives the part array relocating when props are added/removed.
-	firstPartIndex: number | null;
-};
-
-export type PropPartGraphics = {
-	muTypeId: number;    // u32 — owning prop's type id (always little endian per wiki)
-	muPartId: number;    // u32 — part index within the prop
-	// Model resource id for this part's mesh — same import mechanism as PropGraphics.
-	mpModelId: bigint;
+	// This prop's destructible parts (owned by muTypeId). Empty for a partless
+	// prop. Add/remove freely — the writer regroups + rederives all pointers.
+	parts: PropPartGraphics[];
+	// Raw on-disk mpParts pointer, preserved for byte-exact round-trip. Only used
+	// on write when the prop is PARTLESS (the runtime ignores it then, but retail
+	// ships non-zero garbage here we must reproduce). For a prop that owns parts
+	// the writer derives mpParts from the part run and ignores this.
+	_mpPartsRaw: number;
 };
 
 export type ParsedPropGraphicsList = {
 	muZoneNumber: number; // PVS zone / track-unit id (editable)
 	props: PropGraphics[];
-	parts: PropPartGraphics[];
 };
 
 // =============================================================================
@@ -104,6 +110,13 @@ function layout(nProps: number, nParts: number) {
 	return { propGraphicsEnd, partsStart, structuralEnd, importOffset, total };
 }
 
+/** Total parts across all props — the flat on-disk PropPartGraphics count. */
+function countParts(props: PropGraphics[]): number {
+	let n = 0;
+	for (const p of props) n += p.parts.length;
+	return n;
+}
+
 // =============================================================================
 // Reader
 // =============================================================================
@@ -133,14 +146,9 @@ export function parsePropGraphicsList(raw: Uint8Array, littleEndian = true): Par
 	if (muNumberOfPropPartModels > 0 && mpaPropPartGraphics !== partsStart) {
 		throw new Error(`PropGraphicsList: mpaPropPartGraphics is 0x${mpaPropPartGraphics.toString(16)}, expected 0x${partsStart.toString(16)} for ${muNumberOfPropModels} props`);
 	}
-	// muSizeInBytes always equals the structural end across the whole corpus; a
-	// mismatch means an unexpected layout we don't know how to rebuild — fail loud.
 	if (muSizeInBytes !== structuralEnd) {
 		throw new Error(`PropGraphicsList: muSizeInBytes 0x${muSizeInBytes.toString(16)} != derived structural end 0x${structuralEnd.toString(16)} (nProps=${muNumberOfPropModels} nParts=${muNumberOfPropPartModels})`);
 	}
-	// The payload must be exactly the derived length: header + arrays + pads +
-	// (nProps+nParts) import entries. The writer rebuilds to this length, so any
-	// extra/missing trailing bytes would break the byte-exact round-trip.
 	if (raw.byteLength !== total) {
 		throw new Error(`PropGraphicsList: payload is 0x${raw.byteLength.toString(16)} bytes, expected 0x${total.toString(16)} for ${muNumberOfPropModels} props + ${muNumberOfPropPartModels} parts`);
 	}
@@ -169,41 +177,63 @@ export function parsePropGraphicsList(raw: Uint8Array, littleEndian = true): Par
 		importById.set(fieldOffset, resourceId);
 	}
 
-	// --- PropGraphics (12 bytes each, at 0x20) ---
-	const props: PropGraphics[] = [];
+	// --- PropGraphics (12 bytes each, at 0x20) — raw, before nesting parts ---
+	type RawProp = { muTypeId: number; mpModelId: bigint; mpPartsRaw: number };
+	const rawProps: RawProp[] = [];
 	r.position = PROP_GRAPHICS_OFFSET;
 	for (let i = 0; i < muNumberOfPropModels; i++) {
 		const muTypeId = r.readU32();
 		r.readU32();                     // mpPropModel — 0 on disk, ignored (id is in the import table)
 		const mpParts = r.readU32();
-		const fieldOffset = PROP_GRAPHICS_OFFSET + i * PROP_RECORD_SIZE + PROP_MODEL_FIELD;
-		const mpModelId = importById.get(fieldOffset) ?? 0n;
-		// mpParts is an aligned offset into the part array (proven by the sweep) —
-		// store it as a part index so it survives the array relocating on edit.
-		let firstPartIndex: number | null = null;
-		if (mpParts !== 0) {
-			const rel = mpParts - partsStart;
-			if (rel < 0 || rel % PART_RECORD_SIZE !== 0 || rel / PART_RECORD_SIZE >= muNumberOfPropPartModels) {
-				throw new Error(`PropGraphicsList: prop[${i}] mpParts 0x${mpParts.toString(16)} is not an aligned index into the ${muNumberOfPropPartModels}-part array`);
-			}
-			firstPartIndex = rel / PART_RECORD_SIZE;
-		}
-		props.push({ muTypeId, mpModelId, firstPartIndex });
+		const mpModelId = importById.get(PROP_GRAPHICS_OFFSET + i * PROP_RECORD_SIZE + PROP_MODEL_FIELD) ?? 0n;
+		rawProps.push({ muTypeId, mpModelId, mpPartsRaw: mpParts });
 	}
 
-	// --- PropPartGraphics (12 bytes each, at align16(propGraphicsEnd)) ---
-	const parts: PropPartGraphics[] = [];
+	// --- PropPartGraphics (12 bytes each) — grouped CONTIGUOUSLY by muTypeId.
+	// Group runs as we read, asserting contiguity (a typeId must not reappear
+	// after a different one), since the nested model + writer rely on it.
 	r.position = partsStart;
+	const partsByType = new Map<number, PropPartGraphics[]>();
+	const closedTypes = new Set<number>();
+	let prevType: number | null = null;
 	for (let j = 0; j < muNumberOfPropPartModels; j++) {
 		const muTypeId = r.readU32();
 		const muPartId = r.readU32();
 		r.readU32();                     // mpPropModel — 0 on disk, ignored
-		const fieldOffset = partsStart + j * PART_RECORD_SIZE + PART_MODEL_FIELD;
-		const mpModelId = importById.get(fieldOffset) ?? 0n;
-		parts.push({ muTypeId, muPartId, mpModelId });
+		const mpModelId = importById.get(partsStart + j * PART_RECORD_SIZE + PART_MODEL_FIELD) ?? 0n;
+		if (muTypeId !== prevType) {
+			if (closedTypes.has(muTypeId)) {
+				throw new Error(`PropGraphicsList: parts for type 0x${muTypeId.toString(16)} are not contiguous (reappear at part ${j}) — unexpected layout`);
+			}
+			if (prevType !== null) closedTypes.add(prevType);
+			prevType = muTypeId;
+			partsByType.set(muTypeId, []);
+		}
+		partsByType.get(muTypeId)!.push({ muPartId, mpModelId });
 	}
 
-	return { muZoneNumber, props, parts };
+	// --- Attach each part run to the prop whose muTypeId owns it. ---
+	const claimed = new Set<number>();
+	const props: PropGraphics[] = rawProps.map((rp) => {
+		const owned = partsByType.get(rp.muTypeId);
+		if (owned && owned.length > 0) {
+			if (claimed.has(rp.muTypeId)) {
+				throw new Error(`PropGraphicsList: two props share type 0x${rp.muTypeId.toString(16)} which owns parts — ambiguous ownership`);
+			}
+			claimed.add(rp.muTypeId);
+			return { muTypeId: rp.muTypeId, mpModelId: rp.mpModelId, parts: owned, _mpPartsRaw: rp.mpPartsRaw };
+		}
+		return { muTypeId: rp.muTypeId, mpModelId: rp.mpModelId, parts: [], _mpPartsRaw: rp.mpPartsRaw };
+	});
+
+	// Every part run must have found an owning prop (no orphans). Verified across
+	// the corpus; assert so an unexpected layout fails loud instead of dropping parts.
+	if (claimed.size !== partsByType.size) {
+		const orphan = [...partsByType.keys()].find((t) => !claimed.has(t));
+		throw new Error(`PropGraphicsList: part run for type 0x${(orphan ?? 0).toString(16)} has no owning prop — unexpected layout`);
+	}
+
+	return { muZoneNumber, props };
 }
 
 // =============================================================================
@@ -211,21 +241,33 @@ export function parsePropGraphicsList(raw: Uint8Array, littleEndian = true): Par
 // =============================================================================
 
 export function writePropGraphicsList(model: ParsedPropGraphicsList, littleEndian = true): Uint8Array {
-	const { props, parts } = model;
+	const { props } = model;
 	const nProps = props.length;
-	const nParts = parts.length;
+	const nParts = countParts(props);
 
 	// muNumberOfPropPartModels is a u8 on disk; refuse to silently truncate a
-	// model carrying >255 parts into a desynced count. Real fixtures top out at
-	// 82 parts.
+	// model carrying >255 parts into a desynced count. Real fixtures top out at 82.
 	if (nParts > 0xff) {
 		throw new Error(`PropGraphicsList: ${nParts} parts exceeds the u8 muNumberOfPropPartModels field (max 255)`);
 	}
 
+	// Parts are owned BY TYPE (the on-disk flat array is grouped by muTypeId), so
+	// two props sharing a type where one owns parts can't round-trip — on reload
+	// the whole run would attach to the first prop of that type. Fail loud at write
+	// time rather than emit a file that can't be reopened. (Distinct-type props are
+	// the norm; this only guards a user creating a duplicate-type prop + parts.)
+	const typesWithParts = new Set<number>();
+	for (const p of props) if (p.parts.length > 0) typesWithParts.add(p.muTypeId);
+	const seenTypes = new Set<number>();
+	for (const p of props) {
+		if (seenTypes.has(p.muTypeId) && typesWithParts.has(p.muTypeId)) {
+			throw new Error(`PropGraphicsList: prop type 0x${p.muTypeId.toString(16)} appears on more than one prop and owns parts — parts are owned by type and can't be split across props`);
+		}
+		seenTypes.add(p.muTypeId);
+	}
+
 	const { partsStart, structuralEnd, importOffset, total } = layout(nProps, nParts);
 
-	// Stored pointers are null (0) when their array is empty — reproduces the
-	// all-zero header an empty list ships, keeping the round-trip byte-exact.
 	const mpaPropGraphics = nProps > 0 ? PROP_GRAPHICS_OFFSET : 0;
 	const mpaPropPartGraphics = nParts > 0 ? partsStart : 0;
 
@@ -242,45 +284,56 @@ export function writePropGraphicsList(model: ParsedPropGraphicsList, littleEndia
 	while (w.offset < HEADER_SIZE) w.writeU8(0); // pad header up to 0x20
 	if (w.offset !== HEADER_SIZE) throw new Error(`PropGraphicsList writer: header offset mismatch ${w.offset} vs ${HEADER_SIZE}`);
 
-	// --- PropGraphics (12 bytes each) ---
+	// --- PropGraphics (12 bytes each). mpParts is DERIVED for a prop that owns
+	// parts (byte offset of its run's first part) and the preserved raw value for
+	// a partless prop (leftover the runtime ignores). Part runs are emitted in
+	// prop order below, so a prop's run begins at the running part offset. ---
+	let runStart = 0;
 	for (const p of props) {
-		const idx = p.firstPartIndex;
-		if (idx != null && (idx < 0 || idx >= nParts)) {
-			throw new Error(`PropGraphicsList writer: firstPartIndex ${idx} out of range for ${nParts} parts`);
-		}
-		const mpParts = idx == null ? 0 : partsStart + idx * PART_RECORD_SIZE;
+		const mpParts = p.parts.length > 0 ? partsStart + runStart * PART_RECORD_SIZE : p._mpPartsRaw;
 		w.writeU32(p.muTypeId);
 		w.writeU32(0);                            // mpPropModel — 0 on disk, id lives in the import table
-		w.writeU32(mpParts);                      // recomputed internal pointer
+		w.writeU32(mpParts);
+		runStart += p.parts.length;
 	}
 
-	// --- align16 pad → PropPartGraphics (12 bytes each) ---
+	// --- align16 pad → PropPartGraphics (12 bytes each), flattened in prop order
+	// so the contiguous-by-type grouping is reproduced. Each part re-emits its
+	// owning prop's muTypeId. ---
 	if (nParts > 0) {
 		while (w.offset < partsStart) w.writeU8(0);
-		for (const q of parts) {
-			w.writeU32(q.muTypeId);
-			w.writeU32(q.muPartId);
-			w.writeU32(0);                        // mpPropModel — 0 on disk
+		for (const p of props) {
+			for (const part of p.parts) {
+				w.writeU32(p.muTypeId);
+				w.writeU32(part.muPartId);
+				w.writeU32(0);                    // mpPropModel — 0 on disk
+			}
 		}
 	}
-	// Pad up to the structural end. With parts this is already the part-array end
-	// (no-op); with only props the structural end is align16(prop-array end), so
-	// there's an align pad after the last prop record to fill here.
+	// Pad up to the structural end. For a parts-bearing list the parts loop
+	// already lands exactly here; for a props-only list whose prop array isn't
+	// 16-aligned this writes the align pad between propGraphicsEnd and the
+	// align16(propGraphicsEnd) structural end (nProps not a multiple of 4).
 	while (w.offset < structuralEnd) w.writeU8(0);
 	if (w.offset !== structuralEnd) throw new Error(`PropGraphicsList writer: structural-end offset mismatch ${w.offset} vs ${structuralEnd}`);
 
-	// --- align16 pad → inline import table (one entry per prop, then per part) ---
+	// --- align16 pad → inline import table (one entry per prop, then per part in
+	// the same flat prop order). ---
 	while (w.offset < importOffset) w.writeU8(0);
 	props.forEach((p, i) => {
 		w.writeU64(p.mpModelId);
 		w.writeU32(PROP_GRAPHICS_OFFSET + i * PROP_RECORD_SIZE + PROP_MODEL_FIELD);
 		w.writeU32(0);
 	});
-	parts.forEach((q, j) => {
-		w.writeU64(q.mpModelId);
-		w.writeU32(partsStart + j * PART_RECORD_SIZE + PART_MODEL_FIELD);
-		w.writeU32(0);
-	});
+	let partIdx = 0;
+	for (const p of props) {
+		for (const part of p.parts) {
+			w.writeU64(part.mpModelId);
+			w.writeU32(partsStart + partIdx * PART_RECORD_SIZE + PART_MODEL_FIELD);
+			w.writeU32(0);
+			partIdx++;
+		}
+	}
 	if (w.offset !== total) throw new Error(`PropGraphicsList writer: end offset mismatch ${w.offset} vs ${total}`);
 
 	return w.bytes;

--- a/src/lib/core/propGraphicsList.ts
+++ b/src/lib/core/propGraphicsList.ts
@@ -128,8 +128,7 @@ export function parsePropGraphicsList(raw: Uint8Array, littleEndian = true): Par
 	const muSizeInBytes = r.readU32();
 	const muZoneNumber = r.readU32();
 	const muNumberOfPropModels = r.readU32();
-	const muNumberOfPropPartModels = r.readU8();
-	r.readU8(); r.readU8(); r.readU8();          // 3 pad (muNumberOfPropPartModels occupies a 4-byte slot)
+	const muNumberOfPropPartModels = r.readU32(); // full u32 on disk; corpus max is 82 so the high 3 bytes are always 0
 	const mpaPropGraphics = r.readU32();
 	const mpaPropPartGraphics = r.readU32();
 	// 0x18..0x20 is zero pad up to where PropGraphics begins (mpaPropGraphics).
@@ -261,11 +260,8 @@ export function writePropGraphicsList(model: ParsedPropGraphicsList, littleEndia
 	const nProps = props.length;
 	const nParts = countParts(props);
 
-	// muNumberOfPropPartModels is a u8 on disk; refuse to silently truncate a
-	// model carrying >255 parts into a desynced count. Real fixtures top out at 82.
-	if (nParts > 0xff) {
-		throw new Error(`PropGraphicsList: ${nParts} parts exceeds the u8 muNumberOfPropPartModels field (max 255)`);
-	}
+	// muNumberOfPropPartModels is a full u32 on disk (real fixtures top out at 82),
+	// so no field-width cap is needed here.
 
 	// Parts are owned BY TYPE (the on-disk flat array is grouped by muTypeId), so
 	// two props sharing a type where one owns parts can't round-trip — on reload
@@ -293,8 +289,7 @@ export function writePropGraphicsList(model: ParsedPropGraphicsList, littleEndia
 	w.writeU32(structuralEnd);                   // muSizeInBytes — derived structural end
 	w.writeU32(model.muZoneNumber);
 	w.writeU32(nProps);
-	w.writeU8(nParts & 0xff);
-	w.writeU8(0); w.writeU8(0); w.writeU8(0);    // 3 pad
+	w.writeU32(nParts);                          // muNumberOfPropPartModels (u32)
 	w.writeU32(mpaPropGraphics);
 	w.writeU32(mpaPropPartGraphics);
 	while (w.offset < HEADER_SIZE) w.writeU8(0); // pad header up to 0x20
@@ -368,6 +363,6 @@ export function propGraphicsListImportTable(payload: Uint8Array, littleEndian = 
 	const dv = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
 	const muSizeInBytes = dv.getUint32(0x00, littleEndian);
 	const nProps = dv.getUint32(0x08, littleEndian);
-	const nParts = dv.getUint8(0x0c);
+	const nParts = dv.getUint32(0x0c, littleEndian); // full u32
 	return { offset: align16(muSizeInBytes), count: nProps + nParts };
 }

--- a/src/lib/core/registry/handlers/propGraphicsList.ts
+++ b/src/lib/core/registry/handlers/propGraphicsList.ts
@@ -17,20 +17,28 @@ import type { ResourceHandler } from '../handler';
 // A prop-type id distinct from any low index the fixtures start with, so
 // 'edit-prop-type' actually changes the stored value.
 const STRESS_PROP_TYPE = 0x123;
+// A high, almost-certainly-unique prop type for the add-part scenario, so the
+// re-stamped part run can't collide with another prop's type on reparse.
+const STRESS_UNIQUE_TYPE = 0x765;
 // A part id distinct from the low sequential ids parts carry on disk.
 const STRESS_PART_ID = 0x77;
 // A Model resource id marker for the import-table edit/add scenarios.
 const STRESS_MODEL_ID = 0xCAFEF00DBABEn;
 
+/** Total parts across all props — the flat on-disk PropPartGraphics count. */
+function totalParts(m: ParsedPropGraphicsList): number {
+	return m.props.reduce((n, p) => n + p.parts.length, 0);
+}
+
 export const propGraphicsListHandler: ResourceHandler<ParsedPropGraphicsList> = {
 	typeId: PROP_GRAPHICS_LIST_TYPE_ID,
 	key: 'propGraphicsList',
 	name: 'Prop Graphics List',
-	description: 'Per-track-unit catalogue mapping each prop type (and destructible part) to its Model resource',
+	description: 'Per-track-unit catalogue mapping each prop type (and its destructible parts) to its Model resource',
 	category: 'Data',
 	caps: { read: true, write: true },
 	wikiUrl: 'https://burnout.wiki/wiki/Prop_Graphics_List',
-	notes: 'Model references live in the resource\'s inline import table — one entry per prop + per part. Adding/removing entries resizes the table; the bundle envelope recomputes its import metadata via importTable() on export.',
+	notes: 'Model references live in the resource\'s inline import table — one entry per prop + per part. Parts are nested under their owning prop (grouped by type id on disk). Adding/removing props or parts resizes the table; the bundle envelope recomputes its import metadata via importTable() on export.',
 
 	parseRaw(raw, ctx) {
 		return parsePropGraphicsList(raw, ctx.littleEndian);
@@ -44,7 +52,7 @@ export const propGraphicsListHandler: ResourceHandler<ParsedPropGraphicsList> = 
 		return propGraphicsListImportTable(payload, ctx.littleEndian);
 	},
 	describe(model) {
-		return `zone ${model.muZoneNumber}, props ${model.props.length}, parts ${model.parts.length}`;
+		return `zone ${model.muZoneNumber}, props ${model.props.length}, parts ${totalParts(model)}`;
 	},
 
 	fixtures: [
@@ -53,8 +61,8 @@ export const propGraphicsListHandler: ResourceHandler<ParsedPropGraphicsList> = 
 		// The empty-list shape (172/427 track units: no props, no parts, null
 		// pointers, 32-byte payload) is covered by a self-contained unit test in
 		// __tests__/propGraphicsList.test.ts — it can't be a fixture here because
-		// the stress scenarios below edit props[0] / parts[0], which an empty list
-		// doesn't have.
+		// the stress scenarios below edit props[0] / a prop's parts, which an empty
+		// list doesn't have.
 	],
 
 	stressScenarios: [
@@ -67,8 +75,8 @@ export const propGraphicsListHandler: ResourceHandler<ParsedPropGraphicsList> = 
 				if (after.props.length !== before.props.length) {
 					problems.push(`prop count ${after.props.length} != ${before.props.length}`);
 				}
-				if (after.parts.length !== before.parts.length) {
-					problems.push(`part count ${after.parts.length} != ${before.parts.length}`);
+				if (totalParts(after) !== totalParts(before)) {
+					problems.push(`part count ${totalParts(after)} != ${totalParts(before)}`);
 				}
 				return problems;
 			},
@@ -80,30 +88,6 @@ export const propGraphicsListHandler: ResourceHandler<ParsedPropGraphicsList> = 
 			verify: (_before, after) => {
 				const problems: string[] = [];
 				if (after.muZoneNumber !== 4242) problems.push(`muZoneNumber = ${after.muZoneNumber}, expected 4242`);
-				return problems;
-			},
-		},
-		{
-			name: 'edit-prop-type',
-			description: 'set props[0].muTypeId to a marker and verify it survives without perturbing the Model id / parts pointer',
-			mutate: (m) => {
-				const props = m.props.slice();
-				props[0] = { ...props[0], muTypeId: STRESS_PROP_TYPE };
-				return { ...m, props };
-			},
-			verify: (before, after) => {
-				const problems: string[] = [];
-				if (after.props[0].muTypeId !== STRESS_PROP_TYPE) {
-					problems.push(`props[0].muTypeId = ${after.props[0].muTypeId}, expected ${STRESS_PROP_TYPE}`);
-				}
-				// The Model id and the parts pointer share the record and must be
-				// preserved when only the type changes.
-				if (after.props[0].mpModelId !== before.props[0].mpModelId) {
-					problems.push(`props[0].mpModelId changed to 0x${after.props[0].mpModelId.toString(16)}`);
-				}
-				if (after.props[0].firstPartIndex !== before.props[0].firstPartIndex) {
-					problems.push(`props[0].firstPartIndex changed to ${after.props[0].firstPartIndex}`);
-				}
 				return problems;
 			},
 		},
@@ -124,25 +108,90 @@ export const propGraphicsListHandler: ResourceHandler<ParsedPropGraphicsList> = 
 			},
 		},
 		{
-			name: 'edit-part-type-and-id',
-			description: 'set parts[0].muTypeId / muPartId to markers and verify they survive',
+			name: 'edit-prop-type',
+			description: 'set the LAST prop muTypeId to a marker and verify it survives (its part run, if any, follows the new type)',
 			mutate: (m) => {
-				if (m.parts.length === 0) return m;
-				const parts = m.parts.slice();
-				parts[0] = { ...parts[0], muTypeId: STRESS_PROP_TYPE, muPartId: STRESS_PART_ID };
-				return { ...m, parts };
+				const props = m.props.slice();
+				const i = props.length - 1;
+				props[i] = { ...props[i], muTypeId: STRESS_PROP_TYPE };
+				return { ...m, props };
 			},
 			verify: (before, after) => {
 				const problems: string[] = [];
-				if (after.parts.length === 0) return problems; // nothing to check on a parts-less list
-				if (after.parts[0].muTypeId !== STRESS_PROP_TYPE) {
-					problems.push(`parts[0].muTypeId = ${after.parts[0].muTypeId}, expected ${STRESS_PROP_TYPE}`);
+				const i = after.props.length - 1;
+				if (after.props[i].muTypeId !== STRESS_PROP_TYPE) {
+					problems.push(`props[last].muTypeId = ${after.props[i].muTypeId}, expected ${STRESS_PROP_TYPE}`);
 				}
-				if (after.parts[0].muPartId !== STRESS_PART_ID) {
-					problems.push(`parts[0].muPartId = ${after.parts[0].muPartId}, expected ${STRESS_PART_ID}`);
+				if (after.props[i].mpModelId !== before.props[i].mpModelId) {
+					problems.push(`props[last].mpModelId changed to 0x${after.props[i].mpModelId.toString(16)}`);
 				}
-				if (after.parts[0].mpModelId !== before.parts[0].mpModelId) {
-					problems.push(`parts[0].mpModelId changed to 0x${after.parts[0].mpModelId.toString(16)}`);
+				if (after.props[i].parts.length !== before.props[i].parts.length) {
+					problems.push(`props[last].parts count changed to ${after.props[i].parts.length}`);
+				}
+				return problems;
+			},
+		},
+		{
+			name: 'edit-part-id-and-model',
+			description: 'edit the first part of the first parts-bearing prop and verify it survives',
+			mutate: (m) => {
+				const idx = m.props.findIndex((p) => p.parts.length > 0);
+				if (idx < 0) return m;
+				const props = m.props.map((p) => ({ ...p, parts: p.parts.slice() }));
+				props[idx].parts[0] = { muPartId: STRESS_PART_ID, mpModelId: STRESS_MODEL_ID };
+				return { ...m, props };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				const idx = afterMutate.props.findIndex((p) => p.parts.length > 0);
+				if (idx < 0) return problems; // no parts to edit
+				const p = afterReparse.props[idx].parts[0];
+				if (p.muPartId !== STRESS_PART_ID) problems.push(`part muPartId = ${p.muPartId}, expected ${STRESS_PART_ID}`);
+				if (p.mpModelId !== STRESS_MODEL_ID) problems.push(`part mpModelId = 0x${p.mpModelId.toString(16)}`);
+				return problems;
+			},
+		},
+		{
+			name: 'add-part-to-prop',
+			description: 'give the last prop a fresh unique type and append a part to it; verify the new part + rebuilt import table survive and the total part count grows',
+			mutate: (m) => {
+				const props = m.props.map((p) => ({ ...p, parts: p.parts.slice() }));
+				const i = props.length - 1;
+				props[i] = {
+					...props[i],
+					muTypeId: STRESS_UNIQUE_TYPE,
+					parts: [...props[i].parts, { muPartId: STRESS_PART_ID, mpModelId: STRESS_MODEL_ID }],
+				};
+				return { ...m, props };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (totalParts(afterReparse) !== totalParts(afterMutate)) {
+					problems.push(`part count ${totalParts(afterReparse)} != ${totalParts(afterMutate)}`);
+				}
+				const i = afterReparse.props.length - 1;
+				const lp = afterReparse.props[i];
+				if (lp.muTypeId !== STRESS_UNIQUE_TYPE) problems.push(`last prop type = ${lp.muTypeId}`);
+				const added = lp.parts[lp.parts.length - 1];
+				if (!added || added.muPartId !== STRESS_PART_ID) problems.push(`appended part muPartId = ${added?.muPartId}`);
+				if (!added || added.mpModelId !== STRESS_MODEL_ID) problems.push(`appended part mpModelId = 0x${added?.mpModelId.toString(16)}`);
+				return problems;
+			},
+		},
+		{
+			name: 'remove-part-from-prop',
+			description: 'drop the last part of the first parts-bearing prop and verify the total part count shrinks',
+			mutate: (m) => {
+				const idx = m.props.findIndex((p) => p.parts.length > 0);
+				if (idx < 0) return m;
+				const props = m.props.map((p) => ({ ...p, parts: p.parts.slice() }));
+				props[idx].parts.pop();
+				return { ...m, props };
+			},
+			verify: (afterMutate, afterReparse) => {
+				const problems: string[] = [];
+				if (totalParts(afterReparse) !== totalParts(afterMutate)) {
+					problems.push(`part count ${totalParts(afterReparse)} != ${totalParts(afterMutate)}`);
 				}
 				return problems;
 			},
@@ -153,34 +202,22 @@ export const propGraphicsListHandler: ResourceHandler<ParsedPropGraphicsList> = 
 			mutate: (m) => {
 				const props = [
 					...m.props,
-					{ muTypeId: STRESS_PROP_TYPE, mpModelId: STRESS_MODEL_ID, firstPartIndex: null },
+					{ muTypeId: STRESS_UNIQUE_TYPE, mpModelId: STRESS_MODEL_ID, parts: [], _mpPartsRaw: 0 },
 				];
 				return { ...m, props };
 			},
-			// The runner passes (afterMutate, afterReparse): both already carry the
-			// appended prop, so they must AGREE.
 			verify: (afterMutate, afterReparse) => {
 				const problems: string[] = [];
 				if (afterReparse.props.length !== afterMutate.props.length) {
 					problems.push(`prop count ${afterReparse.props.length} != ${afterMutate.props.length}`);
 				}
 				const added = afterReparse.props[afterReparse.props.length - 1];
-				if (added.muTypeId !== STRESS_PROP_TYPE) problems.push(`added muTypeId = ${added.muTypeId}`);
+				if (added.muTypeId !== STRESS_UNIQUE_TYPE) problems.push(`added muTypeId = ${added.muTypeId}`);
 				if (added.mpModelId !== STRESS_MODEL_ID) problems.push(`added mpModelId = 0x${added.mpModelId.toString(16)}`);
-				if (added.firstPartIndex !== null) problems.push(`added firstPartIndex = ${added.firstPartIndex}, expected null`);
-				// Adding a prop shifts the part array; existing part Model ids and
-				// the parts-pointer indices must survive the relocation intact.
-				if (afterReparse.parts.length !== afterMutate.parts.length) {
-					problems.push(`part count changed to ${afterReparse.parts.length}`);
-				}
-				for (let i = 0; i < afterMutate.parts.length; i++) {
-					if (afterReparse.parts[i].mpModelId !== afterMutate.parts[i].mpModelId) {
-						problems.push(`parts[${i}].mpModelId drifted after add`);
-						break;
-					}
-				}
-				if (afterMutate.props[0].firstPartIndex !== afterReparse.props[0].firstPartIndex) {
-					problems.push(`props[0].firstPartIndex drifted after add`);
+				if (added.parts.length !== 0) problems.push(`added prop has ${added.parts.length} parts, expected 0`);
+				// Adding a prop shifts the part array; existing part Model ids must survive.
+				if (totalParts(afterReparse) !== totalParts(afterMutate)) {
+					problems.push(`total part count changed to ${totalParts(afterReparse)}`);
 				}
 				return problems;
 			},
@@ -194,7 +231,6 @@ export const propGraphicsListHandler: ResourceHandler<ParsedPropGraphicsList> = 
 				if (afterReparse.props.length !== afterMutate.props.length) {
 					problems.push(`prop count ${afterReparse.props.length} != ${afterMutate.props.length}`);
 				}
-				// Surviving props keep their Model ids.
 				for (let i = 0; i < afterMutate.props.length; i++) {
 					if (afterReparse.props[i].mpModelId !== afterMutate.props[i].mpModelId) {
 						problems.push(`props[${i}].mpModelId drifted after remove`);

--- a/src/lib/schema/resources/propGraphicsList.test.ts
+++ b/src/lib/schema/resources/propGraphicsList.test.ts
@@ -62,7 +62,7 @@ const model = hasFixture ? loadBundleModel(BUNDLE_9) : (undefined as unknown as 
 describeFixture('propGraphicsListResourceSchema coverage — bundle TRK_UNIT9_GR.BNDL', () => {
 	it('fixture parses with non-trivial content', () => {
 		expect(model.props.length).toBeGreaterThan(0);
-		expect(model.parts.length).toBeGreaterThan(0);
+		expect(model.props.reduce((n, p) => n + p.parts.length, 0)).toBeGreaterThan(0);
 	});
 
 	it('every record type referenced by a `record` or `list<record>` field is registered', () => {
@@ -167,37 +167,41 @@ describe('propGraphicsList path resolution', () => {
 		expect(loc!.field?.kind).toBe('bigint');
 	});
 
-	it('resolves parts[0] as a PropPartGraphics', () => {
-		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['parts', 0]);
+	it('resolves a nested part props[0].parts[0] as a PropPartGraphics', () => {
+		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['props', 0, 'parts', 0]);
 		expect(loc).not.toBeNull();
 		expect(loc!.record?.name).toBe('PropPartGraphics');
 	});
 
-	it('resolves parts[0].muPartId as u32', () => {
-		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['parts', 0, 'muPartId']);
+	it('resolves props[0].parts[0].muPartId as u32', () => {
+		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['props', 0, 'parts', 0, 'muPartId']);
 		expect(loc).not.toBeNull();
 		expect(loc!.field?.kind).toBe('u32');
 	});
 
-	it('resolves parts[0].mpModelId as an editable bigint resource id', () => {
-		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['parts', 0, 'mpModelId']);
+	it('resolves props[0].parts[0].mpModelId as an editable bigint resource id', () => {
+		const loc = resolveSchemaAtPath(propGraphicsListResourceSchema, ['props', 0, 'parts', 0, 'mpModelId']);
 		expect(loc).not.toBeNull();
 		expect(loc!.field?.kind).toBe('bigint');
 	});
 
-	it('exposes props as an addable list but locks parts (firstPartIndex linkage is internal)', () => {
+	it('exposes props AND each prop\'s nested parts as addable/removable lists', () => {
 		const props = propGraphicsListResourceSchema.registry.ParsedPropGraphicsList.fields.props;
-		const parts = propGraphicsListResourceSchema.registry.ParsedPropGraphicsList.fields.parts;
+		const parts = propGraphicsListResourceSchema.registry.PropGraphics.fields.parts;
 		if (props.kind !== 'list' || parts.kind !== 'list') throw new Error('expected lists');
 		expect(props.addable).toBe(true);
 		expect(props.removable).toBe(true);
-		// Parts can't be added/removed (only their fields edited) — see schema note.
-		expect(parts.addable).toBe(false);
-		expect(parts.removable).toBe(false);
-		// makeEmpty supplies a default Model id so a new prop row is valid immediately.
-		const empty = props.makeEmpty!({ root: {}, resource: propGraphicsListResourceSchema }) as { mpModelId: bigint; firstPartIndex: number | null };
-		expect(empty.mpModelId).toBe(0n);
-		expect(empty.firstPartIndex).toBeNull();
+		// Parts are now add/removable, nested under their owning prop.
+		expect(parts.addable).toBe(true);
+		expect(parts.removable).toBe(true);
+		// makeEmpty: a new prop starts partless with a default Model id; a new part
+		// just needs an id + Model (its type is the owning prop's).
+		const emptyProp = props.makeEmpty!({ root: {}, resource: propGraphicsListResourceSchema }) as { mpModelId: bigint; parts: unknown[] };
+		expect(emptyProp.mpModelId).toBe(0n);
+		expect(emptyProp.parts).toEqual([]);
+		const emptyPart = parts.makeEmpty!({ root: {}, resource: propGraphicsListResourceSchema }) as { muPartId: number; mpModelId: bigint };
+		expect(emptyPart.mpModelId).toBe(0n);
+		expect(emptyPart.muPartId).toBe(0);
 	});
 
 	it('resolves muZoneNumber as u32', () => {
@@ -223,10 +227,10 @@ describeFixture('propGraphicsList tree labels', () => {
 		expect(label).toContain('model 0x12F7700A');
 	});
 
-	it('part label includes the index, part number, and Model id', () => {
-		// parts[1] in TRK_UNIT9 is type 0x28, part 1.
-		const part = model.parts[1];
-		const field = propGraphicsListResourceSchema.registry.ParsedPropGraphicsList.fields.parts;
+	it('part label (nested under a prop) includes the index, part number, and Model id', () => {
+		// props[0] in TRK_UNIT9 owns parts 0,1,… of type 0x28.
+		const part = model.props[0].parts[1];
+		const field = propGraphicsListResourceSchema.registry.PropGraphics.fields.parts;
 		if (field.kind !== 'list') throw new Error('expected list');
 		const labelFn = field.itemLabel as (v: unknown, i: number) => string;
 		const label = labelFn(part, 1);
@@ -264,8 +268,8 @@ describeFixture('propGraphicsList getAtPath', () => {
 		expect(id).toBe(0x12f7700an);
 	});
 
-	it('reads a part Model id as a bigint', () => {
-		const id = getAtPath(model, ['parts', 0, 'mpModelId']);
+	it('reads a nested part Model id as a bigint', () => {
+		const id = getAtPath(model, ['props', 0, 'parts', 0, 'mpModelId']);
 		expect(typeof id).toBe('bigint');
 	});
 });

--- a/src/lib/schema/resources/propGraphicsList.test.ts
+++ b/src/lib/schema/resources/propGraphicsList.test.ts
@@ -195,10 +195,15 @@ describe('propGraphicsList path resolution', () => {
 		expect(parts.addable).toBe(true);
 		expect(parts.removable).toBe(true);
 		// makeEmpty: a new prop starts partless with a default Model id; a new part
-		// just needs an id + Model (its type is the owning prop's).
-		const emptyProp = props.makeEmpty!({ root: {}, resource: propGraphicsListResourceSchema }) as { mpModelId: bigint; parts: unknown[] };
+		// just needs an id + Model (its type is the owning prop's). Lock ALL four
+		// fields a partless prop needs to round-trip — _mpPartsRaw and muTypeId are
+		// load-bearing for the writer (writeU32 silently coerces undefined → 0, so a
+		// regression dropping them would otherwise escape the suite).
+		const emptyProp = props.makeEmpty!({ root: {}, resource: propGraphicsListResourceSchema }) as Record<string, unknown>;
 		expect(emptyProp.mpModelId).toBe(0n);
 		expect(emptyProp.parts).toEqual([]);
+		expect(emptyProp).toHaveProperty('_mpPartsRaw', 0);
+		expect(emptyProp).toHaveProperty('muTypeId', 0);
 		const emptyPart = parts.makeEmpty!({ root: {}, resource: propGraphicsListResourceSchema }) as { muPartId: number; mpModelId: bigint };
 		expect(emptyPart.mpModelId).toBe(0n);
 		expect(emptyPart.muPartId).toBe(0);

--- a/src/lib/schema/resources/propGraphicsList.ts
+++ b/src/lib/schema/resources/propGraphicsList.ts
@@ -6,15 +6,15 @@
 //
 // Domain: a PropGraphicsList is the per-track-unit catalogue mapping every prop
 // TYPE placed in that unit (see PropInstanceData / 0x10011) to the Model
-// resource(s) the runtime spawns for it. Two parallel arrays: one PropGraphics
-// per whole prop (its body Model) and one PropPartGraphics per destructible
-// sub-piece (e.g. a billboard panel that breaks off), grouped contiguously by
-// owning prop. The Model references are BND2 imports — modelled here as the
-// editable `mpModelId` (the on-disk pointer is 0; the real id lives in the
-// resource's inline import table, which the writer rebuilds). Entries are
-// addable/removable: a prop instance whose type isn't catalogued needs a new
-// PropGraphics row mapping type → Model. The bundle envelope's import metadata
-// follows a count change via the handler's importTable() hook.
+// resource(s) the runtime spawns for it. Each prop maps to its body Model
+// (mpModelId) and owns a list of destructible PARTS (e.g. a billboard panel that
+// breaks off), each with its own Model. Parts are nested UNDER their prop here —
+// on disk they're a flat array grouped by the owning prop's type id, but
+// ownership is unambiguous by type, so nesting makes "add/remove a part of this
+// prop" a safe, structural edit (no dangling pointer to mis-set). The Model
+// references are BND2 imports (0 on disk) rebuilt from mpModelId on write, so
+// props, parts, and their Models are all freely editable; the bundle envelope's
+// import metadata follows a count change via the handler's importTable() hook.
 
 import type {
 	FieldSchema,
@@ -26,7 +26,7 @@ import type {
 import { PROP_TYPES, propTypeLabel } from '@/lib/core/propTypes';
 
 // ---------------------------------------------------------------------------
-// Local helpers (mirroring environmentTimeLine.ts)
+// Local helpers
 // ---------------------------------------------------------------------------
 
 const u32 = (): FieldSchema => ({ kind: 'u32' });
@@ -42,12 +42,11 @@ const recordList = (
 	type: string,
 	makeEmpty: (ctx: SchemaContext) => unknown,
 	itemLabel?: (item: unknown, index: number, ctx: SchemaContext) => string,
-	addable = true,
 ): FieldSchema => ({
 	kind: 'list',
 	item: record(type),
-	addable,
-	removable: addable,
+	addable: true,
+	removable: true,
 	makeEmpty,
 	itemLabel,
 });
@@ -62,9 +61,11 @@ const hex = (n: number | bigint | undefined): string =>
 function propLabel(prop: unknown, index: number): string {
 	try {
 		if (!prop || typeof prop !== 'object') return `#${index}`;
-		const p = prop as { muTypeId?: number; mpModelId?: bigint };
+		const p = prop as { muTypeId?: number; mpModelId?: bigint; parts?: unknown[] };
 		const name = p.muTypeId != null ? propTypeLabel(p.muTypeId) : '?';
-		return `#${index} · ${name} · model ${hex(p.mpModelId)}`;
+		const n = p.parts?.length ?? 0;
+		const partsStr = n > 0 ? ` · ${n} part${n === 1 ? '' : 's'}` : '';
+		return `#${index} · ${name} · model ${hex(p.mpModelId)}${partsStr}`;
 	} catch {
 		return `#${index}`;
 	}
@@ -73,9 +74,8 @@ function propLabel(prop: unknown, index: number): string {
 function partLabel(part: unknown, index: number): string {
 	try {
 		if (!part || typeof part !== 'object') return `#${index}`;
-		const p = part as { muTypeId?: number; muPartId?: number; mpModelId?: bigint };
-		const name = p.muTypeId != null ? propTypeLabel(p.muTypeId) : '?';
-		return `#${index} · ${name} · part ${p.muPartId ?? '?'} · model ${hex(p.mpModelId)}`;
+		const p = part as { muPartId?: number; mpModelId?: bigint };
+		return `#${index} · part ${p.muPartId ?? '?'} · model ${hex(p.mpModelId)}`;
 	} catch {
 		return `#${index}`;
 	}
@@ -85,64 +85,63 @@ function partLabel(part: unknown, index: number): string {
 // Record schemas
 // ---------------------------------------------------------------------------
 
-const PropGraphics: RecordSchema = {
-	name: 'PropGraphics',
-	description: 'One whole prop — its type plus the Model resource the runtime spawns for the body mesh. The Model is a BND2 import (the on-disk pointer is 0); edit it via the Model id.',
-	fields: {
-		muTypeId: propTypeEnum(),
-		mpModelId: resourceId(),
-		// Internal pointer (mpParts) modelled as a part-array index; null = the
-		// prop has no destructible parts. Round-trip-only — hidden.
-		firstPartIndex: { kind: 'i32' },
-	},
-	fieldMetadata: {
-		muTypeId: {
-			label: 'Prop type',
-			description: 'Which prop this Model catalogue entry is for — an index into the 247-entry prop-types table (same vocabulary as PropInstanceData).',
-		},
-		mpModelId: {
-			label: 'Model',
-			description: 'Resource id of the Model (0x2A) the runtime spawns for this prop. Stored as a BND2 import (the on-disk pointer is 0 until load); the writer rebuilds the import table from this id, so it is freely editable. Prop Models usually live in GLOBALPROPS.BIN.',
-		},
-		firstPartIndex: {
-			label: 'First part index',
-			description: 'Internal pointer to this prop\'s first destructible part (an index into the parts array; absent when the prop has none). Recomputed into a resource-relative offset on write; users shouldn\'t edit it.',
-			hidden: true,
-			readOnly: true,
-		},
-	},
-	propertyGroups: [
-		{ title: 'Identity', properties: ['muTypeId', 'mpModelId'] },
-	],
-	label: (value, index) => propLabel(value, index ?? 0),
-};
-
 const PropPartGraphics: RecordSchema = {
 	name: 'PropPartGraphics',
-	description: 'One destructible sub-piece of a prop (e.g. a billboard panel that breaks off) — the owning prop\'s type, the part index within that prop, and the Model the runtime spawns for it.',
+	description: 'One destructible sub-piece of a prop (e.g. a billboard panel that breaks off) — its index within the prop and the Model the runtime spawns for it. The owning prop is implicit (this part is nested under it); on disk the part also stores the prop\'s type id, which the writer re-emits.',
 	fields: {
-		muTypeId: propTypeEnum(),
 		muPartId: u32(),
 		mpModelId: resourceId(),
 	},
 	fieldMetadata: {
-		muTypeId: {
-			label: 'Prop type',
-			description: 'The owning prop\'s type. Parts are grouped contiguously by this value, matching the PropGraphics entry they belong to.',
-		},
 		muPartId: {
 			label: 'Part ID',
 			description: 'Index of this part within its owning prop (0, 1, 2, …).',
 		},
 		mpModelId: {
 			label: 'Model',
-			description: 'Resource id of the Model (0x2A) for this destructible part. Same import mechanism as a whole prop — the writer rebuilds the import table from this id.',
+			description: 'Resource id of the Model (0x2A) for this destructible part. A BND2 import (0 on disk); the writer rebuilds the import table from this id.',
 		},
 	},
 	propertyGroups: [
-		{ title: 'Identity', properties: ['muTypeId', 'muPartId', 'mpModelId'] },
+		{ title: 'Identity', properties: ['muPartId', 'mpModelId'] },
 	],
 	label: (value, index) => partLabel(value, index ?? 0),
+};
+
+const PropGraphics: RecordSchema = {
+	name: 'PropGraphics',
+	description: 'One whole prop — its type, the body Model the runtime spawns, and its list of destructible parts. Add a prop to catalogue a newly-placed prop type; add parts to give it breakable sub-pieces.',
+	fields: {
+		muTypeId: propTypeEnum(),
+		mpModelId: resourceId(),
+		parts: recordList('PropPartGraphics', () => ({ muPartId: 0, mpModelId: 0n }), partLabel),
+		_mpPartsRaw: u32(),
+	},
+	fieldMetadata: {
+		muTypeId: {
+			label: 'Prop type',
+			description: 'Which prop this Model catalogue entry is for — an index into the 247-entry prop-types table (same vocabulary as PropInstanceData). Also stamps the type id of every part below it.',
+		},
+		mpModelId: {
+			label: 'Model',
+			description: 'Resource id of the Model (0x2A) the runtime spawns for this prop\'s body. A BND2 import (0 on disk); the writer rebuilds the import table from this id. Prop Models usually live in GLOBALPROPS.BIN.',
+		},
+		parts: {
+			label: 'Parts',
+			description: 'This prop\'s destructible sub-pieces. Add/remove freely — each part takes this prop\'s type id and the writer regroups + rebuilds all pointers on export.',
+		},
+		_mpPartsRaw: {
+			label: 'Raw parts pointer',
+			description: 'On-disk pointer to the prop\'s first part — derived on write for a prop that has parts. Preserved verbatim only for a partless prop (where retail ships leftover bytes the runtime ignores); users shouldn\'t edit it.',
+			hidden: true,
+			readOnly: true,
+		},
+	},
+	propertyGroups: [
+		{ title: 'Identity', properties: ['muTypeId', 'mpModelId'] },
+		{ title: 'Parts', properties: ['parts'] },
+	],
+	label: (value, index) => propLabel(value, index ?? 0),
 };
 
 // ---------------------------------------------------------------------------
@@ -151,17 +150,10 @@ const PropPartGraphics: RecordSchema = {
 
 const ParsedPropGraphicsList: RecordSchema = {
 	name: 'ParsedPropGraphicsList',
-	description: 'Root record for the PropGraphicsList resource (0x10010). Maps every prop TYPE placed in one track unit to its Model(s): a props array (one body Model per prop) plus a parts array (one Model per destructible sub-piece). Add a prop entry to catalogue a newly-placed prop type.',
+	description: 'Root record for the PropGraphicsList resource (0x10010). Maps every prop TYPE placed in one track unit to its Model and its destructible parts. Add a prop entry to catalogue a newly-placed prop type; the import table is rebuilt on export.',
 	fields: {
 		muZoneNumber: u32(),
-		props: recordList('PropGraphics', () => ({ muTypeId: 0, mpModelId: 0n, firstPartIndex: null }), propLabel),
-		// Parts are field-editable but NOT addable/removable: a prop's link to its
-		// parts is the internal firstPartIndex pointer (hidden, not user-settable),
-		// so adding a part can't be wired to a prop, and removing/inserting one
-		// would shift the part indices that surviving props point at — silently
-		// re-owning the wrong parts. Edit a prop's parts by editing existing rows;
-		// structural part changes belong in the Blender exporter.
-		parts: recordList('PropPartGraphics', () => ({ muTypeId: 0, muPartId: 0, mpModelId: 0n }), partLabel, false),
+		props: recordList('PropGraphics', () => ({ muTypeId: 0, mpModelId: 0n, parts: [], _mpPartsRaw: 0 }), propLabel),
 	},
 	fieldMetadata: {
 		muZoneNumber: {
@@ -170,17 +162,12 @@ const ParsedPropGraphicsList: RecordSchema = {
 		},
 		props: {
 			label: 'Props',
-			description: 'One entry per whole prop type in this track unit, mapping it to its body Model. Add an entry (type + Model id) to catalogue a prop type you have newly placed via PropInstanceData; the import table is rebuilt on export.',
-		},
-		parts: {
-			label: 'Parts',
-			description: 'One entry per destructible prop sub-piece, mapping it to its Model. Grouped contiguously by owning prop. Fields are editable, but rows can\'t be added/removed here — a part\'s owning-prop link is an internal pointer the UI doesn\'t expose, so structural changes would mis-assign ownership.',
+			description: 'One entry per whole prop type in this track unit, mapping it to its body Model and its parts. Add an entry (type + Model id) to catalogue a prop type you have newly placed via PropInstanceData.',
 		},
 	},
 	propertyGroups: [
 		{ title: 'Header', properties: ['muZoneNumber'] },
 		{ title: 'Props', properties: ['props'] },
-		{ title: 'Parts', properties: ['parts'] },
 	],
 };
 


### PR DESCRIPTION
The community reported that **Parts** in a Prop Graphics List still weren't writable. They were field-editable but not add/removable — I locked that last round because a part's owning-prop link was an internal pointer the flat UI couldn't set, so naive add/remove silently mis-assigned ownership.

This makes parts fully add/removable by first nailing down (and then modelling) the real ownership rule.

## What the data actually says
A sweep of all 234 PGLs-with-parts settled the on-disk model:
- Parts are grouped **contiguously by `muTypeId`**, and the prop with the matching type **owns** that run.
- No two parts-owning props ever share a type; every part run matches a prop; runs appear in prop-array order.
- `mpParts` on a prop is derived for owners but **leftover garbage on partless props** (2951 of them; the runtime never dereferences it).

So ownership is unambiguous *by type* — my earlier `firstPartIndex` model (generalised from TRK9, one of only 8 "clean" fixtures) was wrong for the other 226.

## The change
Model parts **nested under their owning prop** (`PropGraphics.parts`) instead of a flat array + pointer, so adding/removing a part is a structural edit to one prop's list and ownership can never desync:
- **Core** — parser groups parts by type and attaches each run to its prop (asserting contiguity, single-owner, no orphans); writer flattens in prop order and derives each prop's `mpParts`. Partless props' garbage `mpParts` is preserved verbatim (`_mpPartsRaw`). A write-time guard rejects the one shape that can't round-trip (two props of the same type where one owns parts). **Byte-for-byte across all 428 fixtures** (also fixes a props-only align-pad case for prop counts not divisible by 4).
- **Schema** — each prop has a nested addable/removable parts list (`muPartId` + Model id); a new part inherits the prop's type. Top-level `parts` array removed.
- **Handler** — add-part / remove-part / edit-part stress scenarios.

## Tests (per request — lots of them)
~32 core cases (nesting, partless-garbage preservation, add/remove props **and** parts, the give-a-partless-prop-its-first-part path, every layout guard, gold TRK9), schema drift + nested-label coverage, and an **end-to-end "add a part and export"** test proving the new part's Model id is wired into the rebuilt bundle import table. Full suite green; `tsc` clean (0 new errors); 853 registry-stress cases pass.

> Same browser caveat as the prior PRs: I can't drive the inspector here (preview window runs hidden → WebGL rAF-starved), so the UI edit-flow is covered by tests + the export round-trip rather than a manual click-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
