### PR TITLE
feat(rendering): bind engine matrices, skin bone palette at rest, decode DXT3

### DIFF
--- a/scripts/lib/cb0-seed.ts
+++ b/scripts/lib/cb0-seed.ts
@@ -1,0 +1,126 @@
+// cb0 seeding — port of `inferCbLayout` + `seedDefaults` + `__updateCb0`
+// from `src/pages/ShaderPage.tsx` and `src/lib/core/translatedShaderMaterial.ts`,
+// distilled into a single function for the differential harness.
+//
+// Order of operations matters:
+//   1. seedDefaults(vsParsed)  — material/heuristic constants by RDEF name.
+//   2. seedDefaults(psParsed)  — same, in case PS has constants VS doesn't.
+//   3. writeEngineSlots()      — identity world / vp / view-row-2 / depth
+//                                encoder. Engine wins on slot collisions.
+//
+// Without (1) and (2) the harness diff is uninteresting because most
+// shaders compute `albedo * 0 = 0` for their final color.
+
+import type { ParsedDxbc } from '../../src/lib/core/dxbc/parser';
+import type { ParsedShaderConstant } from '../../src/lib/core/shader';
+import { ENGINE_CONSTANT_DEFAULTS, seedSkinningPalettes, type CbLayout } from '../../src/lib/core/shaderEngineConstants';
+
+export type { CbLayout };
+
+// Re-export the shared engine-constant defaults so existing harness callers
+// keep importing HEURISTIC_DEFAULTS from here.
+export const HEURISTIC_DEFAULTS = ENGINE_CONSTANT_DEFAULTS;
+
+export function inferCbLayoutFromParsed(parsed: ParsedDxbc): CbLayout {
+	const slot = (n: string): number | null => {
+		for (const cb of parsed.reflection.constantBuffers)
+			for (const v of cb.variables) if (v.name === n) return Math.floor(v.startOffset / 16);
+		return null;
+	};
+	const vp = slot('ViewProjectionModified') ?? 5;
+	return {
+		worldRow0: slot('world') ?? 44,
+		vpRow0: vp,
+		viewRow2: vp + 2,
+		depthEncode: vp + 3,
+		cameraPos: slot('ViewPosition'),
+		worldViewProjRow0: slot('worldViewProj'),
+		viewProjectionRow0: slot('viewProjection'),
+	};
+}
+
+function writeScalars(f32: Float32Array, slot: number, comp: number, src: ArrayLike<number>, n: number) {
+	const base = slot * 4 + comp;
+	for (let i = 0; i < n; i++) {
+		if (comp + i < 4) f32[base + i] = src[i] ?? 0;
+	}
+}
+
+function seedDefaults(
+	f32: Float32Array,
+	parsed: ParsedDxbc,
+	shaderConstants: readonly ParsedShaderConstant[],
+	maxSlots: number,
+) {
+	for (const cb of parsed.reflection.constantBuffers) {
+		for (const v of cb.variables) {
+			const slot = Math.floor(v.startOffset / 16);
+			if (slot >= maxSlots) continue;
+			const comp = (v.startOffset % 16) / 4;
+			const nFloats = Math.max(1, Math.min(4 - comp, Math.floor(v.size / 4)));
+			const baked = shaderConstants.find((c) => c.name === v.name && c.instanceData);
+			if (baked?.instanceData) {
+				writeScalars(f32, slot, comp, baked.instanceData, nFloats);
+				continue;
+			}
+			const hd = HEURISTIC_DEFAULTS[v.name];
+			if (hd) writeScalars(f32, slot, comp, hd, nFloats);
+		}
+	}
+}
+
+/**
+ * Build a 4 KiB cb0 (256 vec4 slots) seeded with:
+ *   - Per-shader baked constants joined by RDEF variable name.
+ *   - HEURISTIC_DEFAULTS for runtime-bound vars (key light, fog, etc.).
+ *   - Identity world / view·proj rows + depth encoder + zero camera, on
+ *     top, so the engine slots win even if a material constant collides.
+ */
+export function seedCb0(
+	vsParsed: ParsedDxbc,
+	psParsed: ParsedDxbc,
+	shaderConstants: readonly ParsedShaderConstant[],
+	layout: CbLayout,
+): Uint8Array {
+	const SLOTS = 256;
+	const f32 = new Float32Array(SLOTS * 4);
+
+	// 1+2. Material + heuristic defaults from both stages.
+	seedDefaults(f32, vsParsed, shaderConstants, SLOTS);
+	seedDefaults(f32, psParsed, shaderConstants, SLOTS);
+
+	// Identity-fill the bone-matrix palette (skinned vehicle meshes).
+	const writeVec4 = (slot: number, x: number, y: number, z: number, w: number) => {
+		if (slot < 0 || slot >= SLOTS) return;
+		const o = slot * 4;
+		f32[o] = x; f32[o + 1] = y; f32[o + 2] = z; f32[o + 3] = w;
+	};
+	seedSkinningPalettes(vsParsed, writeVec4);
+	seedSkinningPalettes(psParsed, writeVec4);
+
+	// 3. Engine slots overlaid last.
+	const wr = (s: number, x: number, y: number, z: number, w: number) => {
+		if (s < 0 || s >= SLOTS) return;
+		const o = s * 4;
+		f32[o + 0] = x; f32[o + 1] = y; f32[o + 2] = z; f32[o + 3] = w;
+	};
+	wr(layout.worldRow0 + 0, 1, 0, 0, 0);
+	wr(layout.worldRow0 + 1, 0, 1, 0, 0);
+	wr(layout.worldRow0 + 2, 0, 0, 1, 0);
+	wr(layout.worldRow0 + 3, 0, 0, 0, 1);
+	wr(layout.vpRow0 + 0, 1, 0, 0, 0);
+	wr(layout.vpRow0 + 1, 0, 1, 0, 0);
+	wr(layout.viewRow2, 0, 0, 1, 0);
+	wr(layout.depthEncode, 0, 0.5, 0, 1);
+	if (layout.cameraPos != null) wr(layout.cameraPos, 0, 0, 0, 1);
+	// Full 4-row engine matrices (identity here, like world/vp above).
+	for (const base of [layout.viewProjectionRow0, layout.worldViewProjRow0]) {
+		if (base == null) continue;
+		wr(base + 0, 1, 0, 0, 0);
+		wr(base + 1, 0, 1, 0, 0);
+		wr(base + 2, 0, 0, 1, 0);
+		wr(base + 3, 0, 0, 0, 1);
+	}
+
+	return new Uint8Array(f32.buffer);
+}

--- a/scripts/survey-shader-constants.ts
+++ b/scripts/survey-shader-constants.ts
@@ -1,0 +1,75 @@
+// Survey the RDEF constant-buffer variable names across every shader in
+// example/SHADERS.BNDL, joined with the parent Shader (0x32) resources' baked
+// instance data, to find which constants are ENGINE-SUPPLIED (no baked default)
+// and whether the cb0 seeding table covers them.
+//
+// Run: fnm exec --using=22 npx tsx scripts/survey-shader-constants.ts
+
+import { readFileSync } from 'node:fs';
+import { parseBundle } from '../src/lib/core/bundle/index';
+import { getHandlerByKey, resourceCtxFromBundle } from '../src/lib/core/registry';
+import { getResourceBlocks } from '../src/lib/core/resourceManager';
+import { translateDxbc } from '../src/lib/core/dxbc';
+import { parseShaderData } from '../src/lib/core/shader';
+
+import { ENGINE_CONSTANT_DEFAULTS } from '../src/lib/core/shaderEngineConstants';
+
+// The names the cb0 seeding table covers (now sourced from the real shared module).
+const HEURISTIC = new Set(Object.keys(ENGINE_CONSTANT_DEFAULTS));
+// Engine matrices bound structurally per-frame by inferCbLayout + __updateCb0.
+const ENGINE_MATRIX = new Set([
+	'world', 'ViewProjectionModified', 'ViewPosition', 'worldViewProj', 'viewProjection',
+]);
+
+const buf = readFileSync('example/SHADERS.BNDL');
+const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+const bundle = parseBundle(ab);
+const ctx = resourceCtxFromBundle(bundle);
+
+// 1. Collect every constant name that ANY Shader (0x32) bakes instanceData for
+//    (= material default, not engine-supplied).
+const shaderHandler = getHandlerByKey('shader');
+const bakedNames = new Set<string>();
+if (shaderHandler) {
+	for (const r of bundle.resources.filter((x) => x.resourceTypeId === shaderHandler.typeId)) {
+		try {
+			const blocks = getResourceBlocks(ab, bundle, r);
+			const parsed = parseShaderData(blocks[0]);
+			for (const c of parsed.constants) if (c.instanceData) bakedNames.add(c.name);
+		} catch { /* skip */ }
+	}
+}
+
+// 2. Tally cb0 variable names across all shader program buffers.
+const spbHandler = getHandlerByKey('shaderProgramBuffer')!;
+const nameCount = new Map<string, number>();
+let shaders = 0;
+for (const r of bundle.resources.filter((x) => x.resourceTypeId === spbHandler.typeId)) {
+	const blocks = getResourceBlocks(ab, bundle, r);
+	const raw = blocks[1];
+	if (!raw || raw.byteLength < 0x20) continue;
+	let tr;
+	try { tr = translateDxbc(raw); } catch { continue; }
+	shaders++;
+	for (const cb of tr.parsed.reflection.constantBuffers) {
+		for (const v of cb.variables) nameCount.set(v.name, (nameCount.get(v.name) ?? 0) + 1);
+	}
+}
+
+console.log(`shaders translated: ${shaders}; distinct constant names: ${nameCount.size}; baked-default names: ${bakedNames.size}`);
+console.log('');
+console.log('ENGINE-SUPPLIED constants NOT covered by the seeding table (gap):');
+const gap: [string, number][] = [];
+for (const [name, n] of nameCount) {
+	if (HEURISTIC.has(name) || ENGINE_MATRIX.has(name)) continue;
+	if (bakedNames.has(name)) continue; // has a material default -> not engine-supplied
+	gap.push([name, n]);
+}
+for (const [name, n] of gap.sort((a, b) => b[1] - a[1])) {
+	console.log(`  ${name.padEnd(40)} ${n}`);
+}
+console.log('');
+console.log('Covered engine constants seen in fixtures:');
+for (const [name, n] of [...nameCount].filter(([nm]) => HEURISTIC.has(nm) || ENGINE_MATRIX.has(nm)).sort((a, b) => b[1] - a[1])) {
+	console.log(`  ${name.padEnd(40)} ${n}`);
+}

--- a/scripts/survey-vd-attrs.ts
+++ b/scripts/survey-vd-attrs.ts
@@ -1,0 +1,36 @@
+// Survey VertexDescriptor (0xA) attribute types across a bundle — to learn
+// which meshes carry BoneIndexes(13)/BoneWeights(14) skinning attributes.
+//
+// Run: fnm exec --using=22 node node_modules/tsx/dist/cli.mjs scripts/survey-vd-attrs.ts example/VEH_CARBB1GT_GR.BIN
+
+import { readFileSync } from 'node:fs';
+import { parseBundle } from '../src/lib/core/bundle/index';
+import { getResourceBlocks } from '../src/lib/core/resourceManager';
+import { parseVertexDescriptor } from '../src/lib/core/renderable';
+
+const ATTR_NAMES: Record<number, string> = {
+	1: 'Positions', 3: 'Normals', 5: 'UV1', 6: 'UV2', 7: 'Tangents',
+	13: 'BoneIndexes', 14: 'BoneWeights',
+};
+
+const path = process.argv[2] ?? 'example/VEH_CARBB1GT_GR.BIN';
+const buf = readFileSync(path);
+const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+const bundle = parseBundle(ab);
+const VD_TYPE = 0xa;
+
+const typeCount = new Map<number, number>();
+let vds = 0, withBones = 0;
+for (const r of bundle.resources.filter((x) => x.resourceTypeId === VD_TYPE)) {
+	let vd;
+	try { vd = parseVertexDescriptor(getResourceBlocks(ab, bundle, r)[0]); } catch { continue; }
+	vds++;
+	const types = new Set(vd.attributes.map((a) => a.type));
+	for (const t of types) typeCount.set(t, (typeCount.get(t) ?? 0) + 1);
+	if (types.has(13) || types.has(14)) withBones++;
+}
+console.log(`bundle=${path}  VertexDescriptors=${vds}  with-bone-attrs=${withBones}`);
+console.log('attribute type -> # of VDs that use it:');
+for (const [t, n] of [...typeCount].sort((a, b) => b[1] - a[1])) {
+	console.log(`  ${String(t).padStart(3)} ${(ATTR_NAMES[t] ?? '?').padEnd(14)} ${n}`);
+}

--- a/scripts/survey-vehicle-shaders.ts
+++ b/scripts/survey-vehicle-shaders.ts
@@ -1,0 +1,54 @@
+// Survey a vehicle GR bundle's shaders for skinning signals: the vertex input
+// semantics (BLENDINDICES/BLENDWEIGHT) and the cb0 constant names + slot ranges
+// (looking for a bone/verlet matrix palette in the high slots).
+//
+// Run: fnm exec --using=22 node node_modules/tsx/dist/cli.mjs scripts/survey-vehicle-shaders.ts example/VEH_CARBB1GT_GR.BIN
+
+import { readFileSync } from 'node:fs';
+import { parseBundle } from '../src/lib/core/bundle/index';
+import { getHandlerByKey } from '../src/lib/core/registry';
+import { getResourceBlocks } from '../src/lib/core/resourceManager';
+import { translateDxbc } from '../src/lib/core/dxbc';
+
+const path = process.argv[2] ?? 'example/VEH_CARBB1GT_GR.BIN';
+const buf = readFileSync(path);
+const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+const bundle = parseBundle(ab);
+const spb = getHandlerByKey('shaderProgramBuffer')!;
+
+const inputSemantics = new Map<string, number>();   // VS input semantic -> count
+const constMaxSlot = new Map<string, number>();      // const name -> max slot seen
+const constCount = new Map<string, number>();
+let vs = 0, ps = 0;
+
+for (const r of bundle.resources.filter((x) => x.resourceTypeId === spb.typeId)) {
+	const blocks = getResourceBlocks(ab, bundle, r);
+	const raw = blocks[1];
+	if (!raw || raw.byteLength < 0x20) continue;
+	let tr;
+	try { tr = translateDxbc(raw); } catch { continue; }
+	if (tr.parsed.programType === 'vertex') {
+		vs++;
+		for (const i of tr.parsed.inputs) inputSemantics.set(i.semanticName, (inputSemantics.get(i.semanticName) ?? 0) + 1);
+	} else { ps++; }
+	for (const cb of tr.parsed.reflection.constantBuffers) {
+		for (const v of cb.variables) {
+			const slot = Math.floor(v.startOffset / 16);
+			const endSlot = Math.floor((v.startOffset + v.size - 1) / 16);
+			constMaxSlot.set(v.name, Math.max(constMaxSlot.get(v.name) ?? 0, endSlot));
+			constCount.set(v.name, (constCount.get(v.name) ?? 0) + 1);
+		}
+	}
+}
+
+console.log(`bundle=${path}  VS=${vs} PS=${ps}`);
+console.log('\nVS INPUT SEMANTICS (look for BLENDINDICES / BLENDWEIGHT):');
+for (const [s, n] of [...inputSemantics].sort((a, b) => b[1] - a[1])) console.log(`  ${s.padEnd(20)} ${n}`);
+console.log('\nCONSTANTS that span a wide slot range (>= 4 slots = matrix arrays / palettes):');
+const wide = [...constMaxSlot].map(([name, max]) => ({ name, max, n: constCount.get(name) ?? 0 }))
+	.filter((c) => c.max >= 8).sort((a, b) => b.max - a.max);
+for (const c of wide) console.log(`  ${c.name.padEnd(34)} maxSlot=${c.max}  count=${c.n}`);
+console.log('\nALL constant names by count (top 50):');
+for (const [name, n] of [...constCount].sort((a, b) => b[1] - a[1]).slice(0, 50)) {
+	console.log(`  ${name.padEnd(34)} count=${n} maxSlot=${constMaxSlot.get(name)}`);
+}

--- a/src/components/schema-editor/viewports/RenderableViewport.tsx
+++ b/src/components/schema-editor/viewports/RenderableViewport.tsx
@@ -46,6 +46,7 @@ import { translateDxbc, type TranslatedShader } from '@/lib/core/dxbc';
 import { buildTextureCatalog, type TextureCatalogEntry } from '@/lib/core/textureCatalog';
 import { buildMaterialIndex, pickBestMaterial } from '@/lib/core/materialBinding';
 import { buildTranslatedShaderMaterial, type TranslatedMaterial } from '@/lib/core/translatedShaderMaterial';
+import { ENGINE_CONSTANT_DEFAULTS, inferCbLayout } from '@/lib/core/shaderEngineConstants';
 import { decodeTexture } from '@/lib/core/texture';
 import { parseMaterialData } from '@/lib/core/material';
 import {
@@ -227,23 +228,10 @@ function applyWrapping(
 // guesses below.
 // =============================================================================
 
-const TRANSLATED_HEURISTIC_DEFAULTS: Record<string, [number, number, number, number]> = {
-	g_PerVehicleFog: [0, 0, 0, 1],
-	FogColourPlusWhiteLevel: [0.55, 0.70, 0.85, 1],
-	KeyLightColour: [1, 1, 1, 1],
-	KeyLightClampedColour: [1, 1, 1, 1],
-	KeyLightSpecularColour: [1, 1, 1, 1],
-	KeyLightDirection: [0.4, -0.7, 0.6, 0],
-	SkyReflectionColour: [0.55, 0.75, 0.95, 1],
-	ShadowMap_Constants: [1, 1, 1, 1],
-	ShadowMap_Constants2: [1, 1, 1, 1],
-	ShadowMap_Constants3: [1, 1, 1, 1],
-	ScattCoeffs: [0.4, 0.4, 0.5, 1],
-	g_damageConstants: [0, 0, 0, 1],
-	sampleCoverage: [1, 1, 1, 1],
-	g_paintColour: [0.6, 0.1, 0.1, 1],
-	g_pearlescentColour: [0.2, 0.2, 0.3, 1],
-};
+// Engine-supplied cb0 defaults are shared in @/lib/core/shaderEngineConstants
+// (ENGINE_CONSTANT_DEFAULTS) so the viewport, ShaderPage and the harness stay
+// in sync.
+const TRANSLATED_HEURISTIC_DEFAULTS = ENGINE_CONSTANT_DEFAULTS;
 
 type Source = { source: string; bundle: ParsedBundle; arrayBuffer: ArrayBuffer; debug: any[] };
 
@@ -319,30 +307,9 @@ function translateShaderById(shaderId: bigint, sources: Source[]): { vs: Transla
 	return null;
 }
 
-/** Pattern-match the cb0 layout from a translated VS, falling back to the
- *  RDEF variable names when available. Identical to ShaderPage's
- *  `inferCbLayout` — duplicated here so the renderable viewport doesn't
- *  pull React state from the shader-page module. */
-function inferCbLayoutForRV(vsSrc: string, parsed: any) {
-	const slotByName = (name: string): number | null => {
-		if (!parsed) return null;
-		for (const cb of parsed.reflection.constantBuffers) {
-			for (const v of cb.variables) {
-				if (v.name === name) return Math.floor(v.startOffset / 16);
-			}
-		}
-		return null;
-	};
-	const worldMatch = vsSrc.match(/position, 0\.0\)\.xxxx \* cb0\[(\d+)\]/);
-	const worldRow0 = slotByName('world') ?? (worldMatch ? Number(worldMatch[1]) : 44);
-	const viewMatch = vsSrc.match(/r1\.x = vec4\(vec4\(dot\(r0\.xyzw, cb0\[(\d+)\]\.xyzw\)\)\)/);
-	const viewRow2 = viewMatch ? Number(viewMatch[1]) : 7;
-	const vpMatch = vsSrc.match(/o0\.x = vec4\(vec4\(dot\(r0\.xyzw, cb0\[(\d+)\]\.xyzw\)\)\)/);
-	const vpRow0 = slotByName('ViewProjectionModified') ?? (vpMatch ? Number(vpMatch[1]) : 5);
-	const camMatch = vsSrc.match(/-\(r0\.xyzx\) \+ cb0\[(\d+)\]\.xyzx/);
-	const cameraPos = slotByName('ViewPosition') ?? (camMatch ? Number(camMatch[1]) : null);
-	return { worldRow0, vpRow0, viewRow2, depthEncode: 8, cameraPos };
-}
+// cb0 layout inference is shared via @/lib/core/shaderEngineConstants
+// (inferCbLayout), so the viewport and ShaderPage recover slots identically and
+// both pick up the worldViewProj / viewProjection matrix bindings.
 
 // =============================================================================
 // Mesh rendering + materials
@@ -627,7 +594,7 @@ function RenderableMeshes({
 			const matKeyNorm = matKey.padStart(16, '0');
 			const matBinding = materialIndex.get(shaderIdHex)?.find((b) => b.materialId === matKeyNorm)
 				?? pickBestMaterial(shaderIdHex, [], materialIndex);
-			const layout = inferCbLayoutForRV(translated.vs.source, translated.vs.parsed);
+			const layout = inferCbLayout(translated.vs.source, translated.vs.parsed);
 			const sm = buildTranslatedShaderMaterial({
 				vsSource: translated.vs.source,
 				psSource: translated.ps.source,

--- a/src/lib/core/__tests__/dxt.test.ts
+++ b/src/lib/core/__tests__/dxt.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { decodeDXT1, decodeDXT3, decodeDXT5 } from '../dxt';
+
+// Build one 4×4 block: 8-byte explicit-alpha + 8-byte BC1 color (4-color mode,
+// white c0 / black c1, all selectors = 0 → every texel is white).
+function bc2Block(alphaBytes: number[]): Uint8Array {
+	const b = new Uint8Array(16);
+	b.set(alphaBytes, 0);                 // explicit 4-bit alpha (16 texels)
+	b[8] = 0xff; b[9] = 0xff;             // c0 = RGB565 white (0xFFFF)
+	b[10] = 0x00; b[11] = 0x00;           // c1 = black (0x0000) -> c0>c1, 4-color
+	b[12] = b[13] = b[14] = b[15] = 0x00; // all selectors -> color 0 (white)
+	return b;
+}
+
+describe('decodeDXT3 (BC2)', () => {
+	it('decodes explicit 4-bit alpha + BC1 color (all opaque white)', () => {
+		const out = decodeDXT3(bc2Block(new Array(8).fill(0xff)), 4, 4);
+		expect(out.length).toBe(4 * 4 * 4);
+		for (let i = 0; i < 16; i++) {
+			expect([out[i * 4], out[i * 4 + 1], out[i * 4 + 2], out[i * 4 + 3]]).toEqual([255, 255, 255, 255]);
+		}
+	});
+
+	it('reads alpha low-nibble-first (even texel = low nibble)', () => {
+		// alpha byte 0 = 0x0F: texel 0 nibble = 0xF (->255), texel 1 nibble = 0x0 (->0)
+		const out = decodeDXT3(bc2Block([0x0f, 0, 0, 0, 0, 0, 0, 0]), 4, 4);
+		expect(out[3]).toBe(255);  // texel 0 alpha
+		expect(out[7]).toBe(0);    // texel 1 alpha
+		// Color is white regardless of alpha.
+		expect([out[0], out[1], out[2]]).toEqual([255, 255, 255]);
+	});
+
+	it('scales 4-bit alpha to 8-bit via ×17 (0xF→255, 0x8→136)', () => {
+		// byte 0 = 0x80: texel0 low nibble 0x0 -> 0; texel1 high nibble 0x8 -> 136
+		const out = decodeDXT3(bc2Block([0x80, 0, 0, 0, 0, 0, 0, 0]), 4, 4);
+		expect(out[3]).toBe(0);
+		expect(out[7]).toBe(136);
+	});
+
+	it('handles non-multiple-of-4 dimensions without overrun', () => {
+		const out = decodeDXT3(bc2Block(new Array(8).fill(0xff)), 3, 1);
+		expect(out.length).toBe(3 * 1 * 4);
+		expect([out[0], out[1], out[2], out[3]]).toEqual([255, 255, 255, 255]);
+	});
+});
+
+// Smoke tests so the BC1/BC3 decoders stay characterised alongside BC2.
+describe('decodeDXT1 / decodeDXT5 smoke', () => {
+	it('DXT1 all-white opaque block', () => {
+		const b = new Uint8Array([0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+		const out = decodeDXT1(b, 4, 4);
+		expect([out[0], out[1], out[2], out[3]]).toEqual([255, 255, 255, 255]);
+	});
+	it('DXT5 white color + opaque interpolated alpha', () => {
+		const b = new Uint8Array(16);
+		b[0] = 0xff; b[1] = 0xff;             // alpha endpoints both 255 -> all 255
+		b[8] = 0xff; b[9] = 0xff;             // color c0 white
+		const out = decodeDXT5(b, 4, 4);
+		expect([out[0], out[1], out[2], out[3]]).toEqual([255, 255, 255, 255]);
+	});
+});

--- a/src/lib/core/__tests__/shaderEngineConstants.test.ts
+++ b/src/lib/core/__tests__/shaderEngineConstants.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { ENGINE_CONSTANT_DEFAULTS, inferCbLayout } from '../shaderEngineConstants';
+import type { ParsedDxbc } from '../dxbc';
+
+// Build a minimal ParsedDxbc whose RDEF declares the named constants at the
+// given vec4 slots (startOffset = slot * 16).
+function fakeParsed(slots: Record<string, number>): ParsedDxbc {
+	const variables = Object.entries(slots).map(([name, slot]) => ({
+		name,
+		startOffset: slot * 16,
+		size: 16,
+	}));
+	return {
+		reflection: { constantBuffers: [{ variables }], resourceBindings: [] },
+	} as unknown as ParsedDxbc;
+}
+
+describe('inferCbLayout', () => {
+	it('recovers the full 4-row engine matrices from RDEF names', () => {
+		const layout = inferCbLayout('', fakeParsed({
+			world: 44,
+			ViewProjectionModified: 5,
+			ViewPosition: 37,
+			worldViewProj: 50,
+			viewProjection: 54,
+		}));
+		expect(layout.worldRow0).toBe(44);
+		expect(layout.vpRow0).toBe(5);
+		expect(layout.viewRow2).toBe(7); // regex fallback (no GLSL source)
+		expect(layout.cameraPos).toBe(37);
+		// The two matrices that were previously never bound:
+		expect(layout.worldViewProjRow0).toBe(50);
+		expect(layout.viewProjectionRow0).toBe(54);
+	});
+
+	it('returns null matrix slots when the shader does not declare them', () => {
+		const layout = inferCbLayout('', fakeParsed({ world: 44, ViewProjectionModified: 5 }));
+		expect(layout.worldViewProjRow0).toBeNull();
+		expect(layout.viewProjectionRow0).toBeNull();
+	});
+
+	it('falls back to defaults with no parsed reflection', () => {
+		const layout = inferCbLayout('');
+		expect(layout.worldRow0).toBe(44);
+		expect(layout.vpRow0).toBe(5);
+		expect(layout.worldViewProjRow0).toBeNull();
+	});
+});
+
+describe('ENGINE_CONSTANT_DEFAULTS', () => {
+	it('covers the engine-supplied constants the real shaders reference', () => {
+		// These appear in 200+ of the example shaders and previously read zero.
+		for (const name of [
+			'KeyLightDirection', 'KeyLightColour', 'FogColourPlusWhiteLevel',
+			'IrradianceQuadricA', 'IrradianceQuadricB', 'HDRConstants',
+			'ShadowMap_Constants', 'ScattCoeffs', 'g_paintColour',
+		]) {
+			expect(ENGINE_CONSTANT_DEFAULTS[name], name).toBeDefined();
+			expect(ENGINE_CONSTANT_DEFAULTS[name]).toHaveLength(4);
+		}
+	});
+});

--- a/src/lib/core/dxbc/glsl.ts
+++ b/src/lib/core/dxbc/glsl.ts
@@ -637,11 +637,23 @@ function emitHeader(ctx: EmitCtx, p: ParsedDxbc, decoded: DecodedShader): string
 				lines.push(`#define ${dxName} ${builtin}`);
 			} else {
 				const comps = maskBits(el.mask);
-				const zero = comps === 1 ? '0.0'
-					: comps === 2 ? 'vec2(0.0)'
-					: comps === 3 ? 'vec3(0.0)'
-					: 'vec4(0.0)';
-				lines.push(`#define ${dxName} ${zero}`);
+				// BLENDWEIGHT is the skin-blend weight vector. Stubbing it to zero
+				// makes a skinned vertex collapse to the origin (pos = boneMatrix *
+				// pos * 0). With the bone palette seeded to identity at rest (see
+				// shaderEngineConstants), defaulting the dominant weight to 1 makes
+				// the vertex resolve to its rest position instead — so skinned
+				// vehicle meshes render at rest pose rather than vanishing.
+				const isBlendWeight = /^BLENDWEIGHT$/i.test(el.semanticName);
+				const stub = isBlendWeight
+					? (comps === 1 ? '1.0'
+						: comps === 2 ? 'vec2(1.0, 0.0)'
+						: comps === 3 ? 'vec3(1.0, 0.0, 0.0)'
+						: 'vec4(1.0, 0.0, 0.0, 0.0)')
+					: (comps === 1 ? '0.0'
+						: comps === 2 ? 'vec2(0.0)'
+						: comps === 3 ? 'vec3(0.0)'
+						: 'vec4(0.0)');
+				lines.push(`#define ${dxName} ${stub}`);
 			}
 		}
 	}

--- a/src/lib/core/dxt.ts
+++ b/src/lib/core/dxt.ts
@@ -102,6 +102,84 @@ export function decodeDXT1(
 }
 
 // ---------------------------------------------------------------------------
+// BC2 (DXT3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode a BC2 (DXT3) compressed buffer into RGBA pixels.
+ *
+ * BC2: 16 bytes per 4×4 block.
+ *   - 8 bytes: explicit alpha — 16 × 4-bit alpha values (one per texel, row
+ *     major, little-endian within each byte: low nibble = even texel).
+ *   - 8 bytes: BC1 color block, always interpreted in 4-color mode (no 1-bit
+ *     punch-through alpha — alpha comes from the explicit block).
+ *
+ * BC2 stores alpha as a flat 4-bit value (no interpolation), unlike BC3's
+ * interpolated alpha. Used by a few Burnout textures with sharp alpha edges.
+ */
+export function decodeDXT3(
+	src: Uint8Array,
+	width: number,
+	height: number,
+): Uint8Array {
+	const blocksX = Math.max(1, (width + 3) >> 2);
+	const blocksY = Math.max(1, (height + 3) >> 2);
+	const out = new Uint8Array(width * height * 4);
+	const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+
+	let blockOff = 0;
+	for (let by = 0; by < blocksY; by++) {
+		for (let bx = 0; bx < blocksX; bx++) {
+			// ---- Color block (8 bytes, BC1 always-4-color mode) ----
+			const colorOff = blockOff + 8;
+			const c0 = dv.getUint16(colorOff + 0, true);
+			const c1 = dv.getUint16(colorOff + 2, true);
+			const bits = dv.getUint32(colorOff + 4, true);
+
+			const [r0, g0, b0] = unpackRgb565(c0);
+			const [r1, g1, b1] = unpackRgb565(c1);
+
+			const palette = new Uint8Array(12); // 4 colors × RGB (alpha is explicit)
+			palette[0] = r0; palette[1] = g0; palette[2] = b0;
+			palette[3] = r1; palette[4] = g1; palette[5] = b1;
+			palette[6]  = (2 * r0 + r1 + 1) / 3 | 0;
+			palette[7]  = (2 * g0 + g1 + 1) / 3 | 0;
+			palette[8]  = (2 * b0 + b1 + 1) / 3 | 0;
+			palette[9]  = (r0 + 2 * r1 + 1) / 3 | 0;
+			palette[10] = (g0 + 2 * g1 + 1) / 3 | 0;
+			palette[11] = (b0 + 2 * b1 + 1) / 3 | 0;
+
+			for (let py = 0; py < 4; py++) {
+				const y = by * 4 + py;
+				if (y >= height) break;
+				for (let px = 0; px < 4; px++) {
+					const x = bx * 4 + px;
+					if (x >= width) continue;
+
+					const pixelIndex = py * 4 + px;
+					// Explicit 4-bit alpha: byte holds two texels (low nibble first).
+					const alphaByte = src[blockOff + (pixelIndex >> 1)];
+					const nibble = (pixelIndex & 1) ? (alphaByte >> 4) : (alphaByte & 0x0f);
+					const alpha = nibble * 17; // 4-bit → 8-bit (0xf * 17 = 255)
+
+					const colorIdx = (bits >> (pixelIndex * 2)) & 0x3;
+					const dst = (y * width + x) * 4;
+					const csrc = colorIdx * 3;
+					out[dst]     = palette[csrc];
+					out[dst + 1] = palette[csrc + 1];
+					out[dst + 2] = palette[csrc + 2];
+					out[dst + 3] = alpha;
+				}
+			}
+
+			blockOff += 16;
+		}
+	}
+
+	return out;
+}
+
+// ---------------------------------------------------------------------------
 // BC3 (DXT5)
 // ---------------------------------------------------------------------------
 

--- a/src/lib/core/shaderEngineConstants.ts
+++ b/src/lib/core/shaderEngineConstants.ts
@@ -1,0 +1,179 @@
+// Engine-supplied shader constants + cb0 layout inference.
+//
+// Burnout's shaders read two kinds of cb0 slot: material defaults baked into
+// the Shader resource (handled by seedDefaults from the parsed constants), and
+// per-frame ENGINE constants the runtime supplies at draw time (camera /
+// view-projection matrices, key light, fog, sky, irradiance, shadow). A
+// preview/translator has to synthesise that engine state or the slots read zero
+// and the shader collapses to black or fails to transform.
+//
+// The engine constant set + semantics are documented in
+// docs/ShaderConstants_findings.md §4 (the per-frame `BrnShaderConstantsFrame`
+// register). This module is the single source of truth for both the static
+// defaults and the cb0 slot map; ShaderPage, the RenderableViewport and the
+// differential harness all import it (previously each kept its own drifting
+// copy).
+
+import type { ParsedDxbc } from './dxbc';
+
+/** cb0 slot map for a shader. Slots are vec4 indices (byte offset / 16).
+ *  The `Row0` matrix slots are the first of a 4-consecutive-row matrix; null
+ *  means the shader doesn't declare that matrix. */
+export type CbLayout = {
+	/** First row of the per-object world matrix (4 rows). */
+	worldRow0: number;
+	/** First row of the `ViewProjectionModified` block: Burnout packs clip.xy in
+	 *  rows 0/1, view-space z in `viewRow2`, depth-encode coeffs in `depthEncode`. */
+	vpRow0: number;
+	/** View-matrix row 2 (view-space z), part of the ViewProjectionModified block. */
+	viewRow2: number;
+	/** Depth-encode coefficient slot (A, B, -1, 0) for the OpenGL depth range. */
+	depthEncode: number;
+	/** Camera world position slot, or null when the shader doesn't use it. */
+	cameraPos: number | null;
+	/** First row of the combined world*view*projection matrix (4 rows), or null.
+	 *  Many shaders transform with this directly instead of ViewProjectionModified. */
+	worldViewProjRow0: number | null;
+	/** First row of the view*projection matrix (4 rows), or null. */
+	viewProjectionRow0: number | null;
+};
+
+/**
+ * Static defaults for engine-supplied (runtime-bound) cb0 constants, keyed by
+ * the RDEF variable name. These are values the game would fill from its
+ * per-frame constant register; for a static preview we supply representative
+ * stand-ins so a shader that multiplies by, say, `KeyLightColour` or adds
+ * `FogColourPlusWhiteLevel` doesn't read zero and collapse to black.
+ *
+ * Semantics per docs/ShaderConstants_findings.md §4. Matrices (world /
+ * view-projection / worldViewProj / shadow) are NOT here — they are bound
+ * per-frame from the real camera in `bindEngineMatrices`.
+ */
+export const ENGINE_CONSTANT_DEFAULTS: Record<string, [number, number, number, number]> = {
+	// --- Lighting (key/directional light) ---
+	KeyLightColour: [1, 1, 1, 1],
+	KeyLightClampedColour: [1, 1, 1, 1],
+	KeyLightSpecularColour: [1, 1, 1, 1],
+	KeyLightDirection: [0.4, -0.7, 0.6, 0],
+	// --- Ambient irradiance (quadric coefficients). Exact encoding unconfirmed;
+	//     a small flat grey keeps surfaces from going pure-black in ambient-only
+	//     regions without overwhelming the key light. Approximate, not spec-exact. ---
+	IrradianceQuadricA: [0.18, 0.19, 0.22, 1],
+	IrradianceQuadricB: [0, 0, 0, 0],
+	// --- Sky / fog / atmosphere ---
+	FogColourPlusWhiteLevel: [0.55, 0.70, 0.85, 1],
+	SkyReflectionColour: [0.55, 0.75, 0.95, 1],
+	ScattCoeffs: [0.4, 0.4, 0.5, 1],
+	g_PerVehicleFog: [0, 0, 0, 1],
+	// --- HDR / tonemap (neutral exposure) ---
+	HDRConstants: [1, 1, 1, 1],
+	// --- Shadow map (neutral; preview binds a white shadow texture so the
+	//     compare returns "lit", making the cascade-select moot) ---
+	ShadowMap_Constants: [1, 1, 1, 1],
+	ShadowMap_Constants2: [1, 1, 1, 1],
+	ShadowMap_Constants3: [1, 1, 1, 1],
+	ShadowMap_ObjectCsmSelect: [1, 0, 0, 0],
+	// --- Texture / UV animation (identity: no animation in a static preview) ---
+	AnimDuration: [1, 1, 1, 1],
+	AnimNumberOfFramesU: [1, 1, 1, 1],
+	AnimNumberOfFramesV: [1, 1, 1, 1],
+	g_vehicleUvAnimOffset: [0, 0, 0, 0],
+	// --- Misc material/runtime masks (neutral) ---
+	g_selfIlluminationMask: [0, 0, 0, 0],
+	g_policeLightsSelfIlluminationMask: [0, 0, 0, 0],
+	g_wheelConstants: [0, 0, 0, 1],
+	g_damageConstants: [0, 0, 0, 1],
+	sampleCoverage: [1, 1, 1, 1],
+	// --- Vehicle paint (so PaintGloss `r0 *= g_paintColour` doesn't go black) ---
+	g_paintColour: [0.6, 0.1, 0.1, 1],
+	g_pearlescentColour: [0.2, 0.2, 0.3, 1],
+};
+
+/**
+ * Recover the cb0 slot map from a translated VS, preferring RDEF variable names
+ * (authoritative per shader) and falling back to regex pattern-matching on the
+ * emitted GLSL for the few cases without parsed reflection.
+ */
+export function inferCbLayout(vs: string, parsed?: ParsedDxbc): CbLayout {
+	const slotByName = (name: string): number | null => {
+		if (!parsed) return null;
+		for (const cb of parsed.reflection.constantBuffers) {
+			for (const v of cb.variables) {
+				if (v.name === name) return Math.floor(v.startOffset / 16);
+			}
+		}
+		return null;
+	};
+
+	// worldRow0: `pos.xxxx * cb0[N]` — N is the world row-0 slot. fxc emits rows
+	// in {y,x,z,w} accumulation order; the .xxxx row is always row 0.
+	const worldMatch = vs.match(/position, 0\.0\)\.xxxx \* cb0\[(\d+)\]/);
+	const worldRow0 = slotByName('world') ?? (worldMatch ? Number(worldMatch[1]) : 44);
+
+	// viewRow2: first dp4 after the world transform feeding the o0.zw depth pair.
+	const viewMatch = vs.match(/r1\.x = vec4\(vec4\(dot\(r0\.xyzw, cb0\[(\d+)\]\.xyzw\)\)\)/);
+	const viewRow2 = viewMatch ? Number(viewMatch[1]) : 7;
+
+	// vpRow0: the ViewProjectionModified slot, or the first o0.x dp4.
+	const vpMatch = vs.match(/o0\.x = vec4\(vec4\(dot\(r0\.xyzw, cb0\[(\d+)\]\.xyzw\)\)\)/);
+	const vpRow0 = slotByName('ViewProjectionModified') ?? (vpMatch ? Number(vpMatch[1]) : 5);
+
+	const camMatch = vs.match(/-\(r0\.xyzx\) \+ cb0\[(\d+)\]\.xyzx/);
+	const cameraPos = slotByName('ViewPosition') ?? (camMatch ? Number(camMatch[1]) : null);
+
+	return {
+		worldRow0,
+		vpRow0,
+		viewRow2,
+		depthEncode: 8,
+		cameraPos,
+		// Full 4-row engine matrices many shaders transform with directly.
+		worldViewProjRow0: slotByName('worldViewProj'),
+		viewProjectionRow0: slotByName('viewProjection'),
+	};
+}
+
+// =============================================================================
+// Skinning / vehicle-deformation palette
+// =============================================================================
+//
+// Skinned vehicle meshes (those whose VertexDescriptor carries
+// BoneIndexes/BoneWeights) transform each vertex by a bone-matrix palette
+// (`boneMatrices`, a cb0 array of 4-row matrices) blended by the per-vertex
+// weights, then add per-vertex deformation offsets (`g_verletOffsets`). Both
+// are supplied by the runtime: the bone matrices are IDENTITY at rest (this is
+// relative/deformation skinning — vertices are stored in rest position and the
+// matrices only diverge from identity when the car is crashed) and the verlet
+// offsets are zero at rest. Left unseeded they read zero, so a skinned vertex
+// collapses to the origin (boneMatrix·pos·weight = 0·pos·0) and the mesh
+// vanishes. Seeding the palette to identity — together with the BLENDWEIGHT=1
+// stub the GLSL emitter now uses — makes skinned meshes render at rest pose.
+
+/** cb0 array constants that are palettes of 4-row matrices whose rest value is
+ *  the identity matrix. */
+export const SKIN_IDENTITY_MATRIX_PALETTES = new Set(['boneMatrices']);
+
+/**
+ * Identity-fill any matrix-palette constants (e.g. `boneMatrices`) the shader
+ * declares, via the supplied per-slot writer. `g_verletOffsets` rests at zero,
+ * which the zero-initialised cb0 already satisfies, so it needs no seeding.
+ */
+export function seedSkinningPalettes(
+	parsed: ParsedDxbc | undefined,
+	writeVec4: (slot: number, x: number, y: number, z: number, w: number) => void,
+): void {
+	if (!parsed) return;
+	for (const cb of parsed.reflection.constantBuffers) {
+		for (const v of cb.variables) {
+			if (!SKIN_IDENTITY_MATRIX_PALETTES.has(v.name)) continue;
+			const slot = Math.floor(v.startOffset / 16);
+			const nVec4 = Math.max(4, Math.floor(v.size / 16));
+			for (let m = 0; m + 4 <= nVec4; m += 4) {
+				writeVec4(slot + m + 0, 1, 0, 0, 0);
+				writeVec4(slot + m + 1, 0, 1, 0, 0);
+				writeVec4(slot + m + 2, 0, 0, 1, 0);
+				writeVec4(slot + m + 3, 0, 0, 0, 1);
+			}
+		}
+	}
+}

--- a/src/lib/core/texture.ts
+++ b/src/lib/core/texture.ts
@@ -11,7 +11,7 @@
 
 import type { ParsedBundle, ResourceEntry } from './types';
 import { getResourceBlocks } from './resourceManager';
-import { decodeDXT1, decodeDXT5 } from './dxt';
+import { decodeDXT1, decodeDXT3, decodeDXT5 } from './dxt';
 import { BundleError } from './errors';
 
 // =============================================================================
@@ -219,6 +219,9 @@ function decodeTexturePixels(
 		case 'DXT1':
 			return decodeDXT1(pixelData, width, height);
 
+		case 'DXT3':
+			return decodeDXT3(pixelData, width, height);
+
 		case 'DXT5':
 			return decodeDXT5(pixelData, width, height);
 
@@ -271,8 +274,6 @@ function decodeTexturePixels(
 			// Already RGBA — return as-is.
 			return pixelData.slice(0, width * height * 4);
 
-		case 'DXT3':
-			// DXT3 is rare in Burnout; fall through to unsupported for now.
 		default:
 			throw new BundleError(
 				`Unsupported texture format: ${format} (raw 0x${header.formatRaw.toString(16)})`,

--- a/src/lib/core/translatedShaderMaterial.ts
+++ b/src/lib/core/translatedShaderMaterial.ts
@@ -27,16 +27,7 @@ import type { TextureCatalogEntry } from './textureCatalog';
 import { pickTextureForSampler } from './textureCatalog';
 import type { MaterialBinding } from './materialBinding';
 import type { ParsedShaderConstant } from './shader';
-
-/** cb0 slot map for a given shader; matches the inferCbLayout shape used
- *  by the shader-page preview. */
-type CbLayout = {
-	worldRow0: number;
-	vpRow0: number;
-	viewRow2: number;
-	depthEncode: number;
-	cameraPos: number | null;
-};
+import { type CbLayout, seedSkinningPalettes } from './shaderEngineConstants';
 
 export type BuildOptions = {
 	vsSource: string;
@@ -157,12 +148,24 @@ export function buildTranslatedShaderMaterial(opts: BuildOptions): TranslatedMat
 	seedDefaults(vsParsed);
 	seedDefaults(psParsed);
 
+	// Identity-fill the bone-matrix palette so skinned vehicle meshes render at
+	// rest pose instead of collapsing to the origin (see shaderEngineConstants).
+	const cb0Arr = m.uniforms.cb0?.value as THREE.Vector4[] | undefined;
+	if (cb0Arr) {
+		const writeVec4 = (slot: number, x: number, y: number, z: number, w: number) => {
+			if (slot >= 0 && slot < cb0Arr.length) cb0Arr[slot].set(x, y, z, w);
+		};
+		seedSkinningPalettes(vsParsed, writeVec4);
+		seedSkinningPalettes(psParsed, writeVec4);
+	}
+
 	// __updateCb0 — engine-fed slots refreshed per frame from three.js
 	// matrices + clock. The mesh's onBeforeRender invokes this.
 	if (seededCbs.has('cb0')) {
 		const world = new THREE.Matrix4();
 		const viewMat = new THREE.Matrix4();
 		const viewProj = new THREE.Matrix4();
+		const worldViewProj = new THREE.Matrix4();
 		const cameraPos = new THREE.Vector3();
 		const setRow = (cb: THREE.Vector4[], slot: number, mm: THREE.Matrix4, row: number) => {
 			if (slot < 0 || slot >= cb.length) return;
@@ -188,6 +191,17 @@ export function buildTranslatedShaderMaterial(opts: BuildOptions): TranslatedMat
 			setRow(cb0, layout.worldRow0 + 1, world, 1);
 			setRow(cb0, layout.worldRow0 + 2, world, 2);
 			setRow(cb0, layout.worldRow0 + 3, world, 3);
+			// Full 4-row engine matrices: shaders that transform with
+			// `worldViewProj` / `viewProjection` directly (rather than the
+			// ViewProjectionModified depth-encode scheme) need all four rows or
+			// the vertex never reaches clip space and the mesh vanishes.
+			if (layout.viewProjectionRow0 != null) {
+				for (let r = 0; r < 4; r++) setRow(cb0, layout.viewProjectionRow0 + r, viewProj, r);
+			}
+			if (layout.worldViewProjRow0 != null) {
+				worldViewProj.multiplyMatrices(viewProj, world);
+				for (let r = 0; r < 4; r++) setRow(cb0, layout.worldViewProjRow0 + r, worldViewProj, r);
+			}
 			if (layout.cameraPos != null && cb0[layout.cameraPos]) {
 				cb0[layout.cameraPos].set(cameraPos.x, cameraPos.y, cameraPos.z, 1);
 			}

--- a/src/pages/ShaderPage.tsx
+++ b/src/pages/ShaderPage.tsx
@@ -42,6 +42,7 @@ import { u64ToBigInt } from '@/lib/core/u64';
 import { buildTextureCatalog, pickTextureForSampler, type TextureCatalogEntry } from '@/lib/core/textureCatalog';
 import { buildMaterialIndex, pickBestMaterial, type MaterialBinding } from '@/lib/core/materialBinding';
 import { buildTranslatedShaderMaterial, type TranslatedMaterial } from '@/lib/core/translatedShaderMaterial';
+import { ENGINE_CONSTANT_DEFAULTS, inferCbLayout } from '@/lib/core/shaderEngineConstants';
 import type { DecodedTexture } from '@/lib/core/texture';
 import { formatResourceId } from '@/lib/core/bundle';
 
@@ -147,62 +148,9 @@ const FALLBACK_FS = /* glsl */ `
 	void main() { gl_FragColor = vec4(0.6, 0.1, 0.6, 1.0); }
 `;
 
-// Per-shader cb0 slot discovery. Burnout's fxc output is extremely regular,
-// so we can recover the world / view / viewProj / depth-encode slots by
-// pattern-matching the translated GLSL. Anything we can't recover falls
-// back to reasonable defaults so the binding hook always has *something*
-// to bind.
-type CbLayout = {
-	/** Slot of row 0 of the world matrix. Typically 40..48. */
-	worldRow0: number;
-	/** Slot of row 0 of view*projection. Typically 5. */
-	vpRow0: number;
-	/** Slot of view matrix row 2 (used to compute view-space z). Typically 7. */
-	viewRow2: number;
-	/** Slot of the depth encoder `(A, B, C, D)` — always 8 in practice. */
-	depthEncode: number;
-	/** Slot of the camera-position vector (SM5 typically 37..38). */
-	cameraPos: number | null;
-};
-
-function inferCbLayout(vs: string, parsed?: ParsedDxbc): CbLayout {
-	// Prefer slot lookups by RDEF variable name when we have parsed
-	// reflection data — that's the authoritative answer per shader (vehicle
-	// shaders put ViewPosition at slot 37, water at slot 35, etc.). Fall
-	// back to regex pattern matching for the few cases without parsed data.
-	const slotByName = (name: string): number | null => {
-		if (!parsed) return null;
-		for (const cb of parsed.reflection.constantBuffers) {
-			for (const v of cb.variables) {
-				if (v.name === name) return Math.floor(v.startOffset / 16);
-			}
-		}
-		return null;
-	};
-
-	// worldRow0: look for `pos.xxxx * cb0[N]` — N is the row-0 slot. fxc
-	// emits rows in {y, x, z, w} accumulation order; we key on the .xxxx row
-	// which is always the row-0 multiply.
-	const worldMatch = vs.match(/position, 0\.0\)\.xxxx \* cb0\[(\d+)\]/);
-	const worldRow0 = slotByName('world') ?? (worldMatch ? Number(worldMatch[1]) : 44);
-
-	// viewRow2: first `dot(r0.xyzw, cb0[N].xyzw)` after the world transform,
-	// whose result feeds into the `o0.zw` depth-encode pair.
-	const viewMatch = vs.match(/r1\.x = vec4\(vec4\(dot\(r0\.xyzw, cb0\[(\d+)\]\.xyzw\)\)\)/);
-	const viewRow2 = viewMatch ? Number(viewMatch[1]) : 7;
-
-	// vpRow0: the ViewProjectionModified matrix slot, or the first cb used
-	// in an o0.x dp4 if we can't read the RDEF.
-	const vpMatch = vs.match(/o0\.x = vec4\(vec4\(dot\(r0\.xyzw, cb0\[(\d+)\]\.xyzw\)\)\)/);
-	const vpRow0 = slotByName('ViewProjectionModified') ?? (vpMatch ? Number(vpMatch[1]) : 5);
-
-	// cameraPos: prefer the named ViewPosition variable over the regex
-	// pattern, since vehicle shaders put it at a different slot than terrain.
-	const camMatch = vs.match(/-\(r0\.xyzx\) \+ cb0\[(\d+)\]\.xyzx/);
-	const cameraPos = slotByName('ViewPosition') ?? (camMatch ? Number(camMatch[1]) : null);
-
-	return { worldRow0, vpRow0, viewRow2, depthEncode: 8, cameraPos };
-}
+// cb0 slot discovery + engine-constant defaults live in
+// @/lib/core/shaderEngineConstants (shared with the RenderableViewport and the
+// differential harness). inferCbLayout / ENGINE_CONSTANT_DEFAULTS are imported.
 
 // Given a translated program, guess reasonable default three.js attribute
 // aliases so a_POSITION0 / a_NORMAL0 / a_TEXCOORD0 are fed from standard
@@ -361,29 +309,11 @@ function decodedToDataTexture(dt: DecodedTexture): THREE.DataTexture {
 	return tex;
 }
 
-// Defaults applied to runtime-bound cb0 variables that the game would
-// normally fill from the engine but we leave as plausible static values
-// so the preview doesn't collapse to black. Module-scope so the Inputs
-// tab can show users which variables we made up.
-const HEURISTIC_DEFAULTS: Record<string, [number, number, number, number]> = {
-	g_PerVehicleFog: [0, 0, 0, 1],
-	FogColourPlusWhiteLevel: [0.55, 0.70, 0.85, 1],
-	KeyLightColour: [1, 1, 1, 1],
-	KeyLightClampedColour: [1, 1, 1, 1],
-	KeyLightSpecularColour: [1, 1, 1, 1],
-	KeyLightDirection: [0.4, -0.7, 0.6, 0],
-	SkyReflectionColour: [0.55, 0.75, 0.95, 1],
-	ShadowMap_Constants: [1, 1, 1, 1],
-	ShadowMap_Constants2: [1, 1, 1, 1],
-	ShadowMap_Constants3: [1, 1, 1, 1],
-	ScattCoeffs: [0.4, 0.4, 0.5, 1],
-	g_damageConstants: [0, 0, 0, 1],
-	sampleCoverage: [1, 1, 1, 1],
-	// Vehicle paint defaults — without these the vehicle PaintGloss
-	// shader's `r0 *= g_paintColour` collapses the body to black.
-	g_paintColour: [0.6, 0.1, 0.1, 1],
-	g_pearlescentColour: [0.2, 0.2, 0.3, 1],
-};
+// Engine-supplied cb0 defaults (key light, fog, sky, irradiance, shadow, etc.)
+// live in @/lib/core/shaderEngineConstants as ENGINE_CONSTANT_DEFAULTS, shared
+// across the previews + harness. The Inputs tab reads it to show which
+// variables are engine stand-ins vs material-baked.
+const HEURISTIC_DEFAULTS = ENGINE_CONSTANT_DEFAULTS;
 
 // A self-contained, known-good water shader used as a "does the rendering
 // pipeline actually work?" reference. Three.js auto-provides modelMatrix,


### PR DESCRIPTION
Improves the translated-shader (DXBC→GLSL) preview so more shaders — and skinned vehicle meshes — render correctly instead of dark or collapsed. The cb0 slots a shader expects the engine to fill at draw time were reading zero, which silently dropped vertices or collapsed skinned meshes to the origin.

## Changes

**Consolidation.** The cb0-seeding logic was duplicated three times (`ShaderPage`, `RenderableViewport`, and the diff harness). Merged into one source of truth: `src/lib/core/shaderEngineConstants.ts` (`ENGINE_CONSTANT_DEFAULTS` + `inferCbLayout` + `CbLayout`). The callers now import it; the harness re-exports it.

**Engine matrices.** `inferCbLayout` now binds the `worldViewProj` / `viewProjection` matrices it previously left unbound, so shaders that transform with them reach clip space instead of dropping the vertex. The engine-constant default table is expanded to the full per-frame set the shipped shaders reference (key light, fog, irradiance, shadow-map, HDR, texture-anim, …) so those slots no longer read zero. Surveyed against `example/SHADERS.BNDL` (242 shaders) via `scripts/survey-shader-constants.ts`: the unbound/zero gap drops from 23 constants to ~10 (the remainder are low-impact, e.g. a shadow matrix that's moot behind the white-shadow fallback).

**Skinning.** Vehicle meshes carry per-vertex bone indices/weights and their shaders blend a `boneMatrices` palette + `g_verletOffsets`. At rest the palette is identity and the offsets are zero (relative deformation skinning), so left unseeded a skinned vertex computes `boneMatrix·pos·weight = 0·pos·0` and **collapses to the origin**. Fix: `seedSkinningPalettes` identity-fills the `boneMatrices` palette, and the GLSL emitter's `BLENDWEIGHT` attribute stub now defaults to `(1,0,0,0)` — so a skinned vertex resolves to its rest position (`identity·pos·1`). Grounded by `scripts/survey-vehicle-shaders.ts` / `survey-vd-attrs.ts` (26 of 121 VS are skinned; 7 of 15 vehicle vertex descriptors carry bone attributes; `boneMatrices` = 45 four-row matrices at cb0 slot 35).

**Texture.** Added DXT3 (BC2) decode — explicit 4-bit alpha + BC1 colour — wired into `texture.ts`. The format previously threw "unsupported".

## Testing
- New unit tests: `dxt.test.ts` (BC2 decode + BC1/BC3 smoke), `shaderEngineConstants.test.ts` (matrix-slot inference + defaults).
- Full `src/lib` suite green: **3213 passed**; the only 3 failures are pre-existing missing-fixture (`example/older builds/…`) errors unrelated to this change.
- Verified on real fixture data that the skinning seed engages (identity palette at the expected slots, `BLENDWEIGHT` stub = `vec4(1,0,0,0)`).

## Notes / scope
- This affects the translated-shader path; the heuristic `MeshStandardMaterial` fallback already rendered static geometry fine.
- Articulation / crash deformation (non-identity bone matrices) needs the runtime deformation solver and is out of scope — identity gives the correct undamaged rest pose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)