### PR TITLE
Fix WORLDCOL multi-instance save corruption + tree sort; editable Prop header fields

### DIFF
--- a/src/components/workspace/WorkspaceHierarchy.helpers.ts
+++ b/src/components/workspace/WorkspaceHierarchy.helpers.ts
@@ -48,6 +48,15 @@ import type {
 import type { NodePath } from '@/lib/schema/walk';
 import { isWorldViewportFamilyKey } from './WorldViewportComposition.helpers';
 
+// Natural-numeric name collator so `TRK_COL_2` sorts before `TRK_COL_10`
+// instead of lexicographically. Mirrors the `NATURAL_NAME` collator the
+// multi-instance handlers use (polygonSoupList.ts / idList.ts) so the tree's
+// instance order matches the order those handlers' pickers would produce.
+const NAME_COLLATOR = new Intl.Collator(undefined, {
+	numeric: true,
+	sensitivity: 'base',
+});
+
 // ---------------------------------------------------------------------------
 // Visibility predicates
 // ---------------------------------------------------------------------------
@@ -596,7 +605,21 @@ export function buildWorkspaceFlat({
 
 			if (isMulti) {
 				const pickerCtxs = buildInstancePickerCtxs(bundle, handler, entry.count);
-				for (let i = 0; i < entry.count; i++) {
+				// Display rows in natural-name order (TRK_COL_0 → TRK_COL_428),
+				// matching the old Resources page, instead of raw disk order.
+				// Only the ITERATION order changes: the loop variable `i` stays
+				// the TRUE disk index everywhere (key, `index`, instances[i],
+				// selection match) so selection, editing, and on-disk write order
+				// remain byte-identical — we reorder what the user sees, never the
+				// resource's identity.
+				const order = [...Array(entry.count).keys()].sort((a, b) => {
+					const cmp = NAME_COLLATOR.compare(
+						pickerCtxs[a].name,
+						pickerCtxs[b].name,
+					);
+					return cmp !== 0 ? cmp : a - b;
+				});
+				for (const i of order) {
 					const iKey = instanceKey(bundle.id, entry.key, i);
 					const instanceSelected =
 						(level === 'instance' || level === 'schema') &&

--- a/src/components/workspace/WorkspaceHierarchy.test.ts
+++ b/src/components/workspace/WorkspaceHierarchy.test.ts
@@ -707,6 +707,58 @@ describe('buildWorkspaceFlat — multi-instance Instance row labels (issue #29)'
 });
 
 // ---------------------------------------------------------------------------
+// Multi-instance Instance rows sorted by natural name (not disk order)
+// ---------------------------------------------------------------------------
+
+describe('buildWorkspaceFlat — natural-name instance ordering', () => {
+	it('emits Instance rows in natural-name order while preserving disk index', () => {
+		// Disk order is deliberately out of natural order: TRK_COL_10 at slot 0,
+		// TRK_COL_2 at slot 1, TRK_COL_1 at slot 2. The tree must DISPLAY them in
+		// natural-numeric name order (1, 2, 10) — matching the old Resources page —
+		// while each node's `index` keeps pointing at the original disk slot so
+		// selection / editing / write order stay byte-identical.
+		const PSL_TYPE_ID = 0x43;
+		const bundles = [
+			makeBundle(
+				'WORLDCOL.BIN',
+				{ polygonSoupList: [{ soups: [] }, { soups: [] }, { soups: [] }] },
+				{
+					uiResources: {
+						polygonSoupList: [
+							{ id: '0xA', name: 'TRK_COL_10', typeId: PSL_TYPE_ID },
+							{ id: '0xB', name: 'TRK_COL_2', typeId: PSL_TYPE_ID },
+							{ id: '0xC', name: 'TRK_COL_1', typeId: PSL_TYPE_ID },
+						],
+					},
+				},
+			),
+		];
+		const flat = buildWorkspaceFlat({
+			bundles,
+			expanded: new Set([
+				bundleKey('WORLDCOL.BIN'),
+				resourceTypeKey('WORLDCOL.BIN', 'polygonSoupList'),
+			]),
+			selection: null,
+		});
+		const instances = flat.filter(
+			(n): n is InstanceFlatNode => n.kind === 'instance',
+		);
+		// Rows are sorted by natural name.
+		expect(instances.map((n) => n.label)).toEqual([
+			'TRK_COL_1',
+			'TRK_COL_2',
+			'TRK_COL_10',
+		]);
+		// Each node's `index` still points at its original disk slot.
+		const byLabel = new Map(instances.map((n) => [n.label, n.index]));
+		expect(byLabel.get('TRK_COL_1')).toBe(2);
+		expect(byLabel.get('TRK_COL_2')).toBe(1);
+		expect(byLabel.get('TRK_COL_10')).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Visibility-icon rules per acceptance criterion
 // ---------------------------------------------------------------------------
 

--- a/src/context/WorkspaceContext.helpers.test.ts
+++ b/src/context/WorkspaceContext.helpers.test.ts
@@ -9,6 +9,7 @@ import {
 	ancestorKeys,
 	appendBundle,
 	applyResourceWriteToBundle,
+	buildSingleInstanceOverrides,
 	classifyLoad,
 	clearBundleDirty,
 	dropHistoryForBundle,
@@ -245,6 +246,65 @@ describe('clearBundleDirty', () => {
 		// for reverting edits.
 		expect(cleaned.parsedResourcesAll.get('streetData')).toEqual([{ v: 1 }]);
 		expect(cleaned.parsedResources.get('streetData')).toEqual({ v: 1 });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Single-instance export override — the multi-instance save-corruption guard.
+//
+// The bundle writer broadcasts a typeId-keyed override to EVERY resource of
+// that type, so it is only safe for types with exactly one instance. A bundle
+// like WORLDCOL.BIN holds hundreds of one type (428 polygonSoupList); a
+// typeId override there would overwrite every sibling with index 0's model.
+// ---------------------------------------------------------------------------
+
+describe('buildSingleInstanceOverrides', () => {
+	it('includes a single-instance type that is dirty at :0', () => {
+		const parsedResources = new Map<string, unknown>([['streetData', { v: 1 }]]);
+		const parsedResourcesAll = new Map<string, (unknown | null)[]>([
+			['streetData', [{ v: 1 }]],
+		]);
+		const dirty = new Set(['streetData:0']);
+		const out = buildSingleInstanceOverrides(parsedResources, parsedResourcesAll, dirty);
+		expect(out.get('streetData')).toEqual({ v: 1 });
+		expect(out.size).toBe(1);
+	});
+
+	it('EXCLUDES a multi-instance type even when index 0 is dirty (corruption guard)', () => {
+		// Regression guard: before the fix this entry was emitted, and the
+		// writer broadcast index 0's model onto all 427 other polygonSoupList
+		// siblings. With >1 instances, the byResourceId path must carry the
+		// edit instead — never the typeId-keyed override.
+		const parsedResources = new Map<string, unknown>([['polygonSoupList', { soup: 0 }]]);
+		const parsedResourcesAll = new Map<string, (unknown | null)[]>([
+			['polygonSoupList', [{ soup: 0 }, { soup: 1 }, { soup: 2 }]],
+		]);
+		const dirty = new Set(['polygonSoupList:0']);
+		const out = buildSingleInstanceOverrides(parsedResources, parsedResourcesAll, dirty);
+		expect(out.has('polygonSoupList')).toBe(false);
+		expect(out.size).toBe(0);
+	});
+
+	it('excludes a single-instance type that is not dirty', () => {
+		const parsedResources = new Map<string, unknown>([['streetData', { v: 1 }]]);
+		const parsedResourcesAll = new Map<string, (unknown | null)[]>([
+			['streetData', [{ v: 1 }]],
+		]);
+		const out = buildSingleInstanceOverrides(parsedResources, parsedResourcesAll, new Set());
+		expect(out.size).toBe(0);
+	});
+
+	it('treats a missing parsedResourcesAll entry as single-instance (count defaults to 1)', () => {
+		// Defensive: parsedResources holds the model but parsedResourcesAll has
+		// no list. A single-instance bundle is the safe default, matching the
+		// pre-fix behaviour for the common one-resource-per-type case.
+		const parsedResources = new Map<string, unknown>([['streetData', { v: 1 }]]);
+		const out = buildSingleInstanceOverrides(
+			parsedResources,
+			new Map(),
+			new Set(['streetData:0']),
+		);
+		expect(out.get('streetData')).toEqual({ v: 1 });
 	});
 });
 

--- a/src/context/WorkspaceContext.helpers.ts
+++ b/src/context/WorkspaceContext.helpers.ts
@@ -246,6 +246,35 @@ export function applyResourceWriteToBundle(
 }
 
 /**
+ * Builds the typeId-keyed export override for the SINGLE-instance resources a
+ * save touched. The bundle writer broadcasts a typeId-keyed override to every
+ * resource carrying that type id, so it is only safe to emit one for a type
+ * that has exactly one instance in the bundle. A bundle like WORLDCOL.BIN
+ * holds hundreds of resources of the same type (e.g. 428 polygonSoupList);
+ * emitting a typeId override there because instance #0 was edited would
+ * overwrite every sibling with index 0's model. Multi-instance types are
+ * instead covered per-resource by `buildByResourceIdOverrides` (keyed by the
+ * unique resourceId), which already includes index 0, so excluding them here
+ * loses no coverage.
+ *
+ * Returns one entry per `[k, model]` in `parsedResources` that is both dirty
+ * at `:0` and the only instance of its type in the bundle.
+ */
+export function buildSingleInstanceOverrides(
+	parsedResources: ReadonlyMap<string, unknown>,
+	parsedResourcesAll: ReadonlyMap<string, (unknown | null)[]>,
+	dirtyMulti: ReadonlySet<string>,
+): Map<string, unknown> {
+	const out = new Map<string, unknown>();
+	for (const [k, model] of parsedResources) {
+		if (!dirtyMulti.has(`${k}:0`)) continue;
+		if ((parsedResourcesAll.get(k)?.length ?? 1) !== 1) continue;
+		out.set(k, model);
+	}
+	return out;
+}
+
+/**
  * Resets the dirty-tracking bookkeeping after a save. The model maps stay
  * intact — only the dirty set and the modified flag clear.
  */

--- a/src/context/WorkspaceContext.test.ts
+++ b/src/context/WorkspaceContext.test.ts
@@ -15,6 +15,7 @@ import { makeEditableBundle } from './WorkspaceContext.bundle';
 import {
 	appendBundle,
 	applyResourceWriteToBundle,
+	buildSingleInstanceOverrides,
 	classifyLoad,
 	clearBundleDirty,
 	dropHistoryForBundle,
@@ -23,6 +24,10 @@ import {
 	replaceBundleById,
 	visibilityKey,
 } from './WorkspaceContext.helpers';
+import {
+	buildByResourceIdOverrides,
+	keyedOverridesToTypeIdMap,
+} from './WorkspaceContext';
 import {
 	emptyHistory,
 	recordCommit,
@@ -723,3 +728,67 @@ describe('per-Bundle save bookkeeping', () => {
 		expect(after.bundles[1]).toBe(s.bundles[1]);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Multi-instance save-corruption guard (WORLDCOL.BIN)
+//
+// WORLDCOL.BIN holds 428 polygonSoupList resources of the same type. Editing
+// instance #0 must NOT broadcast onto its 427 siblings. The two override maps
+// saveBundle emits encode exactly that:
+//   - the typeId-keyed override (broadcast to every resource of the type) must
+//     be EMPTY for a multi-instance type, and
+//   - byResourceId must carry exactly the edited instance, keyed by its unique
+//     resourceId, so the writer rewrites only that one collision mesh.
+// Gated on the fixture being present — a fresh worktree may not have the big
+// untracked binaries (mirrors the repo's describe.skipIf fixture pattern).
+// ---------------------------------------------------------------------------
+
+const WORLDCOL = path.resolve(__dirname, '../../example/WORLDCOL.BIN');
+
+describe.skipIf(!fs.existsSync(WORLDCOL))(
+	'multi-instance save override (WORLDCOL.BIN polygonSoupList)',
+	() => {
+		function loadWorldcol(): EditableBundle {
+			const raw = fs.readFileSync(WORLDCOL);
+			const bytes = new Uint8Array(raw.byteLength);
+			bytes.set(raw);
+			return makeEditableBundle(bytes.buffer, 'WORLDCOL.BIN');
+		}
+
+		it('editing polygonSoupList #0: typeId override is empty, byResourceId has only #0', () => {
+			const bundle = loadWorldcol();
+			const all = bundle.parsedResourcesAll.get('polygonSoupList');
+			expect(all).toBeDefined();
+			// Sanity: this really is a multi-instance type in this fixture.
+			expect(all!.length).toBeGreaterThan(1);
+
+			// Edit only instance 0 — the exact gesture that corrupted siblings.
+			const original = all![0] as Record<string, unknown>;
+			const edited = applyResourceWriteToBundle(bundle, 'polygonSoupList', 0, {
+				...original,
+				__edited: true,
+			});
+
+			// Typeid-keyed override must NOT include polygonSoupList — otherwise
+			// the writer would broadcast #0's model onto all 427 siblings.
+			const single = buildSingleInstanceOverrides(
+				edited.parsedResources,
+				edited.parsedResourcesAll,
+				edited.dirtyMulti,
+			);
+			expect(single.has('polygonSoupList')).toBe(false);
+			expect(keyedOverridesToTypeIdMap(single)).toEqual({});
+
+			// The per-resource path carries exactly the edited instance, keyed by
+			// its unique resourceId — so only that one collision mesh is rewritten.
+			const byId = buildByResourceIdOverrides(
+				edited.parsed,
+				edited.parsedResourcesAll,
+				edited.dirtyMulti,
+			);
+			const idHexes = Object.keys(byId);
+			expect(idHexes).toHaveLength(1);
+			expect((byId[idHexes[0]] as Record<string, unknown>).__edited).toBe(true);
+		});
+	},
+);

--- a/src/context/WorkspaceContext.tsx
+++ b/src/context/WorkspaceContext.tsx
@@ -63,6 +63,7 @@ import type {
 import {
 	appendBundle,
 	applyResourceWriteToBundle,
+	buildSingleInstanceOverrides,
 	classifyLoad,
 	clearBundleDirty,
 	dropHistoryForBundle,
@@ -639,10 +640,11 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
 					b.dirtyMulti,
 				);
 
-				const filteredSingleResource = new Map<string, unknown>();
-				for (const [k, model] of b.parsedResources) {
-					if (b.dirtyMulti.has(`${k}:0`)) filteredSingleResource.set(k, model);
-				}
+				const filteredSingleResource = buildSingleInstanceOverrides(
+					b.parsedResources,
+					b.parsedResourcesAll,
+					b.dirtyMulti,
+				);
 
 				const outBuffer = writeBundleFresh(
 					b.parsed,
@@ -906,9 +908,12 @@ export function useFirstLoadedBundle(): EditableBundle | null {
 
 // ---------------------------------------------------------------------------
 // Internal helpers — exporter override builders
+//
+// Exported so the save-path override shape can be asserted against a real
+// multi-instance bundle in the integration test (no DOM / provider needed).
 // ---------------------------------------------------------------------------
 
-function keyedOverridesToTypeIdMap(map: Map<string, unknown>): Record<number, unknown> {
+export function keyedOverridesToTypeIdMap(map: Map<string, unknown>): Record<number, unknown> {
 	const out: Record<number, unknown> = {};
 	for (const [key, model] of map) {
 		const handler = getHandlerByKey(key);
@@ -918,7 +923,7 @@ function keyedOverridesToTypeIdMap(map: Map<string, unknown>): Record<number, un
 	return out;
 }
 
-function buildByResourceIdOverrides(
+export function buildByResourceIdOverrides(
 	bundle: ParsedBundle,
 	parsedResourcesAll: Map<string, (unknown | null)[]>,
 	dirty: Set<string>,

--- a/src/lib/core/propInstanceData.ts
+++ b/src/lib/core/propInstanceData.ts
@@ -31,8 +31,9 @@
 //  - muSizeInBytes does NOT track the buffer length (it is an internal stored
 //    field — gold fixture has len-32, others differ), and muNumberOfInstances is
 //    the total runtime instance slots (props + every prop's parts; see its field
-//    comment). Both are preserved verbatim on the model so the writer reproduces
-//    them exactly.
+//    comment). Neither can be auto-recomputed here, so both are editable and
+//    written verbatim — the editor exposes them for hand-fixing and the writer
+//    reproduces whatever the model carries (byte-exact for an untouched file).
 //  - The exact original byte length is reproduced by capturing the trailing zero
 //    pad (end-of-cells → end-of-buffer) as _trailingPad and re-emitting it.
 //  - Per-cell muStartIndex / muCount describe the partition (each cell owns the
@@ -116,15 +117,16 @@ export type PropCell = {
 
 export type ParsedPropInstanceData = {
 	muZoneId: number;                   // track-unit / zone id (editable)
-	// Internal stored size field; does NOT equal the buffer length — preserved
-	// verbatim so the writer reproduces the original header byte-for-byte.
+	// Internal stored size field; does NOT equal the buffer length. Editable and
+	// written verbatim (not derived) — its exact formula is not pinned down, so the
+	// editor exposes it for hand-fixing rather than auto-recomputing it on write.
 	muSizeInBytes: number;
 	// Total RUNTIME instance slots = muNumberOfProps + the sum of every prop's part
 	// count (each prop and each of its parts takes one slot when a zone loads). So
 	// it is >= the stored prop-record count (instances.length). The part counts come
-	// from the PropGraphicsList (0x10010) catalogue, not this resource, so we can't
-	// recompute it here — preserved verbatim. (If a future edit ADDS prop instances
-	// this would go stale; recomputing it needs a PID↔PGL join.)
+	// from the PropGraphicsList (0x10010) catalogue, not this resource, so it can't
+	// be recomputed here. Editable and written verbatim (not derived): adding prop
+	// instances makes it stale, so the editor exposes it for hand-fixing.
 	muNumberOfInstances: number;
 	instances: PropInstance[];
 	cells: PropCell[];

--- a/src/lib/schema/resources/propInstanceData.test.ts
+++ b/src/lib/schema/resources/propInstanceData.test.ts
@@ -23,6 +23,7 @@ import { parseBundle } from '../../core/bundle';
 import { extractResourceRaw, resourceCtxFromBundle } from '../../core/registry';
 import {
 	parsePropInstanceData,
+	writePropInstanceData,
 	type ParsedPropInstanceData,
 } from '../../core/propInstanceData';
 import { PROP_ALT_TYPE_NONE } from '../../core/propTypes';
@@ -68,14 +69,24 @@ function loadBundleModel(fixturePath: string): ParsedPropInstanceData {
 	return parsePropInstanceData(raw, ctx.littleEndian);
 }
 
-const goldModel = loadRawModel(GOLD_RAW);
-const bundleModel = loadBundleModel(BUNDLE_FIXTURE);
+// Some checkouts (e.g. a worktree with only tracked fixtures) lack the binary
+// example/ files. Skip the fixture-backed coverage suites there instead of
+// throwing at import and taking the whole test file down — the schema-only and
+// constructed-model checks below still run everywhere.
+const haveGold = fs.existsSync(GOLD_RAW);
+const haveBundle = fs.existsSync(BUNDLE_FIXTURE);
 
-// Run the same coverage checks against each fixture.
-for (const [label, model] of [
+const goldModel = haveGold ? loadRawModel(GOLD_RAW) : null;
+const bundleModel = haveBundle ? loadBundleModel(BUNDLE_FIXTURE) : null;
+
+// Run the same coverage checks against each fixture that is present.
+const fixtures: [string, ParsedPropInstanceData | null][] = [
 	['raw gold BE_9F_C7_93.dat', goldModel],
 	['bundle TRK_UNIT9_GR.BNDL', bundleModel],
-] as const) {
+];
+for (const [label, model] of fixtures.filter(
+	(entry): entry is [string, ParsedPropInstanceData] => entry[1] != null,
+)) {
 	describe(`propInstanceDataResourceSchema coverage — ${label}`, () => {
 		it('fixture parses with non-trivial content', () => {
 			expect(model.instances.length).toBeGreaterThan(0);
@@ -217,10 +228,12 @@ describe('propInstanceData path resolution', () => {
 // Tree labels
 // ---------------------------------------------------------------------------
 
-describe('propInstanceData tree labels', () => {
+describe.skipIf(goldModel == null)('propInstanceData tree labels', () => {
+	const gold = goldModel!; // non-null inside this block (skipped when the fixture is absent)
+
 	it('instance label includes the prop name, instance id, and (x, z)', () => {
 		// instances[10] in the gold file is billboard_overdrive_YELLOW, id 473825.
-		const inst = goldModel.instances[10];
+		const inst = gold.instances[10];
 		const field = propInstanceDataResourceSchema.registry.ParsedPropInstanceData.fields.instances;
 		if (field.kind !== 'list') throw new Error('expected list');
 		const labelFn = field.itemLabel as (v: unknown, i: number) => string;
@@ -233,7 +246,7 @@ describe('propInstanceData tree labels', () => {
 
 	it('cell label includes grid coords, the index range, and R/D counts', () => {
 		// cells[2] in the gold file: X=70 Z=37 start=10 count=51 R=1 D=4.
-		const cell = goldModel.cells[2];
+		const cell = gold.cells[2];
 		const field = propInstanceDataResourceSchema.registry.ParsedPropInstanceData.fields.cells;
 		if (field.kind !== 'list') throw new Error('expected list');
 		const labelFn = field.itemLabel as (v: unknown, i: number) => string;
@@ -242,14 +255,14 @@ describe('propInstanceData tree labels', () => {
 	});
 
 	it('PropInstance.label and PropCell.label callbacks return strings', () => {
-		const ctx = { root: goldModel, resource: propInstanceDataResourceSchema };
+		const ctx = { root: gold, resource: propInstanceDataResourceSchema };
 		const instLabel = propInstanceDataResourceSchema.registry.PropInstance.label!(
-			goldModel.instances[0] as unknown as Record<string, unknown>,
+			gold.instances[0] as unknown as Record<string, unknown>,
 			0,
 			ctx,
 		);
 		const cellLbl = propInstanceDataResourceSchema.registry.PropCell.label!(
-			goldModel.cells[0] as unknown as Record<string, unknown>,
+			gold.cells[0] as unknown as Record<string, unknown>,
 			0,
 			ctx,
 		);
@@ -264,20 +277,77 @@ describe('propInstanceData tree labels', () => {
 // Sanity: representative reads via getAtPath
 // ---------------------------------------------------------------------------
 
-describe('propInstanceData getAtPath', () => {
+describe.skipIf(goldModel == null)('propInstanceData getAtPath', () => {
+	const gold = goldModel!; // non-null inside this block (skipped when the fixture is absent)
+
 	it('reads an instance world position component as a number', () => {
-		const x = getAtPath(goldModel, ['instances', 0, 'mWorldTransform', 12]);
+		const x = getAtPath(gold, ['instances', 0, 'mWorldTransform', 12]);
 		expect(typeof x).toBe('number');
 		expect(Number.isFinite(x)).toBe(true);
 	});
 
 	it('reads a cell grid coord as a number', () => {
-		const muX = getAtPath(goldModel, ['cells', 0, 'muX']);
+		const muX = getAtPath(gold, ['cells', 0, 'muX']);
 		expect(typeof muX).toBe('number');
 	});
 
 	it('reads instances[0].typeId as a number (enum storage)', () => {
-		const typeId = getAtPath(goldModel, ['instances', 0, 'typeId']);
+		const typeId = getAtPath(gold, ['instances', 0, 'typeId']);
 		expect(typeof typeId).toBe('number');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Header fields muSizeInBytes / muNumberOfInstances are MANUALLY editable.
+//
+// They cannot be auto-recomputed here (muSizeInBytes' formula is unverified and
+// muNumberOfInstances needs a join with the PropGraphicsList resource), so the
+// schema exposes them for hand-fixing rather than flagging them read-only. These
+// checks are fixture-independent: they read the schema directly and round-trip a
+// constructed model, so they run on every checkout.
+// ---------------------------------------------------------------------------
+
+describe('propInstanceData editable header fields', () => {
+	const root = propInstanceDataResourceSchema.registry.ParsedPropInstanceData;
+
+	it('muSizeInBytes field metadata is not read-only', () => {
+		const meta = root.fieldMetadata?.muSizeInBytes;
+		expect(meta).toBeDefined();
+		expect(meta?.readOnly).toBeFalsy();
+		// A warning is surfaced so users know the value is not auto-maintained.
+		expect(meta?.warning).toBeTruthy();
+	});
+
+	it('muNumberOfInstances field metadata is not read-only', () => {
+		const meta = root.fieldMetadata?.muNumberOfInstances;
+		expect(meta).toBeDefined();
+		expect(meta?.readOnly).toBeFalsy();
+		expect(meta?.warning).toBeTruthy();
+	});
+
+	it('manual edits to both header fields survive a write → parse round-trip', () => {
+		// A minimal empty-zone model (no instances/cells) — enough to exercise the
+		// header path without depending on a binary fixture.
+		const model: ParsedPropInstanceData = {
+			muZoneId: 206,
+			muSizeInBytes: 100,
+			muNumberOfInstances: 7,
+			instances: [],
+			cells: [],
+			_trailingPad: new Uint8Array(0),
+		};
+
+		// Set the two header fields to new, distinct values by hand.
+		const edited: ParsedPropInstanceData = {
+			...model,
+			muSizeInBytes: 4242,
+			muNumberOfInstances: 1234,
+		};
+
+		const reparsed = parsePropInstanceData(writePropInstanceData(edited));
+		expect(reparsed.muSizeInBytes).toBe(4242);
+		expect(reparsed.muNumberOfInstances).toBe(1234);
+		// muZoneId is unaffected, confirming the header round-trips intact.
+		expect(reparsed.muZoneId).toBe(206);
 	});
 });

--- a/src/lib/schema/resources/propInstanceData.ts
+++ b/src/lib/schema/resources/propInstanceData.ts
@@ -258,13 +258,13 @@ const ParsedPropInstanceData: RecordSchema = {
 		},
 		muSizeInBytes: {
 			label: 'Size in bytes',
-			description: 'Internal stored size field. Does NOT equal the buffer length (varies per fixture); preserved verbatim so the writer reproduces the header byte-for-byte.',
-			readOnly: true,
+			description: 'Internal stored size field. Does NOT equal the buffer length (varies per file); written verbatim, so you can set it by hand if you need a specific value. Not auto-maintained: its exact formula is not pinned down.',
+			warning: 'Not updated automatically when you add or remove instances - set by hand if the value matters.',
 		},
 		muNumberOfInstances: {
 			label: 'Number of instances',
-			description: 'A larger logical count distinct from the stored record count (instances.length). Meaning not fully understood; preserved verbatim.',
-			readOnly: true,
+			description: 'A larger logical count distinct from the stored record count (instances.length): props plus the sum of every prop\'s part count. Written verbatim, so you can set it by hand. Not auto-maintained: the part counts come from the PropGraphicsList resource and are not available here.',
+			warning: 'Not updated automatically when you add or remove instances - set by hand if the count matters.',
 		},
 		instances: {
 			label: 'Instances',


### PR DESCRIPTION
Three community-requested fixes around WORLDCOL editing and prop placement. All three workstreams touch disjoint files.

## 1. WORLDCOL save corruption (multi-instance resources)
Editing the **first** instance (#0) of a multi-instance resource type — e.g. the 428 `polygonSoupList` / 428 `idList` resources in `WORLDCOL.BIN` — and exporting overwrote **every other instance of that type with a copy of #0**.

**Root cause:** the bundle writer applies a typeId-keyed override to *every* resource carrying that type id (`bundle1.ts` `resolveChunk0Bytes`; same on the BND2 path). `saveBundle` emitted such an override whenever index 0 was dirty, with no instance-count guard, so the broadcast clobbered all siblings.

**Fix:** a new pure helper `buildSingleInstanceOverrides` gates the typeId-keyed override to types with exactly one instance in the bundle. Multi-instance types are already covered per-resource by the `byResourceId` path (keyed by the unique resourceId, includes index 0), so nothing is lost. Verified against the real `WORLDCOL.BIN` (856 resources; both multi-instance types are 428/428 unique resourceIds).

## 2. Natural-sort multi-instance rows in the Workspace tree
The Workspace hierarchy listed multi-instance resources in raw disk order; the (now-removed) Resources page sorted them by natural name. The instance rows are now reordered with a numeric `Intl.Collator` (`TRK_COL_0 → TRK_COL_428`) while each row keeps its **true disk index**, so selection, editing, and on-disk write order stay byte-identical — a display-only reorder. Generic, so it covers both `polygonSoupList` and `idList`.

## 3. Editable PropInstanceData header fields (0x10011)
`muSizeInBytes` and `muNumberOfInstances` were `readOnly` but the writer already emits them verbatim, so adding instances never updated them (user-reported confusion / crash risk). They are now manually editable with an inline warning that they are not auto-maintained. No auto-recompute: the size formula is unverified and the instance count depends on `PropGraphicsList` data not present in this resource — manual control is intended.

## Verification
- Targeted tests: **105 passed / 6 skipped** (the 6 are fixture-presence-guarded), including a live `WORLDCOL.BIN` integration test for the save fix.
- `tsc -p tsconfig.app.json`: 40 pre-existing errors, **0 in touched files**.
- `vite build`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)