### PR TITLE
fix(workspace): translated vehicle parts displaced / swim with camera

### DIFF
--- a/scripts/diag-vs-trace.ts
+++ b/scripts/diag-vs-trace.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { parseBundle, getImportIds } from '../src/lib/core/bundle/index';
+import { SHADER_TYPE_ID, SHADER_PROGRAM_BUFFER_TYPE_ID, parseShaderData } from '../src/lib/core/shader';
+import { getResourceBlocks } from '../src/lib/core/resourceManager';
+import { translateDxbc } from '../src/lib/core/dxbc';
+import { u64ToBigInt } from '../src/lib/core/u64';
+import type { ResourceEntry } from '../src/lib/core/types';
+const buf = readFileSync('example/SHADERS.BNDL');
+const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+const bundle = parseBundle(ab);
+const want = process.argv[2] ?? 'Opaque_Metal_Textured';
+for (let i=0;i<bundle.resources.length;i++){ const r=bundle.resources[i]; if(r.resourceTypeId!==SHADER_TYPE_ID)continue;
+  let s; try{s=parseShaderData(getResourceBlocks(ab,bundle,r as ResourceEntry)[0]!);}catch{continue;}
+  if(s.name!=='Vehicle_'+want && !s.name.endsWith(want))continue;
+  const ids=getImportIds(bundle.imports,bundle.resources,i); let vs:any=null;
+  for(const id of ids){const t=bundle.resources.find(rr=>u64ToBigInt(rr.resourceId)===id&&rr.resourceTypeId===SHADER_PROGRAM_BUFFER_TYPE_ID);if(!t)continue;const bc=getResourceBlocks(ab,bundle,t as ResourceEntry)[1];if(!bc)continue;try{const tr=translateDxbc(bc);if(tr.parsed.programType==='vertex'){vs=tr;break}}catch{}}
+  if(!vs)break;
+  console.log('=== VS '+s.name+' ===');
+  console.log(vs.source);
+  break;
+}

--- a/src/components/schema-editor/viewports/RenderableViewport.tsx
+++ b/src/components/schema-editor/viewports/RenderableViewport.tsx
@@ -513,80 +513,94 @@ function RenderableMeshes({
 		[baseMaterial, hoverMaterial, selectedMaterial, texturedMaterials],
 	);
 
-	// Translated-shader materials. Keyed by materialAssemblyId so shared
-	// materials produce one ShaderMaterial reused across every mesh that
-	// references them. Each entry caches `{ shader translation, material
-	// binding, ShaderMaterial }` so swapping the toggle off then on again
-	// doesn't re-translate every shader.
+	// Translated-shader materials, keyed `${renderableIndex}:${materialAssemblyId}`
+	// — ONE ShaderMaterial PER (renderable, material), NOT one per material.
+	//
+	// Why per-renderable: each material's cb0 holds the per-object `world`
+	// matrix, refreshed every draw from the mesh's locator in __updateCb0. But
+	// three.js uploads a ShaderMaterial's uniforms only once per run of
+	// consecutive draws that use it — so if two DIFFERENT parts (different part
+	// locators) shared one material instance, both would render with whichever
+	// part's world was uploaded last, and three's camera-distance sort makes
+	// that "last" change as the camera orbits (parts visibly swim with the
+	// camera). Meshes WITHIN one renderable share a locator, so they can safely
+	// share an instance — hence the key is per-renderable, not per-mesh.
+	//
+	// Translations (DXBC parse, expensive) are cached per shader id and decoded
+	// textures per texture id, so the extra instances are cheap: ~12 programs +
+	// ~N textures shared across all the per-part material objects.
 	const translatedMaterialMap = useMemo(() => {
 		const out = new Map<string, TranslatedMaterial | null>();
 		if (!translatedSetup) return out;
 		const { sources, textureCatalog, materialIndex } = translatedSetup;
-		// First, find the Material → Shader id for each materialAssemblyId
-		// we've actually seen on a mesh. Walk all sources for the matching
-		// Material resource and read its shaderImport.id.
-		const matIdToShaderId = new Map<string, bigint>();
-		for (const r of renderables) {
-			for (const m of r.meshes) {
-				if (!m.materialAssemblyId) continue;
-				const key = m.materialAssemblyId.toString(16);
-				if (matIdToShaderId.has(key)) continue;
-				// Search loaded sources for the Material with this id and
-				// read its shaderImport.
-				outer: for (const s of sources) {
-					for (const res of s.bundle.resources) {
-						if (res.resourceTypeId !== 0x01) continue;
-						if (u64ToBigInt(res.resourceId) !== m.materialAssemblyId) continue;
-						try {
-							const blocks = getResourceBlocks(s.arrayBuffer, s.bundle, res as ResourceEntry);
-							const block0 = blocks[0];
-							if (!block0) break outer;
-							const parsedMat = parseMaterialData(block0);
-							matIdToShaderId.set(key, parsedMat.shaderImport.id);
-						} catch { /* fall through */ }
-						break outer;
-					}
+
+		const shaderIdByMat = new Map<string, bigint | null>();
+		const translationCache = new Map<string, ReturnType<typeof translateShaderById>>();
+		const texCache = new Map<string, THREE.DataTexture | null>();
+		const decodeTexCached = (entry: TextureCatalogEntry) => {
+			if (texCache.has(entry.id)) return texCache.get(entry.id)!;
+			const t = decodedToDataTextureRV(entry);
+			texCache.set(entry.id, t);
+			return t;
+		};
+		const shaderIdFor = (matAsmId: bigint, matKey: string): bigint | null => {
+			if (shaderIdByMat.has(matKey)) return shaderIdByMat.get(matKey)!;
+			let sid: bigint | null = null;
+			outer: for (const s of sources) {
+				for (const res of s.bundle.resources) {
+					if (res.resourceTypeId !== 0x01) continue;
+					if (u64ToBigInt(res.resourceId) !== matAsmId) continue;
+					try {
+						const block0 = getResourceBlocks(s.arrayBuffer, s.bundle, res as ResourceEntry)[0];
+						if (block0) sid = parseMaterialData(block0).shaderImport.id;
+					} catch { /* fall through */ }
+					break outer;
 				}
 			}
-		}
-		// For each unique material, build a ShaderMaterial by translating
-		// its target shader and pulling per-register bindings from the
-		// material index.
-		for (const [matKey, shaderId] of matIdToShaderId) {
-			const translated = translateShaderById(shaderId, sources);
-			if (!translated) {
-				out.set(matKey, null);
-				continue;
+			shaderIdByMat.set(matKey, sid);
+			return sid;
+		};
+
+		for (let ri = 0; ri < renderables.length; ri++) {
+			for (const m of renderables[ri].meshes) {
+				if (!m.materialAssemblyId) continue;
+				const matKey = m.materialAssemblyId.toString(16);
+				const key = `${ri}:${matKey}`;
+				if (out.has(key)) continue;
+				const shaderId = shaderIdFor(m.materialAssemblyId, matKey);
+				if (shaderId == null) { out.set(key, null); continue; }
+				const shaderHex = shaderId.toString(16);
+				let translated = translationCache.get(shaderHex);
+				if (translated === undefined) {
+					translated = translateShaderById(shaderId, sources);
+					translationCache.set(shaderHex, translated);
+				}
+				if (!translated) { out.set(key, null); continue; }
+				// Bind THIS material's own per-part textures (Skin / AO / Scratch),
+				// not just any material targeting the shader. matKey drops leading
+				// zeros (toString(16)); materialId keeps them, so normalise.
+				const shaderIdHex = shaderId.toString(16).padStart(16, '0');
+				const matKeyNorm = matKey.padStart(16, '0');
+				const matBinding = materialIndex.get(shaderIdHex)?.find((b) => b.materialId === matKeyNorm)
+					?? pickBestMaterial(shaderIdHex, [], materialIndex);
+				const layout = inferCbLayout(translated.vs.source, translated.vs.parsed);
+				out.set(key, buildTranslatedShaderMaterial({
+					vsSource: translated.vs.source,
+					psSource: translated.ps.source,
+					vsParsed: translated.vs.parsed,
+					psParsed: translated.ps.parsed,
+					shaderName: translated.shaderName,
+					shaderConstants: translated.constants,
+					layout,
+					materialBinding: matBinding ?? null,
+					textureCatalog,
+					heuristicDefaults: TRANSLATED_HEURISTIC_DEFAULTS,
+					pickFallbackTexture: pickEngineSamplerFallback,
+					decodedToDataTexture: decodeTexCached,
+					applyPreviewTonemap: true,  // vehicle shaders run HDR; without an engine tonemap, paint-gloss saturates to white
+					side: THREE.DoubleSide,
+				}));
 			}
-			const shaderIdHex = shaderId.toString(16).padStart(16, '0');
-			// Find the Material whose id matches this MESH's materialAssemblyId,
-			// not just any material targeting the shader. Multiple body parts
-			// share the same shader (PaintGloss) but each has its own Material
-			// pointing at its own per-part Skin / AO / Scratch textures —
-			// picking one arbitrarily smears the same texture across every
-			// part. The hex-comparison normalises both sides because matKey
-			// drops leading zeros (toString(16)) while materialId keeps them.
-			const matKeyNorm = matKey.padStart(16, '0');
-			const matBinding = materialIndex.get(shaderIdHex)?.find((b) => b.materialId === matKeyNorm)
-				?? pickBestMaterial(shaderIdHex, [], materialIndex);
-			const layout = inferCbLayout(translated.vs.source, translated.vs.parsed);
-			const sm = buildTranslatedShaderMaterial({
-				vsSource: translated.vs.source,
-				psSource: translated.ps.source,
-				vsParsed: translated.vs.parsed,
-				psParsed: translated.ps.parsed,
-				shaderName: translated.shaderName,
-				shaderConstants: translated.constants,
-				layout,
-				materialBinding: matBinding ?? null,
-				textureCatalog,
-				heuristicDefaults: TRANSLATED_HEURISTIC_DEFAULTS,
-				pickFallbackTexture: pickEngineSamplerFallback,
-				decodedToDataTexture: decodedToDataTextureRV,
-				applyPreviewTonemap: true,  // vehicle shaders run HDR; without an engine tonemap, paint-gloss saturates to white
-				side: THREE.DoubleSide,
-			});
-			out.set(matKey, sm);
 		}
 		return out;
 	}, [translatedSetup, renderables]);
@@ -627,7 +641,7 @@ function RenderableMeshes({
 					// to the PBR-approximation MeshStandardMaterial otherwise
 					// so the toggle is non-destructive.
 					const translatedMat = useTranslatedShaders && matKey
-						? translatedMaterialMap.get(matKey) ?? null
+						? translatedMaterialMap.get(`${ri}:${matKey}`) ?? null
 						: null;
 					const texturedMat = !translatedMat && matKey
 						? texturedMaterials.get(matKey) ?? null

--- a/src/lib/core/__tests__/engineSamplerFallback.test.ts
+++ b/src/lib/core/__tests__/engineSamplerFallback.test.ts
@@ -36,8 +36,9 @@ describe('classifyEngineSampler', () => {
 	});
 });
 
-function rgba(t: { image: { data: Uint8Array | Uint8ClampedArray } }): number[] {
-	return Array.from(t.image.data.slice(0, 4));
+function rgba(t: { image: { data: ArrayLike<number> } }): number[] {
+	const d = t.image.data;
+	return [d[0], d[1], d[2], d[3]];
 }
 
 describe('pickEngineSamplerFallback', () => {

--- a/src/lib/core/translatedShaderMaterial.ts
+++ b/src/lib/core/translatedShaderMaterial.ts
@@ -167,10 +167,28 @@ export function buildTranslatedShaderMaterial(opts: BuildOptions): TranslatedMat
 		const viewProj = new THREE.Matrix4();
 		const worldViewProj = new THREE.Matrix4();
 		const cameraPos = new THREE.Vector3();
+		// Two ways a shader consumes a matrix from cb0, and they need DIFFERENT
+		// extraction:
+		//  - dot pattern  `o.x = dot(v, cb0[N])`  → cb0[N] = math ROW N of the
+		//    matrix. fxc emits this for the view/projection matrices applied to an
+		//    already-transformed worldPos.
+		//  - mad pattern  `wp = v.x*cb0[N] + v.y*cb0[N+1] + v.z*cb0[N+2] + cb0[N+3]`
+		//    → cb0[N..N+3] = the matrix's COLUMNS, so the translation lands in
+		//    cb0[N+3].xyz. fxc emits this for the object `world` matrix applied to
+		//    the local vertex position.
+		// Using setRow for a mad-consumed matrix drops the translation (cb0[N+3]
+		// becomes the (0,0,0,1) bottom row) — every part collapses toward local
+		// origin, which on a multi-part vehicle reads as "GraphicsSpec ignored".
 		const setRow = (cb: THREE.Vector4[], slot: number, mm: THREE.Matrix4, row: number) => {
 			if (slot < 0 || slot >= cb.length) return;
 			const e = mm.elements;
 			cb[slot].set(e[row], e[4 + row], e[8 + row], e[12 + row]);
+		};
+		const setCol = (cb: THREE.Vector4[], slot: number, mm: THREE.Matrix4, col: number) => {
+			if (slot < 0 || slot >= cb.length) return;
+			const e = mm.elements;
+			const o = col * 4;
+			cb[slot].set(e[o], e[o + 1], e[o + 2], e[o + 3]);
 		};
 		m.__updateCb0 = (camera, object) => {
 			world.copy(object.matrixWorld);
@@ -187,10 +205,12 @@ export function buildTranslatedShaderMaterial(opts: BuildOptions): TranslatedMat
 			const A = -(far + near) / (far - near);
 			const B = -2 * far * near / (far - near);
 			if (cb0[layout.depthEncode]) cb0[layout.depthEncode].set(A, B, -1, 0);
-			setRow(cb0, layout.worldRow0 + 0, world, 0);
-			setRow(cb0, layout.worldRow0 + 1, world, 1);
-			setRow(cb0, layout.worldRow0 + 2, world, 2);
-			setRow(cb0, layout.worldRow0 + 3, world, 3);
+			// world is mad-consumed (`wp = pos.x*cb0[w] + … + cb0[w+3]`), so write
+			// COLUMNS — cb0[worldRow0+3] must carry the locator translation.
+			setCol(cb0, layout.worldRow0 + 0, world, 0);
+			setCol(cb0, layout.worldRow0 + 1, world, 1);
+			setCol(cb0, layout.worldRow0 + 2, world, 2);
+			setCol(cb0, layout.worldRow0 + 3, world, 3);
 			// Full 4-row engine matrices: shaders that transform with
 			// `worldViewProj` / `viewProjection` directly (rather than the
 			// ViewProjectionModified depth-encode scheme) need all four rows or


### PR DESCRIPTION
Follow-up to #132 (magenta fix). With translated shaders on, GraphicsSpec-placed vehicle parts scattered and moved as the camera orbited. Two compounding bugs, both grounded in the translated VS arithmetic (verified all 7 vehicle shaders compute `gl_Position` the same way).

## 1. Part-locator translation dropped

The vehicle VS transforms the local vertex through its `world` matrix with the MAD pattern:

```glsl
worldPos = pos.x*cb0[44] + pos.y*cb0[45] + pos.z*cb0[46] + cb0[47];
```

That needs the matrix's **columns** so the locator translation lands in `cb0[47].xyz`. `__updateCb0` wrote it with `setRow` (math-rows), so `cb0[47]` became the `(0,0,0,1)` bottom row — the translation vanished and every part collapsed toward local origin (looked like "all renderables", not GraphicsSpec). Scene shaders never exposed it: their world matrix is identity, where rows == columns.

Added a `setCol` writer and use it for the 4 world rows. The view/projection matrices stay `setRow` — they're dot-consumed (`dot(worldPos, cb0[N])`) and correctly need math-rows. **Rule:** a matrix applied to the local position via the MAD pattern → columns; one applied to `worldPos` via dot → rows.

## 2. Materials shared across parts → "swims with the camera"

`translatedMaterialMap` was keyed by `materialAssemblyId`, so two renderables (different part locators) using the same material shared one `ShaderMaterial`. three uploads a shader material's uniforms only once per run of consecutive same-material draws, so both parts rendered with whichever part's `cb0` world was uploaded last — and three's camera-distance sort changes that as you orbit.

Now keyed per `(renderableIndex, materialAssemblyId)`: meshes within a renderable share a locator so they still share an instance, but the same material in different renderables gets its own. Translations are cached per shader id and decoded textures per texture id, so the extra instances are cheap (~12 programs + shared textures).

Bug 2 was masked until bug 1's fix made world placement actually matter.

## Verification

- `tsc` unchanged (40 pre-existing); `vite build` clean; fallback spec green.
- Live WebGL2 workspace (GR + VEHICLETEX + SHADERS loaded): the vehicle assembles correctly under GraphicsSpec and **stays put while orbiting**.
- Adds `scripts/diag-vs-trace.ts` (dumps a translated VS to trace the transform).

## Known limitation (separate follow-up)

Geometry/placement is now correct, but the translated vehicle render is still **over-bright** — engine-runtime lighting/fog/irradiance constants we can only approximate (the baked per-material constants are seeded correctly). Exposure tuning, distinct from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)