### PR TITLE
fix(workspace): zero verlet at rest (shifted parts) + engine-constant debug knobs

### DIFF
--- a/scripts/diag-clip-scheme.ts
+++ b/scripts/diag-clip-scheme.ts
@@ -1,0 +1,40 @@
+// Classify how each shader computes gl_Position: which cb0 slot feeds o0.x and
+// whether via the MAD pattern (pos.x*cb0[N]+... → needs COLUMNS) or the DOT
+// pattern (dot(v, cb0[N]) → needs ROWS). Finds shaders NOT using the
+// world@W + ViewProjectionModified scheme (those still mislocate after the
+// world-columns fix).
+import { readFileSync } from 'node:fs';
+import { parseBundle, getImportIds } from '../src/lib/core/bundle/index';
+import { SHADER_TYPE_ID, SHADER_PROGRAM_BUFFER_TYPE_ID, parseShaderData } from '../src/lib/core/shader';
+import { getResourceBlocks } from '../src/lib/core/resourceManager';
+import { translateDxbc } from '../src/lib/core/dxbc';
+import { u64ToBigInt } from '../src/lib/core/u64';
+import type { ResourceEntry } from '../src/lib/core/types';
+const buf = readFileSync(process.argv[2] ?? 'example/SHADERS.BNDL');
+const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+const bundle = parseBundle(ab);
+const tally = new Map<string, number>();
+const examples = new Map<string, string>();
+for (let i=0;i<bundle.resources.length;i++){ const r=bundle.resources[i]; if(r.resourceTypeId!==SHADER_TYPE_ID)continue;
+  let s; try{s=parseShaderData(getResourceBlocks(ab,bundle,r as ResourceEntry)[0]!);}catch{continue;}
+  if(!s.name.startsWith('Vehicle'))continue;
+  const ids=getImportIds(bundle.imports,bundle.resources,i); let vs:any=null;
+  for(const id of ids){const t=bundle.resources.find(rr=>u64ToBigInt(rr.resourceId)===id&&rr.resourceTypeId===SHADER_PROGRAM_BUFFER_TYPE_ID);if(!t)continue;const bc=getResourceBlocks(ab,bundle,t as ResourceEntry)[1];if(!bc)continue;try{const tr=translateDxbc(bc);if(tr.parsed.programType==='vertex'){vs=tr;break}}catch{}}
+  if(!vs)continue;
+  // name slots by reflection
+  const names = new Map<number,string>();
+  for(const cb of vs.parsed.reflection.constantBuffers) for(const v of cb.variables){ const start=Math.floor(v.startOffset/16), end=Math.floor((v.startOffset+v.size-1)/16); for(let sl=start;sl<=end;sl++) names.set(sl, v.name); }
+  const src: string = vs.source;
+  const lines = src.split('\n');
+  const oline = lines.find(l=>/o0\.x\s*=/.test(l)) || lines.find(l=>/o0\.xy/.test(l)) || '';
+  // which slot in the o0.x line
+  const m = oline.match(/cb0\[(\d+)\]/);
+  const slot = m ? Number(m[1]) : -1;
+  const slotName = names.get(slot) ?? ('cb0['+slot+']');
+  const pattern = /dot\(/.test(oline) ? 'dot' : (/\*\s*cb0\[/.test(oline) ? 'mad' : '?');
+  const key = `clipVia=${slotName} (${pattern})`;
+  tally.set(key, (tally.get(key)??0)+1);
+  if(!examples.has(key)) examples.set(key, s.name);
+}
+console.log('=== gl_Position scheme tally (vehicle shaders) ===');
+for(const [k,n] of [...tally].sort((a,b)=>b[1]-a[1])) console.log(`  ${n.toString().padStart(3)}  ${k}   e.g. ${examples.get(k)}`);

--- a/src/components/schema-editor/viewports/RenderableViewport.tsx
+++ b/src/components/schema-editor/viewports/RenderableViewport.tsx
@@ -47,7 +47,7 @@ import { buildTextureCatalog, type TextureCatalogEntry } from '@/lib/core/textur
 import { buildMaterialIndex, pickBestMaterial } from '@/lib/core/materialBinding';
 import { buildTranslatedShaderMaterial, type TranslatedMaterial } from '@/lib/core/translatedShaderMaterial';
 import { pickEngineSamplerFallback } from '@/lib/core/engineSamplerFallback';
-import { ENGINE_CONSTANT_DEFAULTS, inferCbLayout } from '@/lib/core/shaderEngineConstants';
+import { ENGINE_CONSTANT_DEFAULTS, inferCbLayout, engineKnobs, DEFAULT_ENGINE_KNOBS, type EngineKnobs } from '@/lib/core/shaderEngineConstants';
 import { decodeTexture } from '@/lib/core/texture';
 import { parseMaterialData } from '@/lib/core/material';
 import {
@@ -165,6 +165,56 @@ function VehicleColorPicker({
 					);
 				})}
 			</div>
+		</div>
+	);
+}
+
+// =============================================================================
+// Engine-constant debug knobs
+//
+// The translated vehicle shaders fold engine-RUNTIME constants (key light,
+// ambient irradiance, fog/white-level) into the output, and those values aren't
+// in the bundle — we stand in heuristic defaults, which tends to blow the paint
+// out to white. These sliders SCALE each group (and a final exposure) live so
+// you can see which term dominates. They mutate the module-global `engineKnobs`,
+// which a translated material's __updateCb0 reads every frame — no rebuild.
+// =============================================================================
+
+const KNOB_ROWS: { key: keyof EngineKnobs; label: string; min: number; max: number; step: number }[] = [
+	{ key: 'exposure', label: 'exposure', min: 0.05, max: 2, step: 0.01 },
+	{ key: 'keyLight', label: 'key light', min: 0, max: 3, step: 0.05 },
+	{ key: 'ambient', label: 'ambient', min: 0, max: 3, step: 0.05 },
+	{ key: 'fog', label: 'fog/white', min: 0, max: 2, step: 0.05 },
+];
+
+function EngineKnobsPanel() {
+	const [knobs, setKnobs] = useState<EngineKnobs>({ ...engineKnobs });
+	const set = (key: keyof EngineKnobs, value: number) => {
+		engineKnobs[key] = value;
+		setKnobs({ ...engineKnobs });
+	};
+	return (
+		<div className="px-3 pb-2 space-y-1 text-xs">
+			<div className="flex items-center gap-2">
+				<span className="font-medium text-muted-foreground">engine knobs (translated)</span>
+				<button
+					className="px-2 py-0.5 rounded bg-muted hover:bg-muted/80"
+					onClick={() => { Object.assign(engineKnobs, DEFAULT_ENGINE_KNOBS); setKnobs({ ...engineKnobs }); }}
+				>
+					reset
+				</button>
+			</div>
+			{KNOB_ROWS.map((r) => (
+				<label key={r.key} className="flex items-center gap-2">
+					<span className="w-20 text-muted-foreground">{r.label}</span>
+					<input
+						type="range" min={r.min} max={r.max} step={r.step} value={knobs[r.key]}
+						onChange={(e) => set(r.key, Number(e.target.value))}
+						className="flex-1"
+					/>
+					<span className="w-10 text-right tabular-nums">{knobs[r.key].toFixed(2)}</span>
+				</label>
+			))}
 		</div>
 	);
 }
@@ -890,6 +940,7 @@ export function RenderableViewport() {
 					paintColor={paintColor}
 					onSelectColor={setPaintColor}
 				/>
+				{useTranslatedShaders && <EngineKnobsPanel />}
 			</div>
 
 			{/* 3D canvas — fills remaining space */}

--- a/src/lib/core/shaderEngineConstants.ts
+++ b/src/lib/core/shaderEngineConstants.ts
@@ -16,6 +16,31 @@
 
 import type { ParsedDxbc } from './dxbc';
 
+// ---------------------------------------------------------------------------
+// Live debug knobs for the over-bright preview.
+//
+// The translated vehicle shaders fold engine-RUNTIME constants (key light,
+// ambient irradiance, fog/white-level) into the output colour, and those values
+// aren't in the bundle — we stand in heuristic defaults. When the result blows
+// out to white it's hard to know which term dominates, so the viewport exposes
+// sliders that SCALE each group plus a final exposure. This object is module-
+// global and mutated in place by the sliders; a translated material's
+// __updateCb0 reads it every frame (R3F renders continuously), so the knobs are
+// live with no material rebuild. `exposure` multiplies gl_FragColor before the
+// preview tonemap; the others scale their cb0 constant group off its seeded base.
+// ---------------------------------------------------------------------------
+export type EngineKnobs = { exposure: number; keyLight: number; ambient: number; fog: number };
+export const DEFAULT_ENGINE_KNOBS: EngineKnobs = { exposure: 1, keyLight: 1, ambient: 1, fog: 1 };
+export const engineKnobs: EngineKnobs = { ...DEFAULT_ENGINE_KNOBS };
+
+/** Which knob group (if any) scales a given engine constant by name. */
+export function knobGroupForConstant(name: string): Exclude<keyof EngineKnobs, 'exposure'> | null {
+	if (/^KeyLight/.test(name)) return 'keyLight';
+	if (/^Irradiance/.test(name)) return 'ambient';
+	if (/^FogColour/.test(name)) return 'fog';
+	return null;
+}
+
 /** cb0 slot map for a shader. Slots are vec4 indices (byte offset / 16).
  *  The `Row0` matrix slots are the first of a 4-consecutive-row matrix; null
  *  means the shader doesn't declare that matrix. */

--- a/src/lib/core/translatedShaderMaterial.ts
+++ b/src/lib/core/translatedShaderMaterial.ts
@@ -27,7 +27,7 @@ import type { TextureCatalogEntry } from './textureCatalog';
 import { pickTextureForSampler } from './textureCatalog';
 import type { MaterialBinding } from './materialBinding';
 import type { ParsedShaderConstant } from './shader';
-import { type CbLayout, seedSkinningPalettes } from './shaderEngineConstants';
+import { type CbLayout, seedSkinningPalettes, engineKnobs, knobGroupForConstant, type EngineKnobs } from './shaderEngineConstants';
 
 export type BuildOptions = {
 	vsSource: string;
@@ -83,9 +83,12 @@ export function buildTranslatedShaderMaterial(opts: BuildOptions): TranslatedMat
 	// standard `position` / `normal` / `uv` attributes.
 	const finalVs = attributeAliasPrefix(harmonizedVs) + harmonizedVs;
 
-	// Optional preview safety net + Reinhard tonemap on gl_FragColor.
+	// Optional preview safety net + exposure-scaled Reinhard tonemap on
+	// gl_FragColor. `uExposure` is driven live by the viewport's exposure knob.
 	const finalPs = applyPreviewTonemap
-		? harmonizedPs.replace(/\}\s*$/, PREVIEW_TONEMAP_SUFFIX)
+		? harmonizedPs
+			.replace(/(precision\s+highp\s+float;\s*)/, '$1uniform float uExposure;\n')
+			.replace(/\}\s*$/, PREVIEW_TONEMAP_SUFFIX)
 		: harmonizedPs;
 
 	const m = new THREE.ShaderMaterial({
@@ -95,6 +98,7 @@ export function buildTranslatedShaderMaterial(opts: BuildOptions): TranslatedMat
 		side,
 		transparent,
 	}) as TranslatedMaterial;
+	if (applyPreviewTonemap) m.uniforms.uExposure = { value: engineKnobs.exposure };
 
 	// Allocate zeroed cb arrays for every `uniform vec4 cbN[...]` declared.
 	const cbDecls = Array.from(finalPs.matchAll(/uniform vec4 (cb\d+)\[(\d+)\];/g)).concat(
@@ -135,6 +139,12 @@ export function buildTranslatedShaderMaterial(opts: BuildOptions): TranslatedMat
 				const comp = (v.startOffset % 16) / 4;
 				const nFloats = Math.max(1, Math.min(4 - comp, Math.floor(v.size / 4)));
 				if (/time/i.test(v.name)) timeSlots.add(slot);
+				// g_verletOffsets is the per-vertex deformation array — zero at rest
+				// (the engine fills it per-vehicle at draw time). Its baked default can
+				// be a non-zero placeholder (e.g. (1,1,1,0) on PaintGloss); seeding that
+				// adds a constant offset to every vertex through the skin/verlet blend,
+				// so the part renders shifted. Leave it zeroed for the rest-pose preview.
+				if (/verlet/i.test(v.name)) continue;
 				const baked = shaderConstants.find((c) => c.name === v.name && c.instanceData);
 				if (baked?.instanceData) {
 					writeScalars(arr, slot, comp, baked.instanceData, nFloats);
@@ -158,6 +168,28 @@ export function buildTranslatedShaderMaterial(opts: BuildOptions): TranslatedMat
 		seedSkinningPalettes(vsParsed, writeVec4);
 		seedSkinningPalettes(psParsed, writeVec4);
 	}
+
+	// Record the cb0 slots the viewport's debug knobs scale, capturing the seeded
+	// BASE value so a knob multiplies (not replaces) it each frame.
+	const knobSlots: { slot: number; base: THREE.Vector4; group: Exclude<keyof EngineKnobs, 'exposure'> }[] = [];
+	const recordKnobs = (parsed: ParsedDxbc | undefined) => {
+		if (!parsed) return;
+		const arr = m.uniforms.cb0?.value as THREE.Vector4[] | undefined;
+		if (!arr) return;
+		for (const cbuf of parsed.reflection.constantBuffers) {
+			for (const v of cbuf.variables) {
+				const group = knobGroupForConstant(v.name);
+				if (!group) continue;
+				const start = Math.floor(v.startOffset / 16);
+				const end = Math.floor((v.startOffset + v.size - 1) / 16);
+				for (let slot = start; slot <= end && slot < arr.length; slot++) {
+					if (!knobSlots.some((k) => k.slot === slot)) knobSlots.push({ slot, base: arr[slot].clone(), group });
+				}
+			}
+		}
+	};
+	recordKnobs(vsParsed);
+	recordKnobs(psParsed);
 
 	// __updateCb0 — engine-fed slots refreshed per frame from three.js
 	// matrices + clock. The mesh's onBeforeRender invokes this.
@@ -231,6 +263,14 @@ export function buildTranslatedShaderMaterial(opts: BuildOptions): TranslatedMat
 					if (cb0[slot]) cb0[slot].set(t, t, t, t);
 				}
 			}
+			// Live debug knobs: scale the key-light / ambient / fog constant groups
+			// off their seeded base. Read every frame so the viewport sliders take
+			// effect without rebuilding the material.
+			for (const k of knobSlots) {
+				const s = engineKnobs[k.group];
+				cb0[k.slot].set(k.base.x * s, k.base.y * s, k.base.z * s, k.base.w * s);
+			}
+			if (m.uniforms.uExposure) m.uniforms.uExposure.value = engineKnobs.exposure;
 		};
 	}
 
@@ -280,7 +320,7 @@ function attributeAliasPrefix(vs: string): string {
 
 const PREVIEW_TONEMAP_SUFFIX = `
 	{
-		vec3 _c = gl_FragColor.rgb;
+		vec3 _c = gl_FragColor.rgb * uExposure;
 		bool _nan = (_c.r != _c.r) || (_c.g != _c.g) || (_c.b != _c.b);
 		bool _inf = (abs(_c.r) > 1e10) || (abs(_c.g) > 1e10) || (abs(_c.b) > 1e10);
 		if (_nan) gl_FragColor = vec4(1.0, 0.0, 1.0, 1.0);


### PR DESCRIPTION
Follow-up to the translated-vehicle rendering fixes. Two things from the last round of feedback: a residual per-shader mislocation, and tuning knobs for the over-bright (white) render.

## 1. Some parts still shifted (e.g. the bonnet) — verlet rest pose

`P_CA_B1Saloon_01_Body_Bonnet_LOD0` (and other parts) rendered shifted up/left. The vehicle VS adds a per-vertex verlet/skin offset to the position *before* the world transform:

```glsl
r0 = g_verletOffsets[blendindex] + position;   // then worldPos = world * r0
```

`g_verletOffsets` is the runtime **deformation** array — zero at rest, filled per-vehicle by the engine. But some shaders **bake a non-zero placeholder** default: `Vehicle_Opaque_PaintGloss_Textured` bakes `(1,1,1,0)`. `seedDefaults` was seeding that, so every vertex of those meshes picked up a constant `(1,1,1)` offset. Now `seedDefaults` **skips `g_verletOffsets`** (leaves it zeroed — rest pose, like the bone palette). Shaders that bake zero (window) or none (decal/chrome/metal) were already correct — which is exactly why only "some shaders" moved.

## 2. Engine-constant debug knobs (for the white-out)

The translated vehicle render is over-bright because the engine-**runtime** lighting constants (key light / ambient irradiance / fog+white-level) aren't in the bundle — we stand in heuristic defaults. Added a live panel (shown when **translated shaders** is on) with sliders that **scale** each group plus a final **exposure** (multiplies `gl_FragColor` before the Reinhard preview tonemap):

- `exposure`, `key light`, `ambient`, `fog/white` + reset.
- They mutate a module-global `engineKnobs` that each material's `__updateCb0` reads **every frame** — live, no rebuild. Lets you find which term dominates the white-out (in testing, dropping exposure to ~0.25 brings the paint back).

## Files

- `shaderEngineConstants.ts`: `engineKnobs` live state + `knobGroupForConstant`.
- `translatedShaderMaterial.ts`: skip the verlet seed; record knob slots off their seeded base and scale them each frame; `uExposure` uniform on the tonemap.
- `RenderableViewport.tsx`: `EngineKnobsPanel`.
- `scripts/diag-clip-scheme.ts`: classifies how each shader computes `gl_Position` (the diagnostic used to track the placement schemes).

## Verification

`tsc` unchanged (40 pre-existing); `vite build` clean; fallback + engine-constant specs green. Live (GR + VEHICLETEX + SHADERS): bonnet/parts assemble correctly, and the exposure slider visibly darkens the white-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)