### PR TITLE
fix(workspace): lower default exposure so translated textures aren't washed white

### DIFF
--- a/scripts/diag-diffuse-alpha.ts
+++ b/scripts/diag-diffuse-alpha.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { parseBundle } from '../src/lib/core/bundle/index';
+import { parseDebugDataFromBuffer, parseDebugDataFromXml } from '../src/lib/core/bundle/debugData';
+import { MATERIAL_TYPE_ID, parseMaterialData } from '../src/lib/core/material';
+import { getResourceBlocks } from '../src/lib/core/resourceManager';
+import { u64ToBigInt } from '../src/lib/core/u64';
+import { decodeAllRenderables } from '../src/lib/core/renderableDecode';
+import type { ResourceEntry } from '../src/lib/core/types';
+const load=(p:string)=>{const b=readFileSync(p);const ab=b.buffer.slice(b.byteOffset,b.byteOffset+b.byteLength) as ArrayBuffer;return {ab,bundle:parseBundle(ab)};};
+const gr=load('example/VEH_CARBB1GT_GR.BIN'); const tex=load('example/VEHICLETEX.BIN'); const sh=load('example/SHADERS.BNDL');
+let dbg:any[]=[]; try{const xml=parseDebugDataFromBuffer(gr.ab, gr.bundle.header); if(xml) dbg=parseDebugDataFromXml(xml);}catch{}
+const norm=(s:string)=>s.toLowerCase().replace(/^0x/,'').replace(/^0+(?=.)/,''); const dn=new Map<string,string>(); for(const d of dbg) if(d.id&&d.name) dn.set(norm(d.id), d.name);
+const dec=decodeAllRenderables(gr.ab, gr.bundle, dn, false, 'graphics', [{buffer:tex.ab,bundle:tex.bundle},{buffer:sh.ab,bundle:sh.bundle}], null);
+const seen=new Set<string>();
+for(const r of dec.renderables){
+  for(const m of r.meshes){
+    const rm=m.resolvedMaterial; if(!rm||!rm.diffuse) continue;
+    const key=(rm.shaderName||'')+'/'+rm.diffuse.header.width+'x'+rm.diffuse.header.height; if(seen.has(key))continue; seen.add(key);
+    const px=rm.diffuse.pixels; let aMin=255,aMax=0,aSum=0,n=0,rgbSum=0;
+    for(let i=0;i<px.length;i+=4*97){ const a=px[i+3]; aMin=Math.min(aMin,a);aMax=Math.max(aMax,a);aSum+=a; rgbSum+=px[i]+px[i+1]+px[i+2]; n++; }
+    console.log((rm.shaderName||'?').padEnd(42), rm.diffuse.header.format.padEnd(6), rm.diffuse.header.width+'x'+rm.diffuse.header.height, 'alpha min/avg/max='+aMin+'/'+Math.round(aSum/n)+'/'+aMax, 'rgbAvg='+Math.round(rgbSum/n/3));
+    if(seen.size>=10) break;
+  }
+  if(seen.size>=10) break;
+}

--- a/src/lib/core/shaderEngineConstants.ts
+++ b/src/lib/core/shaderEngineConstants.ts
@@ -30,7 +30,12 @@ import type { ParsedDxbc } from './dxbc';
 // preview tonemap; the others scale their cb0 constant group off its seeded base.
 // ---------------------------------------------------------------------------
 export type EngineKnobs = { exposure: number; keyLight: number; ambient: number; fog: number };
-export const DEFAULT_ENGINE_KNOBS: EngineKnobs = { exposure: 1, keyLight: 1, ambient: 1, fog: 1 };
+// Default exposure < 1: the translated vehicle shaders output HDR for the game's
+// own tonemap, and with the approximated (white) key light the relatively-dark
+// vehicle albedo lands high enough that the Reinhard preview tonemap saturates
+// toward white — flattening the diffuse texture. ~0.5 keeps the HDR in range so
+// the texture detail reads; the exposure slider fine-tunes from there.
+export const DEFAULT_ENGINE_KNOBS: EngineKnobs = { exposure: 0.5, keyLight: 1, ambient: 1, fog: 1 };
 export const engineKnobs: EngineKnobs = { ...DEFAULT_ENGINE_KNOBS };
 
 /** Which knob group (if any) scales a given engine constant by name. */


### PR DESCRIPTION
## Investigation: "textures not visible with translated shaders"

The diffuse textures **do** bind and sample correctly in the translated path — this is **not** a binding/UV/alpha bug:

- Bindings resolve (diffuse `t0` / normal `t2` / emissive `t3` → real textures from VEHICLETEX).
- The UV varying links: the VS writes `v_TEXCOORD2 = o3 = uv`, and the PS samples the diffuse exactly there (`texture2D(Diffuse, v_TEXCOORD2.xy)`).
- The decoded textures have real RGB and mostly-opaque alpha (body DXT1 ≈ 254/255), so the shader's `mix(materialDiffuse, diffuseTex.rgb, alpha)` resolves to the texture RGB.
- The diffuse reaches the output: `r0 = diffuse * lighting`, then combined with reflection → `gl_FragColor`.

So the texture **is** in the output. It reads as "missing" because the translated vehicle shaders output **HDR** (for the game's own tonemap). With the approximated **white key light**, the relatively dark vehicle albedo (~0.27 avg) lands high enough that the **Reinhard preview tonemap saturates toward white** and flattens the texture detail. Scaling the HDR down before the tonemap brings the variation back.

## Fix

Default exposure is now **0.5** (was 1.0), so textures read out of the box. The **exposure** slider (plus key-light / ambient / fog) fine-tunes from there.

Also adds `scripts/diag-diffuse-alpha.ts` (reports each resolved diffuse texture's format + alpha distribution) — the diagnostic that ruled out an alpha/decode bug.

## Verification

`tsc` unchanged (40 pre-existing), specs green, `vite build` clean. ⚠️ I could **not** capture a live screenshot this session — the preview window was hidden on the host (`document.visibilityState === "hidden"`), which starves the WebGL render loop, and the translated shaders can't run headless (they need WebGL2/GLSL ES 3.0; headless-gl is ES1). The change is low-risk and math-driven (lower exposure → less tonemap saturation → texture variation preserved), and the exposure knob makes it tunable. Please confirm the textures read at the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)