### PR TITLE
fix(workspace): bind per-material textures in translated shaders (key-format mismatch)

### DIFF
--- a/scripts/diag-bumper.ts
+++ b/scripts/diag-bumper.ts
@@ -1,0 +1,48 @@
+// Compare the two texture-resolution paths for the front-bumper material:
+//   PBR  -> resolveMaterialTextures (materialChain.ts)
+//   translated -> buildMaterialIndex (materialBinding.ts) + the shader's PS regs
+import { readFileSync } from 'node:fs';
+import { parseBundle, getImportIds, formatResourceId } from '../src/lib/core/bundle/index';
+import { parseDebugDataFromBuffer, parseDebugDataFromXml } from '../src/lib/core/bundle/debugData';
+import { SHADER_TYPE_ID, SHADER_PROGRAM_BUFFER_TYPE_ID, parseShaderData } from '../src/lib/core/shader';
+import { MATERIAL_TYPE_ID, parseMaterialData } from '../src/lib/core/material';
+import { getResourceBlocks } from '../src/lib/core/resourceManager';
+import { translateDxbc } from '../src/lib/core/dxbc';
+import { u64ToBigInt } from '../src/lib/core/u64';
+import { decodeAllRenderables } from '../src/lib/core/renderableDecode';
+import { resolveMaterialTextures } from '../src/lib/core/materialChain';
+import { buildTextureCatalog } from '../src/lib/core/textureCatalog';
+import { buildMaterialIndex, pickBestMaterial } from '../src/lib/core/materialBinding';
+import type { ResourceEntry } from '../src/lib/core/types';
+
+const load=(p:string)=>{const b=readFileSync(p);const ab=b.buffer.slice(b.byteOffset,b.byteOffset+b.byteLength) as ArrayBuffer;return {ab,bundle:parseBundle(ab)};};
+const gr=load('example/VEH_CARBB1GT_GR.BIN'); const tex=load('example/VEHICLETEX.BIN'); const sh=load('example/SHADERS.BNDL');
+const shName=new Map<string,string>();
+for(let i=0;i<sh.bundle.resources.length;i++){const r=sh.bundle.resources[i];if(r.resourceTypeId!==SHADER_TYPE_ID)continue;try{shName.set(u64ToBigInt(r.resourceId).toString(16),parseShaderData(getResourceBlocks(sh.ab,sh.bundle,r as ResourceEntry)[0]!).name);}catch{}}
+let dbg:any[]=[]; try{const xml=parseDebugDataFromBuffer(gr.ab,gr.bundle.header); if(xml)dbg=parseDebugDataFromXml(xml);}catch{}
+const norm=(s:string)=>s.toLowerCase().replace(/^0x/,'').replace(/^0+(?=.)/,''); const dn=new Map<string,string>(); for(const d of dbg) if(d.id&&d.name) dn.set(norm(d.id),d.name);
+
+const srcs=[{source:'primary',bundle:gr.bundle,arrayBuffer:gr.ab,debug:dbg},{source:'tex',bundle:tex.bundle,arrayBuffer:tex.ab,debug:[]},{source:'sh',bundle:sh.bundle,arrayBuffer:sh.ab,debug:[]}];
+const cat=buildTextureCatalog(srcs as any); const matIdx=buildMaterialIndex(srcs as any, cat);
+const dec=decodeAllRenderables(gr.ab,gr.bundle,dn,false,'graphics',[{buffer:tex.ab,bundle:tex.bundle},{buffer:sh.ab,bundle:sh.bundle}],null);
+const shaderRegs=(sid:bigint)=>{ for(let i=0;i<sh.bundle.resources.length;i++){const r=sh.bundle.resources[i];if(r.resourceTypeId!==SHADER_TYPE_ID||u64ToBigInt(r.resourceId)!==sid)continue; const ids=getImportIds(sh.bundle.imports,sh.bundle.resources,i); for(const id of ids){const t=sh.bundle.resources.find(rr=>u64ToBigInt(rr.resourceId)===id&&rr.resourceTypeId===SHADER_PROGRAM_BUFFER_TYPE_ID);if(!t)continue;const bc=getResourceBlocks(sh.ab,sh.bundle,t as ResourceEntry)[1];if(!bc)continue;try{const tr=translateDxbc(bc);if(tr.parsed.programType==='pixel') return [...tr.source.matchAll(/uniform sampler2D ([A-Za-z0-9_]+);\s*\/\/\s*t(\d+)/g)].map(m=>`t${m[2]}:${m[1]}`);}catch{}}} return []; };
+const cache=new Map<bigint,any>();
+for(const r of dec.renderables){
+  if(!/BumperFront/i.test(r.debugName||'')) continue;
+  console.log('RENDERABLE', r.debugName, 'meshes='+r.meshes.length);
+  for(const m of r.meshes){
+    const matId=m.materialAssemblyId; if(!matId)continue;
+    const matHex=formatResourceId(matId);
+    const matRes=gr.bundle.resources.find(x=>x.resourceTypeId===MATERIAL_TYPE_ID&&u64ToBigInt(x.resourceId)===matId);
+    let shaderId:bigint|null=null; if(matRes){try{shaderId=parseMaterialData(getResourceBlocks(gr.ab,gr.bundle,matRes as ResourceEntry)[0]!).shaderImport.id;}catch{}}
+    const sName=shaderId?shName.get(shaderId.toString(16)):'?';
+    console.log('  mat',matHex,'shader',sName);
+    console.log('    PS regs:', shaderId?shaderRegs(shaderId).join('  '):'-');
+    // PBR path
+    const pbr=resolveMaterialTextures(gr.ab,gr.bundle,matId,cache,[{buffer:tex.ab,bundle:tex.bundle},{buffer:sh.ab,bundle:sh.bundle}],null);
+    console.log('    PBR resolveMaterialTextures: diffuse='+(pbr?.diffuse?pbr.diffuse.header.width+'x'+pbr.diffuse.header.height:'NONE')+' normal='+(pbr?.normal?'y':'-')+' specular='+(pbr?.specular?'y':'-')+' crossMiss='+pbr?.crossBundleMisses);
+    // translated path
+    const sHex=shaderId?formatResourceId(shaderId):""; const b=matIdx.get(sHex)?.find(x=>x.materialId===matHex)??(shaderId?pickBestMaterial(sHex,[],matIdx):null);
+    console.log('    translated buildMaterialIndex bindings:', b?[...b.samplerBindings.keys()].sort((a,c)=>a-c).map(k=>'ch'+k+'→'+b.samplerBindings.get(k)!.id).join('  '):'NO BINDING');
+  }
+}

--- a/src/components/schema-editor/viewports/RenderableViewport.tsx
+++ b/src/components/schema-editor/viewports/RenderableViewport.tsx
@@ -40,7 +40,7 @@ import { D3DTextureAddress } from '@/lib/core/textureState';
 import type { ParsedBundle, ResourceEntry } from '@/lib/core/types';
 import { SHADER_TYPE_ID, parseShaderData, SHADER_PROGRAM_BUFFER_TYPE_ID } from '@/lib/core/shader';
 import { getResourceBlocks } from '@/lib/core/resourceManager';
-import { getImportIds } from '@/lib/core/bundle';
+import { getImportIds, formatResourceId } from '@/lib/core/bundle';
 import { u64ToBigInt } from '@/lib/core/u64';
 import { translateDxbc, type TranslatedShader } from '@/lib/core/dxbc';
 import { buildTextureCatalog, type TextureCatalogEntry } from '@/lib/core/textureCatalog';
@@ -626,12 +626,14 @@ function RenderableMeshes({
 					translationCache.set(shaderHex, translated);
 				}
 				if (!translated) { out.set(key, null); continue; }
-				// Bind THIS material's own per-part textures (Skin / AO / Scratch),
-				// not just any material targeting the shader. matKey drops leading
-				// zeros (toString(16)); materialId keeps them, so normalise.
-				const shaderIdHex = shaderId.toString(16).padStart(16, '0');
-				const matKeyNorm = matKey.padStart(16, '0');
-				const matBinding = materialIndex.get(shaderIdHex)?.find((b) => b.materialId === matKeyNorm)
+				// Bind THIS material's own per-part textures (Diffuse / AO / Scratch),
+				// not just any material targeting the shader. The index is keyed by
+				// formatResourceId (`0x`-prefixed, upper-case, 16 digits) — use the
+				// SAME formatting to look up, or the binding is never found and every
+				// sampler falls through to the name-match/placeholder (untextured).
+				const shaderIdHex = formatResourceId(shaderId);
+				const matIdHex = formatResourceId(m.materialAssemblyId);
+				const matBinding = materialIndex.get(shaderIdHex)?.find((b) => b.materialId === matIdHex)
 					?? pickBestMaterial(shaderIdHex, [], materialIndex);
 				const layout = inferCbLayout(translated.vs.source, translated.vs.parsed);
 				out.set(key, buildTranslatedShaderMaterial({


### PR DESCRIPTION
This is the real fix for "textures not applied with translated shaders" (e.g. the front bumper's logo was a grey blob while PBR showed it). It got left out of #136's squash (only the default-exposure change landed there), so it needs its own PR.

## Root cause

`RenderableViewport` looked up the material→texture binding with the **wrong key format**, so it was never found — every sampler then fell through to name-match / placeholder and the part rendered untextured.

- `buildMaterialIndex` keys its index with `formatResourceId` → ``0x``-prefixed, upper-case, 16 digits: `"0x00000000B46927EA"`.
- The viewport looked it up with `shaderId.toString(16).padStart(16,'0')` → `"00000000b46927ea"` (lower-case, no ``0x``).

Those never match, so `materialIndex.get()` and `pickBestMaterial()` both returned null → no per-register sampler bindings. The PBR path uses a *different* resolver (`resolveMaterialTextures`), which is why it still showed the textures; `ShaderViewport` already used `formatResourceId`, so only the renderable translated path was broken.

## Fix

Look up with `formatResourceId(shaderId)` / `formatResourceId(materialId)` to match the index keys.

Verified against `P_CA_B1Saloon_01_Body_BumperFront_LOD0`: every material now resolves its bindings —
- PaintGloss → `ch0` (diffuse) / `ch2` / `ch3` / `ch5`
- SimpleMetal → `ch0`
- GreyScale_Decal → `ch0` / `ch2`

…and the channels line up with the shaders' `t0/t2/t3/t5` registers, so the diffuse (logo), specular, AO, etc. bind.

Adds `scripts/diag-bumper.ts` — compares the PBR vs translated resolution paths for a named part (the diagnostic that pinned this).

## Verification

`tsc` unchanged (40 pre-existing), `vite build` clean. Bug is data-verified end-to-end (bindings resolve + channels match registers). ⚠️ Couldn't capture a live screenshot — the preview window was hidden on the host (starves the WebGL render loop) and these shaders can't run headless (WebGL2/ES3 vs headless-gl ES1). Please confirm the bumper logo + per-part textures now show with translated shaders on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)