### PR TITLE
feat(save): Burnout Paradise save-profile editor (Profile.BurnoutParadiseSave)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ debug_textures/
 # Stryker mutation-testing reports + incremental cache
 reports/mutation/
 .stryker-tmp/
+
+# Personal Burnout Paradise save profiles — contain player progression and
+# friends' names; used only as local round-trip fixtures, never committed.
+example/SAVE/
+*.BurnoutParadiseSave

--- a/docs/save-profile/README.md
+++ b/docs/save-profile/README.md
@@ -1,0 +1,58 @@
+# Burnout Paradise save-profile support
+
+`Profile.BurnoutParadiseSave` is the game's progression save. It is **not** a
+BND2 bundle, so it lives outside the bundle Workspace: a standalone editor at the
+`/save` route, backed by the codec in
+[`src/lib/core/profileSave/`](../../src/lib/core/profileSave).
+
+The spec mirrors of the wiki pages are alongside this file
+(`container.md`, `progression-profile.md`, …). Source:
+<https://burnout.wiki/wiki/Profile/Burnout_Paradise>.
+
+## File shape
+
+```
+[ platform header ]  [ ProfileStoredData body ]
+  RGMH  (PC / Remastered, no protection, has a thumbnail + metadata strings)
+  MC02  (Xbox 360, big-endian, three CRC32 checksums — recomputed on save)
+  none  (PS3 / PS4 / Switch — the file IS the body)
+```
+
+The body is a fixed sequence of `FixedSizeOpaqueBuffer<T>` chunks at
+platform-specific offsets (see `variants.ts` / `container.md`): Progression,
+Live Revenge, Options, Cagney (+options), Davis, PDLC, Cop, Island, Recent
+Players, Padding. Not every chunk exists on every platform.
+
+## How editing stays byte-exact
+
+The codec is **decode-on-raw + patch-in-place**: each chunk keeps its original
+bytes, decoding produces a display view, and an edit writes a single field back
+at its known offset. Bytes we don't touch (padding, fields we don't model,
+ambiguous regions) survive a load → save unchanged. The round-trip stress test
+(`__tests__/profileSave.test.ts`) asserts this against a real PC Remastered
+fixture, plus per-variant tiling and synthetic MC02 / headerless round-trips.
+
+## Decode coverage (current)
+
+| Chunk | Status |
+|---|---|
+| Progression Profile (**PC Remastered**, v31) | Fully modelled — license, vehicles, liveries, rivals, events, collectibles, discovery, Road Rules, records, counters, flags |
+| Progression Profile (PS3 / X360 / PC / PS4 / Switch) | Preserved opaque (layout differs; no fixture to validate) |
+| Live Revenge / Options / Cagney / Davis / PDLC / Cop / Island / Recent Players | Preserved opaque — documented in this folder, not yet decoded into fields |
+
+Opaque chunks are still loaded, shown (size + hex preview), and saved byte-exact.
+
+## Extending
+
+Adding a chunk decoder is "write a `StructSpec`": model the fields in a layout
+module (see `progression.ts`), point the chunk at it, and the engine + the
+`/save` editor pick it up. A few load-bearing facts the engine already encodes:
+
+- `CgsID` is a `u64` (rendered hex).
+- `CgsBitArray<N>` is 64-bit-word aligned → `ceil(N/64)*8` bytes.
+- `CgsSet<CgsID,Cap>` / `CgsArray<CgsID,Cap>` = `u32 count` + `u32 pad` + `Cap × u64`.
+- `DateAndTime` is `bool mbIsLocal @0` + a trailing 8-byte time (FILETIME on
+  Win/X360, `time_t` elsewhere); its footprint is 0xC or 0x10 by platform.
+- `Vector3` is 4 floats (x, y, z + preserved w) = 0x10.
+
+The size-invariant test will flag any layout whose fields overrun the chunk.

--- a/docs/save-profile/cagney-options-data-profile.md
+++ b/docs/save-profile/cagney-options-data-profile.md
@@ -1,0 +1,28 @@
+# Profile/Burnout Paradise/Cagney Options Data Profile
+
+> Source: https://burnout.wiki/wiki/Profile/Burnout_Paradise/Cagney_Options_Data_Profile (mirrored 2026-06-22)
+
+> Subpage: Development — Information on the development of the Cagney options data profile.
+
+Cagney's options data profile is an unused portion of the profile thought to be associated with the cut developer challenges and Beat the Team DLC pack.
+
+## Structures
+
+### BrnGui::OptionsDataProfileDLC_1_3
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number | 3 |
+| 0x4 | 0x1 | bool | ? | Invert Y Axis Look | Added after version 1 |
+| 0x5 | 0x3 |  |  | Padding |  |
+| 0x8 | 0x4 | uint32_t | ? |  |  |
+| 0xC | 0x1 | uint8_t | ? |  |  |
+| 0xD | 0x1 | uint8_t | ? |  |  |
+| 0xE | 0x1 | uint8_t | ? |  |  |
+| 0xF | 0x1 | uint8_t | ? |  |  |
+| 0x10 | 0x1 | uint8_t | ? |  |  |
+| 0x11 | 0x1 | uint8_t | ? |  |  |
+| 0x12 | 0x1 | uint8_t | ? |  |  |
+| 0x13 | 0x1 | uint8_t | ? |  |  |
+| 0x14 | 0x1 | bool | ? | Custom soundtrack enabled | Added after version 1 |
+| 0x15 | 0x3 |  |  | Padding |  |

--- a/docs/save-profile/cagney-profile.md
+++ b/docs/save-profile/cagney-profile.md
@@ -1,0 +1,106 @@
+# Profile/Burnout Paradise/Cagney Profile
+
+> Source: https://burnout.wiki/wiki/Profile/Burnout_Paradise/Cagney_Profile (mirrored 2026-06-22)
+
+> Subpage: Development — Information on the development of the Cagney profile.
+
+The Cagney profile stores data for timed car challenges, community and online vehicles, and higher precision values for the time played and stunt run high score.
+
+## Structures
+
+### BrnGuiSaveLoad::ProfileDLC_1_3
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number | 29 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x698 | Array<ChallengeScore, 70u> | ? | Timed challenge scores |  |
+| 0x6A0 | 0x28 | Array<int32_t, 8u> | ? | Calendar event data | EVENT_GRAD_ID from Comms Database |
+| 0x6C8 | 0x1E0 | CarData[20] | ? | Vehicles |  |
+| 0x8A8 | 0x1E0 | LiveryData[20] | ? | Liveries |  |
+| 0xA88 | 0x8 | int64_t | ? | Best stunt run score |  |
+| 0xA90 | 0x8 | CgsID | ? | Spawn vehicle ID |  |
+| 0xA98 | 0x4 | uint32_t | ? | Spawn vehicle update version |  |
+| 0xA9C | 0x8 | Time | ? | In-car time played |  |
+| 0xAA4 | 0x8 | Time | ? | Real time played |  |
+| 0xAAC | 0x4 | int32_t | ? | Vehicle count |  |
+| 0xAB0 | 0x4 | int32_t | ? | Livery count |  |
+| 0xAB4 | 0x1 | uint8_t | ? | Active car road rules | See EActiveRoadRule |
+| 0xAB5 | 0x3 |  |  | Padding |  |
+| 0xAB8 | 0x8 | BitArray<20u> | ? | Atomika freeburn chats played | AFB_CHAT streams |
+
+### BrnNetwork::NetworkChallengeManager::ChallengeScore
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | CgsID | ? | Challenge GameDB ID |  |
+| 0x8 | 0x4 | float32_t | ? | Time (seconds) |  |
+| 0xC | 0x4 | uint32_t | ? | Number of players | High nibble is unused |
+| 0x10 | 0x1 | uint8_t | ? |  |  |
+| 0x11 | 0x7 |  |  | Padding |  |
+
+### BrnProgression::CarData
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | CgsID | mId | Vehicle ID |  |
+| 0x8 | 0x1 | uint8_t | mu8ColourIndex | Color index | From the Player Car Colours resource |
+| 0x9 | 0x1 | uint8_t | mu8PaletteIndex | Color palette/type index | From the Player Car Colours resource |
+| 0xA | 0x1 | bool | mbUnlockSequenceAlreadyShown | Has Junkyard unlock animation been played |  |
+| 0xB | 0x1 | uint8_t | ? | Version flags from the Vehicle List resource | Padding prior to game version 1.3 |
+| 0xC | 0x4 | float32_t | mfUnlockDeformedAmount | Damage applied to the car |  |
+| 0x10 | 0x4 | UnlockType | meUnlockType | Vehicle unlock type |  |
+| 0x14 | 0x4 |  |  | Padding |  |
+
+### BrnProgression::LiveryData
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | CgsID | mBaseCarId |  |  |
+| 0x8 | 0x8 | CgsID | mChosenLiveryCarId |  |  |
+| 0x10 | 0x4 | float32_t | mfDistanceDriven |  |  |
+| 0x14 | 0x1 | uint8_t | ? | Version flags from the Vehicle List resource | Padding prior to version 1.3 |
+| 0x15 | 0x3 | ? | ? | Padding |  |
+
+### CgsSystem::Time
+
+Precise time counter used as a replacement for floats starting in version 1.3.
+
+| Offset | Size | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miSeconds | Seconds |  |
+| 0x4 | 0x4 | float32_t | mfFraction | Milliseconds |  |
+
+## Enumerations
+
+### BrnGameState::EActiveRoadRule
+
+| Name | Value | Comment |
+| --- | --- | --- |
+| E_ACTIVE_ROAD_RULE_NONE | 0 |  |
+| E_ACTIVE_ROAD_RULE_OFFLINE_TIME | 1 |  |
+| E_ACTIVE_ROAD_RULE_ONLINE_TIME | 2 |  |
+| E_ACTIVE_ROAD_RULE_OFFLINE_CRASH | 3 |  |
+| E_ACTIVE_ROAD_RULE_ONLINE_CRASH | 4 |  |
+| ? | 5 | Bike offline time (day) |
+| ? | 6 | Bike online time (day) |
+| ? | 7 | Bike offline time (night) |
+| ? | 8 | Bike online time (night) |
+| E_ACTIVE_ROAD_RULE_COUNT | 9 |  |
+
+### BrnProgression::CarData::UnlockType
+
+| Name | Value | Comment |
+| --- | --- | --- |
+| E_UNLOCK_TYPE_UNLOCK | 0 | Unlocked at start |
+| E_UNLOCK_TYPE_GIFT | 1 | Secondary finishes and Burning Route unlocks |
+| E_UNLOCK_TYPE_TROPHY | 2 | Unlocked through achievements (carbon cars) |
+| E_UNLOCK_TYPE_SHUTDOWN_RIVAL | 3 |  |
+| E_UNLOCK_TYPE_GOLD_SILVER | 4 | Gold and platinum cars |
+| E_UNLOCK_TYPE_SPONSOR | 5 | Will not show until a certain rank is reached |
+| ? | 6 | Used on online cars. Causes vehicles to only show while online |
+| ? | 7 | Used on Beat The Team community cars (Tempesta Dream/Tiger GT) |
+| ? | 8 | Used on PDLC vehicles |
+| ? | 9 | Used on Cop Cars |
+| ? | 10 | Island gift |
+| ? | 11 | Island unlock |

--- a/docs/save-profile/container.md
+++ b/docs/save-profile/container.md
@@ -1,0 +1,246 @@
+# Profile/Burnout Paradise
+
+> Source: https://burnout.wiki/wiki/Profile/Burnout_Paradise (mirrored 2026-06-22)
+
+The profile for *Burnout Paradise* contains all saved progression, including event completion, collectible discovery, records, and unlocked vehicles, among other things. It also contains user-selected data such as vehicle colors, options, and custom online race routes.
+
+The only major content not saved in the profile is mugshot data, which is stored independently. Its location is platform-specific.
+
+## Overview
+
+The primary purpose of the Profile is to store progression. To achieve this goal, it is broken up into several different structures and substructures, with the highest levels being demarcated by update (in the instances where updates introduced content relevant to progression). There may also be separate online-related or options-related chunks. Progression chunks are generally split into sections for vehicles, rivals, events, collectibles, discovery, Road Rules, challenges, records, and statistics, among other things. Not all sections are used in each chunk, but all are guaranteed to be present in the stored data in some form.
+
+### Vehicles
+
+Being the main form of progression in Paradise, a significant amount of attention is devoted to vehicles. Each progression-related chunk has a set amount of storage allocated to store IDs, colors, mileage, and other related data. Which vehicles are unlocked is determined by whether or not one has an entry in the profile, while finishes being unlocked depends on whether the damage value is set to 0.
+
+Vehicle chunks have also been split into two parts such that the chosen finish and mileage for a vehicle is separate from the rest of the data. It is not clear why this is the case. Additionally, PDLC and cop cars use a different structure to the rest which lacks certain fields, such as damage, but it is also unclear why this was done; space savings is one theory, but it is more likely a simple lack of foresight.
+
+### Events
+
+Events take up a relatively small portion of the profile, with only an ID and flags to indicate their discovery and completion state. Only completion-related flags are reset when any new license is earned, allowing them to remain on the map if they have been discovered. Event difficulty is not stored explicitly, instead being derived from license progression and/or the number of wins in that event type.
+
+### Collectibles
+
+Collectibles are stored in three sets, one for each type (Burnout Billboards, Smash Gates, and Super Jumps). Each ID within these is referred to as a stunt element. An ID being present means that specific collectible has been collected. Discoverables (drivethrus) are stored in the same way collectibles are.
+
+Notably, the per-county collectible counts displayed in the discovery tab are not tied to the IDs saved in the sets, instead being stored separately in the profile.
+
+### Road Rules
+
+Road Rules have their own specific chunks in progression profiles. These use one of two formats, one for cars (which is also used in the Street Data resource) and one for bikes. Both store essentially the same data: whether or not the offline and online scores have been beaten, the scores set by the player, and the vehicles used to set the player's high scores.
+
+The highest scores of anyone on a player's friends list are also stored along with the winning player's name. This name is displayed at the top of the screen in-game until it is refreshed by either a leaderboard download or the player beating the score.
+
+Road Rules are also split between mainland Road Rules, with 64 roads, and Big Surf Island Road Rules, with 12 roads. The exact order of these roads is known and appears to be either ID-based or based on the time they were added to the game.
+
+### Challenges
+
+Challenges are split in the profile similarly to how they are split in-game, with separate sets for Freeburn, timed, bike, and Island challenges. Like with collectibles, IDs are used to mark specific challenges as complete. The only type of challenge to differ from this is timed, which has additional fields for the saved time and player count.
+
+Timed bike challenges, despite having a personal best field in-game, do not have saved times in the profile and are instead stored exactly like Freeburn bike challenges.
+
+### Records and statistics
+
+A number of values are stored in the profile so the player can keep track of high scores, total play time, total mileage, etc. Many of these are specific to mainland, bike, and Big Surf Island progression, though none are directly contributory to any licenses. No values are notable from a technical perspective, either, although some suffer from certain limitations and others become deprecated by higher-precision values in later versions, as is the case with the Stunt Run high score.
+
+## Known issues and exploits
+
+### Buffer overread via color indices
+
+Colors and color types may be modified by changing the selected index on a given vehicle. As there is no bounds checking in place, it is possible to read data beyond the selected color type and the Player Car Colours resource altogether. What's read in is interpreted as floating-point data representing percentages of 255, leading to values less than 0% and greater than 100%. The resulting colors often glow and have been dubbed "neon" colors. The exact process by which these colors are formed is currently unknown and likely requires shader research to understand.
+
+### Replacement of selected liveries with other vehicles
+
+The selected livery of a given vehicle is stored as a vehicle ID. As there are no checks in place to ensure the selected vehicle is a child of the given vehicle, this can be replaced with any other vehicle, including undrivable vehicles such as traffic. Liveries set this way cannot be selected normally in the junkyard but can be used by other means, such as waiting for the countdown to end in an online race or having the host of an online room start a Marked Man game.
+
+### Time and distance limitations
+
+Time played, measured in seconds, was originally stored as a float. Due to the imprecision inherent to the float datatype, the smallest increments at which a value can increase get larger with bigger values. In this case, time stopped increasing when it could no longer increment by the frametime (16.6 ms), which limited the value to just 262144 seconds (72.8 hours).
+
+Distance travelled suffers the same imprecision woes but at a later point. While it is still added to every frame, the increase changes based on speed, so the limit changes based on speed as well: 10425 mi at 67-134 mph, 20850 mi at 134-268 mph, and 41700 mi at 268-537 mph, to name some common ones. These limits apply to both total and per-car mileage.
+
+In version 1.3, time played was fixed by using a structure created specifically to address the issue:
+
+**CgsSystem::Time**
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miSeconds | Seconds |  |
+| 0x4 | 0x4 | float32_t | mfFraction | Milliseconds |  |
+
+Unfortunately, this fix was only applied to time, meaning distance remains limited even in the latest versions of the game.
+
+### Missing smash gate after updating
+
+The profile upgrade performed by the 1.9 update alters the hit props bit array to accommodate prop changes made when the bridge was opened. A single smash gate on top of the Angus car park can become impossible to collect if the profile is upgraded. This can only be circumvented by downgrading the game, smashing the gate, and updating again.
+
+## Headers and protection
+
+#### Xbox 360
+
+Xbox 360 profiles use EA's proprietary MC02 header to protect the data. Following any edits, the profile must be rehashed using a program such as MC02 Package Tool.
+
+The following information is from symbols in Dead Space 2 (2010-11-19 build).
+
+**RealmcCore::FileHeader**
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | uint32_t | mFileHeaderVersion | Magic | Must be 'MC02'<br>MC = Memory Card<br>02 = version 2 |
+| 0x4 | 0x4 | uint32_t | mFileSize | Length of the save in bytes | Includes the MC02 header |
+| 0x8 | 0x4 | uint32_t | mUserHeaderSize | Save header length in bytes | Unused in Burnout Paradise |
+| 0xC | 0x4 | uint32_t | mUserBodySize | Save data length in bytes |  |
+| 0x10 | 0x4 | uint32_t | mUserHeaderSignature | Save header CRC32 | Unused in Burnout Paradise |
+| 0x14 | 0x4 | uint32_t | mUserBodySignature | Save data CRC32 |  |
+| 0x18 | 0x4 | uint32_t | mFileHeaderSignature | MC02 header CRC32 | Hashes everything prior to this field |
+
+The CRC32 algorithm used is nonstandard. See this gist for an example implementation.
+
+#### PC
+
+The PC profile uses the Rich Game Header (RGMH), which provides no protection from modding. The profile is located at `%LOCALAPPDATA%/Criterion Games/Burnout Paradise/Save/Profile.BurnoutParadiseSave`.
+
+Further information on this header can be found at its Microsoft Learn page.
+
+**RGMH header**
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | DWORD | dwMagicNumber | Used to recognize the header. | Must be 'HMGR' |
+| 0x4 | 0x4 | DWORD | dwHeaderVersion | Version of this header. | Must be 1 |
+| 0x8 | 0x4 | DWORD | dwHeaderSize | Size of this header in bytes. |  |
+| 0xC | 0x8 | LARGE_INTEGER | liThumbnailOffset | Offset to where the thumbnail starts. | Relative to header end |
+| 0x14 | 0x4 | DWORD | dwThumbnailSize | Size of the thumbnail in bytes. |  |
+| 0x18 | 0x10 | GUID | guidGameId | GUID of the game. | {6D5AE2FB-F7AC-45EA-982C-8422649DB55E}<br>See GUID on MS Learn |
+| 0x28 | 0x800 | WCHAR[1024] | szGameName | Name of the game. |  |
+| 0x828 | 0x800 | WCHAR[1024] | szSaveName | Description of the saved game. |  |
+| 0x1028 | 0x800 | WCHAR[1024] | szLevelName | Description of the level. |  |
+| 0x1828 | 0x800 | WCHAR[1024] | szComments | Comments about the saved game. |  |
+
+In practice, this is immediately followed by the thumbnail data.
+
+#### PC (Remastered)
+
+Like with the PC version of the original game, the *Remastered* profile uses the Rich Game Header and has no protection from modding. It is located at `%LOCALAPPDATA%/Criterion Games/Burnout Paradise Remastered/Save/Profile.BurnoutParadiseSave`.
+
+#### Other platforms
+
+No game-specific protection or header is in place on other platforms. See per-platform protections.
+
+## Previous versions
+
+Unlike many of the assets used by the game, the profile is completely backwards compatible with older versions of Burnout Paradise. Data introduced in newer versions is stored in separate chunks, leaving prior chunks untouched; even new vehicles are stored in new arrays instead of the one in the original chunk. Deprecated fields are still written to, such as how the time played statistics are updated despite being replaced with higher-precision fields in 1.3, so progress from updated fields can carry over.
+
+As a result of this system, the ProfileStoredData structure sees no changes between retail versions, only additions. If it is necessary to read profiles from earlier game versions, later chunks can simply be ignored.
+
+## Structures
+
+### BrnGui::ProfileManager::ProfileStoredData
+
+Primary profile structure which holds all data.
+
+#### PlayStation 3
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x1DA30 | FixedSizeOpaqueBuffer<Profile_1_0> | mProgressionProfile | Base progression profile | In 1.0 |
+| 0x1DA30 | 0x7540 | FixedSizeOpaqueBuffer<LiveRevengeProfile> | mLiveRevengeProfile | Live Revenge profile | In 1.0 |
+| 0x24F70 | 0x7370 | FixedSizeOpaqueBuffer<OptionsDataProfile_1_0> | mOptionsDataProfile | Options data profile | In 1.0 |
+| 0x2C2E0 | 0xAC0 | FixedSizeOpaqueBuffer<ProfileDLC_1_3> | ? | Cagney profile | Added in 1.3 |
+| 0x2CDA0 | 0x18 | FixedSizeOpaqueBuffer<OptionsDataProfileDLC_1_3> | ? | Cagney options data profile | Added in 1.3 |
+| 0x2CDB8 | 0x19C8 | FixedSizeOpaqueBuffer<ProfileDLC_1_4> | ? | Davis profile | Added in 1.4 |
+| 0x2E780 | 0x1C60 | FixedSizeOpaqueBuffer<?> | ? | PDLC profile | Added in 1.7. See PDLC Profile |
+| 0x303E0 | 0x268 | FixedSizeOpaqueBuffer<?> | ? | Cop profile | Added in 1.8. See Cop Profile |
+| 0x30648 | 0x10A8 | FixedSizeOpaqueBuffer<?> | ? | Island profile | Added in 1.9. See Island Profile |
+| 0x316F0 | 0xE910 | char[59664] | macPadData | Padding |  |
+
+#### Xbox 360
+
+Offsets are relative to 0x1C, the end of the MC02 header (start of the Profile structure).
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x1CD30 | FixedSizeOpaqueBuffer<Profile_1_0> | mProgressionProfile | Base progression profile | In 1.0 |
+| 0x1CD30 | 0x7540 | FixedSizeOpaqueBuffer<LiveRevengeProfile> | mLiveRevengeProfile | Live Revenge profile | In 1.0 |
+| 0x24270 | 0x7370 | FixedSizeOpaqueBuffer<OptionsDataProfile_1_0> | mOptionsDataProfile | Options data profile | In 1.0 |
+| 0x2B5E0 | 0xAC0 | FixedSizeOpaqueBuffer<ProfileDLC_1_3> | ? | Cagney profile | Added in 1.3 |
+| 0x2C0A0 | 0x18 | FixedSizeOpaqueBuffer<OptionsDataProfileDLC_1_3> | ? | Cagney options data profile | Added in 1.3 |
+| 0x2C0B8 | 0x17C8 | FixedSizeOpaqueBuffer<ProfileDLC_1_4> | ? | Davis profile | Added in 1.4 |
+| 0x2D880 | 0x1C60 | FixedSizeOpaqueBuffer<?> | ? | PDLC profile | Added in 1.7. See PDLC Profile |
+| 0x2F4E0 | 0x268 | FixedSizeOpaqueBuffer<?> | ? | Cop profile | Added in 1.8. See Cop Profile |
+| 0x2F748 | 0xFE0 | FixedSizeOpaqueBuffer<?> | ? | Island profile | Added in 1.9. See Island Profile |
+| 0x30728 | 0xF8D8 | char[63704] | macPadData | Padding |  |
+
+#### PC
+
+Offsets are relative to 0x1D246, the end of the RGMH header (start of the Profile structure).
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x1CC00 | FixedSizeOpaqueBuffer<Profile_1_0> | mProgressionProfile | Base progression profile | In 1.0 |
+| 0x1CC00 | 0x6D68 | FixedSizeOpaqueBuffer<LiveRevengeProfile> | mLiveRevengeProfile | Live Revenge profile | In 1.0 |
+| 0x23968 | 0x7780 | FixedSizeOpaqueBuffer<OptionsDataProfile_1_0> | mOptionsDataProfile | Options data profile | In 1.0 |
+| 0x2B0E8 | 0xAC0 | FixedSizeOpaqueBuffer<ProfileDLC_1_3> | ? | Cagney profile | Added in 1.3 |
+| 0x2BBA8 | 0x18 | FixedSizeOpaqueBuffer<OptionsDataProfileDLC_1_3> | ? | Cagney options data profile | Added in 1.3 |
+| 0x2BBC0 | 0x19C8 | FixedSizeOpaqueBuffer<ProfileDLC_1_4> | ? | Davis profile | Added in 1.4 |
+| 0x2D588 | 0xC88 | FixedSizeOpaqueBuffer<?> | ? | Recent players profile | See Recent Players Profile |
+| 0x2E210 | 0x1C68 | FixedSizeOpaqueBuffer<?> | ? | PDLC profile | Added in 1.7. See PDLC Profile |
+| 0x2FE78 | 0x10188 | char[65928] | macPadData | Padding |  |
+
+#### PlayStation 4
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x66100 | FixedSizeOpaqueBuffer<Profile_1_0> | mProgressionProfile | Base progression profile | In 1.0 |
+| 0x66100 | 0x7D10 | FixedSizeOpaqueBuffer<LiveRevengeProfile> | mLiveRevengeProfile | Live Revenge profile | In 1.0 |
+| 0x6DE10 | 0x7778 | FixedSizeOpaqueBuffer<OptionsDataProfile_1_0> | mOptionsDataProfile | Options data profile | In 1.0 |
+| 0x75588 | 0xAC0 | FixedSizeOpaqueBuffer<ProfileDLC_1_3> | ? | Cagney profile | Added in 1.3 |
+| 0x76048 | 0x18 | FixedSizeOpaqueBuffer<OptionsDataProfileDLC_1_3> | ? | Cagney options data profile | Added in 1.3 |
+| 0x76060 | 0x1C48 | FixedSizeOpaqueBuffer<ProfileDLC_1_4> | ? | Davis profile | Added in 1.4 |
+| 0x77CA8 | 0x1C68 | FixedSizeOpaqueBuffer<?> | ? | PDLC profile | Added in 1.7. See PDLC Profile |
+| 0x79910 | 0x268 | FixedSizeOpaqueBuffer<?> | ? | Cop profile | Added in 1.8. See Cop Profile |
+| 0x79B78 | 0x11E0 | FixedSizeOpaqueBuffer<?> | ? | Island profile | Added in 1.9. See Island Profile |
+| 0x7AD58 | 0x52A9 | char[21161] | macPadData | Padding |  |
+
+#### PC (Remastered)
+
+Offsets are relative to 0x1D246, the end of the RGMH header (start of the Profile structure).
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x65DA0 | FixedSizeOpaqueBuffer<Profile_1_0> | mProgressionProfile | Base progression profile | In 1.0 |
+| 0x65DA0 | 0x7538 | FixedSizeOpaqueBuffer<LiveRevengeProfile> | mLiveRevengeProfile | Live Revenge profile | In 1.0 |
+| 0x6D2D8 | 0x7778 | FixedSizeOpaqueBuffer<OptionsDataProfile_1_0> | mOptionsDataProfile | Options data profile | In 1.0 |
+| 0x74A50 | 0xAC0 | FixedSizeOpaqueBuffer<ProfileDLC_1_3> | ? | Cagney profile | Added in 1.3 |
+| 0x75510 | 0x18 | FixedSizeOpaqueBuffer<OptionsDataProfileDLC_1_3> | ? | Cagney options data profile | Added in 1.3 |
+| 0x75528 | 0x1C48 | FixedSizeOpaqueBuffer<ProfileDLC_1_4> | ? | Davis profile | Added in 1.4 |
+| 0x77170 | 0x1C68 | FixedSizeOpaqueBuffer<?> | ? | PDLC profile | Added in 1.7. See PDLC Profile |
+| 0x78DD8 | 0x268 | FixedSizeOpaqueBuffer<?> | ? | Cop profile | Added in 1.8. See Cop Profile |
+| 0x79040 | 0x11D8 | FixedSizeOpaqueBuffer<?> | ? | Island profile | Added in 1.9. See Island Profile |
+| 0x7A218 | 0x5DE8 | char[24040] | macPadData | Padding |  |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x66820 | FixedSizeOpaqueBuffer<Profile_1_0> | mProgressionProfile | Base progression profile | In 1.0 |
+| 0x66820 | 0x84E0 | FixedSizeOpaqueBuffer<LiveRevengeProfile> | mLiveRevengeProfile | Live Revenge profile | In 1.0 |
+| 0x6ED00 | 0x7778 | FixedSizeOpaqueBuffer<OptionsDataProfile_1_0> | mOptionsDataProfile | Options data profile | In 1.0 |
+| 0x76478 | 0xAC0 | FixedSizeOpaqueBuffer<ProfileDLC_1_3> | ? | Cagney profile | Added in 1.3 |
+| 0x76F38 | 0x18 | FixedSizeOpaqueBuffer<OptionsDataProfileDLC_1_3> | ? | Cagney options data profile | Added in 1.3 |
+| 0x76F50 | 0x2048 | FixedSizeOpaqueBuffer<ProfileDLC_1_4> | ? | Davis profile | Added in 1.4 |
+| 0x78F98 | 0x1C68 | FixedSizeOpaqueBuffer<?> | ? | PDLC profile | Added in 1.7. See PDLC Profile |
+| 0x7AC00 | 0x268 | FixedSizeOpaqueBuffer<?> | ? | Cop profile | Added in 1.8. See Cop Profile |
+| 0x7AE68 | 0x1360 | FixedSizeOpaqueBuffer<?> | ? | Island profile | Added in 1.9. See Island Profile |
+| 0x7C1C8 | 0x3E38 | char[15928] | macPadData | Padding |  |
+
+### BrnGui::ProfileManager::FixedSizeOpaqueBuffer
+
+Buffer type used when loading and saving. It is always the size of the specified type. For example, the Progression Profile on PS3 is stored as:
+
+**FixedSizeOpaqueBuffer<BrnProgression::Profile>**
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x1DA30 | uint8_t[121392] | maData | uint8_t buffer of the exact length of the structure |  |

--- a/docs/save-profile/cop-profile.md
+++ b/docs/save-profile/cop-profile.md
@@ -1,0 +1,57 @@
+# Profile/Burnout Paradise/Cop Profile
+
+> Source: https://burnout.wiki/wiki/Profile/Burnout_Paradise/Cop_Profile (mirrored 2026-06-22)
+
+The cop profile stores entitlements for all cop cars. It is essentially a limited version of the PDLC Profile.
+
+Though space is allocated to 35 vehicles, only 33 entries are used. This is because the PCPD Rai-Jin Turbo and PCPD Olympus were removed during development.
+
+## Structures
+
+### Cop Profile
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number | 2 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x18 | CgsID[3] | ? | Spawn vehicle IDs | Car, bike, and plane, respectively |
+| 0x20 | 0xC | uint32_t[3] | ? | Spawn vehicle update versions | Car, bike, and plane, respectively |
+| 0x2C | 0x4 | uint32_t | ? | Spawn vehicle index |  |
+| 0x30 | 0x238 | ? | ? | Cop entitlements | See entitlements |
+
+### Entitlements
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | uint32_t | ? | Number of entitlements |  |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x118 | CgsID[35] | ? | Vehicle IDs |  |
+| 0x120 | 0x46 | int16_t[35] | ? | Entry indices |  |
+| 0x166 | 0x23 | uint8_t[35] | ? | Color indices and version flags | See color and flags |
+| 0x189 | 0x23 | uint8_t[35] | ? | Palette indices and mileage flag | See palette and flags |
+| 0x1AC | 0x8C | float32_t[35] | ? | Vehicle mileage |  |
+
+### Color and flags
+
+| Offset (bits) | Length (bits) | Name | Description | Comments |
+| --- | --- | --- | --- | --- |
+| 0 | 2 | ? | Vehicle update version | See version flags |
+| 2 | 6 | ? | Color index |  |
+
+### Palette and flags
+
+| Offset (bits) | Length (bits) | Name | Description | Comments |
+| --- | --- | --- | --- | --- |
+| 0 | 1 | ? | Read mileage | Mileage reverts if not set |
+| 1 | 7 | ? | Palette index |  |
+
+## Enumerations
+
+### Version flags
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| ? | 0 | 8 (1.8) |
+| ? | 1 | 2 (1.0) |
+| ? | 2 | 2 (1.0) |
+| ? | 3 | 2 (1.0) |

--- a/docs/save-profile/davis-profile.md
+++ b/docs/save-profile/davis-profile.md
@@ -1,0 +1,410 @@
+# Profile/Burnout Paradise/Davis Profile
+
+> Source: https://burnout.wiki/wiki/Profile/Burnout_Paradise/Davis_Profile (mirrored 2026-06-22)
+
+The Davis profile includes all bike-related fields, excluding those found on the Island Profile. This includes vehicles, events, Road Rules, challenges, awards, and statistics. It also has fields for the time of day feature.
+
+## Structures
+
+### BrnGuiSaveLoad::ProfileDLC_1_4
+
+#### PlayStation 3
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number | 21 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x1E0 | CarData[20] | ? | Vehicles |  |
+| 0x1E8 | 0x1E0 | LiveryData[20] | ? | Liveries |  |
+| 0x3C8 | 0x140 | ProfileEvent[40] | ? | Events |  |
+| 0x508 | 0x4 | int32_t | ? | Number of events |  |
+| 0x50C | 0x4 |  |  | Padding |  |
+| 0x510 | 0x1210 | ? | ? | Bike Road Rules | See bike Road Rules |
+| 0x1720 | 0x238 | Array<CgsID, 70u> | ? | Bike challenges |  |
+| 0x1958 | 0x8 | BitArray<20u> | ? | Bike awards |  |
+| 0x1960 | 0x18 | CgsID[3] | ? | Spawn vehicle IDs | Car, bike, and plane, respectively |
+| 0x1978 | 0xC | uint32_t[3] | ? | Spawn vehicle update versions | Car, bike, and plane, respectively |
+| 0x1984 | 0x4 | uint32_t | ? | Spawn vehicle index |  |
+| 0x1988 | 0x4 | int32_t | ? | Number of vehicles |  |
+| 0x198C | 0x4 | int32_t | ? | Number of liveries |  |
+| 0x1990 | 0x8 | Time | ? | Time of day |  |
+| 0x1998 | 0x10 | DateAndTime | ? | Date bikes 100% completed |  |
+| 0x19A8 | 0x8 | Time | ? | Total time played |  |
+| 0x19B0 | 0x4 | float32_t | ? | Distance ridden offline |  |
+| 0x19B4 | 0x4 | float32_t | ? | Distance ridden online |  |
+| 0x19B8 | 0x4 | float32_t | ? | Longest wheelie |  |
+| 0x19BC | 0x4 | float32_t | ? | Longest jump |  |
+| 0x19C0 | 0x1 | uint8_t | ? | Active bike road rules | See EActiveRoadRule |
+| 0x19C1 | 0x1 | uint8_t | ? | Time of day intro state | See time of day intro state |
+| 0x19C2 | 0x1 | uint8_t | ? | Time setting | See time setting |
+| 0x19C3 | 0x1 | uint8_t | ? | Constant time setting | See constant time setting |
+| 0x19C4 | 0x1 | bool | ? | Is 101% complete |  |
+| 0x19C5 | 0x3 |  |  | Padding |  |
+
+#### Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number | 21 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x1E0 | CarData[20] | ? | Vehicles |  |
+| 0x1E8 | 0x1E0 | LiveryData[20] | ? | Liveries |  |
+| 0x3C8 | 0x140 | ProfileEvent[40] | ? | Events |  |
+| 0x508 | 0x4 | int32_t | ? | Number of events |  |
+| 0x50C | 0x4 |  |  | Padding |  |
+| 0x510 | 0x1010 | ? | ? | Bike Road Rules | See bike Road Rules |
+| 0x1520 | 0x238 | Array<CgsID, 70u> | ? | Bike challenges |  |
+| 0x1758 | 0x8 | BitArray<20u> | ? | Bike awards |  |
+| 0x1760 | 0x18 | CgsID[3] | ? | Spawn vehicle IDs | Car, bike, and plane, respectively |
+| 0x1778 | 0xC | uint32_t[3] | ? | Spawn vehicle update versions | Car, bike, and plane, respectively |
+| 0x1784 | 0x4 | uint32_t | ? | Spawn vehicle index |  |
+| 0x1788 | 0x4 | int32_t | ? | Number of vehicles |  |
+| 0x178C | 0x4 | int32_t | ? | Number of liveries |  |
+| 0x1790 | 0x8 | Time | ? | Time of day |  |
+| 0x1798 | 0xC | DateAndTime | ? | Date bikes 100% completed |  |
+| 0x17A4 | 0x8 | Time | ? | Total time played |  |
+| 0x17AC | 0x4 | float32_t | ? | Distance ridden offline |  |
+| 0x17B0 | 0x4 | float32_t | ? | Distance ridden online |  |
+| 0x17B4 | 0x4 | float32_t | ? | Longest wheelie |  |
+| 0x17B8 | 0x4 | float32_t | ? | Longest jump |  |
+| 0x17BC | 0x1 | uint8_t | ? | Active bike road rules | See EActiveRoadRule |
+| 0x17BD | 0x1 | uint8_t | ? | Time of day intro state | See time of day intro state |
+| 0x17BE | 0x1 | uint8_t | ? | Time setting | See time setting |
+| 0x17BF | 0x1 | uint8_t | ? | Constant time setting | See constant time setting |
+| 0x17C0 | 0x1 | bool | ? | Is 101% complete |  |
+| 0x17C1 | 0x7 |  |  | Padding |  |
+
+#### PC
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number | 22 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x1E0 | CarData[20] | ? | Vehicles |  |
+| 0x1E8 | 0x1E0 | LiveryData[20] | ? | Liveries |  |
+| 0x3C8 | 0x140 | ProfileEvent[40] | ? | Events |  |
+| 0x508 | 0x4 | int32_t | ? | Number of events |  |
+| 0x50C | 0x4 |  |  | Padding |  |
+| 0x510 | 0x1210 | ? | ? | Bike Road Rules | See bike Road Rules |
+| 0x1720 | 0x238 | Array<CgsID, 70u> | ? | Bike challenges |  |
+| 0x1958 | 0x8 | BitArray<20u> | ? | Bike awards |  |
+| 0x1960 | 0x18 | CgsID[3] | ? | Spawn vehicle IDs | Car, bike, and plane, respectively |
+| 0x1978 | 0xC | uint32_t[3] | ? | Spawn vehicle update versions | Car, bike, and plane, respectively |
+| 0x1984 | 0x4 | uint32_t | ? | Spawn vehicle index |  |
+| 0x1988 | 0x4 | int32_t | ? | Number of vehicles |  |
+| 0x198C | 0x4 | int32_t | ? | Number of liveries |  |
+| 0x1990 | 0x8 | Time | ? | Time of day |  |
+| 0x1998 | 0xC | DateAndTime | ? | Date bikes 100% completed |  |
+| 0x19A4 | 0x8 | Time | ? | Total time played |  |
+| 0x19AC | 0x4 | float32_t | ? | Distance ridden offline |  |
+| 0x19B0 | 0x4 | float32_t | ? | Distance ridden online |  |
+| 0x19B4 | 0x4 | float32_t | ? | Longest wheelie |  |
+| 0x19B8 | 0x4 | float32_t | ? | Longest jump |  |
+| 0x19BC | 0x1 | uint8_t | ? | Active bike road rules | See EActiveRoadRule |
+| 0x19BD | 0x1 | uint8_t | ? | Time of day intro state | See time of day intro state |
+| 0x19BE | 0x1 | uint8_t | ? | Time setting | See time setting |
+| 0x19BF | 0x1 | uint8_t | ? | Constant time setting | See constant time setting |
+| 0x19C0 | 0x1 | bool | ? | Is 101% complete |  |
+| 0x19C1 | 0x7 |  |  | Padding |  |
+
+#### PlayStation 4
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number | 21 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x1E0 | CarData[20] | ? | Vehicles |  |
+| 0x1E8 | 0x1E0 | LiveryData[20] | ? | Liveries |  |
+| 0x3C8 | 0x140 | ProfileEvent[40] | ? | Events |  |
+| 0x508 | 0x4 | int32_t | ? | Number of events |  |
+| 0x50C | 0x4 |  |  | Padding |  |
+| 0x510 | 0x1490 | ? | ? | Bike Road Rules | See bike Road Rules |
+| 0x19A0 | 0x238 | Array<CgsID, 70u> | ? | Bike challenges |  |
+| 0x1BD8 | 0x8 | BitArray<20u> | ? | Bike awards |  |
+| 0x1BE0 | 0x18 | CgsID[3] | ? | Spawn vehicle IDs | Car, bike, and plane, respectively |
+| 0x1BF8 | 0xC | uint32_t[3] | ? | Spawn vehicle update versions | Car, bike, and plane, respectively |
+| 0x1C04 | 0x4 | uint32_t | ? | Spawn vehicle index |  |
+| 0x1C08 | 0x4 | int32_t | ? | Number of vehicles |  |
+| 0x1C0C | 0x4 | int32_t | ? | Number of liveries |  |
+| 0x1C10 | 0x8 | Time | ? | Time of day |  |
+| 0x1C18 | 0x10 | DateAndTime | ? | Date bikes 100% completed |  |
+| 0x1C28 | 0x8 | Time | ? | Total time played |  |
+| 0x1C30 | 0x4 | float32_t | ? | Distance ridden offline |  |
+| 0x1C34 | 0x4 | float32_t | ? | Distance ridden online |  |
+| 0x1C38 | 0x4 | float32_t | ? | Longest wheelie |  |
+| 0x1C3C | 0x4 | float32_t | ? | Longest jump |  |
+| 0x1C40 | 0x1 | uint8_t | ? | Active bike road rules | See EActiveRoadRule |
+| 0x1C41 | 0x1 | uint8_t | ? | Time of day intro state | See time of day intro state |
+| 0x1C42 | 0x1 | uint8_t | ? | Time setting | See time setting |
+| 0x1C43 | 0x1 | uint8_t | ? | Constant time setting | See constant time setting |
+| 0x1C44 | 0x1 | bool | ? | Is 101% complete |  |
+| 0x1C45 | 0x3 |  |  | Padding |  |
+
+#### PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number | 22 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x1E0 | CarData[20] | ? | Vehicles |  |
+| 0x1E8 | 0x1E0 | LiveryData[20] | ? | Liveries |  |
+| 0x3C8 | 0x140 | ProfileEvent[40] | ? | Events |  |
+| 0x508 | 0x4 | int32_t | ? | Number of events |  |
+| 0x50C | 0x4 |  |  | Padding |  |
+| 0x510 | 0x1490 | ? | ? | Bike Road Rules | See bike Road Rules |
+| 0x19A0 | 0x238 | Array<CgsID, 70u> | ? | Bike challenges |  |
+| 0x1BD8 | 0x8 | BitArray<20u> | ? | Bike awards |  |
+| 0x1BE0 | 0x18 | CgsID[3] | ? | Spawn vehicle IDs | Car, bike, and plane, respectively |
+| 0x1BF8 | 0xC | uint32_t[3] | ? | Spawn vehicle update versions | Car, bike, and plane, respectively |
+| 0x1C04 | 0x4 | uint32_t | ? | Spawn vehicle index |  |
+| 0x1C08 | 0x4 | int32_t | ? | Number of vehicles |  |
+| 0x1C0C | 0x4 | int32_t | ? | Number of liveries |  |
+| 0x1C10 | 0x8 | Time | ? | Time of day |  |
+| 0x1C18 | 0xC | DateAndTime | ? | Date bikes 100% completed |  |
+| 0x1C24 | 0x8 | Time | ? | Total time played |  |
+| 0x1C2C | 0x4 | float32_t | ? | Distance ridden offline |  |
+| 0x1C30 | 0x4 | float32_t | ? | Distance ridden online |  |
+| 0x1C34 | 0x4 | float32_t | ? | Longest wheelie |  |
+| 0x1C38 | 0x4 | float32_t | ? | Longest jump |  |
+| 0x1C3C | 0x1 | uint8_t | ? | Active bike road rules | See EActiveRoadRule |
+| 0x1C3D | 0x1 | uint8_t | ? | Time of day intro state | See time of day intro state |
+| 0x1C3E | 0x1 | uint8_t | ? | Time setting | See time setting |
+| 0x1C3F | 0x1 | uint8_t | ? | Constant time setting | See constant time setting |
+| 0x1C40 | 0x1 | bool | ? | Is 101% complete |  |
+| 0x1C41 | 0x7 |  |  | Padding |  |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number | 21 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x1E0 | CarData[20] | ? | Vehicles |  |
+| 0x1E8 | 0x1E0 | LiveryData[20] | ? | Liveries |  |
+| 0x3C8 | 0x140 | ProfileEvent[40] | ? | Events |  |
+| 0x508 | 0x4 | int32_t | ? | Number of events |  |
+| 0x50C | 0x4 |  |  | Padding |  |
+| 0x510 | 0x1890 | ? | ? | Bike Road Rules | See bike Road Rules |
+| 0x1DA0 | 0x238 | Array<CgsID, 70u> | ? | Bike challenges |  |
+| 0x1FD8 | 0x8 | BitArray<20u> | ? | Bike awards |  |
+| 0x1FE0 | 0x18 | CgsID[3] | ? | Spawn vehicle IDs | Car, bike, and plane, respectively |
+| 0x1FF8 | 0xC | uint32_t[3] | ? | Spawn vehicle update versions | Car, bike, and plane, respectively |
+| 0x2004 | 0x4 | uint32_t | ? | Spawn vehicle index |  |
+| 0x2008 | 0x4 | int32_t | ? | Number of vehicles |  |
+| 0x200C | 0x4 | int32_t | ? | Number of liveries |  |
+| 0x2010 | 0x8 | Time | ? | Time of day |  |
+| 0x2018 | 0x10 | DateAndTime | ? | Date bikes 100% completed |  |
+| 0x2028 | 0x8 | Time | ? | Total time played |  |
+| 0x2030 | 0x4 | float32_t | ? | Distance ridden offline |  |
+| 0x2034 | 0x4 | float32_t | ? | Distance ridden online |  |
+| 0x2038 | 0x4 | float32_t | ? | Longest wheelie |  |
+| 0x203C | 0x4 | float32_t | ? | Longest jump |  |
+| 0x2040 | 0x1 | uint8_t | ? | Active bike road rules | See EActiveRoadRule |
+| 0x2041 | 0x1 | uint8_t | ? | Time of day intro state | See time of day intro state |
+| 0x2042 | 0x1 | uint8_t | ? | Time setting | See time setting |
+| 0x2043 | 0x1 | uint8_t | ? | Constant time setting | See constant time setting |
+| 0x2044 | 0x1 | bool | ? | Is 101% complete |  |
+| 0x2045 | 0x3 |  |  | Padding |  |
+
+### BrnProgression::CarData
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | CgsID | mId | Vehicle ID |  |
+| 0x8 | 0x1 | uint8_t | mu8ColourIndex | Color index | From the Player Car Colours resource |
+| 0x9 | 0x1 | uint8_t | mu8PaletteIndex | Color palette/type index | From the Player Car Colours resource |
+| 0xA | 0x1 | bool | mbUnlockSequenceAlreadyShown | Has Junkyard unlock animation been played |  |
+| 0xB | 0x1 | uint8_t | ? | Version flags from the Vehicle List resource | Padding prior to game version 1.3 |
+| 0xC | 0x4 | float32_t | mfUnlockDeformedAmount | Damage applied to the car |  |
+| 0x10 | 0x4 | UnlockType | meUnlockType | Vehicle unlock type |  |
+| 0x14 | 0x4 |  |  | Padding |  |
+
+### BrnProgression::LiveryData
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | CgsID | mBaseCarId |  |  |
+| 0x8 | 0x8 | CgsID | mChosenLiveryCarId |  |  |
+| 0x10 | 0x4 | float32_t | mfDistanceDriven |  |  |
+| 0x14 | 0x1 | uint8_t | ? | Version flags from the Vehicle List resource | Padding prior to version 1.3 |
+| 0x15 | 0x3 | ? | ? | Padding |  |
+
+### BrnProgression::ProfileEvent
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | uint32_t | muEventID | Event junction ID |  |
+| 0x4 | 0x2 | uint16_t | muFlags | Event flags | See Flags |
+| 0x6 | 0x2 |  |  | Padding |  |
+
+### Bike Road Rules
+
+2 sets of 64, first is day, second is night.
+
+#### PlayStation 3, PC
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x400 | CgsID[64][2] | ? | Vehicles used |  |
+| 0x400 | 0x200 | int32_t[64][2] | ? | Player scores |  |
+| 0x600 | 0x200 | int32_t[64][2] | ? | Friends' best scores |  |
+| 0x800 | 0xA00 | PlayerName[64][2] | ? | Friends' names |  |
+| 0x1200 | 0x10 | BitArray<64u>[2] | ? | Dirty |  |
+
+#### Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x400 | CgsID[64][2] | ? | Vehicles used |  |
+| 0x400 | 0x200 | int32_t[64][2] | ? | Player scores |  |
+| 0x600 | 0x200 | int32_t[64][2] | ? | Friends' best scores |  |
+| 0x800 | 0x800 | PlayerName[64][2] | ? | Friends' names |  |
+| 0x1000 | 0x10 | BitArray<64u>[2] | ? | Dirty |  |
+
+#### PlayStation 4, PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x400 | CgsID[64][2] | ? | Vehicles used |  |
+| 0x400 | 0x200 | int32_t[64][2] | ? | Player scores |  |
+| 0x600 | 0x200 | int32_t[64][2] | ? | Friends' best scores |  |
+| 0x800 | 0xC80 | PlayerName[64][2] | ? | Friends' names |  |
+| 0x1480 | 0x10 | BitArray<64u>[2] | ? | Dirty |  |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x400 | CgsID[64][2] | ? | Vehicles used |  |
+| 0x400 | 0x200 | int32_t[64][2] | ? | Player scores |  |
+| 0x600 | 0x200 | int32_t[64][2] | ? | Friends' best scores |  |
+| 0x800 | 0x1080 | PlayerName[64][2] | ? | Friends' names |  |
+| 0x1880 | 0x10 | BitArray<64u>[2] | ? | Dirty |  |
+
+### CgsNetwork::PlayerName
+
+#### PlayStation 3, PC
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x14 | char[20] | macName | Online player's name |  |
+
+#### Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x10 | char[16] | macName | Online player's name |  |
+
+#### PlayStation 4, PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x19 | char[25] | macName | Online player's name |  |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x21 | char[33] | macName | Online player's name |  |
+
+### CgsSystem::DateAndTime
+
+#### PlayStation 3, PlayStation 4, Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x1 | bool | mbIsLocal | Defines whether the saved time is in a local time zone or UTC |  |
+| 0x1 | 0x7 |  |  | Padding |  |
+| 0x8 | 0x8 | time_t | mSystemTime | The time value |  |
+
+#### Xbox 360, PC, PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x1 | bool | mbIsLocal | Defines whether the saved time is in a local time zone or UTC |  |
+| 0x1 | 0x3 |  |  | Padding |  |
+| 0x8 | 0x8 | FILETIME | mSystemTime | The time value |  |
+
+### CgsSystem::Time
+
+Precise time counter used as a replacement for floats starting in version 1.3.
+
+| Offset | Size | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miSeconds | Seconds |  |
+| 0x4 | 0x4 | float32_t | mfFraction | Milliseconds |  |
+
+## Enumerations
+
+### BrnGameState::EActiveRoadRule
+
+| Name | Value | Comment |
+| --- | --- | --- |
+| E_ACTIVE_ROAD_RULE_NONE | 0 |  |
+| E_ACTIVE_ROAD_RULE_OFFLINE_TIME | 1 |  |
+| E_ACTIVE_ROAD_RULE_ONLINE_TIME | 2 |  |
+| E_ACTIVE_ROAD_RULE_OFFLINE_CRASH | 3 |  |
+| E_ACTIVE_ROAD_RULE_ONLINE_CRASH | 4 |  |
+| ? | 5 | Bike offline time (day) |
+| ? | 6 | Bike online time (day) |
+| ? | 7 | Bike offline time (night) |
+| ? | 8 | Bike online time (night) |
+| E_ACTIVE_ROAD_RULE_COUNT | 9 |  |
+
+### BrnProgression::CarData::UnlockType
+
+| Name | Value | Comment |
+| --- | --- | --- |
+| E_UNLOCK_TYPE_UNLOCK | 0 | Unlocked at start |
+| E_UNLOCK_TYPE_GIFT | 1 | Secondary finishes and Burning Route unlocks |
+| E_UNLOCK_TYPE_TROPHY | 2 | Unlocked through achievements (carbon cars) |
+| E_UNLOCK_TYPE_SHUTDOWN_RIVAL | 3 |  |
+| E_UNLOCK_TYPE_GOLD_SILVER | 4 | Gold and platinum cars |
+| E_UNLOCK_TYPE_SPONSOR | 5 | Will not show until a certain rank is reached |
+| ? | 6 | Used on online cars. Causes vehicles to only show while online |
+| ? | 7 | Used on Beat The Team community cars (Tempesta Dream/Tiger GT) |
+| ? | 8 | Used on PDLC vehicles |
+| ? | 9 | Used on Cop Cars |
+| ? | 10 | Island gift |
+| ? | 11 | Island unlock |
+
+### BrnProgression::ProfileEvent::Flags
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_FLAG_UNDISCOVERED | 0x0 |  |
+| E_FLAG_DISCOVERED | 0x1 |  |
+| E_FLAG_FINISHED | 0x2 |  |
+| E_FLAG_RANK_WIN | 0x4 |  |
+| E_FLAG_NON_RANK_WIN | 0x8 |  |
+| E_FLAG_WON_SPECIAL_EVENT_BEFORE | 0x10 |  |
+| E_FLAG_WON_EVENT_BEFORE | 0x20 |  |
+
+### Time of day intro state
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| ? | 0 | Initial value for a new save file<br>At Junkyard exit this changes to 1, time of day is set to 8:00 am and time setting becomes 24-Hour Day |
+| ? | 1 | Weather disabled. Bike traffic density is always 0.05. Time only runs if the vehicle's engine is on<br>At 8:15 am this changes to 2 |
+| ? | 2 | Weather disabled. Bike traffic density interpolates from 0.05 to the normal values<br>At 8:20 am this changes to 3 and time setting becomes 48-Minute Day |
+| ? | 3 | Normal time of day and weather management. Saving game options will skip to this state |
+
+### Time setting
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| ? | 0 | 24-Minute Day |
+| ? | 1 | 48-Minute Day |
+| ? | 2 | 2-Hour Day |
+| ? | 3 | 24-Hour Day |
+| ? | 4 | Match Local Time |
+| ? | 5 | Constant Time of Day |
+
+### Constant time setting
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| ? | 0 | Midday |
+| ? | 1 | Sunset |
+| ? | 2 | Midnight |
+| ? | 3 | Sunrise |

--- a/docs/save-profile/island-profile.md
+++ b/docs/save-profile/island-profile.md
@@ -1,0 +1,522 @@
+# Profile/Burnout Paradise/Island Profile
+
+> Source: https://burnout.wiki/wiki/Profile/Burnout_Paradise/Island_Profile (mirrored 2026-06-22)
+
+The island profile contains all saved data associated with Big Surf Island, including vehicles, events, collectibles, Road Rules, challenges, and statistics, as well as all bike-related data.
+
+## Structures
+
+### Island Profile
+
+#### PlayStation 3
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | ? | Version number | 25 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x18 | CgsID[3] | ? | Spawn vehicle IDs | Car, bike, and plane, respectively |
+| 0x20 | 0xC | uint32_t[3] | ? | Spawn vehicle update versions | Car, bike, and plane, respectively |
+| 0x2C | 0x4 | uint32_t | ? | Spawn vehicle index |  |
+| 0x30 | 0x108 | CarData[11] | ? | Island vehicles |  |
+| 0x138 | 0x108 | LiveryData[11] | ? | Liveries |  |
+| 0x240 | 0x4 | uint32_t | ? | Number of island events |  |
+| 0x244 | 0x78 | ProfileEvent[15] | ? | Island events |  |
+| 0x2BC | 0x28 | int32_t[10] | ? | Number of island events present, per type |  |
+| 0x2E4 | 0x28 | int32_t[10] | ? | Number of island events won, per type |  |
+| 0x30C | 0x4 | int32_t | ? | Number of island tours present |  |
+| 0x310 | 0x4 | int32_t | ? | Number of island tours won |  |
+| 0x314 | 0x4 | int32_t | ? | Island vehicle count |  |
+| 0x318 | 0x4 | int32_t | ? | Livery count |  |
+| 0x31C | 0x16C | Array<?, 45u> | ? | Island billboards | Not padded after length. See island collectible |
+| 0x488 | 0x25C | Array<?, 75u> | ? | Island smash gates | Not padded after length. See island collectible |
+| 0x6E4 | 0x7C | Array<?, 15u> | ? | Mega jumps | Not padded after length. See island collectible |
+| 0x760 | 0x8 | Array<uint32_t, 1u> | ? | Junkyards found | Not padded after length |
+| 0x768 | 0x8 | Array<uint32_t, 1u> | ? | Auto repairs found | Not padded after length |
+| 0x770 | 0xC | Array<uint32_t, 2u> | ? | Gas stations found | Not padded after length |
+| 0x77C | 0x8 | Array<uint32_t, 1u> | ? | Paint shops found | Not padded after length |
+| 0x784 | 0x4 |  |  | Padding |  |
+| 0x788 | 0x58 | Array<CgsID, 10u> | ? | Island challenges |  |
+| 0x7E0 | 0x300 | ChallengeHighScoreEntry[12] | ? | Best island road rules |  |
+| 0xAE0 | 0x1E0 | ChallengePlayerScoreEntry[12] | ? | Player island road rules |  |
+| 0xCC0 | 0x370 | ? | ? | Island bike Road Rules | See island bike Road Rules |
+| 0x1030 | 0x4 | int32_t | ? | Barrel roll record |  |
+| 0x1034 | 0x4 | float32_t | ? | Flat spin record |  |
+| 0x1038 | 0x4 | float32_t | ? | Drift distance record |  |
+| 0x103C | 0x8 | Time | ? | In-car time played |  |
+| 0x1044 | 0x8 | Time | ? | Real time played |  |
+| 0x104C | 0x4 | float32_t | ? | Distance driven offline |  |
+| 0x1050 | 0x4 | float32_t | ? | Distance driven online |  |
+| 0x1054 | 0x4 | float32_t | ? | Best air time |  |
+| 0x1058 | 0x4 | float32_t | ? | Best oncoming |  |
+| 0x105C | 0x4 | int32_t | ? | Highest showtime score |  |
+| 0x1060 | 0x4 | int32_t | ? | Best power parking |  |
+| 0x1064 | 0x4 | int32_t | ? | Best Burnout chain |  |
+| 0x1068 | 0x4 | int32_t | ? | Total number of takedowns |  |
+| 0x106C | 0x4 | int32_t | ? | Best Road Rage score |  |
+| 0x1070 | 0x8 | int64_t | ? | Best Stunt Run score |  |
+| 0x1078 | 0x1 | uint8_t | ? |  |  |
+| 0x1079 | 0x1 | bool | ? | Island welcome shown |  |
+| 0x107A | 0x1 | bool | ? | 100% completed |  |
+| 0x107B | 0x5 |  |  | Padding |  |
+| 0x1080 | 0x10 | DateAndTime | ? | Island license issue date |  |
+| 0x1090 | 0x4 | float32_t | ? | Best wheelie |  |
+| 0x1094 | 0x4 | float32_t | ? | Best bike jump distance |  |
+| 0x1098 | 0x8 | Time | ? | Bike time played |  |
+| 0x10A0 | 0x4 | float32_t | ? | Distance ridden online |  |
+| 0x10A4 | 0x4 | float32_t | ? | Distance ridden offline |  |
+
+#### Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | ? | Version number | 25 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x18 | CgsID[3] | ? | Spawn vehicle IDs | Car, bike, and plane, respectively |
+| 0x20 | 0xC | uint32_t[3] | ? | Spawn vehicle update versions | Car, bike, and plane, respectively |
+| 0x2C | 0x4 | uint32_t | ? | Spawn vehicle index |  |
+| 0x30 | 0x108 | CarData[11] | ? | Island vehicles |  |
+| 0x138 | 0x108 | LiveryData[11] | ? | Liveries |  |
+| 0x240 | 0x4 | uint32_t | ? | Number of island events |  |
+| 0x244 | 0x78 | ProfileEvent[15] | ? | Island events |  |
+| 0x2BC | 0x28 | int32_t[10] | ? | Number of island events present, per type |  |
+| 0x2E4 | 0x28 | int32_t[10] | ? | Number of island events won, per type |  |
+| 0x30C | 0x4 | int32_t | ? | Number of island tours present |  |
+| 0x310 | 0x4 | int32_t | ? | Number of island tours won |  |
+| 0x314 | 0x4 | int32_t | ? | Island vehicle count |  |
+| 0x318 | 0x4 | int32_t | ? | Livery count |  |
+| 0x31C | 0x16C | Array<?, 45u> | ? | Island billboards | Not padded after length. See island collectible |
+| 0x488 | 0x25C | Array<?, 75u> | ? | Island smash gates | Not padded after length. See island collectible |
+| 0x6E4 | 0x7C | Array<?, 15u> | ? | Mega jumps | Not padded after length. See island collectible |
+| 0x760 | 0x8 | Array<uint32_t, 1u> | ? | Junkyards found | Not padded after length |
+| 0x768 | 0x8 | Array<uint32_t, 1u> | ? | Auto repairs found | Not padded after length |
+| 0x770 | 0xC | Array<uint32_t, 2u> | ? | Gas stations found | Not padded after length |
+| 0x77C | 0x8 | Array<uint32_t, 1u> | ? | Paint shops found | Not padded after length |
+| 0x784 | 0x4 |  |  | Padding |  |
+| 0x788 | 0x58 | Array<CgsID, 10u> | ? | Island challenges |  |
+| 0x7E0 | 0x2A0 | ChallengeHighScoreEntry[12] | ? | Best island road rules |  |
+| 0xA80 | 0x1E0 | ChallengePlayerScoreEntry[12] | ? | Player island road rules |  |
+| 0xC60 | 0x310 | ? | ? | Island bike Road Rules | See island bike Road Rules |
+| 0xF70 | 0x4 | int32_t | ? | Barrel roll record |  |
+| 0xF74 | 0x4 | float32_t | ? | Flat spin record |  |
+| 0xF78 | 0x4 | float32_t | ? | Drift distance record |  |
+| 0xF7C | 0x8 | Time | ? | In-car time played |  |
+| 0xF84 | 0x8 | Time | ? | Real time played |  |
+| 0xF8C | 0x4 | float32_t | ? | Distance driven offline |  |
+| 0xF90 | 0x4 | float32_t | ? | Distance driven online |  |
+| 0xF94 | 0x4 | float32_t | ? | Best air time |  |
+| 0xF98 | 0x4 | float32_t | ? | Best oncoming |  |
+| 0xF9C | 0x4 | int32_t | ? | Highest showtime score |  |
+| 0xFA0 | 0x4 | int32_t | ? | Best power parking |  |
+| 0xFA4 | 0x4 | int32_t | ? | Best Burnout chain |  |
+| 0xFA8 | 0x4 | int32_t | ? | Total number of takedowns |  |
+| 0xFAC | 0x4 | int32_t | ? | Best Road Rage score |  |
+| 0xFB0 | 0x8 | int64_t | ? | Best Stunt Run score |  |
+| 0xFB8 | 0x1 | uint8_t | ? |  |  |
+| 0xFB9 | 0x1 | bool | ? | Island welcome shown |  |
+| 0xFBA | 0x1 | bool | ? | 100% completed |  |
+| 0xFBB | 0x1 |  |  | Padding |  |
+| 0xFBC | 0xC | DateAndTime | ? | Island license issue date |  |
+| 0xFC8 | 0x4 | float32_t | ? | Best wheelie |  |
+| 0xFCC | 0x4 | float32_t | ? | Best bike jump distance |  |
+| 0xFD0 | 0x8 | Time | ? | Bike time played |  |
+| 0xFD8 | 0x4 | float32_t | ? | Distance ridden online |  |
+| 0xFDC | 0x4 | float32_t | ? | Distance ridden offline |  |
+
+#### PlayStation 4
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | ? | Version number | 25 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x18 | CgsID[3] | ? | Spawn vehicle IDs | Car, bike, and plane, respectively |
+| 0x20 | 0xC | uint32_t[3] | ? | Spawn vehicle update versions | Car, bike, and plane, respectively |
+| 0x2C | 0x4 | uint32_t | ? | Spawn vehicle index |  |
+| 0x30 | 0x108 | CarData[11] | ? | Island vehicles |  |
+| 0x138 | 0x108 | LiveryData[11] | ? | Liveries |  |
+| 0x240 | 0x4 | uint32_t | ? | Number of island events |  |
+| 0x244 | 0x78 | ProfileEvent[15] | ? | Island events |  |
+| 0x2BC | 0x28 | int32_t[10] | ? | Number of island events present, per type |  |
+| 0x2E4 | 0x28 | int32_t[10] | ? | Number of island events won, per type |  |
+| 0x30C | 0x4 | int32_t | ? | Number of island tours present |  |
+| 0x310 | 0x4 | int32_t | ? | Number of island tours won |  |
+| 0x314 | 0x4 | int32_t | ? | Island vehicle count |  |
+| 0x318 | 0x4 | int32_t | ? | Livery count |  |
+| 0x31C | 0x16C | Array<?, 45u> | ? | Island billboards | Not padded after length. See island collectible |
+| 0x488 | 0x25C | Array<?, 75u> | ? | Island smash gates | Not padded after length. See island collectible |
+| 0x6E4 | 0x7C | Array<?, 15u> | ? | Mega jumps | Not padded after length. See island collectible |
+| 0x760 | 0x8 | Array<uint32_t, 1u> | ? | Junkyards found | Not padded after length |
+| 0x768 | 0x8 | Array<uint32_t, 1u> | ? | Auto repairs found | Not padded after length |
+| 0x770 | 0xC | Array<uint32_t, 2u> | ? | Gas stations found | Not padded after length |
+| 0x77C | 0x8 | Array<uint32_t, 1u> | ? | Paint shops found | Not padded after length |
+| 0x784 | 0x4 |  |  | Padding |  |
+| 0x788 | 0x58 | Array<CgsID, 10u> | ? | Island challenges |  |
+| 0x7E0 | 0x3C0 | ChallengeHighScoreEntry[12] | ? | Best island road rules |  |
+| 0xBA0 | 0x1E0 | ChallengePlayerScoreEntry[12] | ? | Player island road rules |  |
+| 0xD80 | 0x3E8 | ? | ? | Island bike Road Rules | See island bike Road Rules |
+| 0x1168 | 0x4 | int32_t | ? | Barrel roll record |  |
+| 0x116C | 0x4 | float32_t | ? | Flat spin record |  |
+| 0x1170 | 0x4 | float32_t | ? | Drift distance record |  |
+| 0x1174 | 0x8 | Time | ? | In-car time played |  |
+| 0x117C | 0x8 | Time | ? | Real time played |  |
+| 0x1184 | 0x4 | float32_t | ? | Distance driven offline |  |
+| 0x1188 | 0x4 | float32_t | ? | Distance driven online |  |
+| 0x118C | 0x4 | float32_t | ? | Best air time |  |
+| 0x1190 | 0x4 | float32_t | ? | Best oncoming |  |
+| 0x1194 | 0x4 | int32_t | ? | Highest showtime score |  |
+| 0x1198 | 0x4 | int32_t | ? | Best power parking |  |
+| 0x119C | 0x4 | int32_t | ? | Best Burnout chain |  |
+| 0x11A0 | 0x4 | int32_t | ? | Total number of takedowns |  |
+| 0x11A4 | 0x4 | int32_t | ? | Best Road Rage score |  |
+| 0x11A8 | 0x8 | int64_t | ? | Best Stunt Run score |  |
+| 0x11B0 | 0x1 | uint8_t | ? |  |  |
+| 0x11B1 | 0x1 | bool | ? | Island welcome shown |  |
+| 0x11B2 | 0x1 | bool | ? | 100% completed |  |
+| 0x11B3 | 0x5 |  |  | Padding |  |
+| 0x11B8 | 0x10 | DateAndTime | ? | Island license issue date |  |
+| 0x11C8 | 0x4 | float32_t | ? | Best wheelie |  |
+| 0x11CC | 0x4 | float32_t | ? | Best bike jump distance |  |
+| 0x11D0 | 0x8 | Time | ? | Bike time played |  |
+| 0x11D8 | 0x4 | float32_t | ? | Distance ridden online |  |
+| 0x11DC | 0x4 | float32_t | ? | Distance ridden offline |  |
+
+#### PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | ? | Version number | 25 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x18 | CgsID[3] | ? | Spawn vehicle IDs | Car, bike, and plane, respectively |
+| 0x20 | 0xC | uint32_t[3] | ? | Spawn vehicle update versions | Car, bike, and plane, respectively |
+| 0x2C | 0x4 | uint32_t | ? | Spawn vehicle index |  |
+| 0x30 | 0x108 | CarData[11] | ? | Island vehicles |  |
+| 0x138 | 0x108 | LiveryData[11] | ? | Liveries |  |
+| 0x240 | 0x4 | uint32_t | ? | Number of island events |  |
+| 0x244 | 0x78 | ProfileEvent[15] | ? | Island events |  |
+| 0x2BC | 0x28 | int32_t[10] | ? | Number of island events present, per type |  |
+| 0x2E4 | 0x28 | int32_t[10] | ? | Number of island events won, per type |  |
+| 0x30C | 0x4 | int32_t | ? | Number of island tours present |  |
+| 0x310 | 0x4 | int32_t | ? | Number of island tours won |  |
+| 0x314 | 0x4 | int32_t | ? | Island vehicle count |  |
+| 0x318 | 0x4 | int32_t | ? | Livery count |  |
+| 0x31C | 0x16C | Array<?, 45u> | ? | Island billboards | Not padded after length. See island collectible |
+| 0x488 | 0x25C | Array<?, 75u> | ? | Island smash gates | Not padded after length. See island collectible |
+| 0x6E4 | 0x7C | Array<?, 15u> | ? | Mega jumps | Not padded after length. See island collectible |
+| 0x760 | 0x8 | Array<uint32_t, 1u> | ? | Junkyards found | Not padded after length |
+| 0x768 | 0x8 | Array<uint32_t, 1u> | ? | Auto repairs found | Not padded after length |
+| 0x770 | 0xC | Array<uint32_t, 2u> | ? | Gas stations found | Not padded after length |
+| 0x77C | 0x8 | Array<uint32_t, 1u> | ? | Paint shops found | Not padded after length |
+| 0x784 | 0x4 |  |  | Padding |  |
+| 0x788 | 0x58 | Array<CgsID, 10u> | ? | Island challenges |  |
+| 0x7E0 | 0x3C0 | ChallengeHighScoreEntry[12] | ? | Best island road rules |  |
+| 0xBA0 | 0x1E0 | ChallengePlayerScoreEntry[12] | ? | Player island road rules |  |
+| 0xD80 | 0x3E8 | ? | ? | Island bike Road Rules | See island bike Road Rules |
+| 0x1168 | 0x4 | int32_t | ? | Barrel roll record |  |
+| 0x116C | 0x4 | float32_t | ? | Flat spin record |  |
+| 0x1170 | 0x4 | float32_t | ? | Drift distance record |  |
+| 0x1174 | 0x8 | Time | ? | In-car time played |  |
+| 0x117C | 0x8 | Time | ? | Real time played |  |
+| 0x1184 | 0x4 | float32_t | ? | Distance driven offline |  |
+| 0x1188 | 0x4 | float32_t | ? | Distance driven online |  |
+| 0x118C | 0x4 | float32_t | ? | Best air time |  |
+| 0x1190 | 0x4 | float32_t | ? | Best oncoming |  |
+| 0x1194 | 0x4 | int32_t | ? | Highest showtime score |  |
+| 0x1198 | 0x4 | int32_t | ? | Best power parking |  |
+| 0x119C | 0x4 | int32_t | ? | Best Burnout chain |  |
+| 0x11A0 | 0x4 | int32_t | ? | Total number of takedowns |  |
+| 0x11A4 | 0x4 | int32_t | ? | Best Road Rage score |  |
+| 0x11A8 | 0x8 | int64_t | ? | Best Stunt Run score |  |
+| 0x11B0 | 0x1 | uint8_t | ? |  |  |
+| 0x11B1 | 0x1 | bool | ? | Island welcome shown |  |
+| 0x11B2 | 0x1 | bool | ? | 100% completed |  |
+| 0x11B3 | 0x1 |  |  | Padding |  |
+| 0x11B4 | 0xC | DateAndTime | ? | Island license issue date |  |
+| 0x11C0 | 0x4 | float32_t | ? | Best wheelie |  |
+| 0x11C4 | 0x4 | float32_t | ? | Best bike jump distance |  |
+| 0x11C8 | 0x8 | Time | ? | Bike time played |  |
+| 0x11D0 | 0x4 | float32_t | ? | Distance ridden online |  |
+| 0x11D4 | 0x4 | float32_t | ? | Distance ridden offline |  |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | ? | Version number | 25 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x18 | CgsID[3] | ? | Spawn vehicle IDs | Car, bike, and plane, respectively |
+| 0x20 | 0xC | uint32_t[3] | ? | Spawn vehicle update versions | Car, bike, and plane, respectively |
+| 0x2C | 0x4 | uint32_t | ? | Spawn vehicle index |  |
+| 0x30 | 0x108 | CarData[11] | ? | Island vehicles |  |
+| 0x138 | 0x108 | LiveryData[11] | ? | Liveries |  |
+| 0x240 | 0x4 | uint32_t | ? | Number of island events |  |
+| 0x244 | 0x78 | ProfileEvent[15] | ? | Island events |  |
+| 0x2BC | 0x28 | int32_t[10] | ? | Number of island events present, per type |  |
+| 0x2E4 | 0x28 | int32_t[10] | ? | Number of island events won, per type |  |
+| 0x30C | 0x4 | int32_t | ? | Number of island tours present |  |
+| 0x310 | 0x4 | int32_t | ? | Number of island tours won |  |
+| 0x314 | 0x4 | int32_t | ? | Island vehicle count |  |
+| 0x318 | 0x4 | int32_t | ? | Livery count |  |
+| 0x31C | 0x16C | Array<?, 45u> | ? | Island billboards | Not padded after length. See island collectible |
+| 0x488 | 0x25C | Array<?, 75u> | ? | Island smash gates | Not padded after length. See island collectible |
+| 0x6E4 | 0x7C | Array<?, 15u> | ? | Mega jumps | Not padded after length. See island collectible |
+| 0x760 | 0x8 | Array<uint32_t, 1u> | ? | Junkyards found | Not padded after length |
+| 0x768 | 0x8 | Array<uint32_t, 1u> | ? | Auto repairs found | Not padded after length |
+| 0x770 | 0xC | Array<uint32_t, 2u> | ? | Gas stations found | Not padded after length |
+| 0x77C | 0x8 | Array<uint32_t, 1u> | ? | Paint shops found | Not padded after length |
+| 0x784 | 0x4 |  |  | Padding |  |
+| 0x788 | 0x58 | Array<CgsID, 10u> | ? | Island challenges |  |
+| 0x7E0 | 0x480 | ChallengeHighScoreEntry[12] | ? | Best island road rules |  |
+| 0xC60 | 0x1E0 | ChallengePlayerScoreEntry[12] | ? | Player island road rules |  |
+| 0xE40 | 0x4A8 | ? | ? | Island bike Road Rules | See island bike Road Rules |
+| 0x12E8 | 0x4 | int32_t | ? | Barrel roll record |  |
+| 0x12EC | 0x4 | float32_t | ? | Flat spin record |  |
+| 0x12F0 | 0x4 | float32_t | ? | Drift distance record |  |
+| 0x12F4 | 0x8 | Time | ? | In-car time played |  |
+| 0x12FC | 0x8 | Time | ? | Real time played |  |
+| 0x1304 | 0x4 | float32_t | ? | Distance driven offline |  |
+| 0x1308 | 0x4 | float32_t | ? | Distance driven online |  |
+| 0x130C | 0x4 | float32_t | ? | Best air time |  |
+| 0x1310 | 0x4 | float32_t | ? | Best oncoming |  |
+| 0x1314 | 0x4 | int32_t | ? | Highest showtime score |  |
+| 0x1318 | 0x4 | int32_t | ? | Best power parking |  |
+| 0x131C | 0x4 | int32_t | ? | Best Burnout chain |  |
+| 0x1320 | 0x4 | int32_t | ? | Total number of takedowns |  |
+| 0x1324 | 0x4 | int32_t | ? | Best Road Rage score |  |
+| 0x1328 | 0x8 | int64_t | ? | Best Stunt Run score |  |
+| 0x1330 | 0x1 | uint8_t | ? |  |  |
+| 0x1331 | 0x1 | bool | ? | Island welcome shown |  |
+| 0x1332 | 0x1 | bool | ? | 100% completed |  |
+| 0x1333 | 0x5 |  |  | Padding |  |
+| 0x1338 | 0x10 | DateAndTime | ? | Island license issue date |  |
+| 0x1348 | 0x4 | float32_t | ? | Best wheelie |  |
+| 0x134C | 0x4 | float32_t | ? | Best bike jump distance |  |
+| 0x1350 | 0x8 | Time | ? | Bike time played |  |
+| 0x1358 | 0x4 | float32_t | ? | Distance ridden online |  |
+| 0x135C | 0x4 | float32_t | ? | Distance ridden offline |  |
+
+### BrnProgression::CarData
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | CgsID | mId | Vehicle ID |  |
+| 0x8 | 0x1 | uint8_t | mu8ColourIndex | Color index | From the Player Car Colours resource |
+| 0x9 | 0x1 | uint8_t | mu8PaletteIndex | Color palette/type index | From the Player Car Colours resource |
+| 0xA | 0x1 | bool | mbUnlockSequenceAlreadyShown | Has Junkyard unlock animation been played |  |
+| 0xB | 0x1 | uint8_t | ? | Version flags from the Vehicle List resource | Padding prior to game version 1.3 |
+| 0xC | 0x4 | float32_t | mfUnlockDeformedAmount | Damage applied to the car |  |
+| 0x10 | 0x4 | UnlockType | meUnlockType | Vehicle unlock type |  |
+| 0x14 | 0x4 |  |  | Padding |  |
+
+### BrnProgression::LiveryData
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | CgsID | mBaseCarId |  |  |
+| 0x8 | 0x8 | CgsID | mChosenLiveryCarId |  |  |
+| 0x10 | 0x4 | float32_t | mfDistanceDriven |  |  |
+| 0x14 | 0x1 | uint8_t | ? | Version flags from the Vehicle List resource | Padding prior to version 1.3 |
+| 0x15 | 0x3 | ? | ? | Padding |  |
+
+### BrnProgression::ProfileEvent
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | uint32_t | muEventID | Event junction ID |  |
+| 0x4 | 0x2 | uint16_t | muFlags | Event flags | See Flags |
+| 0x6 | 0x2 |  |  | Padding |  |
+
+### Island collectible
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | uint32_t | ? | Collectible GameDB ID |  |
+| 0x4 | 0x4 | uint32_t | ? | District | See districts |
+
+### BrnStreetData::ChallengeHighScoreEntry
+
+#### PlayStation 3
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x18 | ChallengeData | super_ChallengeData |  |  |
+| 0x18 | 0x28 | PlayerName[2] | maPlayerNames |  | See ScoreType for index names |
+
+#### Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x18 | ChallengeData | super_ChallengeData |  |  |
+| 0x18 | 0x20 | PlayerName[2] | maPlayerNames |  | See ScoreType for index names |
+
+#### PlayStation 4, PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x18 | ChallengeData | super_ChallengeData |  |  |
+| 0x18 | 0x32 | PlayerName[2] | maPlayerNames |  | See ScoreType for index names |
+| 0x4A | 0x6 |  |  | Padding |  |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x18 | ChallengeData | super_ChallengeData |  |  |
+| 0x18 | 0x42 | PlayerName[2] | maPlayerNames |  | See ScoreType for index names |
+| 0x5A | 0x6 |  |  | Padding |  |
+
+### BrnStreetData::ChallengeData
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | BitArray<2u> | mDirty |  | See ScoreType for index names |
+| 0x8 | 0x8 | BitArray<2u> | mValidScores |  | See ScoreType for index names |
+| 0x10 | 0x8 | ScoreList | mScoreList |  |  |
+
+### BrnStreetData::ScoreList
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | int32_t[2] | maScores | Time and showtime score, respectively | See ScoreType for index names |
+
+### CgsNetwork::PlayerName
+
+#### PlayStation 3
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x14 | char[20] | macName | Online player's name |  |
+
+#### Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x10 | char[16] | macName | Online player's name |  |
+
+#### PlayStation 4, PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x19 | char[25] | macName | Online player's name |  |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x21 | char[33] | macName | Online player's name |  |
+
+### BrnStreetData::ChallengePlayerScoreEntry
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x18 | ChallengeData | super_ChallengeData |  |  |
+| 0x18 | 0x10 | CgsID[2] | maCarIDs |  | See ScoreType for index names |
+
+### Island bike Road Rules
+
+2 sets of 12, first is day, second is night.
+
+#### PlayStation 3
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0xC0 | CgsID[12][2] | ? | Vehicles used |  |
+| 0xC0 | 0x60 | int32_t[12][2] | ? | Player scores |  |
+| 0x120 | 0x60 | int32_t[12][2] | ? | Friends' best scores |  |
+| 0x180 | 0x1E0 | PlayerName[12][2] | ? | Friends' names |  |
+| 0x360 | 0x10 | BitArray<12u>[2] | ? | Dirty |  |
+
+#### Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0xC0 | CgsID[12][2] | ? | Vehicles used |  |
+| 0xC0 | 0x60 | int32_t[12][2] | ? | Player scores |  |
+| 0x120 | 0x60 | int32_t[12][2] | ? | Friends' best scores |  |
+| 0x180 | 0x180 | PlayerName[12][2] | ? | Friends' names |  |
+| 0x300 | 0x10 | BitArray<12u>[2] | ? | Dirty |  |
+
+#### PlayStation 4, PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0xC0 | CgsID[12][2] | ? | Vehicles used |  |
+| 0xC0 | 0x60 | int32_t[12][2] | ? | Player scores |  |
+| 0x120 | 0x60 | int32_t[12][2] | ? | Friends' best scores |  |
+| 0x180 | 0x258 | PlayerName[12][2] | ? | Friends' names |  |
+| 0x3D8 | 0x10 | BitArray<12u>[2] | ? | Dirty |  |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0xC0 | CgsID[12][2] | ? | Vehicles used |  |
+| 0xC0 | 0x60 | int32_t[12][2] | ? | Player scores |  |
+| 0x120 | 0x60 | int32_t[12][2] | ? | Friends' best scores |  |
+| 0x180 | 0x318 | PlayerName[12][2] | ? | Friends' names |  |
+| 0x498 | 0x10 | BitArray<12u>[2] | ? | Dirty |  |
+
+### CgsSystem::Time
+
+Precise time counter used as a replacement for floats starting in version 1.3.
+
+| Offset | Size | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miSeconds | Seconds |  |
+| 0x4 | 0x4 | float32_t | mfFraction | Milliseconds |  |
+
+### CgsSystem::DateAndTime
+
+#### PlayStation 3, PlayStation 4, Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x1 | bool | mbIsLocal | Defines whether the saved time is in a local time zone or UTC |  |
+| 0x1 | 0x7 |  |  | Padding |  |
+| 0x8 | 0x8 | time_t | mSystemTime | The time value |  |
+
+#### Xbox 360, PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x1 | bool | mbIsLocal | Defines whether the saved time is in a local time zone or UTC |  |
+| 0x1 | 0x3 |  |  | Padding |  |
+| 0x8 | 0x8 | FILETIME | mSystemTime | The time value |  |
+
+## Enumerations
+
+### BrnProgression::CarData::UnlockType
+
+| Name | Value | Comment |
+| --- | --- | --- |
+| E_UNLOCK_TYPE_UNLOCK | 0 | Unlocked at start |
+| E_UNLOCK_TYPE_GIFT | 1 | Secondary finishes and Burning Route unlocks |
+| E_UNLOCK_TYPE_TROPHY | 2 | Unlocked through achievements (carbon cars) |
+| E_UNLOCK_TYPE_SHUTDOWN_RIVAL | 3 |  |
+| E_UNLOCK_TYPE_GOLD_SILVER | 4 | Gold and platinum cars |
+| E_UNLOCK_TYPE_SPONSOR | 5 | Will not show until a certain rank is reached |
+| ? | 6 | Used on online cars. Causes vehicles to only show while online |
+| ? | 7 | Used on Beat The Team community cars (Tempesta Dream/Tiger GT) |
+| ? | 8 | Used on PDLC vehicles |
+| ? | 9 | Used on Cop Cars |
+| ? | 10 | Island gift |
+| ? | 11 | Island unlock |
+
+### BrnProgression::ProfileEvent::Flags
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_FLAG_UNDISCOVERED | 0x0 |  |
+| E_FLAG_DISCOVERED | 0x1 |  |
+| E_FLAG_FINISHED | 0x2 |  |
+| E_FLAG_RANK_WIN | 0x4 |  |
+| E_FLAG_NON_RANK_WIN | 0x8 |  |
+| E_FLAG_WON_SPECIAL_EVENT_BEFORE | 0x10 |  |
+| E_FLAG_WON_EVENT_BEFORE | 0x20 |  |
+
+### BrnStreetData::ScoreType
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_SCORE_TYPE_START | 0 |  |
+| E_SCORE_TYPE_TIME | 0 |  |
+| E_SCORE_TYPE_CRASH | 1 |  |
+| E_SCORE_TYPE_COUNT | 2 |  |

--- a/docs/save-profile/live-revenge-profile.md
+++ b/docs/save-profile/live-revenge-profile.md
@@ -1,0 +1,214 @@
+# Profile/Burnout Paradise/Live Revenge Profile
+
+> Source: https://burnout.wiki/wiki/Profile/Burnout_Paradise/Live_Revenge_Profile (mirrored 2026-06-22)
+
+The Live Revenge profile tracks online relationships with with other players, storing statistics such as takedown counts and event wins. These are displayed during online event intros.
+
+## Structures
+
+### BrnNetwork::LiveRevengeProfile
+
+#### PlayStation 3, Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber |  | 6 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x7538 | Array<LiveRevengeRelationship, 250u> | maRelationshipTable |  |  |
+
+#### PC
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber |  | 7 |
+| 0x4 | 0x6D64 | Array<LiveRevengeRelationship, 250u> | maRelationshipTable |  | Array not padded after length |
+
+#### PlayStation 4
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber |  | 6 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x7D08 | Array<LiveRevengeRelationship, 250u> | maRelationshipTable |  |  |
+
+#### Xbox One, PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber |  | 7 |
+| 0x4 | 0x7534 | Array<LiveRevengeRelationship, 250u> | maRelationshipTable |  | Array not padded after length |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber |  | 6 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x84D8 | Array<LiveRevengeRelationship, 250u> | maRelationshipTable |  |  |
+
+### BrnNetwork::LiveRevengeRelationship
+
+#### PlayStation 3
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x48 | CommonRelationship | mOverallStats |  |  |
+| 0x48 | 0x10 | DateAndTime | mLastTimeChanged |  |  |
+| 0x58 | 0x14 | UniquePlayerID | mUniqueID |  |  |
+| 0x6C | 0x4 | int32_t | miCurrentScoreForPlayersPointOfView |  |  |
+| 0x70 | 0x4 | uint32_t | miTotalEvents |  |  |
+| 0x74 | 0x4 |  |  | Padding |  |
+
+#### Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x48 | CommonRelationship | mOverallStats |  |  |
+| 0x48 | 0xC | DateAndTime | mLastTimeChanged |  |  |
+| 0x54 | 0x4 |  |  | Padding |  |
+| 0x58 | 0x18 | UniquePlayerID | mUniqueID |  |  |
+| 0x70 | 0x4 | int32_t | miCurrentScoreForPlayersPointOfView |  |  |
+| 0x74 | 0x4 | uint32_t | miTotalEvents |  |  |
+
+#### PC
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x48 | CommonRelationship | mOverallStats |  |  |
+| 0x48 | 0xC | DateAndTime | mLastTimeChanged |  |  |
+| 0x54 | 0x14 | UniquePlayerID | mUniqueID |  |  |
+| 0x68 | 0x4 | int32_t | miCurrentScoreForPlayersPointOfView |  |  |
+| 0x6C | 0x4 | uint32_t | miTotalEvents |  |  |
+
+#### PlayStation 4
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x48 | CommonRelationship | mOverallStats |  |  |
+| 0x48 | 0x10 | DateAndTime | mLastTimeChanged |  |  |
+| 0x58 | 0x19 | UniquePlayerID | mUniqueID |  |  |
+| 0x71 | 0x3 |  |  | Padding |  |
+| 0x74 | 0x4 | int32_t | miCurrentScoreForPlayersPointOfView |  |  |
+| 0x78 | 0x4 | uint32_t | miTotalEvents |  |  |
+| 0x7C | 0x4 |  |  | Padding |  |
+
+#### Xbox One, PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x48 | CommonRelationship | mOverallStats |  |  |
+| 0x48 | 0xC | DateAndTime | mLastTimeChanged |  |  |
+| 0x54 | 0x19 | UniquePlayerID | mUniqueID |  |  |
+| 0x6D | 0x3 |  |  | Padding |  |
+| 0x70 | 0x4 | int32_t | miCurrentScoreForPlayersPointOfView |  |  |
+| 0x74 | 0x4 | uint32_t | miTotalEvents |  |  |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x48 | CommonRelationship | mOverallStats |  |  |
+| 0x48 | 0x10 | DateAndTime | mLastTimeChanged |  |  |
+| 0x58 | 0x21 | UniquePlayerID | mUniqueID |  |  |
+| 0x79 | 0x3 |  |  | Padding |  |
+| 0x7C | 0x4 | int32_t | miCurrentScoreForPlayersPointOfView |  |  |
+| 0x80 | 0x4 | uint32_t | miTotalEvents |  |  |
+| 0x84 | 0x4 |  |  | Padding |  |
+
+### BrnNetwork::CommonRelationship
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x24 | CommonRelationshipStats | mPlayerStats |  |  |
+| 0x24 | 0x24 | CommonRelationshipStats | mRivalStats |  |  |
+
+### BrnNetwork::CommonRelationshipStats
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miTakedowns |  |  |
+| 0x4 | 0x4 | int32_t | miScalps |  |  |
+| 0x8 | 0x4 | int32_t | miLongestStreak |  |  |
+| 0xC | 0x4 | int32_t | miWins |  |  |
+| 0x10 | 0x4 | int32_t | miMarks |  |  |
+| 0x14 | 0x4 | int32_t | miScoresSettled |  |  |
+| 0x18 | 0x4 | int32_t | miEventsSinceLastTakedown |  |  |
+| 0x1C | 0x4 | int32_t | miPaybacksScored |  |  |
+| 0x20 | 0x4 | int32_t | miPaybacksDealt |  |  |
+
+### CgsSystem::DateAndTime
+
+#### PlayStation 3, PlayStation 4, Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x1 | bool | mbIsLocal | Defines whether the saved time is in a local time zone or UTC |  |
+| 0x1 | 0x7 |  |  | Padding |  |
+| 0x8 | 0x8 | time_t | mSystemTime | The time value |  |
+
+#### Xbox 360, PC, Xbox One, PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x1 | bool | mbIsLocal | Defines whether the saved time is in a local time zone or UTC |  |
+| 0x1 | 0x3 |  |  | Padding |  |
+| 0x4 | 0x8 | FILETIME | mSystemTime | The time value |  |
+
+### CgsNetwork::UniquePlayerIDPS3
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x14 | PlayerName | mPlayerName | Player name |  |
+
+### CgsNetwork::UniquePlayerIDX360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x10 | PlayerName | mPlayerName | Player name |  |
+| 0x10 | 0x8 | int64_t | ? | XUID |  |
+
+### CgsNetwork::PlayerName
+
+#### PlayStation 3, PC
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x14 | char[20] | macName | Online player's name |  |
+
+#### Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x10 | char[16] | macName | Online player's name |  |
+
+#### PlayStation 4, Xbox One, PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x19 | char[25] | macName | Online player's name |  |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x21 | char[33] | macName | Online player's name |  |
+
+## Typedefs
+
+### BrnProgression::MugshotInfo::UniquePlayerID
+
+#### PlayStation 3
+
+| Name | Type | Length | Comments |
+| --- | --- | --- | --- |
+| UniquePlayerID | UniquePlayerIDPS3 | 0x14 |  |
+
+#### Xbox 360
+
+| Name | Type | Length | Comments |
+| --- | --- | --- | --- |
+| UniquePlayerID | UniquePlayerIDX360 | 0x18 |  |
+
+#### Other platforms
+
+Similar to UniquePlayerIDPS3 but with an unknown type name. See PlayerName.

--- a/docs/save-profile/options-data-profile.md
+++ b/docs/save-profile/options-data-profile.md
@@ -1,0 +1,228 @@
+# Profile/Burnout Paradise/Options Data Profile
+
+> Source: https://burnout.wiki/wiki/Profile/Burnout_Paradise/Options_Data_Profile (mirrored 2026-06-22)
+
+> Subpage: Development — Information on the development of the options data profile.
+
+The options data profile contains all options used by the game, including volume, soundtrack, brightness/contrast, gamma, camera, and controller settings. It also stores saved online routes.
+
+**Note:** On PC, some settings are stored in an external configuration file, config.ini, rather than the profile.
+
+## Structures
+
+### BrnGui::OptionsDataProfile_1_0
+
+#### PlayStation 3, Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber |  | 12 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x3980 | OnlineSaveRoute[10] | maCreatedOnlineGameOptions |  |  |
+| 0x3988 | 0x3980 | OnlineSaveRoute[10] | maReceivedOnlineGameOptions |  |  |
+| 0x7308 | 0x4 | int32_t | miNumCreatedOnlineGameOptions |  |  |
+| 0x730C | 0x4 | int32_t | miNumReceivedOnlineGameOptions |  |  |
+| 0x7310 | 0x10 | EATraxArrayType | mTraxAvailableInFreeBurn |  |  |
+| 0x7320 | 0x10 | EATraxArrayType | mTraxAvailableInEvents |  |  |
+| 0x7330 | 0x10 | EATraxArrayType | mTraxFullyPlayed |  |  |
+| 0x7340 | 0x4 | ETraxPlayOrderMode | meTraxPlayOrderMode |  |  |
+| 0x7344 | 0x4 | int32_t | miLastPlayedSongIndex |  |  |
+| 0x7348 | 0x4 | int32_t | miLastPictureParadiseMusicIndex |  |  |
+| 0x734C | 0x4 | DirectorProfileData | mDirectorProfileData |  |  |
+| 0x7350 | 0x4 | int32_t | mBrightness |  |  |
+| 0x7354 | 0x4 | int32_t | mContrast |  |  |
+| 0x7358 | 0x4 | int32_t | miVoipVolume |  |  |
+| 0x735C | 0x4 | int32_t | mMusicVolume |  |  |
+| 0x7360 | 0x4 | int32_t | mSFXVolume |  |  |
+| 0x7364 | 0x4 | ECameraUserOptions | meCameraFeedSetting |  |  |
+| 0x7368 | 0x1 | bool | mbIsNewsUnread |  |  |
+| 0x7369 | 0x1 | bool | mbSixAxisShowtime |  |  |
+| 0x736A | 0x1 | bool | mbSixAxisSteering |  |  |
+| 0x736B | 0x1 | bool | mbForceFeedback |  |  |
+| 0x736C | 0x1 | bool | mbDefaultGameCamera |  | Unused (not written to) |
+| 0x736D | 0x1 | bool | mbTips |  |  |
+| 0x736E | 0x1 | bool | mbIsLocked |  |  |
+| 0x736F | 0x1 |  |  | Padding |  |
+
+#### PC
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber |  | 15 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x3980 | OnlineSaveRoute[10] | maCreatedOnlineGameOptions |  |  |
+| 0x3988 | 0x3980 | OnlineSaveRoute[10] | maReceivedOnlineGameOptions |  |  |
+| 0x7308 | 0x4 | int32_t | miNumCreatedOnlineGameOptions |  |  |
+| 0x730C | 0x4 | int32_t | miNumReceivedOnlineGameOptions |  |  |
+| 0x7310 | 0x10 | EATraxArrayType | mTraxAvailableInFreeBurn |  |  |
+| 0x7320 | 0x10 | EATraxArrayType | mTraxAvailableInEvents |  |  |
+| 0x7330 | 0x10 | EATraxArrayType | mTraxFullyPlayed |  |  |
+| 0x7340 | 0x4 | ETraxPlayOrderMode | meTraxPlayOrderMode |  |  |
+| 0x7344 | 0x4 | int32_t | miLastPlayedSongIndex |  |  |
+| 0x7348 | 0x4 | int32_t | miLastPictureParadiseMusicIndex |  |  |
+| 0x734C | 0x4 | DirectorProfileData | mDirectorProfileData |  |  |
+| 0x7350 | 0x4 | int32_t | mBrightness |  |  |
+| 0x7354 | 0x4 | int32_t | mContrast |  |  |
+| 0x7358 | 0x4 | float32_t | ? | Gamma |  |
+| 0x735C | 0x4 | int32_t | miVoipVolume |  |  |
+| 0x7360 | 0x4 | int32_t | mMusicVolume |  |  |
+| 0x7364 | 0x4 | int32_t | mSFXVolume |  |  |
+| 0x7368 | 0x4 | ECameraUserOptions | meCameraFeedSetting |  |  |
+| 0x736C | 0x1 | bool | mbIsNewsUnread |  |  |
+| 0x736D | 0x1 | bool | mbSixAxisShowtime |  |  |
+| 0x736E | 0x1 | bool | mbSixAxisSteering |  |  |
+| 0x736F | 0x1 | bool | mbForceFeedback |  |  |
+| 0x7370 | 0x1 | bool | mbDefaultGameCamera |  | Unused (not written to) |
+| 0x7371 | 0x1 | bool | mbTips |  |  |
+| 0x7372 | 0x400 | char[1024] | ? | Autologin information? | Token? First 0x2A always same |
+| 0x7772 | 0x2 |  |  | Padding |  |
+| 0x7774 | 0x4 | uint32_t | ? |  | Always 1 |
+| 0x7778 | 0x1 | uint8_t | ? | mbIsLocked? | Always 0 |
+| 0x7779 | 0x7 |  |  | Padding |  |
+
+#### Remastered
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber |  | 12 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x3980 | OnlineSaveRoute[10] | maCreatedOnlineGameOptions |  |  |
+| 0x3988 | 0x3980 | OnlineSaveRoute[10] | maReceivedOnlineGameOptions |  |  |
+| 0x7308 | 0x4 | int32_t | miNumCreatedOnlineGameOptions |  |  |
+| 0x730C | 0x4 | int32_t | miNumReceivedOnlineGameOptions |  |  |
+| 0x7310 | 0x10 | EATraxArrayType | mTraxAvailableInFreeBurn |  |  |
+| 0x7320 | 0x10 | EATraxArrayType | mTraxAvailableInEvents |  |  |
+| 0x7330 | 0x10 | EATraxArrayType | mTraxFullyPlayed |  |  |
+| 0x7340 | 0x4 | ETraxPlayOrderMode | meTraxPlayOrderMode |  |  |
+| 0x7344 | 0x4 | int32_t | miLastPlayedSongIndex |  |  |
+| 0x7348 | 0x4 | int32_t | miLastPictureParadiseMusicIndex |  |  |
+| 0x734C | 0x4 | DirectorProfileData | mDirectorProfileData |  |  |
+| 0x7350 | 0x4 | int32_t | mBrightness |  |  |
+| 0x7354 | 0x4 | int32_t | mContrast |  |  |
+| 0x7358 | 0x4 | float32_t | ? | Gamma |  |
+| 0x735C | 0x400 | char[1024] | ? | Autologin information? | Null in Remastered |
+| 0x775C | 0x4 | int32_t | miVoipVolume |  |  |
+| 0x7760 | 0x4 | int32_t | mMusicVolume |  |  |
+| 0x7764 | 0x4 | int32_t | mSFXVolume |  |  |
+| 0x7768 | 0x4 | ECameraUserOptions | meCameraFeedSetting |  |  |
+| 0x776C | 0x1 | bool | mbIsNewsUnread |  |  |
+| 0x776D | 0x1 | bool | mbSixAxisShowtime |  |  |
+| 0x776E | 0x1 | bool | mbSixAxisSteering |  |  |
+| 0x776F | 0x1 | bool | mbForceFeedback |  |  |
+| 0x7770 | 0x1 | bool | mbDefaultGameCamera |  | Unused (not written to) |
+| 0x7771 | 0x1 | bool | mbTips |  |  |
+| 0x7772 | 0x1 | bool | mbIsLocked |  |  |
+| 0x7773 | 0x5 |  |  | Padding |  |
+
+### BrnGui::OptionsDataProfile::OnlineSaveRoute
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x5A0 | OnlineSaveRouteEvent[10] | maEvents |  |  |
+| 0x5A0 | 0x4 | EGameModeType | meGameMode |  |  |
+| 0x5A4 | 0x4 | EBoostType | meBoostType |  |  |
+| 0x5A8 | 0x4 | EVehicleChoice | meVehicleChoice |  |  |
+| 0x5AC | 0x4 | int32_t | miTimeLimit |  |  |
+| 0x5B0 | 0x4 | int32_t | miNumRounds |  |  |
+| 0x5B4 | 0x4 | int32_t | miVehicleClass |  |  |
+| 0x5B8 | 0x4 | int32_t | miNumRunnerCrashes |  |  |
+| 0x5BC | 0x1 | bool | mbInfiniteBoost |  |  |
+| 0x5BD | 0x1 | bool | mbTrafficOn |  |  |
+| 0x5BE | 0x1 | bool | mbTrafficCheckingOn |  |  |
+| 0x5BF | 0x1 |  |  | Padding |  |
+
+### BrnGui::OptionsDataProfile::OnlineSaveRoute::OnlineSaveRouteEvent
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x80 | CgsID[16] | maLandmarkIndices | Checkpoint and finish Landmarks from Trigger Data |  |
+| 0x80 | 0x4 | uint32_t | mJunctionId | Event start junction from Traffic Data |  |
+| 0x84 | 0x4 | int32_t | miNumLandmarks | Number of checkpoints, including finish |  |
+| 0x88 | 0x4 | int32_t | miEventID | Event tied to the junction in Traffic Data |  |
+| 0x8C | 0x4 |  |  | Padding |  |
+
+### BrnDirector::GameState::DirectorProfileData
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | ECameraMode | meCameraMode |  |  |
+
+## Typedefs
+
+### BrnGui::GuiEventAudioTraxUpdate::EATraxArrayType
+
+| Name | Type | Length | Comments |
+| --- | --- | --- | --- |
+| EATraxArrayType | FastBitArray<128u> | 0x10 |  |
+
+## Enumerations
+
+### BrnGameState::GameStateModuleIO::EGameModeType
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_MODE_NONE | -1 |  |
+| E_MODE_OFFLINE_RACE | 0 |  |
+| E_MODE_FACE_OFF | 1 |  |
+| E_MODE_OFFLINE_SHOWTIME | 2 |  |
+| E_MODE_ROAD_RAGE | 3 |  |
+| E_MODE_PURSUIT | 4 |  |
+| E_MODE_BURNING_ROUTE | 5 |  |
+| E_MODE_ELIMINATOR | 6 |  |
+| E_MODE_STUNT_ATTACK | 7 |  |
+| E_MODE_MARKED_MAN | 8 |  |
+| E_MODE_TRAFFIC_ATTACK | 9 |  |
+| E_MODE_OFFLINE_COUNT | 10 |  |
+| E_MODE_ONLINE_MODE_START | 10 |  |
+| E_MODE_ONLINE_RACE | 10 |  |
+| E_MODE_ONLINE_ROAD_RAGE | 11 |  |
+| E_MODE_ONLINE_FUGITIVE | 12 |  |
+| E_MODE_ONLINE_BURNING_HOME_RUN | 13 |  |
+| E_MODE_ONLINE_FREE_BURN | 14 |  |
+| E_MODE_ONLINE_FREE_BURN_LOBBY | 15 |  |
+| E_MODE_ONLINE_SHOWTIME | 16 |  |
+| E_MODE_ONLINE_MODE_END | 17 |  |
+| E_MODE_COUNT | 17 |  |
+
+### BrnNetwork::EBoostType
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_BOOST_TYPE_NORMAL | 0 |  |
+| E_BOOST_TYPE_DANGER | 1 |  |
+| E_BOOST_TYPE_AGGRESSION | 2 |  |
+| E_BOOST_TYPE_STUNT | 3 |  |
+| E_BOOST_TYPE_INFINITE | 4 |  |
+| E_BOOST_TYPE_COUNT | 5 |  |
+
+### BrnNetwork::EVehicleChoice
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_VEHICLE_CHOICE_FREE | 0 |  |
+| E_VEHICLE_CHOICE_HOST | 1 |  |
+| E_VEHICLE_CHOICE_COUNT | 2 |  |
+
+### BrnGui::GuiEventAudioTraxPlayOrder::ETraxPlayOrderMode
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_TRAX_PLAY_ORDER_MODE_SEQUENTIAL | 0 |  |
+| E_TRAX_PLAY_ORDER_MODE_RANDOM | 1 |  |
+| E_TRAX_PLAY_ORDER_MODE_COUNT | 2 |  |
+
+### BrnDirector::GameState::ECameraMode
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_CAMERA_MODE_FIRST_PERSON | 0 |  |
+| E_CAMERA_MODE_THIRD_PERSON | 1 |  |
+| E_CAMERA_MODE_COUNT | 2 |  |
+
+### BrnNetwork::BrnNetworkModuleIO::ECameraUserOptions
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| CAMERA_USER_OFF | 0 |  |
+| CAMERA_USER_ON | 1 |  |
+| CAMERA_USER_FRIENDS_ONLY | 2 |  |

--- a/docs/save-profile/pdlc-profile.md
+++ b/docs/save-profile/pdlc-profile.md
@@ -1,0 +1,78 @@
+# Profile/Burnout Paradise/PDLC Profile
+
+> Source: https://burnout.wiki/wiki/Profile/Burnout_Paradise/PDLC_Profile (mirrored 2026-06-22)
+
+The PDLC profile stores entitlements for the Toys, Legendary Cars, and Boost Specials.
+
+Adding traffic vehicles to the entitlements makes them drivable offline, though it still does not make them selectable in the junkyard. It would likely have the same effect on other undrivable vehicles.
+
+Entries in this chunk, when converted to a CarData entry at runtime, have `mbUnlockSequenceAlreadyShown` hardcoded to 1, `mfUnlockDeformedAmount` set to 0, and `meUnlockType` set to 8.
+
+## Structures
+
+### PDLC Profile
+
+#### PlayStation 3, Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number | 2 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x18 | CgsID[3] | ? | Spawn vehicle IDs | Car, bike, and plane, respectively |
+| 0x20 | 0xC | uint32_t[3] | ? | Spawn vehicle update versions | Car, bike, and plane, respectively |
+| 0x2C | 0x4 | uint32_t | ? | Spawn vehicle index |  |
+| 0x30 | 0x1 | bool | ? | Show Time Savers pack popup | PrizeTicket |
+| 0x31 | 0x7 |  |  | Padding |  |
+| 0x38 | 0x1C28 | ? | ? | DLC entitlements | See entitlements |
+
+#### PC, Remastered
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number | 3 |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0x18 | CgsID[3] | ? | Spawn vehicle IDs | Car, bike, and plane, respectively |
+| 0x20 | 0xC | uint32_t[3] | ? | Spawn vehicle update versions | Car, bike, and plane, respectively |
+| 0x2C | 0x4 | uint32_t | ? | Spawn vehicle index |  |
+| 0x30 | 0x1 | bool | ? | Show Time Savers pack popup | PrizeTicket |
+| 0x31 | 0x7 |  |  | Padding |  |
+| 0x38 | 0x1C28 | ? | ? | DLC entitlements | See entitlements |
+| 0x1C60 | 0x1 | bool | ? |  | On1stVehCon |
+| 0x1C61 | 0x7 |  |  | Padding |  |
+
+### Entitlements
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | uint32_t | ? | Number of entitlements |  |
+| 0x4 | 0x4 |  |  | Padding |  |
+| 0x8 | 0xE10 | CgsID[450] | ? | Vehicle IDs |  |
+| 0xE18 | 0x384 | int16_t[450] | ? | Entry indices |  |
+| 0x119C | 0x1C2 | uint8_t[450] | ? | Color indices and version flags | See color and flags |
+| 0x135E | 0x1C2 | uint8_t[450] | ? | Palette indices and mileage flag | See palette and flags |
+| 0x1520 | 0x708 | float32_t[450] | ? | Vehicle mileage |  |
+
+### Color and flags
+
+| Offset (bits) | Length (bits) | Name | Description | Comments |
+| --- | --- | --- | --- | --- |
+| 0 | 2 | ? | Vehicle update version | See version flags |
+| 2 | 6 | ? | Color index |  |
+
+### Palette and flags
+
+| Offset (bits) | Length (bits) | Name | Description | Comments |
+| --- | --- | --- | --- | --- |
+| 0 | 1 | ? | Read mileage | Mileage reverts if not set |
+| 1 | 7 | ? | Palette index |  |
+
+## Enumerations
+
+### Version flags
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| ? | 0 | 2 (1.0) |
+| ? | 1 | 3 (1.3) |
+| ? | 2 | 4 (1.4) |
+| ? | 3 | 7 (1.7) |

--- a/docs/save-profile/progression-profile.md
+++ b/docs/save-profile/progression-profile.md
@@ -1,0 +1,1122 @@
+# Profile/Burnout Paradise/Progression Profile
+
+> Source: https://burnout.wiki/wiki/Profile/Burnout_Paradise/Progression_Profile (mirrored 2026-06-22)
+
+> Subpage: Development — Information on the development of the progression profile.
+
+The Progression Profile stores license progression, vehicle unlocks, collectibles, Road Rule scores, and records, among other things.
+
+## Structures
+
+### BrnProgression::Profile
+
+#### PlayStation 3
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number of the Profile structure | 28 |
+| 0x4 | 0x20 | char[32] | macName | Player-chosen profile name | Unused in the final game |
+| 0x24 | 0xC |  |  | Padding |  |
+| 0x30 | 0x10 | Vector3 | mCarPosition | Spawn position of the player vehicle | Unused in the final game |
+| 0x40 | 0x10 | Vector3 | mCarDirection | Spawn direction of the player vehicle | Unused in the final game |
+| 0x50 | 0x8 | CgsID | mSpawnCarId | The vehicle the player spawns in | Deprecated in V1.3 |
+| 0x58 | 0x8 | CgsID | mSpawnWheelId | The wheel the player vehicle spawns with | Unused in the final game |
+| 0x60 | 0x4 | uint32_t | muTimeStampOfLastRoadRulesDownload |  |  |
+| 0x64 | 0x4 | float32_t | mfDistanceDrivenOnline | Distance driven online in cars (meters) | Subject to distance limitations |
+| 0x68 | 0x4 | float32_t | mfDistanceDrivenOffline | Distance driven offline in cars (meters) | Subject to distance limitations |
+| 0x6C | 0x4 | float32_t | mfInCarTimePlayed | Total time spent driving | Subject to time limitations |
+| 0x70 | 0x1 | int8_t | mi8CurrentProgressionRank | Current license of the player | See ranks |
+| 0x71 | 0x1 | int8_t | mi8PowerParkingBestRating | Power Parking record |  |
+| 0x72 | 0x1 | int8_t | mi8PowerParkingBetweenOtherPlayersBestRating | Power Parking between players record | Not displayed in the final game |
+| 0x73 | 0x1 |  |  | Padding |  |
+| 0x74 | 0x4 | uint32_t | muBestNewBurnoutChainScore | Burnout chain record |  |
+| 0x78 | 0x44 | int32_t[17] | maGameModeTypeAmount | Number of events present, per type | See EGameModeType |
+| 0xBC | 0x44 | int32_t[17] | maGameModeTypeAmountDiscovered | Number of events discovered, per type | See EGameModeType |
+| 0x100 | 0x44 | int32_t[17] | maGameModeTypeAmountCompleted | Number of events completed for the current license, per type | See EGameModeType |
+| 0x144 | 0x44 | int32_t[17] | maGameModeTypeAmountCompletedSinceTheStart | Total number of events completed, per type | See EGameModeType |
+| 0x188 | 0x4 | int32_t | miTotalTakedownCount | Number of takedowns performed |  |
+| 0x18C | 0x4 | int32_t | miTotalOnlineVerticleTakedownCount | Number of vertical takedowns performed |  |
+| 0x190 | 0x34 | int32_t[13] | maiTakedownTypeCounts | Number of takedowns performed, per type | See ETakedownType |
+| 0x1C4 | 0x28 | int32_t[10] | maiWinsPerOfflineGameMode | Number of events won, per type | See EGameModeType |
+| 0x1EC | 0x28 | int32_t[10] | maiRankWinsPerOfflineGameMode | Number of events won causing a license upgrade, per type | See EGameModeType |
+| 0x214 | 0x28 | int32_t[10] | maiLossesPerOfflineGameMode | Number of events lost, per type |  |
+| 0x23C | 0x4 | int32_t | miCompletedBarrelRolls | Barrel roll record |  |
+| 0x240 | 0x4 | float32_t | mfCompletedAirSpinAngle | Flat spin record |  |
+| 0x244 | 0x4 | float32_t | mfCompletedHandbreakTurnAngle | Handbrake turn record | Not displayed in the final game |
+| 0x248 | 0x4 | float32_t | mfCompletedDriftDistance | Drift record |  |
+| 0x24C | 0x4 | float32_t | mfOncomingDistance | Oncoming record |  |
+| 0x250 | 0x4 | float32_t | mfAirMaximum | Air time record |  |
+| 0x254 | 0x4 | int32_t | miHighestShowTimeScore | Showtime record |  |
+| 0x258 | 0x4 | int32_t | miBestStuntRunScore | Stunt run record | Deprecated in game version 1.3 |
+| 0x25C | 0x4 | int32_t | miCarCount | Number of vehicle entries |  |
+| 0x260 | 0x4 | int32_t | miLiveryDataCount | Number of livery entries |  |
+| 0x264 | 0x4 | int32_t | miRivalCount | Number of rival entries |  |
+| 0x268 | 0x4 | int32_t | miEventCount | Number of event entries |  |
+| 0x26C | 0x4 |  |  | Padding |  |
+| 0x270 | 0x3000 | CarData[512] | maCars | Vehicle unlocks, colors, and damage |  |
+| 0x3270 | 0x3000 | LiveryData[512] | maLiveryChoices | Selected finishes and mileage |  |
+| 0x6270 | 0xE00 | RivalData[64] | maRivals | Roaming rival/shutdown car info |  |
+| 0x7070 | 0x578 | ProfileEvent[175] | maEvents | Event completion states |  |
+| 0x75E8 | 0x3018 | Set<CgsID, 512u>[3] | maStuntElements | Collectible completion states | See EStuntType |
+| 0xA600 | 0x4 | uint32_t | muMedalCountFromTheStart | Total number of events won |  |
+| 0xA604 | 0x1 | bool | mbGoldCarsUnlocked | Tracks whether gold finishes are unlocked |  |
+| 0xA605 | 0x1 | bool | mbSilverCarsUnlocked | Tracks whether platinum finishes are unlocked |  |
+| 0xA606 | 0x2 |  |  | Padding |  |
+| 0xA608 | 0x30 | Set<CgsID, 5u> | mJunkYardsDriveThruSet | Discovered Junkyards |  |
+| 0xA638 | 0x60 | Set<CgsID, 11u> | mBodyShopsDriveThruSet | Discovered Auto Repairs |  |
+| 0xA698 | 0x30 | Set<CgsID, 5u> | mPaintShopsDriveThruSet | Discovered Paint Shops |  |
+| 0xA6C8 | 0x78 | Set<CgsID, 14u> | mGasStationsDriveThruSet | Discovered Gas Stations |  |
+| 0xA740 | 0x60 | Set<CgsID, 11u> | mCarParksDriveThruSet | Discovered Car Parks |  |
+| 0xA7A0 | 0x3E88 | Array<CgsID, 2000u> | maFreeBurnChallengeData | Completed Freeburn and Timed Challenges |  |
+| 0xE628 | 0x9280 | HitPropsBitArray | mabHitPropBitArray | Smashed billboards and individual gate sections | 500 TRK units, 600 prop hit indicators (bits) each. Not all TRKs are used |
+| 0x178A8 | 0x1E | int16_t[3][5] | maaiStuntCountsByCounty | Collectible progression, per-county | See EStuntType and counties |
+| 0x178C6 | 0x2 |  |  | Padding |  |
+| 0x178C8 | 0x1000 | ChallengeHighScoreEntry[64] | maNetworkChallengeData | Online mainland car Time/Showtime Road Rule scores and player names |  |
+| 0x188C8 | 0xA00 | ChallengePlayerScoreEntry[64] | maChallengeData | Player mainland car Time/Showtime Road Rule scores and vehicles |  |
+| 0x192C8 | 0x4 | uint32_t | muLastRoadRulesResetTime |  |  |
+| 0x192CC | 0x1C | NetworkTexture | mPlayerLicencePicture | License picture header |  |
+| 0x192E8 | 0x2580 | char[9600] | macPlayerLicenceTextureData | License picture data |  |
+| 0x1B868 | 0x1 | bool | mbPlayerLicencePictureIsValid | Tracks whether the license picture is present |  |
+| 0x1B869 | 0x7 |  |  | Padding |  |
+| 0x1B870 | 0x20F8 | Array<MugshotInfo, 30u>[5] | maaMugshotInfo | Information on saved mugshots |  |
+| 0x1D968 | 0x28 | BitArray<30u>[5] | maAvailableMugshotFileIDs | Tracks what mugshot slots are used |  |
+| 0x1D990 | 0xC | float32_t[3] | mafCarTypes |  | Unused in the final game |
+| 0x1D99C | 0x4 | ECarType | meCurrentCarType | Boost type of the current vehicle | See ECarType |
+| 0x1D9A0 | 0x20 | BitArray<256u> | maHasPlayerSeenTraining | Tracks the tips DJ Atomika has used |  |
+| 0x1D9C0 | 0x4 | int32_t | miNumOnlineRacesDone | Number of online races completed |  |
+| 0x1D9C4 | 0x4 | int32_t | miNumOnlineRacesWon | Number of online races won |  |
+| 0x1D9C8 | 0x4 | int32_t | miNumMugshotsSent | Number of mugshots sent by the player |  |
+| 0x1D9CC | 0x4 |  |  | Padding |  |
+| 0x1D9D0 | 0x10 | DateAndTime | mDateLicenceIssued | Date the player's license was created |  |
+| 0x1D9E0 | 0x10 | DateAndTime | mDate100PercentCompleted | Date the player achieved 100% completion |  |
+| 0x1D9F0 | 0x4 | int32_t | miHighestNumberOfTakeDownsInRoadRage | Road Rage record |  |
+| 0x1D9F4 | 0x4 |  |  | Padding |  |
+| 0x1D9F8 | 0x8 | BitArray<35u> | mSeenTrophyAwardBitArray | Tracks which of the primary 35 vehicles unlocks have been shown |  |
+| 0x1DA00 | 0x8 | BitArray<60u> | mAchievementsEarnt | Tracks which Paradise Awards have been earned |  |
+| 0x1DA08 | 0x1 | bool | mb100PercentCompletionSequenceShown | Tracks whether the 100% completion animation has been shown |  |
+| 0x1DA09 | 0x1 | bool | mbIsNewProfile | Tracks whether the profile is new | Intro will be shown if true |
+| 0x1DA0A | 0x1 | bool | mbCreditsSequenceViewed | Tracks whether the credits have been shown |  |
+| 0x1DA0B | 0x1 | bool | mbOneHundredHudMessageViewed | Tracks whether the 100% completion message has been shown |  |
+| 0x1DA0C | 0x1 | bool | mbHasUnlockedCredits | Tracks whether credits are available for viewing |  |
+| 0x1DA0D | 0x1 | bool | mbHaveSet100PercentCompletedDate | Tracks whether the 100% completion date is present |  |
+| 0x1DA0E | 0x1 | bool | mbHaveSeenEliteCompletionSequence | Tracks whether the Elite license animation has been shown |  |
+| 0x1DA0F | 0x1 | bool | mbRedundantBool4 |  | Unused in the final game |
+| 0x1DA10 | 0x1 | int8_t | miPad1 |  | Unused in the final game |
+| 0x1DA11 | 0x1 |  |  | Padding |  |
+| 0x1DA12 | 0x2 | int16_t | miPad2 |  | Unused in the final game |
+| 0x1DA14 | 0x4 | uint32_t | muRoadRulesIDLowBits |  |  |
+| 0x1DA18 | 0x8 | BitArray<6u> | mSeenCompleteAllEventTypeArray | Tracks which event types have had all events completed |  |
+| 0x1DA20 | 0x4 | float32_t | mfRealTimePlayed | Total time played | As opposed to mfInCarTimePlayed |
+| 0x1DA24 | 0x4 | float32_t | mfRedundantFloat4 |  | Unused in the final game |
+| 0x1DA28 | 0x4 | uint32_t | muRoadRulesIDHighBits |  |  |
+| 0x1DA2C | 0x2 | int16_t | miPad3 |  | Unused in the final game |
+| 0x1DA2E | 0x1 | int8_t | miPad4 |  | Unused in the final game |
+| 0x1DA2F | 0x1 |  |  | Padding |  |
+
+#### Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number of the Profile structure | 28 |
+| 0x4 | 0x20 | char[32] | macName | Player-chosen profile name | Unused in the final game |
+| 0x24 | 0xC |  |  | Padding |  |
+| 0x30 | 0x10 | Vector3 | mCarPosition | Spawn position of the player vehicle | Unused in the final game |
+| 0x40 | 0x10 | Vector3 | mCarDirection | Spawn direction of the player vehicle | Unused in the final game |
+| 0x50 | 0x8 | CgsID | mSpawnCarId | The vehicle the player spawns in | Deprecated in V1.3 |
+| 0x58 | 0x8 | CgsID | mSpawnWheelId | The wheel the player vehicle spawns with | Unused in the final game |
+| 0x60 | 0x4 | uint32_t | muTimeStampOfLastRoadRulesDownload |  |  |
+| 0x64 | 0x4 | float32_t | mfDistanceDrivenOnline | Distance driven online in cars (meters) | Subject to distance limitations |
+| 0x68 | 0x4 | float32_t | mfDistanceDrivenOffline | Distance driven offline in cars (meters) | Subject to distance limitations |
+| 0x6C | 0x4 | float32_t | mfInCarTimePlayed | Total time spent driving | Subject to time limitations |
+| 0x70 | 0x1 | int8_t | mi8CurrentProgressionRank | Current license of the player | See ranks |
+| 0x71 | 0x1 | int8_t | mi8PowerParkingBestRating | Power Parking record |  |
+| 0x72 | 0x1 | int8_t | mi8PowerParkingBetweenOtherPlayersBestRating | Power Parking between players record | Not displayed in the final game |
+| 0x73 | 0x1 |  |  | Padding |  |
+| 0x74 | 0x4 | uint32_t | muBestNewBurnoutChainScore | Burnout chain record |  |
+| 0x78 | 0x44 | int32_t[17] | maGameModeTypeAmount | Number of events present, per type | See EGameModeType |
+| 0xBC | 0x44 | int32_t[17] | maGameModeTypeAmountDiscovered | Number of events discovered, per type | See EGameModeType |
+| 0x100 | 0x44 | int32_t[17] | maGameModeTypeAmountCompleted | Number of events completed for the current license, per type | See EGameModeType |
+| 0x144 | 0x44 | int32_t[17] | maGameModeTypeAmountCompletedSinceTheStart | Total number of events completed, per type | See EGameModeType |
+| 0x188 | 0x4 | int32_t | miTotalTakedownCount | Number of takedowns performed |  |
+| 0x18C | 0x4 | int32_t | miTotalOnlineVerticleTakedownCount | Number of vertical takedowns performed |  |
+| 0x190 | 0x34 | int32_t[13] | maiTakedownTypeCounts | Number of takedowns performed, per type | See ETakedownType |
+| 0x1C4 | 0x28 | int32_t[10] | maiWinsPerOfflineGameMode | Number of events won, per type | See EGameModeType |
+| 0x1EC | 0x28 | int32_t[10] | maiRankWinsPerOfflineGameMode | Number of events won causing a license upgrade, per type | See EGameModeType |
+| 0x214 | 0x28 | int32_t[10] | maiLossesPerOfflineGameMode | Number of events lost, per type |  |
+| 0x23C | 0x4 | int32_t | miCompletedBarrelRolls | Barrel roll record |  |
+| 0x240 | 0x4 | float32_t | mfCompletedAirSpinAngle | Flat spin record |  |
+| 0x244 | 0x4 | float32_t | mfCompletedHandbreakTurnAngle | Handbrake turn record | Not displayed in the final game |
+| 0x248 | 0x4 | float32_t | mfCompletedDriftDistance | Drift record |  |
+| 0x24C | 0x4 | float32_t | mfOncomingDistance | Oncoming record |  |
+| 0x250 | 0x4 | float32_t | mfAirMaximum | Air time record |  |
+| 0x254 | 0x4 | int32_t | miHighestShowTimeScore | Showtime record |  |
+| 0x258 | 0x4 | int32_t | miBestStuntRunScore | Stunt run record | Deprecated in game version 1.3 |
+| 0x25C | 0x4 | int32_t | miCarCount | Number of vehicle entries |  |
+| 0x260 | 0x4 | int32_t | miLiveryDataCount | Number of livery entries |  |
+| 0x264 | 0x4 | int32_t | miRivalCount | Number of rival entries |  |
+| 0x268 | 0x4 | int32_t | miEventCount | Number of event entries |  |
+| 0x26C | 0x4 |  |  | Padding |  |
+| 0x270 | 0x3000 | CarData[512] | maCars | Vehicle unlocks, colors, and damage |  |
+| 0x3270 | 0x3000 | LiveryData[512] | maLiveryChoices | Selected finishes and mileage |  |
+| 0x6270 | 0xE00 | RivalData[64] | maRivals | Roaming rival/shutdown car info |  |
+| 0x7070 | 0x578 | ProfileEvent[175] | maEvents | Event completion states |  |
+| 0x75E8 | 0x3018 | Set<CgsID, 512u>[3] | maStuntElements | Collectible completion states | See EStuntType |
+| 0xA600 | 0x4 | uint32_t | muMedalCountFromTheStart | Total number of events won |  |
+| 0xA604 | 0x1 | bool | mbGoldCarsUnlocked | Tracks whether gold finishes are unlocked |  |
+| 0xA605 | 0x1 | bool | mbSilverCarsUnlocked | Tracks whether platinum finishes are unlocked |  |
+| 0xA606 | 0x2 |  |  | Padding |  |
+| 0xA608 | 0x30 | Set<CgsID, 5u> | mJunkYardsDriveThruSet | Discovered Junkyards |  |
+| 0xA638 | 0x60 | Set<CgsID, 11u> | mBodyShopsDriveThruSet | Discovered Auto Repairs |  |
+| 0xA698 | 0x30 | Set<CgsID, 5u> | mPaintShopsDriveThruSet | Discovered Paint Shops |  |
+| 0xA6C8 | 0x78 | Set<CgsID, 14u> | mGasStationsDriveThruSet | Discovered Gas Stations |  |
+| 0xA740 | 0x60 | Set<CgsID, 11u> | mCarParksDriveThruSet | Discovered Car Parks |  |
+| 0xA7A0 | 0x3E88 | Array<CgsID, 2000u> | maFreeBurnChallengeData | Completed Freeburn and Timed Challenges |  |
+| 0xE628 | 0x9280 | HitPropsBitArray | mabHitPropBitArray | Smashed billboards and individual gate sections | 500 TRK units, 600 prop hit indicators (bits) each. Not all TRKs are used |
+| 0x178A8 | 0x1E | int16_t[3][5] | maaiStuntCountsByCounty | Collectible progression, per-county | See EStuntType and counties |
+| 0x178C6 | 0x2 |  |  | Padding |  |
+| 0x178C8 | 0xE00 | ChallengeHighScoreEntry[64] | maNetworkChallengeData | Online mainland car Time/Showtime Road Rule scores and player names |  |
+| 0x186C8 | 0xA00 | ChallengePlayerScoreEntry[64] | maChallengeData | Player mainland car Time/Showtime Road Rule scores and vehicles |  |
+| 0x190C8 | 0x4 | uint32_t | muLastRoadRulesResetTime |  |  |
+| 0x190CC | 0x1C | NetworkTexture | mPlayerLicencePicture | License picture header |  |
+| 0x190E8 | 0x2580 | char[9600] | macPlayerLicenceTextureData | License picture data |  |
+| 0x1B668 | 0x1 | bool | mbPlayerLicencePictureIsValid | Tracks whether the license picture is present |  |
+| 0x1B669 | 0x7 |  |  | Padding |  |
+| 0x1B670 | 0x1608 | Array<MugshotInfo, 20u>[5] | maaMugshotInfo | Information on saved mugshots |  |
+| 0x1CC78 | 0x28 | BitArray<20u>[5] | maAvailableMugshotFileIDs | Tracks what mugshot slots are used |  |
+| 0x1CCA0 | 0xC | float32_t[3] | mafCarTypes |  | Unused in the final game |
+| 0x1CCAC | 0x4 | ECarType | meCurrentCarType | Boost type of the current vehicle | See ECarType |
+| 0x1CCB0 | 0x20 | BitArray<256u> | maHasPlayerSeenTraining | Tracks the tips DJ Atomika has used |  |
+| 0x1CCD0 | 0x4 | int32_t | miNumOnlineRacesDone | Number of online races completed |  |
+| 0x1CCD4 | 0x4 | int32_t | miNumOnlineRacesWon | Number of online races won |  |
+| 0x1CCD8 | 0x4 | int32_t | miNumMugshotsSent | Number of mugshots sent by the player |  |
+| 0x1CCDC | 0x10 | DateAndTime | mDateLicenceIssued | Date the player's license was created |  |
+| 0x1CCE8 | 0x10 | DateAndTime | mDate100PercentCompleted | Date the player achieved 100% completion |  |
+| 0x1CCF4 | 0x4 | int32_t | miHighestNumberOfTakeDownsInRoadRage | Road Rage record |  |
+| 0x1CCF8 | 0x8 | BitArray<35u> | mSeenTrophyAwardBitArray | Tracks which of the primary 35 vehicles unlocks have been shown |  |
+| 0x1CD00 | 0x1 | bool | mb100PercentCompletionSequenceShown | Tracks whether the 100% completion animation has been shown |  |
+| 0x1CD01 | 0x1 | bool | mbIsNewProfile | Tracks whether the profile is new | Intro will be shown if true |
+| 0x1CD02 | 0x1 | bool | mbCreditsSequenceViewed | Tracks whether the credits have been shown |  |
+| 0x1CD03 | 0x1 | bool | mbOneHundredHudMessageViewed | Tracks whether the 100% completion message has been shown |  |
+| 0x1CD04 | 0x1 | bool | mbHasUnlockedCredits | Tracks whether credits are available for viewing |  |
+| 0x1CD05 | 0x1 | bool | mbHaveSet100PercentCompletedDate | Tracks whether the 100% completion date is present |  |
+| 0x1CD06 | 0x1 | bool | mbHaveSeenEliteCompletionSequence | Tracks whether the Elite license animation has been shown |  |
+| 0x1CD07 | 0x1 | bool | mbRedundantBool4 |  | Unused in the final game |
+| 0x1CD08 | 0x1 | int8_t | miPad1 |  | Unused in the final game |
+| 0x1CD09 | 0x1 |  |  | Padding |  |
+| 0x1CD0A | 0x2 | int16_t | miPad2 |  | Unused in the final game |
+| 0x1CD0C | 0x4 | uint32_t | muRoadRulesIDLowBits |  |  |
+| 0x1CD10 | 0x8 | BitArray<6u> | mSeenCompleteAllEventTypeArray | Tracks which event types have had all events completed |  |
+| 0x1CD18 | 0x4 | float32_t | mfRealTimePlayed | Total time played | As opposed to mfInCarTimePlayed |
+| 0x1CD1C | 0x4 | float32_t | mfRedundantFloat4 |  | Unused in the final game |
+| 0x1CD20 | 0x4 | uint32_t | muRoadRulesIDHighBits |  |  |
+| 0x1CD24 | 0x2 | int16_t | miPad3 |  | Unused in the final game |
+| 0x1CD26 | 0x1 | int8_t | miPad4 |  | Unused in the final game |
+| 0x1CD27 | 0x9 |  |  | Padding |  |
+
+#### PC
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number of the Profile structure | 30 |
+| 0x4 | 0x20 | char[32] | macName | Player-chosen profile name | Unused in the final game |
+| 0x24 | 0xC |  |  | Padding |  |
+| 0x30 | 0x10 | Vector3 | mCarPosition | Spawn position of the player vehicle | Unused in the final game |
+| 0x40 | 0x10 | Vector3 | mCarDirection | Spawn direction of the player vehicle | Unused in the final game |
+| 0x50 | 0x8 | CgsID | mSpawnCarId | The vehicle the player spawns in | Deprecated in V1.3 |
+| 0x58 | 0x8 | CgsID | mSpawnWheelId | The wheel the player vehicle spawns with | Unused in the final game |
+| 0x60 | 0x4 | uint32_t | muTimeStampOfLastRoadRulesDownload |  |  |
+| 0x64 | 0x4 | float32_t | mfDistanceDrivenOnline | Distance driven online in cars (meters) | Subject to distance limitations |
+| 0x68 | 0x4 | float32_t | mfDistanceDrivenOffline | Distance driven offline in cars (meters) | Subject to distance limitations |
+| 0x6C | 0x4 | float32_t | mfInCarTimePlayed | Total time spent driving | Subject to time limitations |
+| 0x70 | 0x1 | int8_t | mi8CurrentProgressionRank | Current license of the player | See ranks |
+| 0x71 | 0x1 | int8_t | mi8PowerParkingBestRating | Power Parking record |  |
+| 0x72 | 0x1 | int8_t | mi8PowerParkingBetweenOtherPlayersBestRating | Power Parking between players record | Not displayed in the final game |
+| 0x73 | 0x1 |  |  | Padding |  |
+| 0x74 | 0x4 | uint32_t | muBestNewBurnoutChainScore | Burnout chain record |  |
+| 0x78 | 0x44 | int32_t[17] | maGameModeTypeAmount | Number of events present, per type | See EGameModeType |
+| 0xBC | 0x44 | int32_t[17] | maGameModeTypeAmountDiscovered | Number of events discovered, per type | See EGameModeType |
+| 0x100 | 0x44 | int32_t[17] | maGameModeTypeAmountCompleted | Number of events completed for the current license, per type | See EGameModeType |
+| 0x144 | 0x44 | int32_t[17] | maGameModeTypeAmountCompletedSinceTheStart | Total number of events completed, per type | See EGameModeType |
+| 0x188 | 0x4 | int32_t | miTotalTakedownCount | Number of takedowns performed |  |
+| 0x18C | 0x4 | int32_t | miTotalOnlineVerticleTakedownCount | Number of vertical takedowns performed |  |
+| 0x190 | 0x34 | int32_t[13] | maiTakedownTypeCounts | Number of takedowns performed, per type | See ETakedownType |
+| 0x1C4 | 0x28 | int32_t[10] | maiWinsPerOfflineGameMode | Number of events won, per type | See EGameModeType |
+| 0x1EC | 0x28 | int32_t[10] | maiRankWinsPerOfflineGameMode | Number of events won causing a license upgrade, per type | See EGameModeType |
+| 0x214 | 0x28 | int32_t[10] | maiLossesPerOfflineGameMode | Number of events lost, per type |  |
+| 0x23C | 0x4 | int32_t | miCompletedBarrelRolls | Barrel roll record |  |
+| 0x240 | 0x4 | float32_t | mfCompletedAirSpinAngle | Flat spin record |  |
+| 0x244 | 0x4 | float32_t | mfCompletedHandbreakTurnAngle | Handbrake turn record | Not displayed in the final game |
+| 0x248 | 0x4 | float32_t | mfCompletedDriftDistance | Drift record |  |
+| 0x24C | 0x4 | float32_t | mfOncomingDistance | Oncoming record |  |
+| 0x250 | 0x4 | float32_t | mfAirMaximum | Air time record |  |
+| 0x254 | 0x4 | int32_t | miHighestShowTimeScore | Showtime record |  |
+| 0x258 | 0x4 | int32_t | miBestStuntRunScore | Stunt run record | Deprecated in game version 1.3 |
+| 0x25C | 0x4 | int32_t | miCarCount | Number of vehicle entries |  |
+| 0x260 | 0x4 | int32_t | miLiveryDataCount | Number of livery entries |  |
+| 0x264 | 0x4 | int32_t | miRivalCount | Number of rival entries |  |
+| 0x268 | 0x4 | int32_t | miEventCount | Number of event entries |  |
+| 0x26C | 0x4 |  |  | Padding |  |
+| 0x270 | 0x3000 | CarData[512] | maCars | Vehicle unlocks, colors, and damage |  |
+| 0x3270 | 0x3000 | LiveryData[512] | maLiveryChoices | Selected finishes and mileage |  |
+| 0x6270 | 0xE00 | RivalData[64] | maRivals | Roaming rival/shutdown car info |  |
+| 0x7070 | 0x578 | ProfileEvent[175] | maEvents | Event completion states |  |
+| 0x75E8 | 0x3018 | Set<CgsID, 512u>[3] | maStuntElements | Collectible completion states | See EStuntType |
+| 0xA600 | 0x4 | uint32_t | muMedalCountFromTheStart | Total number of events won |  |
+| 0xA604 | 0x1 | bool | mbGoldCarsUnlocked | Tracks whether gold finishes are unlocked |  |
+| 0xA605 | 0x1 | bool | mbSilverCarsUnlocked | Tracks whether platinum finishes are unlocked |  |
+| 0xA606 | 0x2 |  |  | Padding |  |
+| 0xA608 | 0x30 | Set<CgsID, 5u> | mJunkYardsDriveThruSet | Discovered Junkyards |  |
+| 0xA638 | 0x60 | Set<CgsID, 11u> | mBodyShopsDriveThruSet | Discovered Auto Repairs |  |
+| 0xA698 | 0x30 | Set<CgsID, 5u> | mPaintShopsDriveThruSet | Discovered Paint Shops |  |
+| 0xA6C8 | 0x78 | Set<CgsID, 14u> | mGasStationsDriveThruSet | Discovered Gas Stations |  |
+| 0xA740 | 0x60 | Set<CgsID, 11u> | mCarParksDriveThruSet | Discovered Car Parks |  |
+| 0xA7A0 | 0x3E88 | Array<CgsID, 2000u> | maFreeBurnChallengeData | Completed Freeburn and Timed Challenges |  |
+| 0xE628 | 0x9280 | HitPropsBitArray | mabHitPropBitArray | Smashed billboards and individual gate sections | 500 TRK units, 600 prop hit indicators (bits) each. Not all TRKs are used |
+| 0x178A8 | 0x1E | int16_t[3][5] | maaiStuntCountsByCounty | Collectible progression, per-county | See EStuntType and counties |
+| 0x178C6 | 0x2 |  |  | Padding |  |
+| 0x178C8 | 0x1000 | ChallengeHighScoreEntry[64] | maNetworkChallengeData | Online mainland car Time/Showtime Road Rule scores and player names |  |
+| 0x188C8 | 0xA00 | ChallengePlayerScoreEntry[64] | maChallengeData | Player mainland car Time/Showtime Road Rule scores and vehicles |  |
+| 0x192C8 | 0x4 | uint32_t | muLastRoadRulesResetTime |  |  |
+| 0x192CC | 0x1C | NetworkTexture | mPlayerLicencePicture | License picture header |  |
+| 0x192E8 | 0x2580 | char[9600] | macPlayerLicenceTextureData | License picture data |  |
+| 0x1B868 | 0x1 | bool | mbPlayerLicencePictureIsValid | Tracks whether the license picture is present |  |
+| 0x1B869 | 0x3 |  |  | Padding |  |
+| 0x1B86C | 0x12D4 | Array<MugshotInfo, 20u>[5] | maaMugshotInfo | Information on saved mugshots | Not padded after length |
+| 0x1CB40 | 0x28 | BitArray<20u>[5] | maAvailableMugshotFileIDs | Tracks what mugshot slots are used |  |
+| 0x1CB68 | 0xC | float32_t[3] | mafCarTypes |  | Unused in the final game |
+| 0x1CB74 | 0x4 | ECarType | meCurrentCarType | Boost type of the current vehicle | See ECarType |
+| 0x1CB78 | 0x20 | BitArray<256u> | maHasPlayerSeenTraining | Tracks the tips DJ Atomika has used |  |
+| 0x1CB98 | 0x4 | int32_t | miNumOnlineRacesDone | Number of online races completed |  |
+| 0x1CB9C | 0x4 | int32_t | miNumOnlineRacesWon | Number of online races won |  |
+| 0x1CBA0 | 0x4 | int32_t | miNumMugshotsSent | Number of mugshots sent by the player |  |
+| 0x1CBA4 | 0xC | DateAndTime | mDateLicenceIssued | Date the player's license was created |  |
+| 0x1CBB0 | 0xC | DateAndTime | mDate100PercentCompleted | Date the player achieved 100% completion |  |
+| 0x1CBBC | 0x4 | int32_t | miHighestNumberOfTakeDownsInRoadRage | Road Rage record |  |
+| 0x1CBC0 | 0x8 | BitArray<35u> | mSeenTrophyAwardBitArray | Tracks which of the primary 35 vehicles unlocks have been shown |  |
+| 0x1CBC8 | 0x8 | BitArray<60u> | mAchievementsEarnt | Tracks which Paradise Awards have been earned |  |
+| 0x1CBD0 | 0x1 | bool | mb100PercentCompletionSequenceShown | Tracks whether the 100% completion animation has been shown |  |
+| 0x1CBD1 | 0x1 | bool | mbIsNewProfile | Tracks whether the profile is new | Intro will be shown if true |
+| 0x1CBD2 | 0x1 | bool | mbCreditsSequenceViewed | Tracks whether the credits have been shown |  |
+| 0x1CBD3 | 0x1 | bool | mbOneHundredHudMessageViewed | Tracks whether the 100% completion message has been shown |  |
+| 0x1CBD4 | 0x1 | bool | mbHasUnlockedCredits | Tracks whether credits are available for viewing |  |
+| 0x1CBD5 | 0x1 | bool | mbHaveSet100PercentCompletedDate | Tracks whether the 100% completion date is present |  |
+| 0x1CBD6 | 0x1 | bool | mbHaveSeenEliteCompletionSequence | Tracks whether the Elite license animation has been shown |  |
+| 0x1CBD7 | 0x1 | bool | mbRedundantBool4 |  | Unused in the final game |
+| 0x1CBD8 | 0x1 | int8_t | miPad1 |  | Unused in the final game |
+| 0x1CBD9 | 0x1 |  |  | Padding |  |
+| 0x1CBDA | 0x2 | int16_t | miPad2 |  | Unused in the final game |
+| 0x1CBDC | 0x4 |  |  | Padding |  |
+| 0x1CBE0 | 0x4 | uint32_t | muRoadRulesIDLowBits |  |  |
+| 0x1CBE4 | 0x4 |  |  | Padding |  |
+| 0x1CBE8 | 0x8 | BitArray<6u> | mSeenCompleteAllEventTypeArray | Tracks which event types have had all events completed |  |
+| 0x1CBF0 | 0x4 | float32_t | mfRealTimePlayed | Total time played | As opposed to mfInCarTimePlayed |
+| 0x1CBF4 | 0x4 | float32_t | mfRedundantFloat4 |  | Unused in the final game |
+| 0x1CBF8 | 0x4 | uint32_t | muRoadRulesIDHighBits |  |  |
+| 0x1CBFC | 0x2 | int16_t | miPad3 |  | Unused in the final game |
+| 0x1CBFE | 0x1 | int8_t | miPad4 |  | Unused in the final game |
+| 0x1CBFF | 0x1 |  |  | Padding |  |
+
+#### PlayStation 4
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number of the Profile structure | 31 |
+| 0x4 | 0x20 | char[32] | macName | Player-chosen profile name | Unused in the final game |
+| 0x24 | 0xC |  |  | Padding |  |
+| 0x30 | 0x10 | Vector3 | mCarPosition | Spawn position of the player vehicle | Unused in the final game |
+| 0x40 | 0x10 | Vector3 | mCarDirection | Spawn direction of the player vehicle | Unused in the final game |
+| 0x50 | 0x8 | CgsID | mSpawnCarId | The vehicle the player spawns in | Deprecated in V1.3 |
+| 0x58 | 0x8 | CgsID | mSpawnWheelId | The wheel the player vehicle spawns with | Unused in the final game |
+| 0x60 | 0x4 | uint32_t | muTimeStampOfLastRoadRulesDownload |  |  |
+| 0x64 | 0x4 | float32_t | mfDistanceDrivenOnline | Distance driven online in cars (meters) | Subject to distance limitations |
+| 0x68 | 0x4 | float32_t | mfDistanceDrivenOffline | Distance driven offline in cars (meters) | Subject to distance limitations |
+| 0x6C | 0x4 | float32_t | mfInCarTimePlayed | Total time spent driving | Subject to time limitations |
+| 0x70 | 0x1 | int8_t | mi8CurrentProgressionRank | Current license of the player | See ranks |
+| 0x71 | 0x1 | int8_t | mi8PowerParkingBestRating | Power Parking record |  |
+| 0x72 | 0x1 | int8_t | mi8PowerParkingBetweenOtherPlayersBestRating | Power Parking between players record | Not displayed in the final game |
+| 0x73 | 0x1 |  |  | Padding |  |
+| 0x74 | 0x4 | uint32_t | muBestNewBurnoutChainScore | Burnout chain record |  |
+| 0x78 | 0x44 | int32_t[17] | maGameModeTypeAmount | Number of events present, per type | See EGameModeType |
+| 0xBC | 0x44 | int32_t[17] | maGameModeTypeAmountDiscovered | Number of events discovered, per type | See EGameModeType |
+| 0x100 | 0x44 | int32_t[17] | maGameModeTypeAmountCompleted | Number of events completed for the current license, per type | See EGameModeType |
+| 0x144 | 0x44 | int32_t[17] | maGameModeTypeAmountCompletedSinceTheStart | Total number of events completed, per type | See EGameModeType |
+| 0x188 | 0x4 | int32_t | miTotalTakedownCount | Number of takedowns performed |  |
+| 0x18C | 0x4 | int32_t | miTotalOnlineVerticleTakedownCount | Number of vertical takedowns performed |  |
+| 0x190 | 0x34 | int32_t[13] | maiTakedownTypeCounts | Number of takedowns performed, per type | See ETakedownType |
+| 0x1C4 | 0x28 | int32_t[10] | maiWinsPerOfflineGameMode | Number of events won, per type | See EGameModeType |
+| 0x1EC | 0x28 | int32_t[10] | maiRankWinsPerOfflineGameMode | Number of events won causing a license upgrade, per type | See EGameModeType |
+| 0x214 | 0x28 | int32_t[10] | maiLossesPerOfflineGameMode | Number of events lost, per type |  |
+| 0x23C | 0x4 | int32_t | miCompletedBarrelRolls | Barrel roll record |  |
+| 0x240 | 0x4 | float32_t | mfCompletedAirSpinAngle | Flat spin record |  |
+| 0x244 | 0x4 | float32_t | mfCompletedHandbreakTurnAngle | Handbrake turn record | Not displayed in the final game |
+| 0x248 | 0x4 | float32_t | mfCompletedDriftDistance | Drift record |  |
+| 0x24C | 0x4 | float32_t | mfOncomingDistance | Oncoming record |  |
+| 0x250 | 0x4 | float32_t | mfAirMaximum | Air time record |  |
+| 0x254 | 0x4 | int32_t | miHighestShowTimeScore | Showtime record |  |
+| 0x258 | 0x4 | int32_t | miBestStuntRunScore | Stunt run record | Deprecated in game version 1.3 |
+| 0x25C | 0x4 | int32_t | miCarCount | Number of vehicle entries |  |
+| 0x260 | 0x4 | int32_t | miLiveryDataCount | Number of livery entries |  |
+| 0x264 | 0x4 | int32_t | miRivalCount | Number of rival entries |  |
+| 0x268 | 0x4 | int32_t | miEventCount | Number of event entries |  |
+| 0x26C | 0x4 |  |  | Padding |  |
+| 0x270 | 0x3000 | CarData[512] | maCars | Vehicle unlocks, colors, and damage |  |
+| 0x3270 | 0x3000 | LiveryData[512] | maLiveryChoices | Selected finishes and mileage |  |
+| 0x6270 | 0xE00 | RivalData[64] | maRivals | Roaming rival/shutdown car info |  |
+| 0x7070 | 0x578 | ProfileEvent[175] | maEvents | Event completion states |  |
+| 0x75E8 | 0x3018 | Set<CgsID, 512u>[3] | maStuntElements | Collectible completion states | See EStuntType |
+| 0xA600 | 0x4 | uint32_t | muMedalCountFromTheStart | Total number of events won |  |
+| 0xA604 | 0x1 | bool | mbGoldCarsUnlocked | Tracks whether gold finishes are unlocked |  |
+| 0xA605 | 0x1 | bool | mbSilverCarsUnlocked | Tracks whether platinum finishes are unlocked |  |
+| 0xA606 | 0x2 |  |  | Padding |  |
+| 0xA608 | 0x30 | Set<CgsID, 5u> | mJunkYardsDriveThruSet | Discovered Junkyards |  |
+| 0xA638 | 0x60 | Set<CgsID, 11u> | mBodyShopsDriveThruSet | Discovered Auto Repairs |  |
+| 0xA698 | 0x30 | Set<CgsID, 5u> | mPaintShopsDriveThruSet | Discovered Paint Shops |  |
+| 0xA6C8 | 0x78 | Set<CgsID, 14u> | mGasStationsDriveThruSet | Discovered Gas Stations |  |
+| 0xA740 | 0x60 | Set<CgsID, 11u> | mCarParksDriveThruSet | Discovered Car Parks |  |
+| 0xA7A0 | 0x3E88 | Array<CgsID, 2000u> | maFreeBurnChallengeData | Completed Freeburn and Timed Challenges |  |
+| 0xE628 | 0x9280 | HitPropsBitArray | mabHitPropBitArray | Smashed billboards and individual gate sections | 500 TRK units, 600 prop hit indicators (bits) each. Not all TRKs are used |
+| 0x178A8 | 0x1E | int16_t[3][5] | maaiStuntCountsByCounty | Collectible progression, per-county | See EStuntType and counties |
+| 0x178C6 | 0x2 |  |  | Padding |  |
+| 0x178C8 | 0x1400 | ChallengeHighScoreEntry[64] | maNetworkChallengeData | Online mainland car Time/Showtime Road Rule scores and player names |  |
+| 0x18CC8 | 0xA00 | ChallengePlayerScoreEntry[64] | maChallengeData | Player mainland car Time/Showtime Road Rule scores and vehicles |  |
+| 0x196C8 | 0x4 | uint32_t | muLastRoadRulesResetTime |  |  |
+| 0x196CC | 0x4 |  |  | Padding |  |
+| 0x196D0 | 0x28 | NetworkTexture | mPlayerLicencePicture | License picture header |  |
+| 0x196F8 | 0x4B000 | char[38400][8] | macPlayerLicenceTextureData | License picture data | Only first is used |
+| 0x646F8 | 0x1 | bool | mbPlayerLicencePictureIsValid | Tracks whether the license picture is present |  |
+| 0x646F9 | 0x7 |  |  | Padding |  |
+| 0x64700 | 0x1928 | Array<MugshotInfo, 20u>[5] | maaMugshotInfo | Information on saved mugshots |  |
+| 0x66028 | 0x28 | BitArray<20u>[5] | maAvailableMugshotFileIDs | Tracks what mugshot slots are used |  |
+| 0x66050 | 0xC | float32_t[3] | mafCarTypes |  | Unused in the final game |
+| 0x6605C | 0x4 | ECarType | meCurrentCarType | Boost type of the current vehicle | See ECarType |
+| 0x66060 | 0x20 | BitArray<256u> | maHasPlayerSeenTraining | Tracks the tips DJ Atomika has used |  |
+| 0x66080 | 0x4 | int32_t | miNumOnlineRacesDone | Number of online races completed |  |
+| 0x66084 | 0x4 | int32_t | miNumOnlineRacesWon | Number of online races won |  |
+| 0x66088 | 0x4 | int32_t | miNumMugshotsSent | Number of mugshots sent by the player |  |
+| 0x6608C | 0x4 |  |  | Padding |  |
+| 0x66090 | 0x10 | DateAndTime | mDateLicenceIssued | Date the player's license was created |  |
+| 0x660A0 | 0x10 | DateAndTime | mDate100PercentCompleted | Date the player achieved 100% completion |  |
+| 0x660B0 | 0x4 | int32_t | miHighestNumberOfTakeDownsInRoadRage | Road Rage record |  |
+| 0x660B4 | 0x4 |  |  | Padding |  |
+| 0x660B8 | 0x8 | BitArray<35u> | mSeenTrophyAwardBitArray | Tracks which of the primary 35 vehicles unlocks have been shown |  |
+| 0x660C0 | 0x8 | BitArray<60u> | mAchievementsEarnt | Tracks which Paradise Awards have been earned |  |
+| 0x660C8 | 0x1 | bool | mb100PercentCompletionSequenceShown | Tracks whether the 100% completion animation has been shown |  |
+| 0x660C9 | 0x1 | bool | mbIsNewProfile | Tracks whether the profile is new | Intro will be shown if true |
+| 0x660CA | 0x1 | bool | mbCreditsSequenceViewed | Tracks whether the credits have been shown |  |
+| 0x660CB | 0x1 | bool | mbOneHundredHudMessageViewed | Tracks whether the 100% completion message has been shown |  |
+| 0x660CC | 0x1 | bool | mbHasUnlockedCredits | Tracks whether credits are available for viewing |  |
+| 0x660CD | 0x1 | bool | mbHaveSet100PercentCompletedDate | Tracks whether the 100% completion date is present |  |
+| 0x660CE | 0x1 | bool | mbHaveSeenEliteCompletionSequence | Tracks whether the Elite license animation has been shown |  |
+| 0x660CF | 0x1 | bool | mbRedundantBool4 |  | Unused in the final game |
+| 0x660D0 | 0x1 | int8_t | miPad1 |  | Unused in the final game |
+| 0x660D1 | 0x1 |  |  | Padding |  |
+| 0x660D2 | 0x2 | int16_t | miPad2 |  | Unused in the final game |
+| 0x660D4 | 0x4 |  |  | Padding |  |
+| 0x660D8 | 0x4 | uint32_t | muRoadRulesIDLowBits |  |  |
+| 0x660DC | 0x4 |  |  | Padding |  |
+| 0x660E0 | 0x8 | BitArray<6u> | mSeenCompleteAllEventTypeArray | Tracks which event types have had all events completed |  |
+| 0x660E8 | 0x4 | float32_t | mfRealTimePlayed | Total time played | As opposed to mfInCarTimePlayed |
+| 0x660EC | 0x4 | float32_t | mfRedundantFloat4 |  | Unused in the final game |
+| 0x660F0 | 0x4 | uint32_t | muRoadRulesIDHighBits |  |  |
+| 0x660F4 | 0x1 | bool | ? | License agreement 1 |  |
+| 0x660F5 | 0x1 | bool | ? | License agreement 2 |  |
+| 0x660F6 | 0x1 | int8_t | miPad4 |  | Unused in the final game |
+| 0x660F7 | 0x9 |  |  | Padding |  |
+
+#### PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number of the Profile structure | 31 |
+| 0x4 | 0x20 | char[32] | macName | Player-chosen profile name | Unused in the final game |
+| 0x24 | 0xC |  |  | Padding |  |
+| 0x30 | 0x10 | Vector3 | mCarPosition | Spawn position of the player vehicle | Unused in the final game |
+| 0x40 | 0x10 | Vector3 | mCarDirection | Spawn direction of the player vehicle | Unused in the final game |
+| 0x50 | 0x8 | CgsID | mSpawnCarId | The vehicle the player spawns in | Deprecated in V1.3 |
+| 0x58 | 0x8 | CgsID | mSpawnWheelId | The wheel the player vehicle spawns with | Unused in the final game |
+| 0x60 | 0x4 | uint32_t | muTimeStampOfLastRoadRulesDownload |  |  |
+| 0x64 | 0x4 | float32_t | mfDistanceDrivenOnline | Distance driven online in cars (meters) | Subject to distance limitations |
+| 0x68 | 0x4 | float32_t | mfDistanceDrivenOffline | Distance driven offline in cars (meters) | Subject to distance limitations |
+| 0x6C | 0x4 | float32_t | mfInCarTimePlayed | Total time spent driving | Subject to time limitations |
+| 0x70 | 0x1 | int8_t | mi8CurrentProgressionRank | Current license of the player | See ranks |
+| 0x71 | 0x1 | int8_t | mi8PowerParkingBestRating | Power Parking record |  |
+| 0x72 | 0x1 | int8_t | mi8PowerParkingBetweenOtherPlayersBestRating | Power Parking between players record | Not displayed in the final game |
+| 0x73 | 0x1 |  |  | Padding |  |
+| 0x74 | 0x4 | uint32_t | muBestNewBurnoutChainScore | Burnout chain record |  |
+| 0x78 | 0x44 | int32_t[17] | maGameModeTypeAmount | Number of events present, per type | See EGameModeType |
+| 0xBC | 0x44 | int32_t[17] | maGameModeTypeAmountDiscovered | Number of events discovered, per type | See EGameModeType |
+| 0x100 | 0x44 | int32_t[17] | maGameModeTypeAmountCompleted | Number of events completed for the current license, per type | See EGameModeType |
+| 0x144 | 0x44 | int32_t[17] | maGameModeTypeAmountCompletedSinceTheStart | Total number of events completed, per type | See EGameModeType |
+| 0x188 | 0x4 | int32_t | miTotalTakedownCount | Number of takedowns performed |  |
+| 0x18C | 0x4 | int32_t | miTotalOnlineVerticleTakedownCount | Number of vertical takedowns performed |  |
+| 0x190 | 0x34 | int32_t[13] | maiTakedownTypeCounts | Number of takedowns performed, per type | See ETakedownType |
+| 0x1C4 | 0x28 | int32_t[10] | maiWinsPerOfflineGameMode | Number of events won, per type | See EGameModeType |
+| 0x1EC | 0x28 | int32_t[10] | maiRankWinsPerOfflineGameMode | Number of events won causing a license upgrade, per type | See EGameModeType |
+| 0x214 | 0x28 | int32_t[10] | maiLossesPerOfflineGameMode | Number of events lost, per type |  |
+| 0x23C | 0x4 | int32_t | miCompletedBarrelRolls | Barrel roll record |  |
+| 0x240 | 0x4 | float32_t | mfCompletedAirSpinAngle | Flat spin record |  |
+| 0x244 | 0x4 | float32_t | mfCompletedHandbreakTurnAngle | Handbrake turn record | Not displayed in the final game |
+| 0x248 | 0x4 | float32_t | mfCompletedDriftDistance | Drift record |  |
+| 0x24C | 0x4 | float32_t | mfOncomingDistance | Oncoming record |  |
+| 0x250 | 0x4 | float32_t | mfAirMaximum | Air time record |  |
+| 0x254 | 0x4 | int32_t | miHighestShowTimeScore | Showtime record |  |
+| 0x258 | 0x4 | int32_t | miBestStuntRunScore | Stunt run record | Deprecated in game version 1.3 |
+| 0x25C | 0x4 | int32_t | miCarCount | Number of vehicle entries |  |
+| 0x260 | 0x4 | int32_t | miLiveryDataCount | Number of livery entries |  |
+| 0x264 | 0x4 | int32_t | miRivalCount | Number of rival entries |  |
+| 0x268 | 0x4 | int32_t | miEventCount | Number of event entries |  |
+| 0x26C | 0x4 |  |  | Padding |  |
+| 0x270 | 0x3000 | CarData[512] | maCars | Vehicle unlocks, colors, and damage |  |
+| 0x3270 | 0x3000 | LiveryData[512] | maLiveryChoices | Selected finishes and mileage |  |
+| 0x6270 | 0xE00 | RivalData[64] | maRivals | Roaming rival/shutdown car info |  |
+| 0x7070 | 0x578 | ProfileEvent[175] | maEvents | Event completion states |  |
+| 0x75E8 | 0x3018 | Set<CgsID, 512u>[3] | maStuntElements | Collectible completion states | See EStuntType |
+| 0xA600 | 0x4 | uint32_t | muMedalCountFromTheStart | Total number of events won |  |
+| 0xA604 | 0x1 | bool | mbGoldCarsUnlocked | Tracks whether gold finishes are unlocked |  |
+| 0xA605 | 0x1 | bool | mbSilverCarsUnlocked | Tracks whether platinum finishes are unlocked |  |
+| 0xA606 | 0x2 |  |  | Padding |  |
+| 0xA608 | 0x30 | Set<CgsID, 5u> | mJunkYardsDriveThruSet | Discovered Junkyards |  |
+| 0xA638 | 0x60 | Set<CgsID, 11u> | mBodyShopsDriveThruSet | Discovered Auto Repairs |  |
+| 0xA698 | 0x30 | Set<CgsID, 5u> | mPaintShopsDriveThruSet | Discovered Paint Shops |  |
+| 0xA6C8 | 0x78 | Set<CgsID, 14u> | mGasStationsDriveThruSet | Discovered Gas Stations |  |
+| 0xA740 | 0x60 | Set<CgsID, 11u> | mCarParksDriveThruSet | Discovered Car Parks |  |
+| 0xA7A0 | 0x3E88 | Array<CgsID, 2000u> | maFreeBurnChallengeData | Completed Freeburn and Timed Challenges |  |
+| 0xE628 | 0x9280 | HitPropsBitArray | mabHitPropBitArray | Smashed billboards and individual gate sections | 500 TRK units, 600 prop hit indicators (bits) each. Not all TRKs are used |
+| 0x178A8 | 0x1E | int16_t[3][5] | maaiStuntCountsByCounty | Collectible progression, per-county | See EStuntType and counties |
+| 0x178C6 | 0x2 |  |  | Padding |  |
+| 0x178C8 | 0x1400 | ChallengeHighScoreEntry[64] | maNetworkChallengeData | Online mainland car Time/Showtime Road Rule scores and player names |  |
+| 0x18CC8 | 0xA00 | ChallengePlayerScoreEntry[64] | maChallengeData | Player mainland car Time/Showtime Road Rule scores and vehicles |  |
+| 0x196C8 | 0x4 | uint32_t | muLastRoadRulesResetTime |  |  |
+| 0x196CC | 0x1C | NetworkTexture | mPlayerLicencePicture | License picture header |  |
+| 0x196E8 | 0x4B000 | char[38400][8] | macPlayerLicenceTextureData | License picture data | Only first is used |
+| 0x646E8 | 0x1 | bool | mbPlayerLicencePictureIsValid | Tracks whether the license picture is present |  |
+| 0x646E9 | 0x3 |  |  | Padding |  |
+| 0x646EC | 0x15F4 | Array<MugshotInfo, 20u>[5] | maaMugshotInfo | Information on saved mugshots | Not padded after length |
+| 0x65CE0 | 0x28 | BitArray<20u>[5] | maAvailableMugshotFileIDs | Tracks what mugshot slots are used |  |
+| 0x65D08 | 0xC | float32_t[3] | mafCarTypes |  | Unused in the final game |
+| 0x65D14 | 0x4 | ECarType | meCurrentCarType | Boost type of the current vehicle | See ECarType |
+| 0x65D18 | 0x20 | BitArray<256u> | maHasPlayerSeenTraining | Tracks the tips DJ Atomika has used |  |
+| 0x65D38 | 0x4 | int32_t | miNumOnlineRacesDone | Number of online races completed |  |
+| 0x65D3C | 0x4 | int32_t | miNumOnlineRacesWon | Number of online races won |  |
+| 0x65D40 | 0x4 | int32_t | miNumMugshotsSent | Number of mugshots sent by the player |  |
+| 0x65D44 | 0xC | DateAndTime | mDateLicenceIssued | Date the player's license was created |  |
+| 0x65D50 | 0xC | DateAndTime | mDate100PercentCompleted | Date the player achieved 100% completion |  |
+| 0x65D5C | 0x4 | int32_t | miHighestNumberOfTakeDownsInRoadRage | Road Rage record |  |
+| 0x65D60 | 0x8 | BitArray<35u> | mSeenTrophyAwardBitArray | Tracks which of the primary 35 vehicles unlocks have been shown |  |
+| 0x65D68 | 0x8 | BitArray<60u> | mAchievementsEarnt | Tracks which Paradise Awards have been earned |  |
+| 0x65D70 | 0x1 | bool | mb100PercentCompletionSequenceShown | Tracks whether the 100% completion animation has been shown |  |
+| 0x65D71 | 0x1 | bool | mbIsNewProfile | Tracks whether the profile is new | Intro will be shown if true |
+| 0x65D72 | 0x1 | bool | mbCreditsSequenceViewed | Tracks whether the credits have been shown |  |
+| 0x65D73 | 0x1 | bool | mbOneHundredHudMessageViewed | Tracks whether the 100% completion message has been shown |  |
+| 0x65D74 | 0x1 | bool | mbHasUnlockedCredits | Tracks whether credits are available for viewing |  |
+| 0x65D75 | 0x1 | bool | mbHaveSet100PercentCompletedDate | Tracks whether the 100% completion date is present |  |
+| 0x65D76 | 0x1 | bool | mbHaveSeenEliteCompletionSequence | Tracks whether the Elite license animation has been shown |  |
+| 0x65D77 | 0x1 | bool | mbRedundantBool4 |  | Unused in the final game |
+| 0x65D78 | 0x1 | int8_t | miPad1 |  | Unused in the final game |
+| 0x65D79 | 0x1 |  |  | Padding |  |
+| 0x65D7A | 0x2 | int16_t | miPad2 |  | Unused in the final game |
+| 0x65D7C | 0x4 |  |  | Padding |  |
+| 0x65D80 | 0x4 | uint32_t | muRoadRulesIDLowBits |  |  |
+| 0x65D84 | 0x4 |  |  | Padding |  |
+| 0x65D88 | 0x8 | BitArray<6u> | mSeenCompleteAllEventTypeArray | Tracks which event types have had all events completed |  |
+| 0x65D90 | 0x4 | float32_t | mfRealTimePlayed | Total time played | As opposed to mfInCarTimePlayed |
+| 0x65D94 | 0x4 | float32_t | mfRedundantFloat4 |  | Unused in the final game |
+| 0x65D98 | 0x4 | uint32_t | muRoadRulesIDHighBits |  |  |
+| 0x65D9C | 0x2 | int16_t | miPad3 |  | Unused in the final game |
+| 0x65D9E | 0x1 | int8_t | miPad4 |  | Unused in the final game |
+| 0x65D9F | 0x1 |  |  | Padding |  |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number of the Profile structure | 31 |
+| 0x4 | 0x20 | char[32] | macName | Player-chosen profile name | Unused in the final game |
+| 0x24 | 0xC |  |  | Padding |  |
+| 0x30 | 0x10 | Vector3 | mCarPosition | Spawn position of the player vehicle | Unused in the final game |
+| 0x40 | 0x10 | Vector3 | mCarDirection | Spawn direction of the player vehicle | Unused in the final game |
+| 0x50 | 0x8 | CgsID | mSpawnCarId | The vehicle the player spawns in | Deprecated in V1.3 |
+| 0x58 | 0x8 | CgsID | mSpawnWheelId | The wheel the player vehicle spawns with | Unused in the final game |
+| 0x60 | 0x4 | uint32_t | muTimeStampOfLastRoadRulesDownload |  |  |
+| 0x64 | 0x4 | float32_t | mfDistanceDrivenOnline | Distance driven online in cars (meters) | Subject to distance limitations |
+| 0x68 | 0x4 | float32_t | mfDistanceDrivenOffline | Distance driven offline in cars (meters) | Subject to distance limitations |
+| 0x6C | 0x4 | float32_t | mfInCarTimePlayed | Total time spent driving | Subject to time limitations |
+| 0x70 | 0x1 | int8_t | mi8CurrentProgressionRank | Current license of the player | See ranks |
+| 0x71 | 0x1 | int8_t | mi8PowerParkingBestRating | Power Parking record |  |
+| 0x72 | 0x1 | int8_t | mi8PowerParkingBetweenOtherPlayersBestRating | Power Parking between players record | Not displayed in the final game |
+| 0x73 | 0x1 |  |  | Padding |  |
+| 0x74 | 0x4 | uint32_t | muBestNewBurnoutChainScore | Burnout chain record |  |
+| 0x78 | 0x44 | int32_t[17] | maGameModeTypeAmount | Number of events present, per type | See EGameModeType |
+| 0xBC | 0x44 | int32_t[17] | maGameModeTypeAmountDiscovered | Number of events discovered, per type | See EGameModeType |
+| 0x100 | 0x44 | int32_t[17] | maGameModeTypeAmountCompleted | Number of events completed for the current license, per type | See EGameModeType |
+| 0x144 | 0x44 | int32_t[17] | maGameModeTypeAmountCompletedSinceTheStart | Total number of events completed, per type | See EGameModeType |
+| 0x188 | 0x4 | int32_t | miTotalTakedownCount | Number of takedowns performed |  |
+| 0x18C | 0x4 | int32_t | miTotalOnlineVerticleTakedownCount | Number of vertical takedowns performed |  |
+| 0x190 | 0x34 | int32_t[13] | maiTakedownTypeCounts | Number of takedowns performed, per type | See ETakedownType |
+| 0x1C4 | 0x28 | int32_t[10] | maiWinsPerOfflineGameMode | Number of events won, per type | See EGameModeType |
+| 0x1EC | 0x28 | int32_t[10] | maiRankWinsPerOfflineGameMode | Number of events won causing a license upgrade, per type | See EGameModeType |
+| 0x214 | 0x28 | int32_t[10] | maiLossesPerOfflineGameMode | Number of events lost, per type |  |
+| 0x23C | 0x4 | int32_t | miCompletedBarrelRolls | Barrel roll record |  |
+| 0x240 | 0x4 | float32_t | mfCompletedAirSpinAngle | Flat spin record |  |
+| 0x244 | 0x4 | float32_t | mfCompletedHandbreakTurnAngle | Handbrake turn record | Not displayed in the final game |
+| 0x248 | 0x4 | float32_t | mfCompletedDriftDistance | Drift record |  |
+| 0x24C | 0x4 | float32_t | mfOncomingDistance | Oncoming record |  |
+| 0x250 | 0x4 | float32_t | mfAirMaximum | Air time record |  |
+| 0x254 | 0x4 | int32_t | miHighestShowTimeScore | Showtime record |  |
+| 0x258 | 0x4 | int32_t | miBestStuntRunScore | Stunt run record | Deprecated in game version 1.3 |
+| 0x25C | 0x4 | int32_t | miCarCount | Number of vehicle entries |  |
+| 0x260 | 0x4 | int32_t | miLiveryDataCount | Number of livery entries |  |
+| 0x264 | 0x4 | int32_t | miRivalCount | Number of rival entries |  |
+| 0x268 | 0x4 | int32_t | miEventCount | Number of event entries |  |
+| 0x26C | 0x4 |  |  | Padding |  |
+| 0x270 | 0x3000 | CarData[512] | maCars | Vehicle unlocks, colors, and damage |  |
+| 0x3270 | 0x3000 | LiveryData[512] | maLiveryChoices | Selected finishes and mileage |  |
+| 0x6270 | 0xE00 | RivalData[64] | maRivals | Roaming rival/shutdown car info |  |
+| 0x7070 | 0x578 | ProfileEvent[175] | maEvents | Event completion states |  |
+| 0x75E8 | 0x3018 | Set<CgsID, 512u>[3] | maStuntElements | Collectible completion states | See EStuntType |
+| 0xA600 | 0x4 | uint32_t | muMedalCountFromTheStart | Total number of events won |  |
+| 0xA604 | 0x1 | bool | mbGoldCarsUnlocked | Tracks whether gold finishes are unlocked |  |
+| 0xA605 | 0x1 | bool | mbSilverCarsUnlocked | Tracks whether platinum finishes are unlocked |  |
+| 0xA606 | 0x2 |  |  | Padding |  |
+| 0xA608 | 0x30 | Set<CgsID, 5u> | mJunkYardsDriveThruSet | Discovered Junkyards |  |
+| 0xA638 | 0x60 | Set<CgsID, 11u> | mBodyShopsDriveThruSet | Discovered Auto Repairs |  |
+| 0xA698 | 0x30 | Set<CgsID, 5u> | mPaintShopsDriveThruSet | Discovered Paint Shops |  |
+| 0xA6C8 | 0x78 | Set<CgsID, 14u> | mGasStationsDriveThruSet | Discovered Gas Stations |  |
+| 0xA740 | 0x60 | Set<CgsID, 11u> | mCarParksDriveThruSet | Discovered Car Parks |  |
+| 0xA7A0 | 0x3E88 | Array<CgsID, 2000u> | maFreeBurnChallengeData | Completed Freeburn and Timed Challenges |  |
+| 0xE628 | 0x9280 | HitPropsBitArray | mabHitPropBitArray | Smashed billboards and individual gate sections | 500 TRK units, 600 prop hit indicators (bits) each. Not all TRKs are used |
+| 0x178A8 | 0x1E | int16_t[3][5] | maaiStuntCountsByCounty | Collectible progression, per-county | See EStuntType and counties |
+| 0x178C6 | 0x2 |  |  | Padding |  |
+| 0x178C8 | 0x1800 | ChallengeHighScoreEntry[64] | maNetworkChallengeData | Online mainland car Time/Showtime Road Rule scores and player names |  |
+| 0x190C8 | 0xA00 | ChallengePlayerScoreEntry[64] | maChallengeData | Player mainland car Time/Showtime Road Rule scores and vehicles |  |
+| 0x19AC8 | 0x4 | uint32_t | muLastRoadRulesResetTime |  |  |
+| 0x19ACC | 0x4 |  |  | Padding |  |
+| 0x19AD0 | 0x28 | NetworkTexture | mPlayerLicencePicture | License picture header |  |
+| 0x19AF8 | 0x4B000 | char[38400][8] | macPlayerLicenceTextureData | License picture data | Only first is used |
+| 0x64AF8 | 0x1 | bool | mbPlayerLicencePictureIsValid | Tracks whether the license picture is present |  |
+| 0x64AF9 | 0x7 |  |  | Padding |  |
+| 0x64B00 | 0x1C48 | Array<MugshotInfo, 20u>[5] | maaMugshotInfo | Information on saved mugshots |  |
+| 0x66748 | 0x28 | BitArray<20u>[5] | maAvailableMugshotFileIDs | Tracks what mugshot slots are used |  |
+| 0x66770 | 0xC | float32_t[3] | mafCarTypes |  | Unused in the final game |
+| 0x6677C | 0x4 | ECarType | meCurrentCarType | Boost type of the current vehicle | See ECarType |
+| 0x66780 | 0x20 | BitArray<256u> | maHasPlayerSeenTraining | Tracks the tips DJ Atomika has used |  |
+| 0x667A0 | 0x4 | int32_t | miNumOnlineRacesDone | Number of online races completed |  |
+| 0x667A4 | 0x4 | int32_t | miNumOnlineRacesWon | Number of online races won |  |
+| 0x667A8 | 0x4 | int32_t | miNumMugshotsSent | Number of mugshots sent by the player |  |
+| 0x667AC | 0x4 |  |  | Padding |  |
+| 0x667B0 | 0x10 | DateAndTime | mDateLicenceIssued | Date the player's license was created |  |
+| 0x667C0 | 0x10 | DateAndTime | mDate100PercentCompleted | Date the player achieved 100% completion |  |
+| 0x667D0 | 0x4 | int32_t | miHighestNumberOfTakeDownsInRoadRage | Road Rage record |  |
+| 0x667D4 | 0x4 |  |  | Padding |  |
+| 0x667D8 | 0x8 | BitArray<35u> | mSeenTrophyAwardBitArray | Tracks which of the primary 35 vehicles unlocks have been shown |  |
+| 0x667E0 | 0x8 | BitArray<60u> | mAchievementsEarnt | Tracks which Paradise Awards have been earned |  |
+| 0x667E8 | 0x1 | bool | mb100PercentCompletionSequenceShown | Tracks whether the 100% completion animation has been shown |  |
+| 0x667E9 | 0x1 | bool | mbIsNewProfile | Tracks whether the profile is new | Intro will be shown if true |
+| 0x667EA | 0x1 | bool | mbCreditsSequenceViewed | Tracks whether the credits have been shown |  |
+| 0x667EB | 0x1 | bool | mbOneHundredHudMessageViewed | Tracks whether the 100% completion message has been shown |  |
+| 0x667EC | 0x1 | bool | mbHasUnlockedCredits | Tracks whether credits are available for viewing |  |
+| 0x667ED | 0x1 | bool | mbHaveSet100PercentCompletedDate | Tracks whether the 100% completion date is present |  |
+| 0x667EE | 0x1 | bool | mbHaveSeenEliteCompletionSequence | Tracks whether the Elite license animation has been shown |  |
+| 0x667EF | 0x1 | bool | mbRedundantBool4 |  | Unused in the final game |
+| 0x667F0 | 0x1 | int8_t | miPad1 |  | Unused in the final game |
+| 0x667F1 | 0x1 |  |  | Padding |  |
+| 0x667F2 | 0x2 | int16_t | miPad2 |  | Unused in the final game |
+| 0x667F4 | 0x4 |  |  | Padding |  |
+| 0x667F8 | 0x4 | uint32_t | muRoadRulesIDLowBits |  |  |
+| 0x667FC | 0x4 |  |  | Padding |  |
+| 0x66800 | 0x8 | BitArray<6u> | mSeenCompleteAllEventTypeArray | Tracks which event types have had all events completed |  |
+| 0x66808 | 0x4 | float32_t | mfRealTimePlayed | Total time played | As opposed to mfInCarTimePlayed |
+| 0x6680C | 0x4 | float32_t | mfRedundantFloat4 |  | Unused in the final game |
+| 0x66810 | 0x4 | uint32_t | muRoadRulesIDHighBits |  |  |
+| 0x66814 | 0x2 | int16_t | miPad3 |  | Unused in the final game |
+| 0x66816 | 0x1 | int8_t | miPad4 |  | Unused in the final game |
+| 0x66817 | 0x9 |  |  | Padding |  |
+
+### BrnProgression::CarData
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | CgsID | mId | Vehicle ID |  |
+| 0x8 | 0x1 | uint8_t | mu8ColourIndex | Color index | From the Player Car Colours resource |
+| 0x9 | 0x1 | uint8_t | mu8PaletteIndex | Color palette/type index | From the Player Car Colours resource |
+| 0xA | 0x1 | bool | mbUnlockSequenceAlreadyShown | Has Junkyard unlock animation been played |  |
+| 0xB | 0x1 | uint8_t | ? | Version flags from the Vehicle List resource | Padding prior to game version 1.3 |
+| 0xC | 0x4 | float32_t | mfUnlockDeformedAmount | Damage applied to the car |  |
+| 0x10 | 0x4 | UnlockType | meUnlockType | Vehicle unlock type |  |
+| 0x14 | 0x4 |  |  | Padding |  |
+
+### BrnProgression::LiveryData
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | CgsID | mBaseCarId |  |  |
+| 0x8 | 0x8 | CgsID | mChosenLiveryCarId |  |  |
+| 0x10 | 0x4 | float32_t | mfDistanceDriven |  |  |
+| 0x14 | 0x1 | uint8_t | ? | Version flags from the Vehicle List resource | Padding prior to version 1.3 |
+| 0x15 | 0x3 |  |  | Padding |  |
+
+### BrnProgression::RivalData
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | CgsID | mRivalId |  | GameDB ID |
+| 0x8 | 0x8 | CgsID | mCarId |  |  |
+| 0x10 | 0x4 | EState | meState |  |  |
+| 0x14 | 0x4 | int32_t | miEventCount |  |  |
+| 0x18 | 0x4 | int32_t | miTakedownFromCount |  |  |
+| 0x1C | 0x4 | int32_t | miVerticalTakedownFromCount |  |  |
+| 0x20 | 0x4 | int32_t | miTakedownToCount |  |  |
+| 0x24 | 0x4 | int32_t | miVerticalTakedownToCount |  |  |
+| 0x28 | 0x4 | int32_t | miTakedownToInEventCount |  |  |
+| 0x2C | 0x4 | int32_t | miTakedownToInLastEventCount |  |  |
+| 0x30 | 0x4 | int32_t | miEventMissingCount |  |  |
+| 0x34 | 0x1 | bool | mbHasBeenHit |  |  |
+| 0x35 | 0x3 |  |  | Padding |  |
+
+### BrnProgression::ProfileEvent
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | uint32_t | muEventID | Event junction ID |  |
+| 0x4 | 0x2 | uint16_t | muFlags | Event flags | See Flags |
+| 0x6 | 0x2 |  |  | Padding |  |
+
+### BrnStreetData::ChallengeHighScoreEntry
+
+#### PlayStation 3, PC
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x18 | ChallengeData | super_ChallengeData |  |  |
+| 0x18 | 0x28 | PlayerName[2] | maPlayerNames |  | See ScoreType for index names |
+
+#### Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x18 | ChallengeData | super_ChallengeData |  |  |
+| 0x18 | 0x20 | PlayerName[2] | maPlayerNames |  | See ScoreType for index names |
+
+#### PlayStation 4, PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x18 | ChallengeData | super_ChallengeData |  |  |
+| 0x18 | 0x32 | PlayerName[2] | maPlayerNames |  | See ScoreType for index names |
+| 0x4A | 0x6 |  |  | Padding |  |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x18 | ChallengeData | super_ChallengeData |  |  |
+| 0x18 | 0x42 | PlayerName[2] | maPlayerNames |  | See ScoreType for index names |
+| 0x5A | 0x6 |  |  | Padding |  |
+
+### BrnStreetData::ChallengeData
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | BitArray<2u> | mDirty |  | See ScoreType for index names |
+| 0x8 | 0x8 | BitArray<2u> | mValidScores |  | See ScoreType for index names |
+| 0x10 | 0x8 | ScoreList | mScoreList |  |  |
+
+### BrnStreetData::ScoreList
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | int32_t[2] | maScores | Time and showtime score, respectively | See ScoreType for index names |
+
+### CgsNetwork::PlayerName
+
+#### PlayStation 3, PC
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x14 | char[20] | macName | Online player's name |  |
+
+#### Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x10 | char[16] | macName | Online player's name |  |
+
+#### PlayStation 4, PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x19 | char[25] | macName | Online player's name |  |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x21 | char[33] | macName | Online player's name |  |
+
+### BrnStreetData::ChallengePlayerScoreEntry
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x18 | ChallengeData | super_ChallengeData |  |  |
+| 0x18 | 0x10 | CgsID[2] | maCarIDs |  | See ScoreType for index names |
+
+### CgsNetwork::NetworkTexture
+
+#### PlayStation 3
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | HeapMalloc* | mpHeapMalloc |  |  |
+| 0x4 | 0x4 | int32_t | miBitsPerPixel |  |  |
+| 0x8 | 0x4 | int32_t | miWidth |  |  |
+| 0xC | 0x4 | int32_t | miHeight |  |  |
+| 0x10 | 0x4 | PixelFormat | mFormat |  |
+| 0x14 | 0x4 | char* | mpcTexture |  |  |
+| 0x18 | 0x1 | bool | mbTextureAllocatedFromHeap |  |  |
+| 0x19 | 0x1 | bool | mbIsUncompressedYUV |  |  |
+| 0x1A | 0x2 |  |  | Padding |  |
+
+#### Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | HeapMalloc* | mpHeapMalloc |  |  |
+| 0x4 | 0x4 | int32_t | miBitsPerPixel |  |  |
+| 0x8 | 0x4 | int32_t | miWidth |  |  |
+| 0xC | 0x4 | int32_t | miHeight |  |  |
+| 0x10 | 0x4 | Parameters | mFormat |  |
+| 0x14 | 0x4 | char* | mpcTexture |  |  |
+| 0x18 | 0x1 | bool | mbTextureAllocatedFromHeap |  |  |
+| 0x19 | 0x1 | bool | mbIsUncompressedYUV |  |  |
+| 0x1A | 0x2 |  |  | Padding |  |
+
+#### Parameters
+
+Parameters for the MAKED3DFMT2 macro. Xbox 360 only.
+
+| Offset (bits) | Length (bits) | Name | Description | Comments |
+| --- | --- | --- | --- | --- |
+| 0 | 2 |  | Padding |  |
+| 2 | 3 | SwizzleW |  | See GPUSWIZZLE on the Xbox 360 texture page. |
+| 5 | 3 | SwizzleZ |  | See GPUSWIZZLE on the Xbox 360 texture page. |
+| 8 | 3 | SwizzleY |  | See GPUSWIZZLE on the Xbox 360 texture page. |
+| 11 | 3 | SwizzleX |  | See GPUSWIZZLE on the Xbox 360 texture page. |
+| 14 | 1 | NumFormat |  | See GPUNUMFORMAT on the Xbox 360 texture page. |
+| 15 | 2 | TextureSignW |  | See GPUSIGN on the Xbox 360 texture page. |
+| 17 | 2 | TextureSignZ |  | See GPUSIGN on the Xbox 360 texture page. |
+| 19 | 2 | TextureSignY |  | See GPUSIGN on the Xbox 360 texture page. |
+| 21 | 2 | TextureSignX |  | See GPUSIGN on the Xbox 360 texture page. |
+| 23 | 1 | Tiled |  |  |
+| 24 | 2 | Endian |  | See GPUENDIAN on the Xbox 360 texture page. |
+| 26 | 6 | TextureFormat |  | See GPUTEXTUREFORMAT. |
+
+#### PC
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | HeapMalloc* | mpHeapMalloc |  |  |
+| 0x4 | 0x4 | int32_t | miBitsPerPixel |  |  |
+| 0x8 | 0x4 | int32_t | miWidth |  |  |
+| 0xC | 0x4 | int32_t | miHeight |  |  |
+| 0x10 | 0x4 | D3DFORMAT | mFormat |  |
+| 0x14 | 0x4 | char* | mpcTexture |  |  |
+| 0x18 | 0x1 | bool | mbTextureAllocatedFromHeap |  |  |
+| 0x19 | 0x1 | bool | mbIsUncompressedYUV |  |  |
+| 0x1A | 0x2 |  |  | Padding |  |
+
+#### PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | HeapMalloc* | mpHeapMalloc |  |  |
+| 0x4 | 0x4 | int32_t | miBitsPerPixel |  |  |
+| 0x8 | 0x4 | int32_t | miWidth |  |  |
+| 0xC | 0x4 | int32_t | miHeight |  |  |
+| 0x10 | 0x4 | DXGI_FORMAT | mFormat |  |
+| 0x14 | 0x4 | char* | mpcTexture |  |  |
+| 0x18 | 0x1 | bool | mbTextureAllocatedFromHeap |  |  |
+| 0x19 | 0x1 | bool | mbIsUncompressedYUV |  |  |
+| 0x1A | 0x2 |  |  | Padding |  |
+
+#### PlayStation 4, Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x8 | HeapMalloc* | mpHeapMalloc |  |  |
+| 0x8 | 0x4 | int32_t | miBitsPerPixel |  |  |
+| 0xC | 0x4 | int32_t | miWidth |  |  |
+| 0x10 | 0x4 | int32_t | miHeight |  |  |
+| 0x14 | 0x4 | DXGI_FORMAT | mFormat |  |
+| 0x18 | 0x8 | char* | mpcTexture |  |  |
+| 0x20 | 0x1 | bool | mbTextureAllocatedFromHeap |  |  |
+| 0x21 | 0x1 | bool | mbIsUncompressedYUV |  |  |
+| 0x22 | 0x6 |  |  | Padding |  |
+
+### BrnProgression::MugshotInfo
+
+#### PlayStation 3
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x14 | UniquePlayerID | mUniquePlayerID |  |  |
+| 0x14 | 0x4 |  |  | Padding |  |
+| 0x18 | 0x10 | DateAndTime | mCaptureDate |  |  |
+| 0x28 | 0x8 | WorldRegion | mWorldRegion |  |  |
+| 0x30 | 0x4 | int32_t | miNumCaptures |  |  |
+| 0x34 | 0x2 | uint16_t | mu16FileID |  |  |
+| 0x36 | 0x1 | bool | mbLocked |  |  |
+| 0x37 | 0x1 |  |  | Padding |  |
+
+#### Xbox 360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x18 | UniquePlayerID | mUniquePlayerID |  |  |
+| 0x18 | 0xC | DateAndTime | mCaptureDate |  |  |
+| 0x24 | 0x8 | WorldRegion | mWorldRegion |  |  |
+| 0x2C | 0x4 | int32_t | miNumCaptures |  |  |
+| 0x30 | 0x2 | uint16_t | mu16FileID |  |  |
+| 0x32 | 0x1 | bool | mbLocked |  |  |
+| 0x33 | 0x5 |  |  | Padding |  |
+
+#### PC
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x14 | UniquePlayerID | mUniquePlayerID |  |  |
+| 0x14 | 0xC | DateAndTime | mCaptureDate |  |  |
+| 0x20 | 0x8 | WorldRegion | mWorldRegion |  |  |
+| 0x28 | 0x4 | int32_t | miNumCaptures |  |  |
+| 0x2C | 0x2 | uint16_t | mu16FileID |  |  |
+| 0x2E | 0x1 | bool | mbLocked |  |  |
+| 0x2F | 0x1 |  |  | Padding |  |
+
+#### PlayStation 4
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x19 | UniquePlayerID | mUniquePlayerID |  |  |
+| 0x19 | 0x3 |  |  | Padding |  |
+| 0x1C | 0x10 | DateAndTime | mCaptureDate |  |  |
+| 0x2C | 0x8 | WorldRegion | mWorldRegion |  |  |
+| 0x34 | 0x4 | int32_t | miNumCaptures |  |  |
+| 0x38 | 0x2 | uint16_t | mu16FileID |  |  |
+| 0x3A | 0x1 | bool | mbLocked |  |  |
+| 0x3B | 0x5 |  |  | Padding |  |
+
+#### PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x19 | UniquePlayerID | mUniquePlayerID |  |  |
+| 0x19 | 0x3 |  |  | Padding |  |
+| 0x1C | 0xC | DateAndTime | mCaptureDate |  |  |
+| 0x28 | 0x8 | WorldRegion | mWorldRegion |  |  |
+| 0x30 | 0x4 | int32_t | miNumCaptures |  |  |
+| 0x34 | 0x2 | uint16_t | mu16FileID |  |  |
+| 0x36 | 0x1 | bool | mbLocked |  |  |
+| 0x37 | 0x1 |  |  | Padding |  |
+
+#### Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x21 | UniquePlayerID | mUniquePlayerID |  |  |
+| 0x21 | 0x3 |  |  | Padding |  |
+| 0x24 | 0x10 | DateAndTime | mCaptureDate |  |  |
+| 0x34 | 0x8 | WorldRegion | mWorldRegion |  |  |
+| 0x3C | 0x4 | int32_t | miNumCaptures |  |  |
+| 0x40 | 0x2 | uint16_t | mu16FileID |  |  |
+| 0x42 | 0x1 | bool | mbLocked |  |  |
+| 0x43 | 0x5 |  |  | Padding |  |
+
+### CgsNetwork::UniquePlayerIDPS3
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x14 | PlayerName | mPlayerName | Player name |  |
+
+### CgsNetwork::UniquePlayerIDX360
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x10 | PlayerName | mPlayerName | Player name |  |
+| 0x10 | 0x8 | int64_t | ? | XUID |  |
+
+### CgsSystem::DateAndTime
+
+#### PlayStation 3, PlayStation 4, Switch
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x1 | bool | mbIsLocal | Defines whether the saved time is in a local time zone or UTC |  |
+| 0x1 | 0x7 |  |  | Padding |  |
+| 0x8 | 0x8 | time_t | mSystemTime | The time value |  |
+
+#### Xbox 360, PC, PC (Remastered)
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x1 | bool | mbIsLocal | Defines whether the saved time is in a local time zone or UTC |  |
+| 0x1 | 0x3 |  |  | Padding |  |
+| 0x8 | 0x8 | FILETIME | mSystemTime | The time value |  |
+
+### BrnWorld::WorldRegion
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | ECounty | meCounty |  | See counties |
+| 0x4 | 0x4 | EDistrict | meDistrict |  | See districts |
+
+## Typedefs
+
+### BrnProgression::Profile::HitPropsBitArray
+
+| Name | Type | Length | Comments |
+| --- | --- | --- | --- |
+| HitPropsBitArray | BitArray<300000u> | 0x9280 |  |
+
+### BrnProgression::MugshotInfo::UniquePlayerID
+
+#### PlayStation 3
+
+| Name | Type | Length | Comments |
+| --- | --- | --- | --- |
+| UniquePlayerID | UniquePlayerIDPS3 | 0x14 |  |
+
+#### Xbox 360
+
+| Name | Type | Length | Comments |
+| --- | --- | --- | --- |
+| UniquePlayerID | UniquePlayerIDX360 | 0x18 |  |
+
+#### Other platforms
+
+Similar to UniquePlayerIDPS3 but with an unknown type name. See PlayerName.
+
+## Enumerations
+
+### Progression rank
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| ? | 0 | Learner's Permit |
+| ? | 1 | D License |
+| ? | 2 | C License |
+| ? | 3 | B License |
+| ? | 4 | A License |
+| ? | 5 | Burnout License |
+| ? | 6 | Elite License |
+
+### BrnGameState::GameStateModuleIO::EGameModeType
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_MODE_NONE | -1 |  |
+| E_MODE_OFFLINE_RACE | 0 |  |
+| E_MODE_FACE_OFF | 1 |  |
+| E_MODE_OFFLINE_SHOWTIME | 2 |  |
+| E_MODE_ROAD_RAGE | 3 |  |
+| E_MODE_PURSUIT | 4 |  |
+| E_MODE_BURNING_ROUTE | 5 |  |
+| E_MODE_ELIMINATOR | 6 |  |
+| E_MODE_STUNT_ATTACK | 7 |  |
+| E_MODE_MARKED_MAN | 8 |  |
+| E_MODE_TRAFFIC_ATTACK | 9 |  |
+| E_MODE_OFFLINE_COUNT | 10 |  |
+| E_MODE_ONLINE_MODE_START | 10 |  |
+| E_MODE_ONLINE_RACE | 10 |  |
+| E_MODE_ONLINE_ROAD_RAGE | 11 |  |
+| E_MODE_ONLINE_FUGITIVE | 12 |  |
+| E_MODE_ONLINE_BURNING_HOME_RUN | 13 |  |
+| E_MODE_ONLINE_FREE_BURN | 14 |  |
+| E_MODE_ONLINE_FREE_BURN_LOBBY | 15 |  |
+| E_MODE_ONLINE_SHOWTIME | 16 |  |
+| E_MODE_ONLINE_MODE_END | 17 |  |
+| E_MODE_COUNT | 17 |  |
+
+### BrnGameState::ETakedownType
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_TAKEDOWN_NONE | -1 |  |
+| E_TAKEDOWN_STANDARD | 0 |  |
+| E_TAKEDOWN_GRINDING | 1 |  |
+| E_TAKEDOWN_T_BONE | 2 |  |
+| E_TAKEDOWN_VERTICAL | 3 |  |
+| E_TAKEDOWN_TRAFFIC_CHECK | 4 |  |
+| E_TAKEDOWN_HEAD_ON | 5 |  |
+| E_TAKEDOWN_UNKNOWN0 | 6 |  |
+| E_TAKEDOWN_UNKNOWN1 | 7 |  |
+| E_TAKEDOWN_DOUBLE | 8 |  |
+| E_TAKEDOWN_REVENGE | 9 |  |
+| E_TAKEDOWN_INTO_CAR | 10 |  |
+| E_TAKEDOWN_INTO_VAN | 11 |  |
+| E_TAKEDOWN_INTO_BUS | 12 |  |
+| E_TAKEDOWN_COUNT | 13 |  |
+
+### BrnProgression::CarData::UnlockType
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_UNLOCK_TYPE_UNLOCK | 0 | Unlocked at start |
+| E_UNLOCK_TYPE_GIFT | 1 | Secondary finishes and Burning Route unlocks |
+| E_UNLOCK_TYPE_TROPHY | 2 | Unlocked through achievements (carbon cars) |
+| E_UNLOCK_TYPE_SHUTDOWN_RIVAL | 3 |  |
+| E_UNLOCK_TYPE_GOLD_SILVER | 4 | Gold and platinum cars |
+| E_UNLOCK_TYPE_SPONSOR | 5 | Will not show until a certain rank is reached |
+| ? | 6 | Used on online cars. Causes vehicles to only show while online |
+| ? | 7 | Used on Beat The Team community cars (Tempesta Dream/Tiger GT) |
+| ? | 8 | Used on PDLC vehicles |
+| ? | 9 | Used on Cop Cars |
+| ? | 10 | Island gift |
+| ? | 11 | Island unlock |
+
+### BrnProgression::RivalData::EState
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_STATE_LOCKED | 0 |  |
+| E_STATE_UNLOCKED | 1 | Roaming rival |
+| E_STATE_FLEEING | 2 |  |
+| E_STATE_BEATEN | 3 | Shut down |
+
+### BrnProgression::ProfileEvent::Flags
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_FLAG_UNDISCOVERED | 0x0 |  |
+| E_FLAG_DISCOVERED | 0x1 |  |
+| E_FLAG_FINISHED | 0x2 |  |
+| E_FLAG_RANK_WIN | 0x4 |  |
+| E_FLAG_NON_RANK_WIN | 0x8 |  |
+| E_FLAG_WON_SPECIAL_EVENT_BEFORE | 0x10 |  |
+| E_FLAG_WON_EVENT_BEFORE | 0x20 |  |
+
+### BrnGameState::EStuntType
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_STUNT_ELEMENT_TYPE_JUMP | 0 |  |
+| E_STUNT_ELEMENT_TYPE_SMASH | 1 |  |
+| E_STUNT_ELEMENT_TYPE_BILLBOARD | 2 |  |
+| E_STUNT_ELEMENT_TYPE_COUNT | 3 |  |
+
+### BrnStreetData::ScoreType
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_SCORE_TYPE_START | 0 |  |
+| E_SCORE_TYPE_TIME | 0 |  |
+| E_SCORE_TYPE_CRASH | 1 |  |
+| E_SCORE_TYPE_COUNT | 2 |  |
+
+### BrnResource::ECarType
+
+| Name | Value | Comments |
+| --- | --- | --- |
+| E_CARTYPE_DANGER | 0 |  |
+| E_CARTYPE_AGGRESSION | 1 |  |
+| E_CARTYPE_STUNTS | 2 |  |
+| E_CARTYPE_COUNT | 3 |  |
+| E_CARTYPE_INVALID | 3 |  |

--- a/docs/save-profile/recent-players-profile.md
+++ b/docs/save-profile/recent-players-profile.md
@@ -1,0 +1,35 @@
+# Profile/Burnout Paradise/Recent Players Profile
+
+> Source: https://burnout.wiki/wiki/Profile/Burnout_Paradise/Recent_Players_Profile (mirrored 2026-06-22)
+
+The recent players profile stores a list of players encountered online. It is specific to the original PC version of Burnout Paradise due to that version using a discreet friends list. Other versions use either the platform's built-in services or use Origin.
+
+## Structures
+
+### Recent players profile
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x4 | int32_t | miVersionNumber | Version number |  |
+| 0x4 | 1F44 | Array<?, 100u> | ? | Recent players list | Not padded after length. See recent player |
+
+### Recent player
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x14 | PlayerName | ? | Player name |  |
+| 0x4 | 0xC | DateAndTime | ? | Date encountered |  |
+
+### CgsNetwork::PlayerName
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x14 | char[20] | macName | Online player's name |  |
+
+### CgsSystem::DateAndTime
+
+| Offset | Length | Type | Name | Description | Comments |
+| --- | --- | --- | --- | --- | --- |
+| 0x0 | 0x1 | bool | mbIsLocal | Defines whether the saved time is in a local time zone or UTC |  |
+| 0x1 | 0x3 |  |  | Padding |  |
+| 0x8 | 0x8 | FILETIME | mSystemTime | The time value |  |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import BundleLayout from "./layouts/BundleLayout";
 import HexViewPage from "./pages/HexViewPage";
 import ResourceInspectorPage from "./pages/ResourceInspectorPage";
 import WorkspacePage from "./pages/WorkspacePage";
+import SaveProfilePage from "./pages/SaveProfilePage";
 
 const queryClient = new QueryClient();
 
@@ -31,6 +32,8 @@ const App = () => (
               <Route path="/hexview" element={<HexViewPage />} />
               <Route path="/inspect" element={<ResourceInspectorPage />} />
             </Route>
+            {/* Save-game profile editor — standalone (not a BND2 bundle), own layout */}
+            <Route path="/save" element={<SaveProfilePage />} />
             {/* Legacy index route kept if needed */}
             <Route path="/legacy" element={<Index />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/saveprofile/ChunkEditor.tsx
+++ b/src/components/saveprofile/ChunkEditor.tsx
@@ -1,0 +1,73 @@
+// Renders one decoded save chunk. Modelled chunks (currently the PC Remastered
+// Progression Profile) group their fields into tabs by the field's `group`
+// metadata; everything else falls back to an opaque, byte-preserved view.
+
+import { useMemo } from 'react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Badge } from '@/components/ui/badge';
+import { useSaveProfile } from '@/context/SaveProfileContext';
+import { decodeChunk, type ProfileSave, type ProfileChunk } from '@/lib/core/profileSave';
+import { FieldRow } from './FieldRow';
+
+export function ChunkEditor({ save, chunk }: { save: ProfileSave; chunk: ProfileChunk }) {
+	const { version } = useSaveProfile();
+	// chunk.raw is mutated in place; re-decode whenever an edit bumps `version`.
+	const decoded = useMemo(() => decodeChunk(save, chunk), [save, chunk, version]);
+
+	if (!chunk.spec || !decoded) {
+		return <OpaqueChunkView chunk={chunk} />;
+	}
+
+	const fields = chunk.spec.fields;
+	const groups: string[] = [];
+	for (const f of fields) {
+		const g = f.group ?? 'Fields';
+		if (!groups.includes(g)) groups.push(g);
+	}
+
+	return (
+		<div>
+			<div className="mb-3 flex items-center gap-2">
+				<h2 className="text-lg font-semibold">{chunk.name}</h2>
+				<Badge variant="outline" className="font-mono">{chunk.spec.name}</Badge>
+				<Badge variant="outline" className="font-mono">0x{chunk.size.toString(16)} B</Badge>
+				{chunk.addedIn && <Badge variant="secondary">added {chunk.addedIn}</Badge>}
+			</div>
+			<Tabs defaultValue={groups[0]}>
+				<TabsList className="flex flex-wrap h-auto">
+					{groups.map((g) => <TabsTrigger key={g} value={g} className="text-xs">{g}</TabsTrigger>)}
+				</TabsList>
+				{groups.map((g) => (
+					<TabsContent key={g} value={g} className="mt-3">
+						<div className="divide-y divide-border/40">
+							{fields.filter((f) => (f.group ?? 'Fields') === g).map((f) => (
+								<FieldRow key={f.name} chunkKey={chunk.key} label={f.label ?? f.name} note={f.note}
+									type={f} value={(decoded as Record<string, unknown>)[f.name]} path={[f.name]} reg={save.registry} />
+							))}
+						</div>
+					</TabsContent>
+				))}
+			</Tabs>
+		</div>
+	);
+}
+
+function OpaqueChunkView({ chunk }: { chunk: ProfileChunk }) {
+	const preview = Array.from(chunk.raw.subarray(0, 64))
+		.map((b) => b.toString(16).padStart(2, '0')).join(' ');
+	return (
+		<div>
+			<div className="mb-3 flex items-center gap-2">
+				<h2 className="text-lg font-semibold">{chunk.name}</h2>
+				<Badge variant="outline" className="font-mono">0x{chunk.size.toString(16)} B</Badge>
+				{chunk.addedIn && <Badge variant="secondary">added {chunk.addedIn}</Badge>}
+			</div>
+			<p className="text-sm text-muted-foreground mb-3">
+				This chunk isn't decoded into fields yet — its layout is documented in
+				<code className="mx-1 px-1 rounded bg-muted">docs/save-profile/</code>. It's preserved byte-exact on
+				save; the raw bytes are shown below for reference.
+			</p>
+			<pre className="text-[11px] font-mono leading-5 bg-muted/40 rounded p-3 overflow-auto max-h-72 whitespace-pre-wrap break-all">{preview}{chunk.raw.length > 64 ? '\n…' : ''}</pre>
+		</div>
+	);
+}

--- a/src/components/saveprofile/FieldRow.tsx
+++ b/src/components/saveprofile/FieldRow.tsx
@@ -1,0 +1,292 @@
+// Recursive renderer for one decoded save-profile field. Walks the same
+// TypeSpec the codec uses; leaf kinds get an inline editor that writes back
+// through SaveProfileContext.editField (patch-in-place at the field's offset).
+
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
+import { useSaveProfile } from '@/context/SaveProfileContext';
+import type { Path, Field } from '@/lib/core/profileSave';
+import type { TypeSpec, StructRegistry } from '@/lib/core/profileSave/struct';
+
+type Props = {
+	chunkKey: string;
+	label: string;
+	type: TypeSpec;
+	value: unknown;
+	path: Path;
+	reg: StructRegistry;
+	note?: string;
+};
+
+const inputCls = 'h-7 w-full max-w-[22rem] font-mono text-xs';
+
+export function FieldRow({ chunkKey, label, type, value, path, reg, note }: Props) {
+	const { editField } = useSaveProfile();
+	const set = (v: number | bigint | boolean | string) => editField(chunkKey, path, v);
+
+	switch (type.kind) {
+		case 'i8': case 'u8': case 'i16': case 'u16': case 'i32': case 'u32':
+			return (
+				<Row label={label} note={note}>
+					<Input type="number" defaultValue={String(value)} className={inputCls}
+						onBlur={(e) => set(parseInt(e.target.value || '0', 10) | 0)} />
+				</Row>
+			);
+		case 'f32':
+			return (
+				<Row label={label} note={note}>
+					<Input type="number" step="any" defaultValue={String(value)} className={inputCls}
+						onBlur={(e) => set(parseFloat(e.target.value || '0'))} />
+				</Row>
+			);
+		case 'u64': case 'cgsid':
+			return (
+				<Row label={label} note={note}>
+					<HexBigIntInput value={value as bigint} onCommit={set} />
+				</Row>
+			);
+		case 'bool':
+			return (
+				<Row label={label} note={note}>
+					<Switch checked={!!value} onCheckedChange={(c) => set(c)} />
+				</Row>
+			);
+		case 'enum':
+			return (
+				<Row label={label} note={note}>
+					<select className={`${inputCls} rounded-md border bg-background px-2`}
+						defaultValue={String(value)}
+						onChange={(e) => set(parseInt(e.target.value, 10) | 0)}>
+						{Object.entries(type.values).map(([v, name]) => (
+							<option key={v} value={v}>{v} — {name}</option>
+						))}
+						{!(String(value) in type.values) && <option value={String(value)}>{String(value)} — (unknown)</option>}
+					</select>
+				</Row>
+			);
+		case 'flags':
+			return <FlagsRow label={label} note={note} value={value as number} bits={type.bits} onChange={set} />;
+		case 'ascii':
+			return (
+				<Row label={label} note={note}>
+					<Input defaultValue={String(value)} maxLength={type.len - 1} className={inputCls}
+						onBlur={(e) => set(e.target.value)} />
+				</Row>
+			);
+		case 'vector3': {
+			const v = value as { x: number; y: number; z: number };
+			return (
+				<Row label={label} note={note}>
+					<div className="flex gap-1">
+						{(['x', 'y', 'z'] as const).map((c) => (
+							<Input key={c} type="number" step="any" defaultValue={String(v[c])} className="h-7 w-24 font-mono text-xs"
+								onBlur={(e) => editField(chunkKey, [...path, c], parseFloat(e.target.value || '0'))} />
+						))}
+					</div>
+				</Row>
+			);
+		}
+		case 'datetime':
+			return <DateTimeRow label={label} note={note} value={value as { mbIsLocal: boolean; mSystemTime: bigint }} />;
+		case 'bytes':
+			return <BytesRow label={label} note={note} value={value as Uint8Array} />;
+		case 'bitset':
+			return <BitsetRow chunkKey={chunkKey} label={label} note={note} path={path} bits={type.bits} value={value as number[]} />;
+		case 'cgsidset': case 'cgsidarray':
+			return <CgsIdSetRow chunkKey={chunkKey} label={label} note={note} path={path} capacity={type.capacity} value={value as { count: number; ids: bigint[] }} />;
+		case 'struct':
+			return <StructRow chunkKey={chunkKey} label={label} refName={type.ref} value={value as Record<string, unknown>} path={path} reg={reg} />;
+		case 'array':
+			return <ArrayRow chunkKey={chunkKey} label={label} type={type} value={value as unknown[]} path={path} reg={reg} />;
+	}
+}
+
+// --- layout helpers --------------------------------------------------------
+
+function Row({ label, note, children }: { label: string; note?: string; children: React.ReactNode }) {
+	return (
+		<div className="flex items-center gap-3 py-1">
+			<div className="w-56 shrink-0 text-xs text-muted-foreground truncate" title={`${label}${note ? ` — ${note}` : ''}`}>
+				{label}{note && <span className="ml-1 opacity-60">· {note}</span>}
+			</div>
+			<div className="flex-1 min-w-0">{children}</div>
+		</div>
+	);
+}
+
+function HexBigIntInput({ value, onCommit }: { value: bigint; onCommit: (v: bigint) => void }) {
+	const [text, setText] = useState('0x' + value.toString(16).toUpperCase());
+	const [bad, setBad] = useState(false);
+	return (
+		<Input value={text} className={`${inputCls} ${bad ? 'border-red-500' : ''}`}
+			onChange={(e) => setText(e.target.value)}
+			onBlur={() => {
+				try { onCommit(BigInt(text.trim())); setBad(false); }
+				catch { setBad(true); }
+			}} />
+	);
+}
+
+function FlagsRow({ label, note, value, bits, onChange }: { label: string; note?: string; value: number; bits: Record<number, string>; onChange: (v: number) => void }) {
+	return (
+		<Row label={label} note={note}>
+			<div className="flex flex-wrap gap-1">
+				{Object.entries(bits).map(([mask, name]) => {
+					const m = Number(mask);
+					const on = (value & m) !== 0;
+					return (
+						<button key={mask} type="button"
+							onClick={() => onChange(on ? value & ~m : value | m)}
+							className={`px-2 py-0.5 rounded text-[11px] border ${on ? 'bg-primary/15 border-primary/40 text-primary' : 'border-border text-muted-foreground hover:bg-muted/60'}`}>
+							{name}
+						</button>
+					);
+				})}
+				<span className="text-[11px] text-muted-foreground self-center">0x{value.toString(16)}</span>
+			</div>
+		</Row>
+	);
+}
+
+function DateTimeRow({ label, note, value }: { label: string; note?: string; value: { mbIsLocal: boolean; mSystemTime: bigint } }) {
+	// PC/PCR store a Win32 FILETIME (100 ns ticks since 1601-01-01).
+	const t = value.mSystemTime;
+	let pretty = '(unset)';
+	if (t !== 0n) {
+		const ms = Number(t / 10000n) - 11644473600000;
+		const d = new Date(ms);
+		if (!Number.isNaN(d.getTime())) pretty = d.toISOString().replace('T', ' ').replace('.000Z', ' UTC');
+	}
+	return (
+		<Row label={label} note={note}>
+			<span className="text-xs font-mono text-muted-foreground">{pretty} {value.mbIsLocal ? '(local)' : ''} · raw 0x{t.toString(16)}</span>
+		</Row>
+	);
+}
+
+function BytesRow({ label, note, value }: { label: string; note?: string; value: Uint8Array }) {
+	const preview = Array.from(value.subarray(0, 24)).map((b) => b.toString(16).padStart(2, '0')).join(' ');
+	return (
+		<Row label={label} note={note}>
+			<span className="text-xs font-mono text-muted-foreground">
+				<Badge variant="outline" className="mr-2">{value.length.toLocaleString()} B · opaque</Badge>
+				{preview}{value.length > 24 ? ' …' : ''}
+			</span>
+		</Row>
+	);
+}
+
+function BitsetRow({ chunkKey, label, note, path, bits, value }: { chunkKey: string; label: string; note?: string; path: Path; bits: number; value: number[] }) {
+	const { editBit } = useSaveProfile();
+	const setBits = new Set(value);
+	return (
+		<Row label={label} note={`${note ? note + ' · ' : ''}${value.length}/${bits} set`}>
+			{bits <= 256 ? (
+				<div className="flex flex-wrap gap-0.5 max-h-24 overflow-auto">
+					{Array.from({ length: bits }, (_, i) => {
+						const on = setBits.has(i);
+						return (
+							<button key={i} type="button" title={`bit ${i}`}
+								onClick={() => editBit(chunkKey, path, i, !on)}
+								className={`w-5 h-5 text-[9px] rounded-sm ${on ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:bg-muted/70'}`}>
+								{i}
+							</button>
+						);
+					})}
+				</div>
+			) : (
+				<span className="text-xs text-muted-foreground">{value.length} bits set</span>
+			)}
+		</Row>
+	);
+}
+
+function CgsIdSetRow({ chunkKey, label, note, path, capacity, value }: { chunkKey: string; label: string; note?: string; path: Path; capacity: number; value: { count: number; ids: bigint[] } }) {
+	const { editField } = useSaveProfile();
+	const [open, setOpen] = useState(false);
+	const shown = Math.min(value.count, capacity);
+	return (
+		<div className="py-1">
+			<div className="flex items-center gap-3">
+				<div className="w-56 shrink-0 text-xs text-muted-foreground truncate" title={label}>
+					{label}{note && <span className="ml-1 opacity-60">· {note}</span>}
+				</div>
+				<div className="flex items-center gap-2">
+					<span className="text-[11px] text-muted-foreground">count</span>
+					<Input type="number" defaultValue={String(value.count)} min={0} max={capacity}
+						className="h-7 w-20 font-mono text-xs"
+						onBlur={(e) => editField(chunkKey, [...path, 'count'], Math.max(0, Math.min(capacity, parseInt(e.target.value || '0', 10))))} />
+					<span className="text-[11px] text-muted-foreground">/ {capacity}</span>
+					<button type="button" className="text-[11px] text-primary hover:underline" onClick={() => setOpen((o) => !o)}>
+						{open ? 'hide' : 'edit IDs'}
+					</button>
+				</div>
+			</div>
+			{open && (
+				<div className="ml-56 pl-3 mt-1 grid grid-cols-2 gap-1">
+					{Array.from({ length: shown }, (_, i) => (
+						<HexBigIntInput key={i} value={value.ids[i]} onCommit={(v) => editField(chunkKey, [...path, 'ids', i], v)} />
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function StructRow({ chunkKey, label, refName, value, path, reg }: { chunkKey: string; label: string; refName: string; value: Record<string, unknown>; path: Path; reg: StructRegistry }) {
+	const spec = reg[refName];
+	return (
+		<div className="py-1">
+			<div className="text-xs font-medium text-foreground/80 mb-1">{label}</div>
+			<div className="ml-3 border-l pl-3">
+				{spec.fields.map((f: Field) => (
+					<FieldRow key={f.name} chunkKey={chunkKey} label={f.label ?? f.name} note={f.note}
+						type={f} value={value[f.name]} path={[...path, f.name]} reg={reg} />
+				))}
+			</div>
+		</div>
+	);
+}
+
+function ArrayRow({ chunkKey, label, type, value, path, reg }: { chunkKey: string; label: string; type: Extract<TypeSpec, { kind: 'array' }>; value: unknown[]; path: Path; reg: StructRegistry }) {
+	const { editField } = useSaveProfile();
+	const [idx, setIdx] = useState(0);
+	const el = type.element;
+	const isScalar = ['i8', 'u8', 'i16', 'u16', 'i32', 'u32', 'f32'].includes(el.kind);
+
+	// Compact grid for short scalar arrays (per-type counters etc.).
+	if (isScalar && type.count <= 32) {
+		const commit = (i: number, raw: string) =>
+			editField(chunkKey, [...path, i], el.kind === 'f32' ? parseFloat(raw || '0') : parseInt(raw || '0', 10) | 0);
+		return (
+			<div className="py-1">
+				<div className="text-xs text-muted-foreground mb-1">{label} <span className="opacity-60">· {type.count}</span></div>
+				<div className="ml-3 grid grid-cols-6 gap-1">
+					{value.map((v, i) => (
+						<Input key={i} type="number" defaultValue={String(v)} title={`[${i}]`} className="h-7 w-full font-mono text-[11px]"
+							onBlur={(e) => commit(i, e.target.value)} />
+					))}
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="py-1">
+			<div className="flex items-center gap-3">
+				<div className="w-56 shrink-0 text-xs text-muted-foreground truncate" title={label}>{label} <span className="opacity-60">· {value.length}</span></div>
+				<div className="flex items-center gap-2">
+					<span className="text-[11px] text-muted-foreground">index</span>
+					<Input type="number" value={idx} min={0} max={type.count - 1} className="h-7 w-24 font-mono text-xs"
+						onChange={(e) => setIdx(Math.max(0, Math.min(type.count - 1, parseInt(e.target.value || '0', 10))))} />
+				</div>
+			</div>
+			<div className="ml-3 border-l pl-3 mt-1">
+				{/* key on idx so the uncontrolled inputs remount with the new entry's values */}
+				<FieldRow key={idx} chunkKey={chunkKey} label={`[${idx}]`} type={el} value={value[idx]} path={[...path, idx]} reg={reg} />
+			</div>
+		</div>
+	);
+}

--- a/src/components/saveprofile/HeaderInfoPanel.tsx
+++ b/src/components/saveprofile/HeaderInfoPanel.tsx
@@ -1,0 +1,67 @@
+// File-level metadata: platform variant, header format, and (for RGMH/PC) the
+// editable Rich Game Media strings + GUID. MC02/headerless have nothing the
+// user should hand-edit (checksums are recomputed on save).
+
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { useSaveProfile } from '@/context/SaveProfileContext';
+import type { ProfileSave, RgmhStringField } from '@/lib/core/profileSave';
+
+export function HeaderInfoPanel({ save }: { save: ProfileSave }) {
+	const { setHeaderString, setHeaderGuid } = useSaveProfile();
+	const h = save.header;
+
+	return (
+		<div>
+			<div className="mb-3 flex items-center gap-2">
+				<h2 className="text-lg font-semibold">File Header</h2>
+				<Badge variant="outline">{save.variant.label}</Badge>
+				<Badge variant="outline" className="uppercase font-mono">{h.kind}</Badge>
+				<Badge variant="outline" className="font-mono">{(save.fileSize / 1024).toFixed(1)} KB</Badge>
+			</div>
+
+			{h.kind === 'rgmh' && (
+				<div className="space-y-2">
+					<p className="text-xs text-muted-foreground">
+						Rich Game Media header (no protection). These metadata strings are shown by Windows;
+						editing them is safe and round-trips byte-exact.
+					</p>
+					{([
+						['gameName', 'Game name'], ['saveName', 'Save name'],
+						['levelName', 'Level name'], ['comments', 'Comments'],
+					] as [RgmhStringField, string][]).map(([field, label]) => (
+						<LabeledInput key={field} label={label} defaultValue={h[field]} onCommit={(v) => setHeaderString(field, v)} />
+					))}
+					<LabeledInput label="Game GUID" mono defaultValue={h.guid} onCommit={setHeaderGuid} />
+					<div className="text-[11px] text-muted-foreground font-mono pt-1">
+						header 0x{h.headerSize.toString(16)} · thumbnail 0x{h.thumbnailSize.toString(16)} B
+					</div>
+				</div>
+			)}
+
+			{h.kind === 'mc02' && (
+				<div className="space-y-1 text-xs text-muted-foreground font-mono">
+					<p className="text-sm">Xbox 360 MC02 header — the three CRC32 checksums are recomputed automatically on save.</p>
+					<div>fileSize 0x{h.fileSize.toString(16)} · userBody 0x{h.userBodySize.toString(16)}</div>
+					<div>body CRC 0x{h.userBodySignature.toString(16).padStart(8, '0')} · header CRC 0x{h.fileHeaderSignature.toString(16).padStart(8, '0')}</div>
+				</div>
+			)}
+
+			{h.kind === 'none' && (
+				<p className="text-sm text-muted-foreground">
+					{save.variant.label} profiles have no game-specific header — the file is the raw ProfileStoredData body.
+				</p>
+			)}
+		</div>
+	);
+}
+
+function LabeledInput({ label, defaultValue, onCommit, mono }: { label: string; defaultValue: string; onCommit: (v: string) => void; mono?: boolean }) {
+	return (
+		<div className="flex items-center gap-3">
+			<div className="w-28 shrink-0 text-xs text-muted-foreground">{label}</div>
+			<Input defaultValue={defaultValue} className={`h-8 max-w-md text-sm ${mono ? 'font-mono text-xs' : ''}`}
+				onBlur={(e) => { if (e.target.value !== defaultValue) onCommit(e.target.value); }} />
+		</div>
+	);
+}

--- a/src/context/SaveProfileContext.tsx
+++ b/src/context/SaveProfileContext.tsx
@@ -1,0 +1,123 @@
+// State for the standalone Burnout Paradise save-profile editor (/save). The
+// profile is NOT a BND2 bundle, so it lives outside WorkspaceContext entirely.
+//
+// Edits mutate the parsed model's chunk bytes in place (the codec patches at
+// known offsets, preserving every untouched byte). React can't see in-place
+// mutation, so a monotonically increasing `version` is bumped on every edit to
+// trigger re-decode / re-render.
+
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+import { toast } from 'sonner';
+import {
+	parseProfileSave, writeProfileSave, getChunk,
+	editChunkField, editChunkBit, editHeaderString, editHeaderGuid,
+	UnknownProfileError,
+	type ProfileSave, type Path, type LeafValue, type RgmhStringField,
+} from '@/lib/core/profileSave';
+
+type SaveProfileContextValue = {
+	save: ProfileSave | null;
+	fileName: string | null;
+	dirty: boolean;
+	version: number;
+	error: string | null;
+	load: (file: File) => Promise<void>;
+	download: () => void;
+	editField: (chunkKey: string, path: Path, value: LeafValue) => void;
+	editBit: (chunkKey: string, path: Path, bit: number, on: boolean) => void;
+	setHeaderString: (field: RgmhStringField, value: string) => void;
+	setHeaderGuid: (guid: string) => void;
+};
+
+const SaveProfileContext = createContext<SaveProfileContextValue | null>(null);
+
+export function SaveProfileProvider({ children }: { children: ReactNode }) {
+	const [save, setSave] = useState<ProfileSave | null>(null);
+	const [fileName, setFileName] = useState<string | null>(null);
+	const [dirty, setDirty] = useState(false);
+	const [version, setVersion] = useState(0);
+	const [error, setError] = useState<string | null>(null);
+
+	const load = useCallback(async (file: File) => {
+		try {
+			const buf = await file.arrayBuffer();
+			const parsed = parseProfileSave(new Uint8Array(buf));
+			setSave(parsed);
+			setFileName(file.name);
+			setDirty(false);
+			setVersion(0);
+			setError(null);
+			toast.success(`Loaded ${file.name}`, {
+				description: `${parsed.variant.label} · ${parsed.chunks.length} chunks`,
+			});
+		} catch (e) {
+			const msg = e instanceof UnknownProfileError ? e.message : e instanceof Error ? e.message : 'Failed to parse file';
+			setError(msg);
+			setSave(null);
+			setFileName(null);
+			toast.error('Could not load profile', { description: msg });
+		}
+	}, []);
+
+	const download = useCallback(() => {
+		if (!save) return;
+		const bytes = writeProfileSave(save);
+		const blob = new Blob([bytes], { type: 'application/octet-stream' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = fileName ?? 'Profile.BurnoutParadiseSave';
+		document.body.appendChild(a);
+		a.click();
+		a.remove();
+		setTimeout(() => URL.revokeObjectURL(url), 0);
+		toast.success('Saved profile', { description: `${(bytes.byteLength / 1024).toFixed(1)} KB` });
+	}, [save, fileName]);
+
+	const editField = useCallback((chunkKey: string, path: Path, value: LeafValue) => {
+		setSave((s) => {
+			if (!s) return s;
+			const chunk = getChunk(s, chunkKey);
+			if (chunk) editChunkField(s, chunk, path, value);
+			return s;
+		});
+		setDirty(true);
+		setVersion((v) => v + 1);
+	}, []);
+
+	const editBit = useCallback((chunkKey: string, path: Path, bit: number, on: boolean) => {
+		setSave((s) => {
+			if (!s) return s;
+			const chunk = getChunk(s, chunkKey);
+			if (chunk) editChunkBit(s, chunk, path, bit, on);
+			return s;
+		});
+		setDirty(true);
+		setVersion((v) => v + 1);
+	}, []);
+
+	const setHeaderString = useCallback((field: RgmhStringField, value: string) => {
+		setSave((s) => { if (s) editHeaderString(s, field, value); return s; });
+		setDirty(true);
+		setVersion((v) => v + 1);
+	}, []);
+
+	const setHeaderGuid = useCallback((guid: string) => {
+		setSave((s) => { if (s) editHeaderGuid(s, guid); return s; });
+		setDirty(true);
+		setVersion((v) => v + 1);
+	}, []);
+
+	const value = useMemo<SaveProfileContextValue>(
+		() => ({ save, fileName, dirty, version, error, load, download, editField, editBit, setHeaderString, setHeaderGuid }),
+		[save, fileName, dirty, version, error, load, download, editField, editBit, setHeaderString, setHeaderGuid],
+	);
+
+	return <SaveProfileContext.Provider value={value}>{children}</SaveProfileContext.Provider>;
+}
+
+export function useSaveProfile(): SaveProfileContextValue {
+	const ctx = useContext(SaveProfileContext);
+	if (!ctx) throw new Error('useSaveProfile must be used within SaveProfileProvider');
+	return ctx;
+}

--- a/src/layouts/BundleLayout.tsx
+++ b/src/layouts/BundleLayout.tsx
@@ -1,7 +1,7 @@
 import { Outlet, NavLink } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Upload, Download, Hexagon, Box, Layers } from 'lucide-react';
+import { Upload, Download, Hexagon, Box, Layers, Save } from 'lucide-react';
 import {
   useFirstLoadedBundle,
   useFirstLoadedBundleId,
@@ -307,6 +307,9 @@ const BundleLayout = () => {
         <div className="flex items-center gap-2">
           <NavLink to="/workspace" className={({ isActive }) => `px-3 py-1.5 rounded ${isActive ? 'bg-muted' : 'hover:bg-muted/60'}`}>
             <Layers className="inline w-4 h-4 mr-1" /> Workspace
+          </NavLink>
+          <NavLink to="/save" className={({ isActive }) => `px-3 py-1.5 rounded ${isActive ? 'bg-muted' : 'hover:bg-muted/60'}`}>
+            <Save className="inline w-4 h-4 mr-1" /> Save Editor
           </NavLink>
           <div className="ml-auto" />
           <NavLink to="/hexview" className={({ isActive }) => `px-3 py-1.5 rounded ${isActive ? 'bg-muted' : 'hover:bg-muted/60'}`}>

--- a/src/lib/core/profileSave/__tests__/profileSave.test.ts
+++ b/src/lib/core/profileSave/__tests__/profileSave.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+	parseProfileSave, writeProfileSave, decodeChunk, getChunk,
+	editChunkField, editChunkBit, editHeaderString, editHeaderGuid,
+	VARIANTS, variantById,
+} from '../index';
+import { validateStruct } from '../struct';
+import { PROGRESSION_REGISTRY } from '../progression';
+import { mc02Checksum } from '../crc32mc02';
+import { parseHeader, writeFile } from '../header';
+
+const FIXTURE = path.resolve(__dirname, '../../../../../example/SAVE/Profile.BurnoutParadiseSave');
+const hasFixture = fs.existsSync(FIXTURE);
+
+const bytesEqual = (a: Uint8Array, b: Uint8Array) => a.length === b.length && a.every((v, i) => v === b[i]);
+const firstDiff = (a: Uint8Array, b: Uint8Array) => {
+	for (let i = 0; i < Math.min(a.length, b.length); i++) if (a[i] !== b[i]) return i;
+	return a.length === b.length ? -1 : Math.min(a.length, b.length);
+};
+
+// ---------------------------------------------------------------------------
+// Container variant tables — every variant must tile its body with no gaps or
+// overlaps. A typo'd offset/size in variants.ts corrupts a save, so gate it.
+// ---------------------------------------------------------------------------
+
+describe('container variant tables', () => {
+	for (const v of VARIANTS) {
+		it(`${v.id} chunks tile [0, 0x${v.bodyLength.toString(16)}) exactly`, () => {
+			let cursor = 0;
+			for (const c of v.chunks) {
+				expect(c.offset, `${v.id}/${c.key} starts at the running cursor`).toBe(cursor);
+				cursor += c.size;
+			}
+			expect(cursor, `${v.id} chunks sum to bodyLength`).toBe(v.bodyLength);
+		});
+	}
+});
+
+// ---------------------------------------------------------------------------
+// Struct layout sanity — modelled fields must fit inside their struct.
+// ---------------------------------------------------------------------------
+
+describe('progression struct layout', () => {
+	it('every struct passes layout validation', () => {
+		for (const name of Object.keys(PROGRESSION_REGISTRY)) {
+			expect(validateStruct(PROGRESSION_REGISTRY[name], PROGRESSION_REGISTRY)).toEqual([]);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// MC02 checksum — deterministic, and a self-built MC02 file round-trips
+// byte-exact (the write path recomputes the three checksums).
+// ---------------------------------------------------------------------------
+
+describe('MC02 header', () => {
+	it('checksum is deterministic and returns 0 for <4 bytes', () => {
+		const buf = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+		expect(mc02Checksum(buf)).toBe(mc02Checksum(buf));
+		expect(mc02Checksum(new Uint8Array([1, 2, 3]))).toBe(0);
+	});
+
+	it('round-trips a synthetic X360 (MC02) profile byte-exact', () => {
+		const x360 = variantById('xbox360');
+		const body = new Uint8Array(x360.bodyLength);
+		for (let i = 0; i < body.length; i++) body[i] = (i * 7) & 0xff;
+
+		// Build a correct MC02 file (big-endian header) with valid checksums.
+		const file = new Uint8Array(0x1c + body.length);
+		const dv = new DataView(file.buffer);
+		file.set([0x4d, 0x43, 0x30, 0x32], 0); // "MC02"
+		dv.setUint32(0x4, file.length, false); // mFileSize
+		dv.setUint32(0x8, 0, false); // mUserHeaderSize
+		dv.setUint32(0xc, body.length, false); // mUserBodySize
+		file.set(body, 0x1c);
+		dv.setUint32(0x10, mc02Checksum(file.subarray(0x1c, 0x1c)), false);
+		dv.setUint32(0x14, mc02Checksum(body), false);
+		dv.setUint32(0x18, mc02Checksum(file.subarray(0, 0x18)), false);
+
+		const save = parseProfileSave(file);
+		expect(save.variant.id).toBe('xbox360');
+		expect(bytesEqual(writeProfileSave(save), file)).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Headerless + RGMH header round-trips on synthetic bodies.
+// ---------------------------------------------------------------------------
+
+describe('headerless (PS3) container', () => {
+	it('round-trips a synthetic PS3 body byte-exact', () => {
+		const ps3 = variantById('ps3');
+		const body = new Uint8Array(ps3.bodyLength);
+		for (let i = 0; i < body.length; i++) body[i] = (i * 13) & 0xff;
+		const save = parseProfileSave(body);
+		expect(save.variant.id).toBe('ps3');
+		expect(bytesEqual(writeProfileSave(save), body)).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Real fixture (PC Remastered). Skipped when the personal save isn't present.
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!hasFixture)('real PC Remastered profile', () => {
+	const load = () => parseProfileSave(fs.readFileSync(FIXTURE));
+
+	it('detects the PC Remastered variant via RGMH + body length', () => {
+		const save = load();
+		expect(save.variant.id).toBe('pc-remastered');
+		expect(save.header.kind).toBe('rgmh');
+	});
+
+	it('round-trips byte-exact with no edits', () => {
+		const original = new Uint8Array(fs.readFileSync(FIXTURE));
+		const out = writeProfileSave(parseProfileSave(original));
+		expect(out.length).toBe(original.length);
+		expect(firstDiff(out, original)).toBe(-1);
+	});
+
+	it('writer is idempotent', () => {
+		const original = new Uint8Array(fs.readFileSync(FIXTURE));
+		const once = writeProfileSave(parseProfileSave(original));
+		const twice = writeProfileSave(parseProfileSave(once));
+		expect(bytesEqual(once, twice)).toBe(true);
+	});
+
+	it('decodes plausible Progression values (validates the layout)', () => {
+		const save = load();
+		const prog = getChunk(save, 'progression')!;
+		const d = decodeChunk(save, prog) as Record<string, unknown>;
+		expect(d.miVersionNumber).toBe(31);
+		expect(d.mi8CurrentProgressionRank).toBe(5); // Burnout License
+		// Counts must be within their fixed array capacities.
+		expect(d.miCarCount).toBeGreaterThan(0);
+		expect(d.miCarCount as number).toBeLessThanOrEqual(512);
+		expect(d.miEventCount as number).toBeLessThanOrEqual(175);
+		expect(d.miRivalCount as number).toBeLessThanOrEqual(64);
+		// The first car entry should have a non-zero vehicle ID.
+		const cars = d.maCars as Array<Record<string, unknown>>;
+		expect(typeof cars[0].mId).toBe('bigint');
+		expect(cars[0].mId).not.toBe(0n);
+	});
+
+	it('field edit round-trips and touches only that field', () => {
+		const save = load();
+		const prog = getChunk(save, 'progression')!;
+		const before = prog.raw.slice();
+		editChunkField(save, prog, ['mi8CurrentProgressionRank'], 6); // -> Elite
+		// exactly one byte changed (the rank int8 at 0x70)
+		let changed = 0, at = -1;
+		for (let i = 0; i < before.length; i++) if (before[i] !== prog.raw[i]) { changed++; at = i; }
+		expect(changed).toBe(1);
+		expect(at).toBe(0x70);
+		const reparsed = parseProfileSave(writeProfileSave(save));
+		const d = decodeChunk(reparsed, getChunk(reparsed, 'progression')!) as Record<string, unknown>;
+		expect(d.mi8CurrentProgressionRank).toBe(6);
+	});
+
+	it('nested array field edit round-trips', () => {
+		const save = load();
+		const prog = getChunk(save, 'progression')!;
+		editChunkField(save, prog, ['maCars', 0, 'mu8ColourIndex'], 7);
+		editChunkField(save, prog, ['maRivals', 1, 'meState'], 3);
+		const reparsed = parseProfileSave(writeProfileSave(save));
+		const d = decodeChunk(reparsed, getChunk(reparsed, 'progression')!) as Record<string, unknown>;
+		expect((d.maCars as Array<Record<string, unknown>>)[0].mu8ColourIndex).toBe(7);
+		expect((d.maRivals as Array<Record<string, unknown>>)[1].meState).toBe(3);
+	});
+
+	it('bitset bit edit flips exactly one bit', () => {
+		const save = load();
+		const prog = getChunk(save, 'progression')!;
+		const before = decodeChunk(save, prog) as Record<string, unknown>;
+		const seen0 = (before.maHasPlayerSeenTraining as number[]).includes(0);
+		editChunkBit(save, prog, ['maHasPlayerSeenTraining'], 0, !seen0);
+		const reparsed = parseProfileSave(writeProfileSave(save));
+		const after = decodeChunk(reparsed, getChunk(reparsed, 'progression')!) as Record<string, unknown>;
+		expect((after.maHasPlayerSeenTraining as number[]).includes(0)).toBe(!seen0);
+	});
+
+	it('RGMH header string + GUID edits round-trip', () => {
+		const save = load();
+		editHeaderString(save, 'comments', 'edited by steward');
+		editHeaderGuid(save, '{6D5AE2FB-F7AC-45EA-982C-8422649DB55E}');
+		const reparsed = parseProfileSave(writeProfileSave(save));
+		expect(reparsed.header.kind).toBe('rgmh');
+		if (reparsed.header.kind === 'rgmh') {
+			expect(reparsed.header.comments).toBe('edited by steward');
+			expect(reparsed.header.guid).toBe('{6D5AE2FB-F7AC-45EA-982C-8422649DB55E}');
+		}
+	});
+
+	it('header parse start matches the documented 0x1D246 profile offset', () => {
+		const { bodyStart } = parseHeader(new Uint8Array(fs.readFileSync(FIXTURE)));
+		expect(bodyStart).toBe(0x1d246);
+	});
+});
+
+describe('writeFile passthrough', () => {
+	it('headerless writeFile returns a copy of the body', () => {
+		const body = new Uint8Array([9, 8, 7, 6]);
+		const out = writeFile({ kind: 'none' }, body);
+		expect(bytesEqual(out, body)).toBe(true);
+		expect(out).not.toBe(body);
+	});
+});

--- a/src/lib/core/profileSave/binio.ts
+++ b/src/lib/core/profileSave/binio.ts
@@ -1,0 +1,110 @@
+// Endian-aware scalar + structured reads/writes over a single backing buffer,
+// addressed by absolute byte offset. The save-profile codec works "in place":
+// edits patch the original bytes at known offsets rather than re-serialising a
+// model, which keeps every untouched byte identical on save (the round-trip
+// guarantee). These helpers are the leaf operations that engine.ts drives.
+
+export type Endian = 'le' | 'be';
+
+export const isLE = (e: Endian): boolean => e === 'le';
+
+// --- scalar reads ----------------------------------------------------------
+
+export function readU8(v: DataView, o: number): number { return v.getUint8(o); }
+export function readI8(v: DataView, o: number): number { return v.getInt8(o); }
+export function readU16(v: DataView, o: number, e: Endian): number { return v.getUint16(o, isLE(e)); }
+export function readI16(v: DataView, o: number, e: Endian): number { return v.getInt16(o, isLE(e)); }
+export function readU32(v: DataView, o: number, e: Endian): number { return v.getUint32(o, isLE(e)) >>> 0; }
+export function readI32(v: DataView, o: number, e: Endian): number { return v.getInt32(o, isLE(e)) | 0; }
+export function readF32(v: DataView, o: number, e: Endian): number { return v.getFloat32(o, isLE(e)); }
+
+export function readU64(v: DataView, o: number, e: Endian): bigint {
+	const lo = BigInt(v.getUint32(o + (isLE(e) ? 0 : 4), isLE(e)));
+	const hi = BigInt(v.getUint32(o + (isLE(e) ? 4 : 0), isLE(e)));
+	return (hi << 32n) | (lo & 0xffffffffn);
+}
+
+// --- scalar writes ---------------------------------------------------------
+
+export function writeU8(v: DataView, o: number, x: number): void { v.setUint8(o, x & 0xff); }
+export function writeI8(v: DataView, o: number, x: number): void { v.setInt8(o, x | 0); }
+export function writeU16(v: DataView, o: number, x: number, e: Endian): void { v.setUint16(o, x & 0xffff, isLE(e)); }
+export function writeI16(v: DataView, o: number, x: number, e: Endian): void { v.setInt16(o, x | 0, isLE(e)); }
+export function writeU32(v: DataView, o: number, x: number, e: Endian): void { v.setUint32(o, x >>> 0, isLE(e)); }
+export function writeI32(v: DataView, o: number, x: number, e: Endian): void { v.setInt32(o, x | 0, isLE(e)); }
+export function writeF32(v: DataView, o: number, x: number, e: Endian): void { v.setFloat32(o, x, isLE(e)); }
+
+export function writeU64(v: DataView, o: number, x: bigint, e: Endian): void {
+	const lo = Number(x & 0xffffffffn) >>> 0;
+	const hi = Number((x >> 32n) & 0xffffffffn) >>> 0;
+	v.setUint32(o + (isLE(e) ? 0 : 4), lo, isLE(e));
+	v.setUint32(o + (isLE(e) ? 4 : 0), hi, isLE(e));
+}
+
+// --- fixed-length strings --------------------------------------------------
+// char[N]: single-byte, NUL-padded. Display value is trimmed at the first NUL;
+// trailing bytes after the NUL are NOT preserved on rewrite (they are padding),
+// but the codec only rewrites a string field when its display value changes.
+
+export function readAscii(bytes: Uint8Array, o: number, len: number): string {
+	let end = o;
+	const limit = o + len;
+	while (end < limit && bytes[end] !== 0) end++;
+	return new TextDecoder('latin1').decode(bytes.subarray(o, end));
+}
+
+export function writeAscii(bytes: Uint8Array, o: number, len: number, str: string): void {
+	bytes.fill(0, o, o + len);
+	const enc = new TextEncoder().encode(str);
+	const n = Math.min(enc.length, len - 1); // leave room for a NUL terminator
+	bytes.set(enc.subarray(0, n), o);
+}
+
+// WCHAR[N] UTF-16LE wide string (RGMH header). `byteLen` is the field size in
+// bytes (2 per char). Always little-endian — the Rich Game Media header is a
+// Windows/PC structure regardless of game platform.
+export function readWideString(bytes: Uint8Array, o: number, byteLen: number): string {
+	let end = o;
+	const limit = o + byteLen;
+	while (end + 1 < limit && !(bytes[end] === 0 && bytes[end + 1] === 0)) end += 2;
+	return new TextDecoder('utf-16le').decode(bytes.subarray(o, end));
+}
+
+export function writeWideString(bytes: Uint8Array, o: number, byteLen: number, str: string): void {
+	bytes.fill(0, o, o + byteLen);
+	const maxChars = byteLen / 2 - 1; // reserve a NUL terminator
+	for (let i = 0; i < str.length && i < maxChars; i++) {
+		const code = str.charCodeAt(i);
+		bytes[o + i * 2] = code & 0xff;
+		bytes[o + i * 2 + 1] = (code >> 8) & 0xff;
+	}
+}
+
+// --- GUID ------------------------------------------------------------------
+// Microsoft GUID on-disk layout: Data1 (u32 LE), Data2 (u16 LE), Data3 (u16
+// LE), Data4 (8 bytes, big-endian / verbatim). Rendered canonically as
+// {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.
+
+export function readGuid(bytes: Uint8Array, o: number): string {
+	const hex = (i: number) => bytes[i].toString(16).padStart(2, '0');
+	const d1 = `${hex(o + 3)}${hex(o + 2)}${hex(o + 1)}${hex(o + 0)}`;
+	const d2 = `${hex(o + 5)}${hex(o + 4)}`;
+	const d3 = `${hex(o + 7)}${hex(o + 6)}`;
+	const d4 = `${hex(o + 8)}${hex(o + 9)}`;
+	const d5 = `${hex(o + 10)}${hex(o + 11)}${hex(o + 12)}${hex(o + 13)}${hex(o + 14)}${hex(o + 15)}`;
+	return `{${d1}-${d2}-${d3}-${d4}-${d5}}`.toUpperCase();
+}
+
+export function writeGuid(bytes: Uint8Array, o: number, guid: string): void {
+	const h = guid.replace(/[{}-]/g, '');
+	if (h.length !== 32) throw new Error(`invalid GUID: ${guid}`);
+	const b = (i: number) => parseInt(h.slice(i * 2, i * 2 + 2), 16);
+	// Data1 (LE)
+	bytes[o + 0] = b(3); bytes[o + 1] = b(2); bytes[o + 2] = b(1); bytes[o + 3] = b(0);
+	// Data2 (LE)
+	bytes[o + 4] = b(5); bytes[o + 5] = b(4);
+	// Data3 (LE)
+	bytes[o + 6] = b(7); bytes[o + 7] = b(6);
+	// Data4 (verbatim)
+	for (let i = 8; i < 16; i++) bytes[o + i] = b(i);
+}

--- a/src/lib/core/profileSave/crc32mc02.ts
+++ b/src/lib/core/profileSave/crc32mc02.ts
@@ -1,0 +1,51 @@
+// MC02 checksum — EA's "Memory Card v2" save protection used by Xbox 360
+// Burnout Paradise profiles. Ported verbatim from the public reversal of the
+// Dead Space MC02 fixer (https://gist.github.com/Experiment5X/5025310), which
+// is the reference implementation the wiki points at.
+//
+// WHY this is its own function and not a standard CRC-32: the algorithm is an
+// MSB-first CRC with polynomial 0x04C11DB7, BUT it seeds from the first four
+// bytes of the buffer (seed = ~(big-endian u32 of bytes[0..4])) and then folds
+// the remaining bytes with `table[idx] ^ ((crc << 8) | byte)` — note the byte is
+// OR'd into the low bits rather than XOR'd into the table index. Using an
+// off-the-shelf CRC-32 produces the wrong value and the 360 rejects the save.
+//
+// NOTE: only the X360 variant uses MC02. We have no X360 fixture to validate
+// against, so the recompute path is implemented per the public algorithm but is
+// untested on a real console save. The RGMH (PC) path needs no checksum.
+
+// Standard MSB-first CRC-32 table for polynomial 0x04C11DB7. table[1] === the
+// polynomial, matching the constants in the reference gist.
+const TABLE: Uint32Array = (() => {
+	const t = new Uint32Array(256);
+	for (let n = 0; n < 256; n++) {
+		let c = (n << 24) >>> 0;
+		for (let k = 0; k < 8; k++) {
+			c = (c & 0x80000000) !== 0 ? ((c << 1) ^ 0x04c11db7) >>> 0 : (c << 1) >>> 0;
+		}
+		t[n] = c >>> 0;
+	}
+	return t;
+})();
+
+/**
+ * Compute the MC02 checksum over `data` (a contiguous byte range). Returns an
+ * unsigned 32-bit value. Mirrors `MC02(const BYTE* pb, DWORD cb)` from the gist.
+ */
+export function mc02Checksum(data: Uint8Array): number {
+	const cb = data.length;
+	if (cb < 4) return 0;
+
+	// seed = ~(big-endian u32 of the first four bytes)
+	let seed =
+		~(((data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3]) >>> 0) >>> 0;
+
+	for (let i = 4; i < cb; i++) {
+		const idx = (seed >>> 24) & 0xff; // == ((seed >> 22) & 0x3FC) >> 2
+		const looked = TABLE[idx];
+		const inserted = (((seed << 8) >>> 0) | data[i]) >>> 0;
+		seed = (looked ^ inserted) >>> 0;
+	}
+
+	return ~seed >>> 0;
+}

--- a/src/lib/core/profileSave/header.ts
+++ b/src/lib/core/profileSave/header.ts
@@ -1,0 +1,168 @@
+// Platform headers that wrap BrnGui::ProfileManager::ProfileStoredData.
+//
+//  - RGMH (PC / PC Remastered): Microsoft "Rich Game Media" header. No
+//    protection; carries a thumbnail and four WCHAR[1024] metadata strings.
+//  - MC02 (Xbox 360): EA "Memory Card v2" header, big-endian, CRC-protected.
+//    Edits require the three checksums to be recomputed (see crc32mc02.ts).
+//  - none (PS3 / PS4 / Switch): the file IS the ProfileStoredData body.
+//
+// The header keeps its original bytes verbatim (`raw`); field edits patch that
+// buffer in place so unrelated header bytes (thumbnail, padding) survive a
+// round-trip untouched.
+
+import { readU32, readU64, readGuid, writeGuid, readWideString, writeWideString } from './binio';
+import { mc02Checksum } from './crc32mc02';
+import type { HeaderKind } from './variants';
+
+// RGMH field offsets (always little-endian; it is a Windows structure).
+const RGMH = {
+	gameName: { offset: 0x28, bytes: 0x800 },
+	saveName: { offset: 0x828, bytes: 0x800 },
+	levelName: { offset: 0x1028, bytes: 0x800 },
+	comments: { offset: 0x1828, bytes: 0x800 },
+	guid: 0x18,
+} as const;
+
+export type RgmhStringField = 'gameName' | 'saveName' | 'levelName' | 'comments';
+
+export type RgmhHeader = {
+	kind: 'rgmh';
+	raw: Uint8Array; // [0, profileStart): RGMH header + thumbnail
+	version: number;
+	headerSize: number;
+	thumbnailOffset: bigint;
+	thumbnailSize: number;
+	guid: string;
+	gameName: string;
+	saveName: string;
+	levelName: string;
+	comments: string;
+};
+
+export type Mc02Header = {
+	kind: 'mc02';
+	raw: Uint8Array; // [0, profileStart): 0x1C header (+ any user-header region)
+	fileSize: number;
+	userHeaderSize: number;
+	userBodySize: number;
+	userHeaderSignature: number;
+	userBodySignature: number;
+	fileHeaderSignature: number;
+};
+
+export type NoneHeader = { kind: 'none' };
+
+export type ProfileHeader = RgmhHeader | Mc02Header | NoneHeader;
+
+export type ParsedHeader = {
+	header: ProfileHeader;
+	bodyStart: number;
+	bodyLength: number;
+};
+
+function magic4(bytes: Uint8Array): string {
+	return String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3]);
+}
+
+// Independent copy — Node's Buffer.slice aliases its source, which would let a
+// header edit mutate the caller's input buffer.
+const copyOf = (u8: Uint8Array, start: number, end: number): Uint8Array =>
+	new Uint8Array(u8.subarray(start, end));
+
+export function detectHeaderKind(bytes: Uint8Array): HeaderKind {
+	if (bytes.length < 4) return 'none';
+	const m = magic4(bytes);
+	if (m === 'RGMH') return 'rgmh';
+	if (m === 'MC02') return 'mc02';
+	return 'none';
+}
+
+export function parseHeader(bytes: Uint8Array): ParsedHeader {
+	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	const kind = detectHeaderKind(bytes);
+
+	if (kind === 'rgmh') {
+		const headerSize = readU32(view, 0x8, 'le');
+		const thumbnailOffset = readU64(view, 0xc, 'le');
+		const thumbnailSize = readU32(view, 0x14, 'le');
+		const profileStart = headerSize + Number(thumbnailOffset) + thumbnailSize;
+		const raw = copyOf(bytes, 0, profileStart);
+		const str = (f: keyof typeof RGMH & RgmhStringField) =>
+			readWideString(bytes, RGMH[f].offset, RGMH[f].bytes);
+		return {
+			header: {
+				kind: 'rgmh', raw,
+				version: readU32(view, 0x4, 'le'),
+				headerSize, thumbnailOffset, thumbnailSize,
+				guid: readGuid(bytes, RGMH.guid),
+				gameName: str('gameName'), saveName: str('saveName'),
+				levelName: str('levelName'), comments: str('comments'),
+			},
+			bodyStart: profileStart,
+			bodyLength: bytes.length - profileStart,
+		};
+	}
+
+	if (kind === 'mc02') {
+		// MC02 header is big-endian on disk.
+		const fileSize = readU32(view, 0x4, 'be');
+		const userHeaderSize = readU32(view, 0x8, 'be');
+		const userBodySize = readU32(view, 0xc, 'be');
+		const profileStart = 0x1c + userHeaderSize;
+		return {
+			header: {
+				kind: 'mc02', raw: copyOf(bytes, 0, profileStart),
+				fileSize, userHeaderSize, userBodySize,
+				userHeaderSignature: readU32(view, 0x10, 'be'),
+				userBodySignature: readU32(view, 0x14, 'be'),
+				fileHeaderSignature: readU32(view, 0x18, 'be'),
+			},
+			bodyStart: profileStart,
+			bodyLength: userBodySize,
+		};
+	}
+
+	return { header: { kind: 'none' }, bodyStart: 0, bodyLength: bytes.length };
+}
+
+export function setRgmhString(h: RgmhHeader, field: RgmhStringField, value: string): void {
+	writeWideString(h.raw, RGMH[field].offset, RGMH[field].bytes, value);
+	h[field] = value;
+}
+
+export function setRgmhGuid(h: RgmhHeader, guid: string): void {
+	writeGuid(h.raw, RGMH.guid, guid);
+	h.guid = guid;
+}
+
+/** Serialise header + body to the full file bytes (recomputing MC02 CRCs). */
+export function writeFile(header: ProfileHeader, body: Uint8Array): Uint8Array {
+	if (header.kind === 'none') return body.slice();
+
+	if (header.kind === 'rgmh') {
+		const out = new Uint8Array(header.raw.length + body.length);
+		out.set(header.raw, 0);
+		out.set(body, header.raw.length);
+		return out;
+	}
+
+	// mc02 — recompute the three checksums over the new body.
+	const raw = header.raw.slice();
+	const out = new Uint8Array(raw.length + body.length);
+	out.set(raw, 0);
+	out.set(body, raw.length);
+	const view = new DataView(out.buffer);
+
+	const userHeader = out.subarray(0x1c, 0x1c + header.userHeaderSize);
+	const sig0 = mc02Checksum(userHeader);
+	const sig1 = mc02Checksum(body);
+	view.setUint32(0x10, sig0, false);
+	view.setUint32(0x14, sig1, false);
+	const sig2 = mc02Checksum(out.subarray(0, 0x18));
+	view.setUint32(0x18, sig2, false);
+
+	header.userHeaderSignature = sig0;
+	header.userBodySignature = sig1;
+	header.fileHeaderSignature = sig2;
+	return out;
+}

--- a/src/lib/core/profileSave/index.ts
+++ b/src/lib/core/profileSave/index.ts
@@ -1,0 +1,105 @@
+// Burnout Paradise save-profile codec (Profile.BurnoutParadiseSave).
+//
+// A save file = optional platform header (RGMH / MC02 / none) + a fixed-size
+// ProfileStoredData body. The body is a sequence of FixedSizeOpaqueBuffer
+// chunks (Progression, Live Revenge, Options, DLC profiles, …). We split the
+// body into those chunks (each byte-exact) and decode the ones we model.
+//
+// Editing is patch-in-place: a `ProfileChunk.raw` is mutated at a field's known
+// offset, so any byte we don't touch survives load → save unchanged. The
+// round-trip stress test asserts this against a real fixture.
+
+import { parseHeader, writeFile, setRgmhString, setRgmhGuid, type ProfileHeader, type RgmhStringField } from './header';
+import { detectVariant, type ProfileVariant, type ChunkDef } from './variants';
+import { progressionSpec, PROGRESSION_REGISTRY } from './progression';
+import { decodeStruct, writeFieldByPath, writeBit, type StructSpec, type StructRegistry, type Path, type LeafValue } from './struct';
+import type { Endian } from './binio';
+
+export * from './variants';
+export type { ProfileHeader, RgmhStringField } from './header';
+export type { StructSpec, Field, Path, LeafValue } from './struct';
+
+export type ProfileChunk = ChunkDef & {
+	/** Current bytes for this chunk (a mutable copy; edits patch it in place). */
+	raw: Uint8Array;
+	/** Decode spec, present only for chunks we model for this variant. */
+	spec: StructSpec | null;
+};
+
+export type ProfileSave = {
+	variant: ProfileVariant;
+	header: ProfileHeader;
+	endian: Endian;
+	chunks: ProfileChunk[];
+	/** The decode registry that the chunk specs resolve against. */
+	registry: StructRegistry;
+	/** Original file size, for display / sanity checks. */
+	fileSize: number;
+};
+
+export class UnknownProfileError extends Error {}
+
+// Force an independent byte copy. Node's Buffer.slice/subarray ALIAS the source
+// buffer, so without this an edit to a chunk would mutate the caller's input;
+// constructing a Uint8Array from a view always copies.
+const copyOf = (u8: Uint8Array, start: number, end: number): Uint8Array =>
+	new Uint8Array(u8.subarray(start, end));
+
+export function parseProfileSave(input: Uint8Array | ArrayBuffer): ProfileSave {
+	const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
+	const { header, bodyStart, bodyLength } = parseHeader(bytes);
+	const variant = detectVariant(header.kind, bodyLength);
+	if (!variant) {
+		throw new UnknownProfileError(
+			`Not a recognised Burnout Paradise profile (header=${header.kind}, body=0x${bodyLength.toString(16)}).`,
+		);
+	}
+	const body = copyOf(bytes, bodyStart, bodyStart + bodyLength);
+
+	const chunks: ProfileChunk[] = variant.chunks.map((c) => ({
+		...c,
+		raw: copyOf(body, c.offset, c.offset + c.size),
+		spec: c.key === 'progression' ? progressionSpec(variant.id) : null,
+	}));
+
+	return { variant, header, endian: variant.endian, chunks, registry: PROGRESSION_REGISTRY, fileSize: bytes.length };
+}
+
+export function writeProfileSave(save: ProfileSave): Uint8Array {
+	const body = new Uint8Array(save.variant.bodyLength);
+	for (const chunk of save.chunks) body.set(chunk.raw, chunk.offset);
+	return writeFile(save.header, body);
+}
+
+export function getChunk(save: ProfileSave, key: string): ProfileChunk | undefined {
+	return save.chunks.find((c) => c.key === key);
+}
+
+/** Decode a chunk to a display object, or null if the chunk isn't modelled. */
+export function decodeChunk(save: ProfileSave, chunk: ProfileChunk): Record<string, unknown> | null {
+	if (!chunk.spec) return null;
+	return decodeStruct(chunk.spec, chunk.raw, 0, save.endian, save.registry);
+}
+
+/** Patch one scalar field inside a chunk (mutates chunk.raw). */
+export function editChunkField(save: ProfileSave, chunk: ProfileChunk, path: Path, value: LeafValue): void {
+	if (!chunk.spec) throw new Error(`chunk ${chunk.key} is not modelled`);
+	writeFieldByPath(chunk.spec, chunk.raw, 0, path, value, save.endian, save.registry);
+}
+
+/** Flip a single bit inside a bitset field of a chunk. */
+export function editChunkBit(save: ProfileSave, chunk: ProfileChunk, path: Path, bit: number, on: boolean): void {
+	if (!chunk.spec) throw new Error(`chunk ${chunk.key} is not modelled`);
+	writeBit(chunk.spec, chunk.raw, 0, path, bit, on, save.registry);
+}
+
+/** Edit an RGMH header metadata string (game/save/level/comments). */
+export function editHeaderString(save: ProfileSave, field: RgmhStringField, value: string): void {
+	if (save.header.kind !== 'rgmh') throw new Error('header has no editable strings');
+	setRgmhString(save.header, field, value);
+}
+
+export function editHeaderGuid(save: ProfileSave, guid: string): void {
+	if (save.header.kind !== 'rgmh') throw new Error('header has no GUID');
+	setRgmhGuid(save.header, guid);
+}

--- a/src/lib/core/profileSave/progression.ts
+++ b/src/lib/core/profileSave/progression.ts
@@ -1,0 +1,243 @@
+// BrnProgression::Profile layout — the largest and most interesting save chunk
+// (license, vehicles, rivals, events, collectibles, Road Rules, records).
+//
+// This models the PC (Remastered) variant (miVersionNumber 31), which is the
+// one we can validate against a real fixture. Other platforms share the early
+// layout but diverge later (DateAndTime / PlayerName / texture sizes), so they
+// are decoded opaquely until a fixture is available. The decode engine patches
+// in place, so any field NOT modelled here (padding, the genuinely ambiguous
+// mugshot region) is preserved byte-exact on save.
+//
+// Source: docs/save-profile/progression-profile.md.
+
+import type { Field, StructSpec, StructRegistry } from './struct';
+
+// --- enumerations ----------------------------------------------------------
+
+export const PROGRESSION_RANK: Record<number, string> = {
+	0: "Learner's Permit", 1: 'D License', 2: 'C License', 3: 'B License',
+	4: 'A License', 5: 'Burnout License', 6: 'Elite License',
+};
+
+export const CAR_TYPE: Record<number, string> = {
+	0: 'Danger', 1: 'Aggression', 2: 'Stunts', 3: 'Invalid',
+};
+
+export const UNLOCK_TYPE: Record<number, string> = {
+	0: 'Unlocked at start', 1: 'Gift (finish / Burning Route)', 2: 'Trophy (carbon)',
+	3: 'Shutdown rival', 4: 'Gold / platinum', 5: 'Sponsor', 6: 'Online only',
+	7: 'Beat The Team', 8: 'PDLC', 9: 'Cop car', 10: 'Island gift', 11: 'Island unlock',
+};
+
+export const RIVAL_STATE: Record<number, string> = {
+	0: 'Locked', 1: 'Unlocked (roaming)', 2: 'Fleeing', 3: 'Beaten (shut down)',
+};
+
+export const EVENT_FLAGS: Record<number, string> = {
+	0x1: 'Discovered', 0x2: 'Finished', 0x4: 'Rank win', 0x8: 'Non-rank win',
+	0x10: 'Won special event before', 0x20: 'Won event before',
+};
+
+// --- substructures ---------------------------------------------------------
+
+const CarData: StructSpec = {
+	name: 'CarData', size: 0x18,
+	fields: [
+		{ name: 'mId', offset: 0x0, kind: 'cgsid', label: 'Vehicle ID' },
+		{ name: 'mu8ColourIndex', offset: 0x8, kind: 'u8', label: 'Colour index' },
+		{ name: 'mu8PaletteIndex', offset: 0x9, kind: 'u8', label: 'Palette index' },
+		{ name: 'mbUnlockSequenceAlreadyShown', offset: 0xa, kind: 'bool', label: 'Unlock shown' },
+		{ name: 'mfUnlockDeformedAmount', offset: 0xc, kind: 'f32', label: 'Damage', note: 'Finish unlocked when 0' },
+		{ name: 'meUnlockType', offset: 0x10, kind: 'enum', storage: 'u32', values: UNLOCK_TYPE, label: 'Unlock type' },
+	],
+};
+
+const LiveryData: StructSpec = {
+	name: 'LiveryData', size: 0x18,
+	fields: [
+		{ name: 'mBaseCarId', offset: 0x0, kind: 'cgsid', label: 'Base car ID' },
+		{ name: 'mChosenLiveryCarId', offset: 0x8, kind: 'cgsid', label: 'Chosen livery car ID' },
+		{ name: 'mfDistanceDriven', offset: 0x10, kind: 'f32', label: 'Distance driven' },
+	],
+};
+
+const RivalData: StructSpec = {
+	name: 'RivalData', size: 0x38,
+	fields: [
+		{ name: 'mRivalId', offset: 0x0, kind: 'cgsid', label: 'Rival ID (GameDB)' },
+		{ name: 'mCarId', offset: 0x8, kind: 'cgsid', label: 'Car ID' },
+		{ name: 'meState', offset: 0x10, kind: 'enum', storage: 'u32', values: RIVAL_STATE, label: 'State' },
+		{ name: 'miEventCount', offset: 0x14, kind: 'i32', label: 'Event count' },
+		{ name: 'miTakedownFromCount', offset: 0x18, kind: 'i32' },
+		{ name: 'miVerticalTakedownFromCount', offset: 0x1c, kind: 'i32' },
+		{ name: 'miTakedownToCount', offset: 0x20, kind: 'i32' },
+		{ name: 'miVerticalTakedownToCount', offset: 0x24, kind: 'i32' },
+		{ name: 'miTakedownToInEventCount', offset: 0x28, kind: 'i32' },
+		{ name: 'miTakedownToInLastEventCount', offset: 0x2c, kind: 'i32' },
+		{ name: 'miEventMissingCount', offset: 0x30, kind: 'i32' },
+		{ name: 'mbHasBeenHit', offset: 0x34, kind: 'bool' },
+	],
+};
+
+const ProfileEvent: StructSpec = {
+	name: 'ProfileEvent', size: 0x8,
+	fields: [
+		{ name: 'muEventID', offset: 0x0, kind: 'u32', label: 'Event ID' },
+		{ name: 'muFlags', offset: 0x4, kind: 'flags', storage: 'u16', bits: EVENT_FLAGS, label: 'Flags' },
+	],
+};
+
+const ScoreList: StructSpec = {
+	name: 'ScoreList', size: 0x8,
+	fields: [
+		{ name: 'maScores', offset: 0x0, kind: 'array', count: 2, stride: 4, element: { kind: 'i32' }, label: 'Scores (Time, Showtime)' },
+	],
+};
+
+const ChallengeData: StructSpec = {
+	name: 'ChallengeData', size: 0x18,
+	fields: [
+		{ name: 'mDirty', offset: 0x0, kind: 'bitset', bits: 2 },
+		{ name: 'mValidScores', offset: 0x8, kind: 'bitset', bits: 2 },
+		{ name: 'mScoreList', offset: 0x10, kind: 'struct', ref: 'ScoreList' },
+	],
+};
+
+// PC (Remastered): PlayerName is char[25]; ChallengeHighScoreEntry is 0x50.
+const PlayerName: StructSpec = {
+	name: 'PlayerName', size: 0x19,
+	fields: [{ name: 'macName', offset: 0x0, kind: 'ascii', len: 25, label: 'Player name' }],
+};
+
+const ChallengeHighScoreEntry: StructSpec = {
+	name: 'ChallengeHighScoreEntry', size: 0x50,
+	fields: [
+		{ name: 'super_ChallengeData', offset: 0x0, kind: 'struct', ref: 'ChallengeData' },
+		{ name: 'maPlayerNames', offset: 0x18, kind: 'array', count: 2, stride: 0x19, element: { kind: 'struct', ref: 'PlayerName' }, label: 'Top friend names' },
+	],
+};
+
+const ChallengePlayerScoreEntry: StructSpec = {
+	name: 'ChallengePlayerScoreEntry', size: 0x28,
+	fields: [
+		{ name: 'super_ChallengeData', offset: 0x0, kind: 'struct', ref: 'ChallengeData' },
+		{ name: 'maCarIDs', offset: 0x18, kind: 'array', count: 2, stride: 8, element: { kind: 'cgsid' }, label: 'Cars used (Time, Showtime)' },
+	],
+};
+
+// NetworkTexture (PC Remastered) — pointers are runtime-only; kept verbatim.
+const NetworkTexture: StructSpec = {
+	name: 'NetworkTexture', size: 0x1c,
+	fields: [
+		{ name: 'miBitsPerPixel', offset: 0x4, kind: 'i32', label: 'Bits/pixel' },
+		{ name: 'miWidth', offset: 0x8, kind: 'i32', label: 'Width' },
+		{ name: 'miHeight', offset: 0xc, kind: 'i32', label: 'Height' },
+		{ name: 'mFormat', offset: 0x10, kind: 'u32', label: 'Format (DXGI)' },
+		{ name: 'mbTextureAllocatedFromHeap', offset: 0x18, kind: 'bool' },
+		{ name: 'mbIsUncompressedYUV', offset: 0x19, kind: 'bool' },
+	],
+};
+
+// --- the Profile root (PC Remastered) --------------------------------------
+
+const G = {
+	id: 'Identity', rec: 'Records', cnt: 'Counters', veh: 'Vehicles', riv: 'Rivals',
+	evt: 'Events', col: 'Collectibles', dis: 'Discovery', chl: 'Challenges',
+	rr: 'Road Rules', lic: 'License', mug: 'Mugshots', flg: 'Flags', misc: 'Misc',
+};
+
+const intArray = (name: string, offset: number, count: number, group: string, label: string): Field =>
+	({ name, offset, kind: 'array', count, stride: 4, element: { kind: 'i32' }, group, label });
+
+const ProfilePCR: StructSpec = {
+	name: 'Profile', size: 0x65da0,
+	fields: [
+		{ name: 'miVersionNumber', offset: 0x0, kind: 'i32', group: G.id, label: 'Version', note: '31 on PC Remastered' },
+		{ name: 'macName', offset: 0x4, kind: 'ascii', len: 32, group: G.id, label: 'Profile name', note: 'Unused in the final game' },
+		{ name: 'mSpawnCarId', offset: 0x50, kind: 'cgsid', group: G.misc, label: 'Spawn car ID', note: 'Deprecated in 1.3' },
+		{ name: 'muTimeStampOfLastRoadRulesDownload', offset: 0x60, kind: 'u32', group: G.rr, label: 'Last Road Rules download' },
+		{ name: 'mfDistanceDrivenOnline', offset: 0x64, kind: 'f32', group: G.cnt, label: 'Distance driven online (m)' },
+		{ name: 'mfDistanceDrivenOffline', offset: 0x68, kind: 'f32', group: G.cnt, label: 'Distance driven offline (m)' },
+		{ name: 'mfInCarTimePlayed', offset: 0x6c, kind: 'f32', group: G.cnt, label: 'In-car time played (s)' },
+		{ name: 'mi8CurrentProgressionRank', offset: 0x70, kind: 'enum', storage: 'i8', values: PROGRESSION_RANK, group: G.id, label: 'License' },
+		{ name: 'mi8PowerParkingBestRating', offset: 0x71, kind: 'i8', group: G.rec, label: 'Power Parking best' },
+		{ name: 'muBestNewBurnoutChainScore', offset: 0x74, kind: 'u32', group: G.rec, label: 'Burnout chain record' },
+		intArray('maGameModeTypeAmount', 0x78, 17, G.cnt, 'Events present per type'),
+		intArray('maGameModeTypeAmountDiscovered', 0xbc, 17, G.cnt, 'Events discovered per type'),
+		intArray('maGameModeTypeAmountCompleted', 0x100, 17, G.cnt, 'Events completed (this license) per type'),
+		intArray('maGameModeTypeAmountCompletedSinceTheStart', 0x144, 17, G.cnt, 'Events completed total per type'),
+		{ name: 'miTotalTakedownCount', offset: 0x188, kind: 'i32', group: G.cnt, label: 'Total takedowns' },
+		{ name: 'miTotalOnlineVerticleTakedownCount', offset: 0x18c, kind: 'i32', group: G.cnt, label: 'Vertical takedowns' },
+		intArray('maiTakedownTypeCounts', 0x190, 13, G.cnt, 'Takedowns per type'),
+		intArray('maiWinsPerOfflineGameMode', 0x1c4, 10, G.cnt, 'Wins per offline mode'),
+		intArray('maiRankWinsPerOfflineGameMode', 0x1ec, 10, G.cnt, 'Rank wins per offline mode'),
+		intArray('maiLossesPerOfflineGameMode', 0x214, 10, G.cnt, 'Losses per offline mode'),
+		{ name: 'miCompletedBarrelRolls', offset: 0x23c, kind: 'i32', group: G.rec, label: 'Barrel roll record' },
+		{ name: 'mfCompletedAirSpinAngle', offset: 0x240, kind: 'f32', group: G.rec, label: 'Flat spin record' },
+		{ name: 'mfCompletedDriftDistance', offset: 0x248, kind: 'f32', group: G.rec, label: 'Drift record' },
+		{ name: 'mfOncomingDistance', offset: 0x24c, kind: 'f32', group: G.rec, label: 'Oncoming record' },
+		{ name: 'mfAirMaximum', offset: 0x250, kind: 'f32', group: G.rec, label: 'Air time record' },
+		{ name: 'miHighestShowTimeScore', offset: 0x254, kind: 'i32', group: G.rec, label: 'Showtime record' },
+		{ name: 'miBestStuntRunScore', offset: 0x258, kind: 'i32', group: G.rec, label: 'Stunt Run record', note: 'Deprecated in 1.3' },
+		{ name: 'miCarCount', offset: 0x25c, kind: 'i32', group: G.veh, label: 'Vehicle entry count' },
+		{ name: 'miLiveryDataCount', offset: 0x260, kind: 'i32', group: G.veh, label: 'Livery entry count' },
+		{ name: 'miRivalCount', offset: 0x264, kind: 'i32', group: G.riv, label: 'Rival entry count' },
+		{ name: 'miEventCount', offset: 0x268, kind: 'i32', group: G.evt, label: 'Event entry count' },
+		{ name: 'maCars', offset: 0x270, kind: 'array', count: 512, stride: 0x18, element: { kind: 'struct', ref: 'CarData' }, group: G.veh, label: 'Vehicles' },
+		{ name: 'maLiveryChoices', offset: 0x3270, kind: 'array', count: 512, stride: 0x18, element: { kind: 'struct', ref: 'LiveryData' }, group: G.veh, label: 'Livery choices' },
+		{ name: 'maRivals', offset: 0x6270, kind: 'array', count: 64, stride: 0x38, element: { kind: 'struct', ref: 'RivalData' }, group: G.riv, label: 'Rivals' },
+		{ name: 'maEvents', offset: 0x7070, kind: 'array', count: 175, stride: 0x8, element: { kind: 'struct', ref: 'ProfileEvent' }, group: G.evt, label: 'Events' },
+		{ name: 'maStuntElements', offset: 0x75e8, kind: 'array', count: 3, stride: 0x1008, element: { kind: 'cgsidset', capacity: 512 }, group: G.col, label: 'Collectibles (Jump, Smash, Billboard)' },
+		{ name: 'muMedalCountFromTheStart', offset: 0xa600, kind: 'u32', group: G.cnt, label: 'Total events won' },
+		{ name: 'mbGoldCarsUnlocked', offset: 0xa604, kind: 'bool', group: G.veh, label: 'Gold finishes unlocked' },
+		{ name: 'mbSilverCarsUnlocked', offset: 0xa605, kind: 'bool', group: G.veh, label: 'Platinum finishes unlocked' },
+		{ name: 'mJunkYardsDriveThruSet', offset: 0xa608, kind: 'cgsidset', capacity: 5, group: G.dis, label: 'Junkyards discovered' },
+		{ name: 'mBodyShopsDriveThruSet', offset: 0xa638, kind: 'cgsidset', capacity: 11, group: G.dis, label: 'Auto Repairs discovered' },
+		{ name: 'mPaintShopsDriveThruSet', offset: 0xa698, kind: 'cgsidset', capacity: 5, group: G.dis, label: 'Paint Shops discovered' },
+		{ name: 'mGasStationsDriveThruSet', offset: 0xa6c8, kind: 'cgsidset', capacity: 14, group: G.dis, label: 'Gas Stations discovered' },
+		{ name: 'mCarParksDriveThruSet', offset: 0xa740, kind: 'cgsidset', capacity: 11, group: G.dis, label: 'Car Parks discovered' },
+		{ name: 'maFreeBurnChallengeData', offset: 0xa7a0, kind: 'cgsidarray', capacity: 2000, group: G.chl, label: 'Freeburn/Timed challenges completed' },
+		{ name: 'mabHitPropBitArray', offset: 0xe628, kind: 'bytes', len: 0x9280, group: G.col, label: 'Smashed billboards/gates (bit array)' },
+		{ name: 'maaiStuntCountsByCounty', offset: 0x178a8, kind: 'array', count: 15, stride: 2, element: { kind: 'i16' }, group: G.col, label: 'Collectible counts per county' },
+		{ name: 'maNetworkChallengeData', offset: 0x178c8, kind: 'array', count: 64, stride: 0x50, element: { kind: 'struct', ref: 'ChallengeHighScoreEntry' }, group: G.rr, label: 'Online Road Rule scores' },
+		{ name: 'maChallengeData', offset: 0x18cc8, kind: 'array', count: 64, stride: 0x28, element: { kind: 'struct', ref: 'ChallengePlayerScoreEntry' }, group: G.rr, label: 'Player Road Rule scores' },
+		{ name: 'muLastRoadRulesResetTime', offset: 0x196c8, kind: 'u32', group: G.rr, label: 'Last Road Rules reset' },
+		{ name: 'mPlayerLicencePicture', offset: 0x196cc, kind: 'struct', ref: 'NetworkTexture', group: G.lic, label: 'License picture header' },
+		{ name: 'macPlayerLicenceTextureData', offset: 0x196e8, kind: 'bytes', len: 0x4b000, group: G.lic, label: 'License picture data' },
+		{ name: 'mbPlayerLicencePictureIsValid', offset: 0x646e8, kind: 'bool', group: G.lic, label: 'License picture present' },
+		{ name: 'maaMugshotInfo', offset: 0x646ec, kind: 'bytes', len: 0x15f4, group: G.mug, label: 'Mugshot info (raw)' },
+		{ name: 'maAvailableMugshotFileIDs', offset: 0x65ce0, kind: 'bytes', len: 0x28, group: G.mug, label: 'Mugshot slots used (raw)' },
+		{ name: 'meCurrentCarType', offset: 0x65d14, kind: 'enum', storage: 'u32', values: CAR_TYPE, group: G.misc, label: 'Current boost type' },
+		{ name: 'maHasPlayerSeenTraining', offset: 0x65d18, kind: 'bitset', bits: 256, group: G.flg, label: 'DJ tips seen' },
+		{ name: 'miNumOnlineRacesDone', offset: 0x65d38, kind: 'i32', group: G.cnt, label: 'Online races done' },
+		{ name: 'miNumOnlineRacesWon', offset: 0x65d3c, kind: 'i32', group: G.cnt, label: 'Online races won' },
+		{ name: 'miNumMugshotsSent', offset: 0x65d40, kind: 'i32', group: G.cnt, label: 'Mugshots sent' },
+		{ name: 'mDateLicenceIssued', offset: 0x65d44, kind: 'datetime', size: 0xc, group: G.id, label: 'License issued' },
+		{ name: 'mDate100PercentCompleted', offset: 0x65d50, kind: 'datetime', size: 0xc, group: G.id, label: '100% completed' },
+		{ name: 'miHighestNumberOfTakeDownsInRoadRage', offset: 0x65d5c, kind: 'i32', group: G.rec, label: 'Road Rage record' },
+		{ name: 'mSeenTrophyAwardBitArray', offset: 0x65d60, kind: 'bitset', bits: 35, group: G.flg, label: 'Vehicle unlock trophies seen' },
+		{ name: 'mAchievementsEarnt', offset: 0x65d68, kind: 'bitset', bits: 60, group: G.flg, label: 'Paradise Awards earned' },
+		{ name: 'mb100PercentCompletionSequenceShown', offset: 0x65d70, kind: 'bool', group: G.flg, label: '100% sequence shown' },
+		{ name: 'mbIsNewProfile', offset: 0x65d71, kind: 'bool', group: G.flg, label: 'Is new profile', note: 'Intro plays if true' },
+		{ name: 'mbCreditsSequenceViewed', offset: 0x65d72, kind: 'bool', group: G.flg, label: 'Credits viewed' },
+		{ name: 'mbOneHundredHudMessageViewed', offset: 0x65d73, kind: 'bool', group: G.flg, label: '100% HUD message viewed' },
+		{ name: 'mbHasUnlockedCredits', offset: 0x65d74, kind: 'bool', group: G.flg, label: 'Credits unlocked' },
+		{ name: 'mbHaveSet100PercentCompletedDate', offset: 0x65d75, kind: 'bool', group: G.flg, label: '100% date set' },
+		{ name: 'mbHaveSeenEliteCompletionSequence', offset: 0x65d76, kind: 'bool', group: G.flg, label: 'Elite sequence seen' },
+		{ name: 'muRoadRulesIDLowBits', offset: 0x65d80, kind: 'u32', group: G.rr, label: 'Road Rules ID (low)' },
+		{ name: 'mSeenCompleteAllEventTypeArray', offset: 0x65d88, kind: 'bitset', bits: 6, group: G.flg, label: 'All-events-of-type seen' },
+		{ name: 'mfRealTimePlayed', offset: 0x65d90, kind: 'f32', group: G.cnt, label: 'Real time played (s)' },
+		{ name: 'muRoadRulesIDHighBits', offset: 0x65d98, kind: 'u32', group: G.rr, label: 'Road Rules ID (high)' },
+	],
+};
+
+export const PROGRESSION_REGISTRY: StructRegistry = {
+	CarData, LiveryData, RivalData, ProfileEvent, ScoreList, ChallengeData,
+	PlayerName, ChallengeHighScoreEntry, ChallengePlayerScoreEntry, NetworkTexture,
+	Profile: ProfilePCR,
+};
+
+/** Returns the Progression StructSpec for a variant, or null if not modelled. */
+export function progressionSpec(variantId: string): StructSpec | null {
+	return variantId === 'pc-remastered' ? ProfilePCR : null;
+}

--- a/src/lib/core/profileSave/struct.ts
+++ b/src/lib/core/profileSave/struct.ts
@@ -1,0 +1,212 @@
+// Declarative struct engine for the save profile. A `StructSpec` mirrors a
+// fixed-size C++ struct from the wiki; the engine decodes a byte range into a
+// plain JS object for display and patches a single field (addressed by path)
+// back into the bytes for editing. Untouched bytes are never rewritten, so a
+// load → save with no edits is byte-identical, regardless of how much of the
+// struct is actually modelled (padding and not-yet-modelled fields just pass
+// through).
+
+import {
+	type Endian,
+	readU8, readI8, readU16, readI16, readU32, readI32, readF32, readU64,
+	writeU8, writeI8, writeU16, writeI16, writeU32, writeI32, writeF32, writeU64,
+	readAscii, writeAscii,
+} from './binio';
+
+// A TypeSpec describes how to read/write one value. Fields and array elements
+// share it; a Field is just a TypeSpec plus a name/offset and UI metadata.
+export type ScalarKind = 'i8' | 'u8' | 'i16' | 'u16' | 'i32' | 'u32' | 'f32';
+
+export type TypeSpec =
+	| { kind: ScalarKind }
+	| { kind: 'u64' | 'cgsid' } // 64-bit; cgsid renders as hex
+	| { kind: 'bool' }
+	| { kind: 'enum'; storage: ScalarKind; values: Record<number, string> }
+	| { kind: 'flags'; storage: ScalarKind; bits: Record<number, string> }
+	| { kind: 'ascii'; len: number }
+	| { kind: 'vector3' } // 4×f32 (x,y,z + preserved w), 0x10 bytes
+	| { kind: 'datetime'; size: number } // bool mbIsLocal @0 + u64 time @8
+	| { kind: 'bytes'; len: number } // opaque blob, surfaced as hex only
+	| { kind: 'bitset'; bits: number } // BitArray<N>: N bits, ceil(N/8) bytes
+	| { kind: 'cgsidset'; capacity: number } // u32 count + u32 pad + capacity×u64
+	| { kind: 'cgsidarray'; capacity: number } // same on-disk shape as cgsidset
+	| { kind: 'struct'; ref: string }
+	| { kind: 'array'; count: number; stride: number; element: TypeSpec };
+
+export type Field = TypeSpec & {
+	name: string;
+	offset: number;
+	label?: string;
+	group?: string;
+	note?: string;
+};
+
+export type StructSpec = {
+	name: string;
+	size: number;
+	fields: Field[];
+};
+
+export type StructRegistry = Record<string, StructSpec>;
+
+export type Path = (string | number)[];
+
+// --- size + validation -----------------------------------------------------
+
+export function typeSize(t: TypeSpec, reg: StructRegistry): number {
+	switch (t.kind) {
+		case 'i8': case 'u8': case 'bool': return 1;
+		case 'i16': case 'u16': return 2;
+		case 'i32': case 'u32': case 'f32': return 4;
+		case 'u64': case 'cgsid': return 8;
+		case 'enum': case 'flags': return typeSize({ kind: t.storage }, reg);
+		case 'ascii': return t.len;
+		case 'vector3': return 0x10;
+		case 'datetime': return t.size;
+		case 'bytes': return t.len;
+		// CgsBitArray<N> is backed by 64-bit words, so it rounds up to 8 bytes
+		// (e.g. BitArray<35u> occupies 0x8, BitArray<300000u> occupies 0x9280).
+		case 'bitset': return Math.ceil(t.bits / 64) * 8;
+		case 'cgsidset': case 'cgsidarray': return 8 + t.capacity * 8;
+		case 'struct': return reg[t.ref].size;
+		case 'array': return t.count * t.stride;
+	}
+}
+
+/** Returns a list of layout problems (overruns / size mismatch), empty if OK. */
+export function validateStruct(spec: StructSpec, reg: StructRegistry): string[] {
+	const issues: string[] = [];
+	for (const f of spec.fields) {
+		const end = f.offset + typeSize(f, reg);
+		if (end > spec.size) {
+			issues.push(`${spec.name}.${f.name} ends at 0x${end.toString(16)} > size 0x${spec.size.toString(16)}`);
+		}
+	}
+	return issues;
+}
+
+// --- decode (bytes → display object) ---------------------------------------
+
+export function decodeType(t: TypeSpec, view: DataView, bytes: Uint8Array, base: number, e: Endian, reg: StructRegistry): unknown {
+	switch (t.kind) {
+		case 'u8': return readU8(view, base);
+		case 'i8': return readI8(view, base);
+		case 'u16': return readU16(view, base, e);
+		case 'i16': return readI16(view, base, e);
+		case 'u32': return readU32(view, base, e);
+		case 'i32': return readI32(view, base, e);
+		case 'f32': return readF32(view, base, e);
+		case 'u64': case 'cgsid': return readU64(view, base, e);
+		case 'bool': return readU8(view, base) !== 0;
+		case 'enum': return decodeType({ kind: t.storage }, view, bytes, base, e, reg);
+		case 'flags': return decodeType({ kind: t.storage }, view, bytes, base, e, reg);
+		case 'ascii': return readAscii(bytes, base, t.len);
+		case 'vector3':
+			return { x: readF32(view, base, e), y: readF32(view, base + 4, e), z: readF32(view, base + 8, e) };
+		case 'datetime':
+			// mbIsLocal @0; the 64-bit time is the trailing 8 bytes (the field is
+			// 0xC on Win/FILETIME platforms and 0x10 on the time_t platforms).
+			return { mbIsLocal: readU8(view, base) !== 0, mSystemTime: readU64(view, base + t.size - 8, e) };
+		case 'bytes':
+			return bytes.subarray(base, base + t.len);
+		case 'bitset': {
+			const set: number[] = [];
+			for (let i = 0; i < t.bits; i++) {
+				if ((bytes[base + (i >> 3)] >> (i & 7)) & 1) set.push(i);
+			}
+			return set;
+		}
+		case 'cgsidset': case 'cgsidarray': {
+			const count = readU32(view, base, e);
+			const ids: bigint[] = [];
+			for (let i = 0; i < t.capacity; i++) ids.push(readU64(view, base + 8 + i * 8, e));
+			return { count, ids };
+		}
+		case 'struct': {
+			const spec = reg[t.ref];
+			const obj: Record<string, unknown> = {};
+			for (const f of spec.fields) obj[f.name] = decodeType(f, view, bytes, base + f.offset, e, reg);
+			return obj;
+		}
+		case 'array': {
+			const arr: unknown[] = [];
+			for (let i = 0; i < t.count; i++) arr.push(decodeType(t.element, view, bytes, base + i * t.stride, e, reg));
+			return arr;
+		}
+	}
+}
+
+export function decodeStruct(spec: StructSpec, bytes: Uint8Array, base: number, e: Endian, reg: StructRegistry): Record<string, unknown> {
+	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	return decodeType({ kind: 'struct', ref: spec.name }, view, bytes, base, e, { ...reg, [spec.name]: spec }) as Record<string, unknown>;
+}
+
+// --- locate (path → leaf type + absolute offset) ---------------------------
+
+type Located = { type: TypeSpec; offset: number };
+
+function locate(t: TypeSpec, base: number, path: Path, reg: StructRegistry): Located {
+	if (path.length === 0) return { type: t, offset: base };
+	const head = path[0];
+	const rest = path.slice(1);
+	switch (t.kind) {
+		case 'struct': {
+			const f = reg[t.ref].fields.find((x) => x.name === head);
+			if (!f) throw new Error(`no field ${String(head)} in ${t.ref}`);
+			return locate(f, base + f.offset, rest, reg);
+		}
+		case 'array':
+			return locate(t.element, base + (head as number) * t.stride, rest, reg);
+		case 'vector3': {
+			const comp = { x: 0, y: 1, z: 2, w: 3 }[head as 'x' | 'y' | 'z' | 'w'];
+			return { type: { kind: 'f32' }, offset: base + comp * 4 };
+		}
+		case 'datetime':
+			if (head === 'mbIsLocal') return { type: { kind: 'bool' }, offset: base };
+			return { type: { kind: 'u64' }, offset: base + t.size - 8 };
+		case 'cgsidset': case 'cgsidarray':
+			if (head === 'count') return { type: { kind: 'u32' }, offset: base };
+			// path: ['ids', index]
+			return { type: { kind: 'cgsid' }, offset: base + 8 + (rest[0] as number) * 8 };
+		default:
+			throw new Error(`cannot descend into ${t.kind} with path ${JSON.stringify(path)}`);
+	}
+}
+
+// --- write a single field, addressed by path -------------------------------
+
+export type LeafValue = number | bigint | boolean | string;
+
+export function writeFieldByPath(spec: StructSpec, bytes: Uint8Array, base: number, path: Path, value: LeafValue, e: Endian, reg: StructRegistry): void {
+	const full = { ...reg, [spec.name]: spec };
+	const { type, offset } = locate({ kind: 'struct', ref: spec.name }, base, path, full);
+	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	switch (type.kind) {
+		case 'u8': writeU8(view, offset, value as number); break;
+		case 'i8': writeI8(view, offset, value as number); break;
+		case 'u16': writeU16(view, offset, value as number, e); break;
+		case 'i16': writeI16(view, offset, value as number, e); break;
+		case 'u32': writeU32(view, offset, value as number, e); break;
+		case 'i32': writeI32(view, offset, value as number, e); break;
+		case 'f32': writeF32(view, offset, value as number, e); break;
+		case 'u64': case 'cgsid': writeU64(view, offset, value as bigint, e); break;
+		case 'bool': writeU8(view, offset, value ? 1 : 0); break;
+		case 'enum': case 'flags': {
+			const w = { ...type, kind: type.storage } as TypeSpec;
+			writeFieldByPath({ name: '_', size: 0, fields: [{ ...w, name: 'v', offset: 0 }] }, bytes, offset, ['v'], value, e, reg);
+			break;
+		}
+		case 'ascii': writeAscii(bytes, offset, type.len, value as string); break;
+		default:
+			throw new Error(`unsupported leaf write for ${type.kind}`);
+	}
+}
+
+/** Flip a single bit inside a `bitset` field. Path = [...to bitset field]. */
+export function writeBit(spec: StructSpec, bytes: Uint8Array, base: number, path: Path, bit: number, on: boolean, reg: StructRegistry): void {
+	const full = { ...reg, [spec.name]: spec };
+	const { offset } = locate({ kind: 'struct', ref: spec.name }, base, path, full);
+	const byte = offset + (bit >> 3);
+	const mask = 1 << (bit & 7);
+	if (on) bytes[byte] |= mask; else bytes[byte] &= ~mask & 0xff;
+}

--- a/src/lib/core/profileSave/variants.ts
+++ b/src/lib/core/profileSave/variants.ts
@@ -1,0 +1,155 @@
+// Container layout for BrnGui::ProfileManager::ProfileStoredData. The save body
+// (everything after any platform header) is a fixed sequence of
+// FixedSizeOpaqueBuffer<T> chunks at platform-specific offsets. Each variant
+// tiles its body exactly; the codec splits the body into these chunks (each one
+// is byte-exact on its own) and decodes the ones it understands.
+//
+// Source: docs/save-profile/container.md (wiki "Profile/Burnout Paradise").
+
+import type { Endian } from './binio';
+
+export type HeaderKind = 'rgmh' | 'mc02' | 'none';
+
+export type ChunkKey =
+	| 'progression'
+	| 'liveRevenge'
+	| 'options'
+	| 'cagney'
+	| 'cagneyOptions'
+	| 'davis'
+	| 'recentPlayers'
+	| 'pdlc'
+	| 'cop'
+	| 'island'
+	| 'padding';
+
+export type ChunkDef = {
+	key: ChunkKey;
+	name: string;
+	offset: number;
+	size: number;
+	addedIn?: string; // game version that introduced it
+};
+
+export type ProfileVariantId = 'ps3' | 'xbox360' | 'pc' | 'ps4' | 'pc-remastered' | 'switch';
+
+export type ProfileVariant = {
+	id: ProfileVariantId;
+	label: string;
+	header: HeaderKind;
+	endian: Endian;
+	bodyLength: number; // sum of all chunk sizes
+	chunks: ChunkDef[];
+};
+
+const C = (key: ChunkKey, name: string, offset: number, size: number, addedIn?: string): ChunkDef =>
+	({ key, name, offset, size, addedIn });
+
+export const VARIANTS: ProfileVariant[] = [
+	{
+		id: 'ps3', label: 'PlayStation 3', header: 'none', endian: 'be', bodyLength: 0x40000,
+		chunks: [
+			C('progression', 'Progression Profile', 0x0, 0x1da30),
+			C('liveRevenge', 'Live Revenge Profile', 0x1da30, 0x7540),
+			C('options', 'Options Data Profile', 0x24f70, 0x7370),
+			C('cagney', 'Cagney Profile', 0x2c2e0, 0xac0, '1.3'),
+			C('cagneyOptions', 'Cagney Options Data Profile', 0x2cda0, 0x18, '1.3'),
+			C('davis', 'Davis Profile', 0x2cdb8, 0x19c8, '1.4'),
+			C('pdlc', 'PDLC Profile', 0x2e780, 0x1c60, '1.7'),
+			C('cop', 'Cop Profile', 0x303e0, 0x268, '1.8'),
+			C('island', 'Island Profile', 0x30648, 0x10a8, '1.9'),
+			C('padding', 'Padding', 0x316f0, 0xe910),
+		],
+	},
+	{
+		id: 'xbox360', label: 'Xbox 360', header: 'mc02', endian: 'be', bodyLength: 0x40000,
+		chunks: [
+			C('progression', 'Progression Profile', 0x0, 0x1cd30),
+			C('liveRevenge', 'Live Revenge Profile', 0x1cd30, 0x7540),
+			C('options', 'Options Data Profile', 0x24270, 0x7370),
+			C('cagney', 'Cagney Profile', 0x2b5e0, 0xac0, '1.3'),
+			C('cagneyOptions', 'Cagney Options Data Profile', 0x2c0a0, 0x18, '1.3'),
+			C('davis', 'Davis Profile', 0x2c0b8, 0x17c8, '1.4'),
+			C('pdlc', 'PDLC Profile', 0x2d880, 0x1c60, '1.7'),
+			C('cop', 'Cop Profile', 0x2f4e0, 0x268, '1.8'),
+			C('island', 'Island Profile', 0x2f748, 0xfe0, '1.9'),
+			C('padding', 'Padding', 0x30728, 0xf8d8),
+		],
+	},
+	{
+		id: 'pc', label: 'PC', header: 'rgmh', endian: 'le', bodyLength: 0x40000,
+		chunks: [
+			C('progression', 'Progression Profile', 0x0, 0x1cc00),
+			C('liveRevenge', 'Live Revenge Profile', 0x1cc00, 0x6d68),
+			C('options', 'Options Data Profile', 0x23968, 0x7780),
+			C('cagney', 'Cagney Profile', 0x2b0e8, 0xac0, '1.3'),
+			C('cagneyOptions', 'Cagney Options Data Profile', 0x2bba8, 0x18, '1.3'),
+			C('davis', 'Davis Profile', 0x2bbc0, 0x19c8, '1.4'),
+			C('recentPlayers', 'Recent Players Profile', 0x2d588, 0xc88),
+			C('pdlc', 'PDLC Profile', 0x2e210, 0x1c68, '1.7'),
+			C('padding', 'Padding', 0x2fe78, 0x10188),
+		],
+	},
+	{
+		id: 'ps4', label: 'PlayStation 4', header: 'none', endian: 'le', bodyLength: 0x80001,
+		chunks: [
+			C('progression', 'Progression Profile', 0x0, 0x66100),
+			C('liveRevenge', 'Live Revenge Profile', 0x66100, 0x7d10),
+			C('options', 'Options Data Profile', 0x6de10, 0x7778),
+			C('cagney', 'Cagney Profile', 0x75588, 0xac0, '1.3'),
+			C('cagneyOptions', 'Cagney Options Data Profile', 0x76048, 0x18, '1.3'),
+			C('davis', 'Davis Profile', 0x76060, 0x1c48, '1.4'),
+			C('pdlc', 'PDLC Profile', 0x77ca8, 0x1c68, '1.7'),
+			C('cop', 'Cop Profile', 0x79910, 0x268, '1.8'),
+			C('island', 'Island Profile', 0x79b78, 0x11e0, '1.9'),
+			C('padding', 'Padding', 0x7ad58, 0x52a9),
+		],
+	},
+	{
+		id: 'pc-remastered', label: 'PC (Remastered)', header: 'rgmh', endian: 'le', bodyLength: 0x80000,
+		chunks: [
+			C('progression', 'Progression Profile', 0x0, 0x65da0),
+			C('liveRevenge', 'Live Revenge Profile', 0x65da0, 0x7538),
+			C('options', 'Options Data Profile', 0x6d2d8, 0x7778),
+			C('cagney', 'Cagney Profile', 0x74a50, 0xac0, '1.3'),
+			C('cagneyOptions', 'Cagney Options Data Profile', 0x75510, 0x18, '1.3'),
+			C('davis', 'Davis Profile', 0x75528, 0x1c48, '1.4'),
+			C('pdlc', 'PDLC Profile', 0x77170, 0x1c68, '1.7'),
+			C('cop', 'Cop Profile', 0x78dd8, 0x268, '1.8'),
+			C('island', 'Island Profile', 0x79040, 0x11d8, '1.9'),
+			C('padding', 'Padding', 0x7a218, 0x5de8),
+		],
+	},
+	{
+		id: 'switch', label: 'Switch', header: 'none', endian: 'le', bodyLength: 0x80000,
+		chunks: [
+			C('progression', 'Progression Profile', 0x0, 0x66820),
+			C('liveRevenge', 'Live Revenge Profile', 0x66820, 0x84e0),
+			C('options', 'Options Data Profile', 0x6ed00, 0x7778),
+			C('cagney', 'Cagney Profile', 0x76478, 0xac0, '1.3'),
+			C('cagneyOptions', 'Cagney Options Data Profile', 0x76f38, 0x18, '1.3'),
+			C('davis', 'Davis Profile', 0x76f50, 0x2048, '1.4'),
+			C('pdlc', 'PDLC Profile', 0x78f98, 0x1c68, '1.7'),
+			C('cop', 'Cop Profile', 0x7ac00, 0x268, '1.8'),
+			C('island', 'Island Profile', 0x7ae68, 0x1360, '1.9'),
+			C('padding', 'Padding', 0x7c1c8, 0x3e38),
+		],
+	},
+];
+
+export function variantById(id: ProfileVariantId): ProfileVariant {
+	const v = VARIANTS.find((x) => x.id === id);
+	if (!v) throw new Error(`unknown profile variant: ${id}`);
+	return v;
+}
+
+/**
+ * Pick the variant from the detected header kind and the body length. The pair
+ * is unambiguous: PC / PC-Remastered carry RGMH, X360 carries MC02, and the
+ * three header-less platforms (PS3 / PS4 / Switch) have distinct body sizes.
+ */
+export function detectVariant(header: HeaderKind, bodyLength: number): ProfileVariant | null {
+	return (
+		VARIANTS.find((v) => v.header === header && v.bodyLength === bodyLength) ?? null
+	);
+}

--- a/src/pages/SaveProfilePage.tsx
+++ b/src/pages/SaveProfilePage.tsx
@@ -1,0 +1,118 @@
+// Standalone Burnout Paradise save-profile editor (/save). The profile is a
+// platform-headered ProfileStoredData file, not a BND2 bundle, so it has its
+// own route/layout and never touches the bundle Workspace.
+
+import { useRef, useState } from 'react';
+import { NavLink } from 'react-router-dom';
+import { Upload, Download, Save, Layers, FileWarning } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { SaveProfileProvider, useSaveProfile } from '@/context/SaveProfileContext';
+import { HeaderInfoPanel } from '@/components/saveprofile/HeaderInfoPanel';
+import { ChunkEditor } from '@/components/saveprofile/ChunkEditor';
+
+const ACCEPT = '.BurnoutParadiseSave,.sav,.dat,application/octet-stream';
+
+function SaveProfileInner() {
+	const { save, fileName, dirty, error, load, download } = useSaveProfile();
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const [selected, setSelected] = useState<string>('header');
+
+	const selectedChunk = save?.chunks.find((c) => c.key === selected) ?? null;
+
+	return (
+		<div className="h-screen flex flex-col bg-background">
+			<header className="border-b bg-card/50 backdrop-blur">
+				<div className="px-6 py-4 flex items-center justify-between">
+					<div>
+						<h1 className="text-2xl font-bold tracking-tight">Save Profile Editor</h1>
+						<p className="text-muted-foreground">Burnout Paradise progression profile (Profile.BurnoutParadiseSave)</p>
+					</div>
+					<div className="flex items-center gap-3">
+						{save && <Badge variant="outline">{save.variant.label}</Badge>}
+						{dirty && <Badge variant="secondary" className="bg-yellow-500/10 text-yellow-600 border-yellow-500/20">Modified</Badge>}
+						<input ref={fileInputRef} type="file" accept={ACCEPT} className="hidden"
+							onChange={(e) => { const f = e.target.files?.[0]; if (f) void load(f); e.target.value = ''; }} />
+						<Button onClick={() => fileInputRef.current?.click()} className="gap-2">
+							<Upload className="w-4 h-4" /> Load Profile
+						</Button>
+						{save && (
+							<Button onClick={download} variant="outline" className="gap-2">
+								<Download className="w-4 h-4" /> Save Profile
+							</Button>
+						)}
+					</div>
+				</div>
+				<nav className="px-6 py-2 border-t flex items-center gap-2">
+					<NavLink to="/workspace" className="px-3 py-1.5 rounded hover:bg-muted/60 text-sm">
+						<Layers className="inline w-4 h-4 mr-1" /> Bundle Workspace
+					</NavLink>
+					<NavLink to="/save" className="px-3 py-1.5 rounded bg-muted text-sm">
+						<Save className="inline w-4 h-4 mr-1" /> Save Editor
+					</NavLink>
+				</nav>
+			</header>
+
+			<main className="flex-1 min-h-0 overflow-hidden">
+				{!save ? (
+					<EmptyState error={error} onLoad={() => fileInputRef.current?.click()} />
+				) : (
+					<div className="h-full flex">
+						<aside className="w-64 shrink-0 border-r overflow-auto p-2">
+							<SidebarItem label="File Header" active={selected === 'header'} onClick={() => setSelected('header')} />
+							<div className="px-2 py-1 mt-2 text-[11px] uppercase tracking-wide text-muted-foreground">Chunks</div>
+							{save.chunks.map((c) => (
+								<SidebarItem key={c.key} label={c.name} decoded={!!c.spec} sub={`0x${c.size.toString(16)}`}
+									active={selected === c.key} onClick={() => setSelected(c.key)} />
+							))}
+						</aside>
+						<section className="flex-1 min-w-0 overflow-auto p-6">
+							{selected === 'header' && <HeaderInfoPanel save={save} />}
+							{selectedChunk && <ChunkEditor save={save} chunk={selectedChunk} />}
+						</section>
+					</div>
+				)}
+			</main>
+		</div>
+	);
+}
+
+function SidebarItem({ label, sub, active, decoded, onClick }: { label: string; sub?: string; active: boolean; decoded?: boolean; onClick: () => void }) {
+	return (
+		<button type="button" onClick={onClick}
+			className={`w-full text-left px-2 py-1.5 rounded text-sm flex items-center justify-between gap-2 ${active ? 'bg-muted font-medium' : 'hover:bg-muted/50'}`}>
+			<span className="truncate">{label}</span>
+			<span className="flex items-center gap-1 shrink-0">
+				{decoded && <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" title="decoded into fields" />}
+				{sub && <span className="text-[10px] font-mono text-muted-foreground">{sub}</span>}
+			</span>
+		</button>
+	);
+}
+
+function EmptyState({ error, onLoad }: { error: string | null; onLoad: () => void }) {
+	return (
+		<div className="h-full flex flex-col items-center justify-center text-center space-y-4 p-6">
+			<div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center">
+				{error ? <FileWarning className="w-8 h-8 text-yellow-600" /> : <Upload className="w-8 h-8 text-muted-foreground" />}
+			</div>
+			<div>
+				<h3 className="text-lg font-medium">No profile loaded</h3>
+				<p className="text-muted-foreground max-w-md">
+					Load a <code className="px-1 rounded bg-muted">Profile.BurnoutParadiseSave</code> (PC / Remastered RGMH,
+					Xbox 360 MC02, or a raw PS3/PS4/Switch profile). Editing patches bytes in place; saving round-trips byte-exact.
+				</p>
+				{error && <p className="text-sm text-yellow-600 mt-2">{error}</p>}
+			</div>
+			<Button onClick={onLoad} className="gap-2"><Upload className="w-4 h-4" /> Load Profile File</Button>
+		</div>
+	);
+}
+
+export default function SaveProfilePage() {
+	return (
+		<SaveProfileProvider>
+			<SaveProfileInner />
+		</SaveProfileProvider>
+	);
+}


### PR DESCRIPTION
## What

Adds save-game editing to steward. `Profile.BurnoutParadiseSave` is the game's progression save — a platform-headered `ProfileStoredData` file, **not** a BND2 bundle — so it gets its own standalone **`/save`** editor outside the bundle Workspace.

## Codec — `src/lib/core/profileSave/`

- **Headers**: RGMH (PC / Remastered, with thumbnail + metadata strings), MC02 (Xbox 360, big-endian, three CRC32 checksums recomputed on save), and headerless (PS3 / PS4 / Switch).
- **Container**: a 6-platform chunk table (Progression, Live Revenge, Options, Cagney ±options, Davis, PDLC, Cop, Island, Recent Players, Padding), auto-detected by header kind + body length.
- **Engine**: decode-on-raw + **patch-in-place** — each chunk keeps its original bytes, decoding produces a display view, and an edit writes a single field at its known offset. Every untouched byte (padding, unmodelled fields, ambiguous regions) survives a load → save unchanged, so the round-trip is **byte-exact by construction**.

## Decode coverage

- **PC (Remastered) Progression Profile (v31)** is fully field-editable: license, vehicles, liveries, rivals, events, collectibles, discovery, Road Rules, records, counters, flags — with enums, `CgsID` sets/arrays, bit arrays and FILETIME dates.
- Every other chunk (and Progression on other platforms) loads, displays and **saves byte-exact**, but is shown opaque (size + hex) rather than field-decoded. Each is "write one `StructSpec`" away — the engine, docs and a size-invariant test are all in place. Full layouts are mirrored under [`docs/save-profile/`](docs/save-profile/).

## Tests — 20, pure-node (`__tests__/profileSave.test.ts`)

- Byte-exact round-trip **+ idempotence against a real PC Remastered save** (skipped when the personal fixture is absent).
- Field / nested-array / bitset / RGMH-header edits that touch **only** the intended bytes.
- All-6-variant chunk-table tiling invariants and struct layout validation.
- Synthetic MC02 CRC + headerless round-trips.

## UI

`/save` route + `SaveProfileContext` + grouped, tabbed field editors (`components/saveprofile/`), reachable via a new "Save Editor" nav link from the Workspace. Verified live against the real save: load → decode all field groups → edit scalars/enums/arrays/bits → byte-exact download.

## Notes

- Personal save files are **gitignored** (they contain progression + friends' names); used only as local fixtures.
- Pre-existing `trafficData` `tsc` errors are unrelated to this change; the new files are type-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)