### PR TITLE
feat(triggerData): bulk export/import-to-file for cross-bundle trigger handoff

### DIFF
--- a/src/components/workspace/BulkPanelStack.tsx
+++ b/src/components/workspace/BulkPanelStack.tsx
@@ -10,9 +10,8 @@
 //     instance (path: []), so the user can return to the inspector form
 //     for that resource without losing their bulk.
 //   - [✕] click: clears that bulk only (other bulks coexist).
-//   - Body (when expanded): per-resource — AI Sections shows the export
-//     buttons; TriggerData shows just `[Clear]` until a TriggerData-
-//     specific aggregate editor is designed (issue #60 follow-up).
+//   - Body (when expanded): per-resource export buttons (Export → clipboard /
+//     file…). AI Sections and TriggerData share the same export-button row.
 //
 // PSL retrofit (mounting PSL bulks here too) remains out of scope. This
 // stack consults the AI Sections + TriggerData providers; adding more
@@ -37,11 +36,14 @@ import {
 import { sortBulkSummaries } from './bulkPanelStack.helpers';
 import {
 	buildEnvelopeFromBulk,
+	buildTriggerEnvelopeFromBulk,
 	exportEnvelopeFilename,
+	exportTriggerEnvelopeFilename,
 } from './bulkPanelExport.helpers';
 import { encodeBulkEnvelope } from '@/lib/clipboard/bulkEnvelope';
 import type { EditableBundle } from '@/context/WorkspaceContext.types';
 import type { ParsedAISections } from '@/lib/core/aiSections';
+import type { ParsedTriggerData } from '@/lib/core/triggerData';
 
 const AI_KEY = 'aiSections';
 const TRIGGER_KEY = 'triggerData';
@@ -280,53 +282,80 @@ function BulkPanel({
 				</button>
 			</div>
 			{expanded && (
-				<div className="px-3 py-2 border-t border-amber-500/40 space-y-2">
-					<div className="flex flex-wrap gap-1.5">
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							className="h-7 text-xs gap-1"
-							disabled={!canExport}
-							onClick={() => void handleExportClipboard()}
-							title="Copy this bulk as JSON to the OS clipboard"
-						>
-							<Clipboard className="h-3 w-3" />
-							Export → clipboard
-						</Button>
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							className="h-7 text-xs gap-1"
-							disabled={!canExport}
-							onClick={handleExportFile}
-							title="Download this bulk as a JSON file"
-						>
-							<Download className="h-3 w-3" />
-							Export → file…
-						</Button>
-						<Button
-							type="button"
-							variant="ghost"
-							size="sm"
-							className="h-7 text-xs ml-auto"
-							onClick={onClear}
-						>
-							Clear
-						</Button>
-					</div>
-				</div>
+				<BulkExportButtons
+					canExport={canExport}
+					onExportClipboard={() => void handleExportClipboard()}
+					onExportFile={handleExportFile}
+					onClear={onClear}
+				/>
 			)}
 		</div>
 	);
 }
 
 // ---------------------------------------------------------------------------
-// One TriggerData panel — minimal body (just `[Clear]`) until a TriggerData-
-// specific aggregate editor is designed (issue #60 leaves this stub on
-// purpose; bulk-edit UI is a follow-up). Keeps the header chrome identical
-// to `BulkPanel` so users see one consistent panel shape across resources.
+// Shared export-button row — identical chrome for every bulk panel's expanded
+// body (Export → clipboard / Export → file… / Clear). Each panel wires its own
+// resource-specific handlers; only the disabled state + click targets differ.
+// ---------------------------------------------------------------------------
+
+function BulkExportButtons({
+	canExport,
+	onExportClipboard,
+	onExportFile,
+	onClear,
+}: {
+	canExport: boolean;
+	onExportClipboard: () => void;
+	onExportFile: () => void;
+	onClear: () => void;
+}) {
+	return (
+		<div className="px-3 py-2 border-t border-amber-500/40 space-y-2">
+			<div className="flex flex-wrap gap-1.5">
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					className="h-7 text-xs gap-1"
+					disabled={!canExport}
+					onClick={onExportClipboard}
+					title="Copy this bulk as JSON to the OS clipboard"
+				>
+					<Clipboard className="h-3 w-3" />
+					Export → clipboard
+				</Button>
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					className="h-7 text-xs gap-1"
+					disabled={!canExport}
+					onClick={onExportFile}
+					title="Download this bulk as a JSON file"
+				>
+					<Download className="h-3 w-3" />
+					Export → file…
+				</Button>
+				<Button
+					type="button"
+					variant="ghost"
+					size="sm"
+					className="h-7 text-xs ml-auto"
+					onClick={onClear}
+				>
+					Clear
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// One TriggerData panel — same export chrome as `BulkPanel` (Export →
+// clipboard / file…), wired through the six-list TriggerData export pipeline.
+// Keeps the header chrome identical so users see one consistent panel shape
+// across resources.
 // ---------------------------------------------------------------------------
 
 function TriggerDataBulkPanel({
@@ -345,6 +374,65 @@ function TriggerDataBulkPanel({
 	const handler = getHandlerByKey(TRIGGER_KEY);
 	const resourceLabel = handler?.name ?? TRIGGER_KEY;
 	const filename = bundle?.id ?? summary.bundleId;
+
+	const model = bundle?.parsedResourcesAll.get(TRIGGER_KEY)?.[summary.index] as
+		| ParsedTriggerData
+		| undefined;
+	const canExport = summary.count > 0 && model != null;
+
+	const handleExportClipboard = async () => {
+		if (!canExport || !model) return;
+		try {
+			const envelope = buildTriggerEnvelopeFromBulk(model, summary, filename);
+			const json = encodeBulkEnvelope({
+				resourceKey: envelope.resourceKey,
+				profile: envelope.profile,
+				items: envelope.items,
+				sourceBundle: envelope.sourceBundle,
+			});
+			if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+				await navigator.clipboard.writeText(json);
+				toast.success(`Copied ${envelope.items.length} trigger${envelope.items.length === 1 ? '' : 's'} to clipboard`);
+			} else {
+				toast.error('Clipboard API unavailable', {
+					description: 'Use [Export → file…] instead — your browser blocks clipboard writes.',
+				});
+			}
+		} catch (err) {
+			console.error('Trigger bulk export to clipboard failed:', err);
+			toast.error('Copy to clipboard failed', {
+				description: err instanceof Error ? err.message : 'Unknown error',
+			});
+		}
+	};
+
+	const handleExportFile = () => {
+		if (!canExport || !model) return;
+		try {
+			const envelope = buildTriggerEnvelopeFromBulk(model, summary, filename);
+			const json = encodeBulkEnvelope({
+				resourceKey: envelope.resourceKey,
+				profile: envelope.profile,
+				items: envelope.items,
+				sourceBundle: envelope.sourceBundle,
+			});
+			const blob = new Blob([json], { type: 'application/json' });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = exportTriggerEnvelopeFilename(filename);
+			document.body.appendChild(a);
+			a.click();
+			a.remove();
+			setTimeout(() => URL.revokeObjectURL(url), 0);
+			toast.success(`Saved ${envelope.items.length} trigger${envelope.items.length === 1 ? '' : 's'}`);
+		} catch (err) {
+			console.error('Trigger bulk export to file failed:', err);
+			toast.error('Save to file failed', {
+				description: err instanceof Error ? err.message : 'Unknown error',
+			});
+		}
+	};
 
 	return (
 		<div className="rounded border border-amber-500/40 bg-amber-500/5">
@@ -390,19 +478,12 @@ function TriggerDataBulkPanel({
 				</button>
 			</div>
 			{expanded && (
-				<div className="px-3 py-2 border-t border-amber-500/40 space-y-2">
-					<div className="flex flex-wrap gap-1.5">
-						<Button
-							type="button"
-							variant="ghost"
-							size="sm"
-							className="h-7 text-xs ml-auto"
-							onClick={onClear}
-						>
-							Clear
-						</Button>
-					</div>
-				</div>
+				<BulkExportButtons
+					canExport={canExport}
+					onExportClipboard={() => void handleExportClipboard()}
+					onExportFile={handleExportFile}
+					onClear={onClear}
+				/>
 			)}
 		</div>
 	);

--- a/src/components/workspace/TriggerDataBulkImportDialog.tsx
+++ b/src/components/workspace/TriggerDataBulkImportDialog.tsx
@@ -1,0 +1,265 @@
+// TriggerDataBulkImportDialog — modal for pasting / loading a steward.bulk
+// envelope onto a TriggerData destination.
+//
+// Mirrors BulkImportDialog (AI Sections) but is typed to ParsedTriggerData and
+// drives the TriggerData import pipeline. Two differences from the AI dialog:
+//
+//   - No "Starting ID" field. TriggerData box-region ids + regionIndices are
+//     auto-assigned by importTriggerDataBulk above the destination's current
+//     max (the writer's consolidated region table requires dense, unique
+//     regionIndices — the user can't pick them). The preview shows the ranges
+//     that WILL be assigned so there's no surprise.
+//   - Six heterogeneous lists, so the preview is a per-list count breakdown
+//     rather than a single section count.
+//
+// The preview never re-derives assignment math — buildTriggerImportPreview runs
+// the real import so what's shown is exactly what Confirm produces.
+
+import { useMemo, useRef, useState } from 'react';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { AlertTriangle } from 'lucide-react';
+import { toast } from 'sonner';
+import { cn } from '@/lib/utils';
+import {
+	importTriggerDataBulk,
+	type TriggerImportMode,
+} from '@/lib/clipboard/triggerDataBulkImport';
+import {
+	decodeTriggerEnvelope,
+	buildTriggerImportPreview,
+} from './triggerDataBulkImportDialog.helpers';
+import { TriggerImportPreviewBlock } from './TriggerImportPreviewBlock';
+import type { TriggerDataBulkItem } from '@/lib/clipboard/triggerDataBulkExport';
+import type { BulkEnvelope } from '@/lib/clipboard/bulkEnvelope';
+import type { ParsedTriggerData } from '@/lib/core/triggerData';
+
+type Props = {
+	open: boolean;
+	onOpenChange: (next: boolean) => void;
+	destination: ParsedTriggerData;
+	bundleId: string;
+	onConfirm: (result: ParsedTriggerData) => void;
+};
+
+type EnvelopeState =
+	| { kind: 'idle' }
+	| { kind: 'error'; reason: string }
+	| { kind: 'ready'; envelope: BulkEnvelope<TriggerDataBulkItem> };
+
+export function TriggerDataBulkImportDialog({
+	open,
+	onOpenChange,
+	destination,
+	bundleId,
+	onConfirm,
+}: Props) {
+	const [envelopeState, setEnvelopeState] = useState<EnvelopeState>({ kind: 'idle' });
+	const [pasteText, setPasteText] = useState('');
+	const [mode, setMode] = useState<TriggerImportMode>('append');
+	const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+	const preview = useMemo(
+		() =>
+			envelopeState.kind === 'ready'
+				? buildTriggerImportPreview(envelopeState.envelope, destination, mode)
+				: null,
+		[envelopeState, destination, mode],
+	);
+
+	const reset = () => {
+		setEnvelopeState({ kind: 'idle' });
+		setPasteText('');
+		setMode('append');
+	};
+
+	const handleClose = (next: boolean) => {
+		if (!next) reset();
+		onOpenChange(next);
+	};
+
+	const decodeInto = (raw: string) => {
+		const decoded = decodeTriggerEnvelope(raw);
+		if (!decoded.ok) {
+			setEnvelopeState({ kind: 'error', reason: decoded.reason });
+			return;
+		}
+		setEnvelopeState({ kind: 'ready', envelope: decoded.envelope });
+	};
+
+	const handlePasteChange = (raw: string) => {
+		setPasteText(raw);
+		if (raw.trim().length === 0) {
+			setEnvelopeState({ kind: 'idle' });
+			return;
+		}
+		decodeInto(raw);
+	};
+
+	const handleFile = async (file: File) => {
+		try {
+			const raw = await file.text();
+			setPasteText(raw);
+			decodeInto(raw);
+		} catch (err) {
+			console.error('File read failed:', err);
+			toast.error('Could not read file', {
+				description: err instanceof Error ? err.message : 'Unknown error',
+			});
+		}
+	};
+
+	const handleConfirm = () => {
+		if (envelopeState.kind !== 'ready' || !preview || preview.error) return;
+		const out = importTriggerDataBulk({
+			envelope: envelopeState.envelope,
+			destination,
+			mode,
+		});
+		onConfirm(out.result);
+		const counts = preview.perList
+			.filter((l) => l.count > 0)
+			.map((l) => `${l.count} ${l.listKey}`)
+			.join(', ');
+		toast.success(`Imported ${preview.total} ${preview.total === 1 ? 'entry' : 'entries'}`, {
+			description: counts.length > 0 ? counts : undefined,
+		});
+		handleClose(false);
+	};
+
+	const confirmDisabled =
+		envelopeState.kind !== 'ready' ||
+		preview == null ||
+		preview.error != null ||
+		preview.total === 0;
+
+	return (
+		<Dialog open={open} onOpenChange={handleClose}>
+			<DialogContent className="max-w-2xl">
+				<DialogHeader>
+					<DialogTitle>Import bulk JSON</DialogTitle>
+					<DialogDescription>
+						Paste a Steward bulk envelope or load it from a JSON file. Imports merge into{' '}
+						<strong>{bundleId}</strong>.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-3">
+					<div className="flex items-center justify-between gap-2">
+						<Label htmlFor="trigger-import-paste">Envelope JSON</Label>
+						<div>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => fileInputRef.current?.click()}
+							>
+								From file…
+							</Button>
+							<input
+								ref={fileInputRef}
+								type="file"
+								accept="application/json,.json"
+								className="hidden"
+								onChange={(e) => {
+									const f = e.target.files?.[0];
+									if (f) void handleFile(f);
+									// Reset so re-selecting the same file fires onChange again.
+									if (e.target) e.target.value = '';
+								}}
+							/>
+						</div>
+					</div>
+					<textarea
+						id="trigger-import-paste"
+						value={pasteText}
+						onChange={(e) => handlePasteChange(e.target.value)}
+						placeholder="Paste the exported bulk JSON here…"
+						spellCheck={false}
+						className={cn(
+							'flex min-h-[120px] w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs',
+							'ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none',
+							'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+						)}
+					/>
+				</div>
+
+				{envelopeState.kind === 'error' && (
+					<div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm">
+						<div className="mb-1 flex items-center gap-2 font-medium text-destructive">
+							<AlertTriangle className="h-4 w-4" />
+							Could not parse envelope
+						</div>
+						<p className="break-all text-xs text-muted-foreground">{envelopeState.reason}</p>
+					</div>
+				)}
+
+				{envelopeState.kind === 'ready' && (
+					<div className="space-y-4">
+						<div className="rounded-md border bg-muted/30 p-3 text-sm">
+							<div className="mb-1 font-medium">Envelope</div>
+							<dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs">
+								<dt className="text-muted-foreground">Source profile</dt>
+								<dd className="font-mono">{envelopeState.envelope.profile}</dd>
+								<dt className="text-muted-foreground">Source bundle</dt>
+								<dd className="font-mono">{envelopeState.envelope.sourceBundle ?? '—'}</dd>
+								<dt className="text-muted-foreground">Items</dt>
+								<dd>{envelopeState.envelope.items.length}</dd>
+								<dt className="text-muted-foreground">Exported at</dt>
+								<dd className="font-mono">{envelopeState.envelope.exportedAt}</dd>
+							</dl>
+						</div>
+
+						<div className="space-y-2">
+							<Label>Mode</Label>
+							<RadioGroup
+								value={mode}
+								onValueChange={(v) => setMode(v as TriggerImportMode)}
+								className="flex flex-row gap-4"
+							>
+								<div className="flex items-center gap-2">
+									<RadioGroupItem value="append" id="trigger-import-append" />
+									<Label htmlFor="trigger-import-append" className="cursor-pointer text-xs">
+										Append (default)
+									</Label>
+								</div>
+								<div className="flex items-center gap-2">
+									<RadioGroupItem value="replace" id="trigger-import-replace" />
+									<Label htmlFor="trigger-import-replace" className="cursor-pointer text-xs">
+										Replace
+									</Label>
+								</div>
+							</RadioGroup>
+							<p className="text-[11px] text-muted-foreground">
+								Replace empties only the lists present in this import; lists you didn't bring data
+								for are left untouched.
+							</p>
+						</div>
+
+						{preview && <TriggerImportPreviewBlock preview={preview} mode={mode} />}
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button variant="outline" onClick={() => handleClose(false)}>
+						Cancel
+					</Button>
+					<Button onClick={handleConfirm} disabled={confirmDisabled}>
+						{preview && preview.total > 0
+							? `Import ${preview.total} ${preview.total === 1 ? 'entry' : 'entries'}`
+							: 'Import'}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/components/workspace/TriggerImportPreviewBlock.tsx
+++ b/src/components/workspace/TriggerImportPreviewBlock.tsx
@@ -1,0 +1,88 @@
+// Live-preview block for TriggerDataBulkImportDialog. Split out so the dialog
+// itself stays focused on wiring (paste/file/mode + confirm) and this renders
+// the per-list breakdown + assigned id / regionIndex ranges + profile / note
+// warnings derived by buildTriggerImportPreview.
+
+import { AlertTriangle, Info } from 'lucide-react';
+import {
+	formatTriggerIdLabel,
+	type TriggerImportPreview,
+} from './triggerDataBulkImportDialog.helpers';
+import type { TriggerImportMode } from '@/lib/clipboard/triggerDataBulkImport';
+
+export function TriggerImportPreviewBlock({
+	preview,
+	mode,
+}: {
+	preview: TriggerImportPreview;
+	mode: TriggerImportMode;
+}) {
+	if (preview.error) {
+		return (
+			<div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm">
+				<div className="mb-1 flex items-center gap-2 font-medium text-destructive">
+					<AlertTriangle className="h-4 w-4" />
+					Cannot import
+				</div>
+				<p className="text-xs text-muted-foreground">{preview.error}</p>
+			</div>
+		);
+	}
+
+	const nonEmpty = preview.perList.filter((l) => l.count > 0);
+
+	return (
+		<div className="space-y-2 rounded-md border bg-muted/30 p-3 text-sm">
+			<div className="font-medium">Preview</div>
+			<div className="text-xs">
+				{preview.total} {preview.total === 1 ? 'entry' : 'entries'} will be imported in {mode}{' '}
+				mode.
+			</div>
+			{nonEmpty.length > 0 && (
+				<ul className="ml-4 list-disc space-y-0.5 text-xs">
+					{nonEmpty.map((l) => (
+						<li key={l.listKey}>
+							<span className="font-mono">{l.listKey}</span>: {l.count}
+						</li>
+					))}
+				</ul>
+			)}
+			{preview.assignedIdRange && (
+				<div className="text-xs text-muted-foreground">
+					IDs assigned: {formatTriggerIdLabel(preview.assignedIdRange.firstId)} –{' '}
+					{formatTriggerIdLabel(preview.assignedIdRange.lastId)}
+				</div>
+			)}
+			{preview.assignedRegionIndexRange && (
+				<div className="text-xs text-muted-foreground">
+					Region indices assigned: {preview.assignedRegionIndexRange.first} –{' '}
+					{preview.assignedRegionIndexRange.last}
+				</div>
+			)}
+			{preview.profileMismatch && (
+				<div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-2 text-[11px]">
+					<div className="flex items-center gap-1.5 font-medium text-amber-700 dark:text-amber-400">
+						<AlertTriangle className="h-3 w-3" />
+						Source profile differs from this resource's version
+					</div>
+					<div className="mt-1 text-muted-foreground">
+						TriggerData needs no migration across versions — importing as-is.
+					</div>
+				</div>
+			)}
+			{preview.notes.length > 0 && (
+				<ul className="ml-4 list-disc space-y-0.5 text-[11px] text-muted-foreground">
+					{preview.notes.map((n, i) => (
+						<li key={i}>{n}</li>
+					))}
+				</ul>
+			)}
+			{preview.notes.length === 0 && !preview.profileMismatch && (
+				<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+					<Info className="h-3 w-3" />
+					Clean import — fresh ids and region indices assigned automatically.
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/workspace/__tests__/triggerBulkPanelExport.helpers.test.ts
+++ b/src/components/workspace/__tests__/triggerBulkPanelExport.helpers.test.ts
@@ -1,0 +1,176 @@
+// Spec for the TriggerData additions to the BulkPanel export helpers.
+
+import { describe, it, expect } from 'vitest';
+import {
+	triggerBulkPathKeysToEntries,
+	buildTriggerEnvelopeFromBulk,
+	exportTriggerEnvelopeFilename,
+} from '../bulkPanelExport.helpers';
+import type { WorkspaceTriggerDataBulkSummary } from '../TriggerDataBulkProvider';
+import {
+	TriggerRegionType,
+	GenericRegionType,
+	SpawnType,
+	type ParsedTriggerData,
+	type Landmark,
+	type GenericRegion,
+	type SpawnLocation,
+} from '@/lib/core/triggerData';
+
+function box() {
+	return {
+		position: { x: 0, y: 0, z: 0 },
+		rotation: { x: 0, y: 0, z: 0 },
+		dimensions: { x: 1, y: 1, z: 1 },
+	};
+}
+
+function landmark(id: number): Landmark {
+	return {
+		box: box(),
+		id,
+		regionIndex: id,
+		type: TriggerRegionType.E_TYPE_LANDMARK,
+		enabled: 1,
+		startingGrids: [],
+		designIndex: 0,
+		district: 0,
+		flags: 0,
+	};
+}
+
+function genericRegion(id: number): GenericRegion {
+	return {
+		box: box(),
+		id,
+		regionIndex: id,
+		type: TriggerRegionType.E_TYPE_GENERIC_REGION,
+		enabled: 1,
+		groupId: 0,
+		cameraCut1: 0,
+		cameraCut2: 0,
+		cameraType1: 0,
+		cameraType2: 0,
+		genericType: GenericRegionType.E_TYPE_JUMP,
+		isOneWay: 0,
+	};
+}
+
+function spawn(junkyardId: bigint): SpawnLocation {
+	return {
+		position: { x: 0, y: 0, z: 0, w: 1 },
+		direction: { x: 1, y: 0, z: 0, w: 0 },
+		junkyardId,
+		type: SpawnType.E_TYPE_PLAYER_SPAWN,
+	};
+}
+
+function model(over: Partial<ParsedTriggerData> = {}): ParsedTriggerData {
+	return {
+		version: 5,
+		size: 0,
+		playerStartPosition: { x: 0, y: 0, z: 0, w: 1 },
+		playerStartDirection: { x: 1, y: 0, z: 0, w: 0 },
+		landmarks: [],
+		onlineLandmarkCount: 0,
+		signatureStunts: [],
+		genericRegions: [],
+		killzones: [],
+		blackspots: [],
+		vfxBoxRegions: [],
+		roamingLocations: [],
+		spawnLocations: [],
+		...over,
+	};
+}
+
+function summary(pathKeys: string[]): WorkspaceTriggerDataBulkSummary {
+	return {
+		bundleId: 'TRIGGERS.DAT',
+		index: 0,
+		count: pathKeys.length,
+		lastTouchedAt: 1000,
+		pathKeys: new Set(pathKeys),
+	};
+}
+
+describe('triggerBulkPathKeysToEntries', () => {
+	it('decodes per-list path keys into {listKey,index} entries', () => {
+		const md = model({
+			landmarks: [landmark(1), landmark(2)],
+			genericRegions: [genericRegion(10)],
+		});
+		const entries = triggerBulkPathKeysToEntries(
+			new Set(['landmarks/0', 'landmarks/1', 'genericRegions/0']),
+			md,
+		);
+		expect(entries).toEqual(
+			expect.arrayContaining([
+				{ listKey: 'landmarks', index: 0 },
+				{ listKey: 'landmarks', index: 1 },
+				{ listKey: 'genericRegions', index: 0 },
+			]),
+		);
+		expect(entries).toHaveLength(3);
+	});
+
+	it('drops indices out of range for the model', () => {
+		const md = model({ landmarks: [landmark(1)] });
+		const entries = triggerBulkPathKeysToEntries(
+			new Set(['landmarks/0', 'landmarks/5']),
+			md,
+		);
+		expect(entries).toEqual([{ listKey: 'landmarks', index: 0 }]);
+	});
+
+	it('drops malformed / non-bulk path keys', () => {
+		const md = model({ landmarks: [landmark(1)] });
+		const entries = triggerBulkPathKeysToEntries(
+			new Set(['playerStartPosition', 'header/flags', 'a/b/c', 'killzones/0']),
+			md,
+		);
+		expect(entries).toEqual([]);
+	});
+});
+
+describe('buildTriggerEnvelopeFromBulk', () => {
+	it('produces a triggerData envelope from model + path keys', () => {
+		const md = model({
+			landmarks: [landmark(1), landmark(2)],
+			genericRegions: [genericRegion(10)],
+		});
+		const env = buildTriggerEnvelopeFromBulk(
+			md,
+			summary(['landmarks/0', 'genericRegions/0']),
+			'TRIGGERS.DAT',
+		);
+		expect(env.resourceKey).toBe('triggerData');
+		expect(env.profile).toBe('5'); // version coerced to string
+		expect(env.sourceBundle).toBe('TRIGGERS.DAT');
+		expect(env.items.map((i) => i.listKey)).toEqual(['landmarks', 'genericRegions']);
+	});
+
+	it('serialises a spawn junkyardId bigint as a hex string (JSON-safe)', () => {
+		const md = model({ spawnLocations: [spawn(0xdeadn)] });
+		const env = buildTriggerEnvelopeFromBulk(
+			md,
+			summary(['spawnLocations/0']),
+			'TRIGGERS.DAT',
+		);
+		// The whole point of the wire conversion: JSON.stringify would throw on
+		// a raw bigint. Round-trip through JSON to prove the envelope is safe.
+		const json = JSON.stringify(env);
+		expect(json).toContain('0xdead');
+		const wire = env.items[0].entry as { junkyardId: string };
+		expect(wire.junkyardId).toBe('0xdead');
+	});
+});
+
+describe('exportTriggerEnvelopeFilename', () => {
+	it('uses the triggerdata slug with a stable timestamp', () => {
+		const d = new Date(2026, 4, 5, 13, 7, 9); // 2026-05-05 13:07:09 local
+		expect(exportTriggerEnvelopeFilename('TRIGGERS.DAT', d)).toBe(
+			'bulk-triggerdata-TRIGGERS-20260505-130709.json',
+		);
+	});
+});

--- a/src/components/workspace/__tests__/triggerDataBulkImportDialog.helpers.test.ts
+++ b/src/components/workspace/__tests__/triggerDataBulkImportDialog.helpers.test.ts
@@ -1,0 +1,282 @@
+// Coverage for TriggerDataBulkImportDialog's pure helpers.
+
+import { describe, it, expect } from 'vitest';
+import {
+	decodeTriggerEnvelope,
+	buildTriggerImportPreview,
+	formatTriggerIdLabel,
+	TRIGGER_PREVIEW_LIST_ORDER,
+} from '../triggerDataBulkImportDialog.helpers';
+import { exportTriggerDataBulk } from '@/lib/clipboard/triggerDataBulkExport';
+import type {
+	TriggerDataBulkItem,
+	TriggerDataBulkListKey,
+} from '@/lib/clipboard/triggerDataBulkExport';
+import type { BulkEnvelope } from '@/lib/clipboard/bulkEnvelope';
+import type {
+	ParsedTriggerData,
+	Vector4,
+	Landmark,
+	GenericRegion,
+	Blackspot,
+	VFXBoxRegion,
+	SpawnLocation,
+	RoamingLocation,
+	BoxRegion,
+} from '@/lib/core/triggerData';
+
+// ---------------------------------------------------------------------------
+// Builders (mirror the import-pipeline test's fixtures)
+// ---------------------------------------------------------------------------
+
+const vec4 = (n: number): Vector4 => ({ x: n, y: n + 1, z: n + 2, w: n + 3 });
+
+const box = (n: number): BoxRegion => ({
+	position: { x: n, y: n, z: n },
+	rotation: { x: 0, y: 0, z: 0 },
+	dimensions: { x: 1, y: 1, z: 1 },
+});
+
+function landmark(over: Partial<Landmark> = {}): Landmark {
+	return {
+		box: box(1),
+		id: 100,
+		regionIndex: 0,
+		type: 0,
+		enabled: 1,
+		startingGrids: [],
+		designIndex: 7,
+		district: 2,
+		flags: 0,
+		...over,
+	};
+}
+
+function genericRegion(over: Partial<GenericRegion> = {}): GenericRegion {
+	return {
+		box: box(2),
+		id: 200,
+		regionIndex: 1,
+		type: 2,
+		enabled: 1,
+		groupId: 42,
+		cameraCut1: 0,
+		cameraCut2: 0,
+		cameraType1: 0,
+		cameraType2: 0,
+		genericType: 8,
+		isOneWay: 0,
+		...over,
+	};
+}
+
+function blackspot(over: Partial<Blackspot> = {}): Blackspot {
+	return {
+		box: box(3),
+		id: 300,
+		regionIndex: 2,
+		type: 1,
+		enabled: 1,
+		scoreType: 0,
+		scoreAmount: 5000,
+		...over,
+	};
+}
+
+function vfxBoxRegion(over: Partial<VFXBoxRegion> = {}): VFXBoxRegion {
+	return { box: box(4), id: 400, regionIndex: 3, type: 3, enabled: 1, ...over };
+}
+
+function spawnLocation(over: Partial<SpawnLocation> = {}): SpawnLocation {
+	return {
+		position: vec4(10),
+		direction: vec4(20),
+		junkyardId: 0x1122334455667788n,
+		type: 0,
+		...over,
+	};
+}
+
+function roamingLocation(over: Partial<RoamingLocation> = {}): RoamingLocation {
+	return { position: vec4(30), districtIndex: 4, ...over };
+}
+
+function makeDestination(over: Partial<ParsedTriggerData> = {}): ParsedTriggerData {
+	return {
+		version: 9,
+		size: 1024,
+		playerStartPosition: vec4(0),
+		playerStartDirection: vec4(0),
+		landmarks: [landmark()],
+		onlineLandmarkCount: 1,
+		signatureStunts: [],
+		genericRegions: [genericRegion()],
+		killzones: [],
+		blackspots: [blackspot()],
+		vfxBoxRegions: [vfxBoxRegion()],
+		roamingLocations: [roamingLocation()],
+		spawnLocations: [spawnLocation()],
+		...over,
+	};
+}
+
+function envelopeFrom(
+	source: ParsedTriggerData,
+	selected: ReadonlyArray<{ listKey: TriggerDataBulkListKey; index: number }>,
+): BulkEnvelope<TriggerDataBulkItem> {
+	return exportTriggerDataBulk({ model: source, selectedEntries: selected });
+}
+
+// ---------------------------------------------------------------------------
+// decodeTriggerEnvelope
+// ---------------------------------------------------------------------------
+
+describe('decodeTriggerEnvelope', () => {
+	it('accepts a well-formed triggerData envelope', () => {
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'genericRegions', index: 0 }]);
+		const raw = JSON.stringify(env);
+		const decoded = decodeTriggerEnvelope(raw);
+		expect(decoded.ok).toBe(true);
+		if (decoded.ok) {
+			expect(decoded.envelope.resourceKey).toBe('triggerData');
+			expect(decoded.envelope.items).toHaveLength(1);
+		}
+	});
+
+	it('rejects an envelope for a different resource (aiSections)', () => {
+		const env: BulkEnvelope = {
+			kind: 'steward.bulk',
+			version: 1,
+			resourceKey: 'aiSections',
+			profile: 'v12',
+			exportedAt: new Date().toISOString(),
+			items: [],
+		};
+		const decoded = decodeTriggerEnvelope(JSON.stringify(env));
+		expect(decoded.ok).toBe(false);
+		if (!decoded.ok) {
+			expect(decoded.reason).toMatch(/aiSections/);
+			expect(decoded.reason).toMatch(/expected triggerData/);
+		}
+	});
+
+	it('rejects malformed JSON, surfacing the decoder reason', () => {
+		const decoded = decodeTriggerEnvelope('{ not json ');
+		expect(decoded.ok).toBe(false);
+		if (!decoded.ok) expect(decoded.reason).toMatch(/not valid json/i);
+	});
+
+	it('rejects a non-bulk JSON object', () => {
+		const decoded = decodeTriggerEnvelope(JSON.stringify({ hello: 'world' }));
+		expect(decoded.ok).toBe(false);
+		if (!decoded.ok) expect(decoded.reason).toMatch(/steward\.bulk|kind/i);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildTriggerImportPreview
+// ---------------------------------------------------------------------------
+
+describe('buildTriggerImportPreview', () => {
+	it('counts per list in canonical order with zero-filled absent lists', () => {
+		const env = envelopeFrom(makeDestination(), [
+			{ listKey: 'genericRegions', index: 0 },
+			{ listKey: 'blackspots', index: 0 },
+			{ listKey: 'spawnLocations', index: 0 },
+		]);
+		const preview = buildTriggerImportPreview(env, makeDestination(), 'append');
+		expect(preview.error).toBeNull();
+		expect(preview.total).toBe(3);
+		expect(preview.perList.map((l) => l.listKey)).toEqual([...TRIGGER_PREVIEW_LIST_ORDER]);
+		const byKey = Object.fromEntries(preview.perList.map((l) => [l.listKey, l.count]));
+		expect(byKey.genericRegions).toBe(1);
+		expect(byKey.blackspots).toBe(1);
+		expect(byKey.spawnLocations).toBe(1);
+		expect(byKey.landmarks).toBe(0);
+		expect(byKey.vfxBoxRegions).toBe(0);
+		expect(byKey.roamingLocations).toBe(0);
+	});
+
+	it('reports the box-region id + regionIndex ranges that confirm will assign', () => {
+		// Destination box maxes: ids 100/200/300/400, regionIndex 0/1/2/3 → max id
+		// 400, max regionIndex 3. Importing two box regions takes 401..402 / 4..5.
+		const env = envelopeFrom(makeDestination(), [
+			{ listKey: 'genericRegions', index: 0 },
+			{ listKey: 'blackspots', index: 0 },
+		]);
+		const preview = buildTriggerImportPreview(env, makeDestination(), 'append');
+		expect(preview.assignedIdRange).toEqual({ firstId: 401, lastId: 402 });
+		expect(preview.assignedRegionIndexRange).toEqual({ first: 4, last: 5 });
+	});
+
+	it('returns null id/index ranges for a spawn-only import (no box region)', () => {
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'spawnLocations', index: 0 }]);
+		const preview = buildTriggerImportPreview(env, makeDestination(), 'append');
+		expect(preview.total).toBe(1);
+		expect(preview.assignedIdRange).toBeNull();
+		expect(preview.assignedRegionIndexRange).toBeNull();
+	});
+
+	it('append vs replace differ: replace reclaims the floor from preserved lists', () => {
+		const dest = makeDestination({
+			genericRegions: [genericRegion({ id: 999, regionIndex: 50 })],
+			landmarks: [landmark({ id: 100, regionIndex: 10 })],
+			blackspots: [blackspot({ id: 300, regionIndex: 20 })],
+			vfxBoxRegions: [vfxBoxRegion({ id: 400, regionIndex: 30 })],
+		});
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'genericRegions', index: 0 }]);
+
+		const appendPreview = buildTriggerImportPreview(env, dest, 'append');
+		// Append counts the emptied generic region's 999/50 — next is 1000/51.
+		expect(appendPreview.assignedIdRange).toEqual({ firstId: 1000, lastId: 1000 });
+		expect(appendPreview.assignedRegionIndexRange).toEqual({ first: 51, last: 51 });
+
+		const replacePreview = buildTriggerImportPreview(env, dest, 'replace');
+		// Replace empties genericRegions; floor falls to the surviving lists'
+		// max (id 400, regionIndex 30) → next is 401/31.
+		expect(replacePreview.assignedIdRange).toEqual({ firstId: 401, lastId: 401 });
+		expect(replacePreview.assignedRegionIndexRange).toEqual({ first: 31, last: 31 });
+	});
+
+	it('surfaces profileMismatch + a note when source version differs', () => {
+		const env = envelopeFrom(makeDestination({ version: 7 }), [
+			{ listKey: 'genericRegions', index: 0 },
+		]);
+		expect(env.profile).toBe('7');
+		const preview = buildTriggerImportPreview(env, makeDestination({ version: 9 }), 'append');
+		expect(preview.profileMismatch).toBe(true);
+		expect(preview.notes.some((n) => /profile/i.test(n))).toBe(true);
+	});
+
+	it('clears profileMismatch when source and destination versions match', () => {
+		const env = envelopeFrom(makeDestination({ version: 9 }), [
+			{ listKey: 'genericRegions', index: 0 },
+		]);
+		const preview = buildTriggerImportPreview(env, makeDestination({ version: 9 }), 'append');
+		expect(preview.profileMismatch).toBe(false);
+	});
+
+	it('captures the i16 overflow as an error instead of throwing', () => {
+		const dest = makeDestination({
+			genericRegions: [genericRegion({ id: 1, regionIndex: 0x7fff })],
+			landmarks: [],
+			blackspots: [],
+			vfxBoxRegions: [],
+		});
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'blackspots', index: 0 }]);
+		const preview = buildTriggerImportPreview(env, dest, 'append');
+		expect(preview.error).toMatch(/regionIndex would overflow i16/);
+		expect(preview.assignedIdRange).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatTriggerIdLabel
+// ---------------------------------------------------------------------------
+
+describe('formatTriggerIdLabel', () => {
+	it('formats hex + decimal', () => {
+		expect(formatTriggerIdLabel(0x9000)).toBe('0x9000 (36864)');
+		expect(formatTriggerIdLabel(0)).toBe('0x0 (0)');
+	});
+});

--- a/src/components/workspace/bulkPanelExport.helpers.ts
+++ b/src/components/workspace/bulkPanelExport.helpers.ts
@@ -12,8 +12,16 @@ import {
 	exportAISectionsBulk,
 	type AISectionsBulkItem,
 } from '@/lib/clipboard/aiSectionsBulkExport';
+import {
+	exportTriggerDataBulk,
+	type TriggerDataBulkItem,
+	type TriggerDataBulkListKey,
+} from '@/lib/clipboard/triggerDataBulkExport';
 import { parseSectionPathKey } from './aiSectionsBulk';
+import { parseEntryPathKey } from './triggerDataBulk';
 import type { WorkspaceAISectionsBulkSummary } from './AISectionsBulkProvider';
+import type { WorkspaceTriggerDataBulkSummary } from './TriggerDataBulkProvider';
+import type { ParsedTriggerData } from '@/lib/core/triggerData';
 import type { BulkEnvelope } from '@/lib/clipboard/bulkEnvelope';
 
 /** Translate a workspace bulk summary's path-keyed Set into the
@@ -55,16 +63,66 @@ export function buildEnvelopeFromBulk(
 	});
 }
 
-/** Build the export filename. Format: `bulk-aisections-${bundleFilename}-${YYYYMMDD-HHMMSS}.json`.
+/** Build the export filename. Format: `bulk-${slug}-${bundleFilename}-${YYYYMMDD-HHMMSS}.json`.
  *  The timestamp is local-clock so users on the same machine can sort their
- *  exports without timezone surprises. */
+ *  exports without timezone surprises. `slug` defaults to `'aisections'` so
+ *  the AI call sites stay unchanged; the trigger panel passes `'triggerdata'`. */
 export function exportEnvelopeFilename(
 	bundleFilename: string,
 	now: Date = new Date(),
+	slug = 'aisections',
 ): string {
 	const stamp = formatTimestamp(now);
 	const safeName = bundleFilename.replace(/\.[^.]+$/, '').replace(/[^A-Za-z0-9._-]/g, '_');
-	return `bulk-aisections-${safeName}-${stamp}.json`;
+	return `bulk-${slug}-${safeName}-${stamp}.json`;
+}
+
+/** Filename for a TriggerData bulk export — same shape as the AI export, only
+ *  the resource slug differs. */
+export function exportTriggerEnvelopeFilename(
+	bundleFilename: string,
+	now: Date = new Date(),
+): string {
+	return exportEnvelopeFilename(bundleFilename, now, 'triggerdata');
+}
+
+/** Translate a workspace TriggerData bulk summary's path-key Set (keys like
+ *  `'genericRegions/3'`) into the `{ listKey, index }[]` that
+ *  `exportTriggerDataBulk` expects. Unlike AI, triggers have no cross-variant
+ *  disambiguation — keys just group by `listKey`. Indices past the end of
+ *  their list in the model are dropped so a stale selection never emits a
+ *  phantom entry. */
+export function triggerBulkPathKeysToEntries(
+	pathKeys: ReadonlySet<string>,
+	model: ParsedTriggerData,
+): Array<{ listKey: TriggerDataBulkListKey; index: number }> {
+	const out: Array<{ listKey: TriggerDataBulkListKey; index: number }> = [];
+	for (const key of pathKeys) {
+		const addr = parseEntryPathKey(key);
+		if (!addr) continue;
+		const listKey = addr.listKey as TriggerDataBulkListKey;
+		const list = model[listKey];
+		// parseEntryPathKey already gates listKey to the six bulk lists, but the
+		// index can still be out of range if the model shrank since selection.
+		if (!Array.isArray(list) || addr.index < 0 || addr.index >= list.length) continue;
+		out.push({ listKey, index: addr.index });
+	}
+	return out;
+}
+
+/** Build a BulkEnvelope ready to feed encodeBulkEnvelope from a workspace
+ *  TriggerData bulk summary + the parsed model the summary points at. */
+export function buildTriggerEnvelopeFromBulk(
+	model: ParsedTriggerData,
+	summary: WorkspaceTriggerDataBulkSummary,
+	sourceBundleFilename: string,
+): BulkEnvelope<TriggerDataBulkItem> {
+	const selectedEntries = triggerBulkPathKeysToEntries(summary.pathKeys, model);
+	return exportTriggerDataBulk({
+		model,
+		selectedEntries,
+		sourceBundleFilename,
+	});
 }
 
 function formatTimestamp(d: Date): string {

--- a/src/components/workspace/triggerDataBulkImportDialog.helpers.ts
+++ b/src/components/workspace/triggerDataBulkImportDialog.helpers.ts
@@ -1,0 +1,151 @@
+// Pure helpers for TriggerDataBulkImportDialog.
+//
+// Two jobs, both kept out of the .tsx so they're node-testable:
+//   1. decodeTriggerEnvelope — wrap the resource-agnostic decodeBulkEnvelope,
+//      then narrow to a TriggerData envelope by asserting resourceKey. Returns
+//      a discriminated ok/err so the dialog can switch without try/catch.
+//   2. buildTriggerImportPreview — produce the live preview block. It DOES NOT
+//      re-derive the id / regionIndex assignment math; it runs the real
+//      importTriggerDataBulk (the single source of truth) against the chosen
+//      mode and reads the ranges + counts straight off the result. Re-deriving
+//      would risk the preview drifting from what Confirm actually does.
+//
+// The import is total in normal use, but the regionIndex assignment can throw
+// (i16 overflow past 32767 — see triggerDataBulkImport.ts). The preview catches
+// that and surfaces it as an `error` field rather than letting it escape, so a
+// destination already at the region cap shows a readable warning instead of a
+// crashed dialog.
+
+import { decodeBulkEnvelope, type BulkEnvelope } from '@/lib/clipboard/bulkEnvelope';
+import {
+	importTriggerDataBulk,
+	type TriggerImportMode,
+} from '@/lib/clipboard/triggerDataBulkImport';
+import type {
+	TriggerDataBulkItem,
+	TriggerDataBulkListKey,
+} from '@/lib/clipboard/triggerDataBulkExport';
+import type { ParsedTriggerData } from '@/lib/core/triggerData';
+
+const RESOURCE_KEY = 'triggerData';
+
+/** Canonical list order for displaying per-list counts — mirrors the export
+ *  pipeline's fixed ordering so the preview reads the same way every time. */
+export const TRIGGER_PREVIEW_LIST_ORDER: readonly TriggerDataBulkListKey[] = [
+	'landmarks',
+	'genericRegions',
+	'blackspots',
+	'vfxBoxRegions',
+	'spawnLocations',
+	'roamingLocations',
+];
+
+// Each branch carries a field absent on the other (`reason?: undefined` /
+// `envelope?: undefined`) so narrowing on `ok` works under the project's
+// `strict: false` tsconfig — same trick bulkEnvelope.ts uses.
+export type DecodedTriggerEnvelope =
+	| { ok: true; envelope: BulkEnvelope<TriggerDataBulkItem>; reason?: undefined }
+	| { ok: false; reason: string; envelope?: undefined };
+
+/**
+ * Decode a pasted / loaded string into a TriggerData bulk envelope. Wraps the
+ * resource-agnostic validator, then enforces `resourceKey === 'triggerData'`
+ * so a well-formed envelope for a DIFFERENT resource (e.g. an aiSections bulk)
+ * is rejected with a clear message instead of silently importing garbage.
+ */
+export function decodeTriggerEnvelope(raw: string): DecodedTriggerEnvelope {
+	const parsed = decodeBulkEnvelope(raw);
+	if (!parsed.ok) return { ok: false, reason: parsed.reason };
+	if (parsed.envelope.resourceKey !== RESOURCE_KEY) {
+		return {
+			ok: false,
+			reason: `Wrong resource type: envelope is for ${parsed.envelope.resourceKey}, expected triggerData.`,
+		};
+	}
+	// decodeBulkEnvelope returns `unknown[]` items by design; the import
+	// pipeline structuredClones + casts each entry per listKey, so the cast
+	// here is the same trust boundary the AI dialog uses.
+	// TODO(types): a per-resource item validator that narrows TriggerDataBulkItem
+	// shape lives outside this slice.
+	return {
+		ok: true,
+		envelope: parsed.envelope as BulkEnvelope<TriggerDataBulkItem>,
+	};
+}
+
+/** A single per-list line in the preview: the list and how many entries from
+ *  the envelope land in it. Zero-count lists are still emitted so the preview
+ *  shows the full six-list shape. */
+export type TriggerPreviewListCount = {
+	listKey: TriggerDataBulkListKey;
+	count: number;
+};
+
+export type TriggerImportPreview = {
+	/** Total entries across all six lists. */
+	total: number;
+	/** Per-list counts in canonical list order. */
+	perList: TriggerPreviewListCount[];
+	/** Box-region mId range that WILL be assigned on confirm (null when no
+	 *  box-region — landmarks/genericRegions/blackspots/vfxBoxRegions — is in
+	 *  the import; spawn/roaming carry no id). */
+	assignedIdRange: { firstId: number; lastId: number } | null;
+	/** Box-region regionIndex range that WILL be assigned on confirm (null when
+	 *  no box-region is in the import). */
+	assignedRegionIndexRange: { first: number; last: number } | null;
+	/** True when the envelope profile != String(destination.version). Purely
+	 *  informational — TriggerData needs no cross-version migration. */
+	profileMismatch: boolean;
+	/** Human-readable notes from the import pipeline (offline-landmark, profile
+	 *  mismatch, etc.). */
+	notes: string[];
+	/** Set when the import would throw (i16 regionIndex overflow). When present
+	 *  the dialog must block confirm. */
+	error: string | null;
+};
+
+/**
+ * Build the live preview for a decoded envelope against a destination + mode.
+ * Runs the real import so the displayed ranges are EXACTLY what Confirm will
+ * assign — no parallel math to drift out of sync.
+ */
+export function buildTriggerImportPreview(
+	envelope: BulkEnvelope<TriggerDataBulkItem>,
+	destination: ParsedTriggerData,
+	mode: TriggerImportMode,
+): TriggerImportPreview {
+	try {
+		const out = importTriggerDataBulk({ envelope, destination, mode });
+		const perList: TriggerPreviewListCount[] = TRIGGER_PREVIEW_LIST_ORDER.map(
+			(listKey) => ({ listKey, count: out.perListCounts[listKey] }),
+		);
+		const total = perList.reduce((sum, l) => sum + l.count, 0);
+		return {
+			total,
+			perList,
+			assignedIdRange: out.assignedIdRange,
+			assignedRegionIndexRange: out.assignedRegionIndexRange,
+			profileMismatch: out.profileMismatch,
+			notes: out.notes,
+			error: null,
+		};
+	} catch (err) {
+		return {
+			total: 0,
+			perList: TRIGGER_PREVIEW_LIST_ORDER.map((listKey) => ({ listKey, count: 0 })),
+			assignedIdRange: null,
+			assignedRegionIndexRange: null,
+			profileMismatch: envelope.profile !== String(destination.version),
+			notes: [],
+			error: err instanceof Error ? err.message : String(err),
+		};
+	}
+}
+
+/** Format a box-region id / index as a decimal+hex paired string
+ *  (`0x9000 (36864)`). Matches the AI dialog's id labelling so the two import
+ *  dialogs read consistently. */
+export function formatTriggerIdLabel(id: number): string {
+	const u = id >>> 0;
+	return `0x${u.toString(16).toUpperCase()} (${u})`;
+}

--- a/src/lib/clipboard/__tests__/triggerDataBulkExport.test.ts
+++ b/src/lib/clipboard/__tests__/triggerDataBulkExport.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from 'vitest';
+import {
+	exportTriggerDataBulk,
+	type TriggerDataBulkExportInput,
+	type WireSpawnLocation,
+} from '../triggerDataBulkExport';
+import type {
+	ParsedTriggerData,
+	Vector4,
+	Landmark,
+	GenericRegion,
+	Blackspot,
+	VFXBoxRegion,
+	SpawnLocation,
+	RoamingLocation,
+	BoxRegion,
+} from '@/lib/core/triggerData';
+
+const vec4 = (n: number): Vector4 => ({ x: n, y: n + 1, z: n + 2, w: n + 3 });
+
+const box = (n: number): BoxRegion => ({
+	position: { x: n, y: n, z: n },
+	rotation: { x: 0, y: 0, z: 0 },
+	dimensions: { x: 1, y: 1, z: 1 },
+});
+
+const SPAWN_JUNKYARD_ID = 0x1122334455667788n;
+
+function makeModel(): ParsedTriggerData {
+	const landmark: Landmark = {
+		box: box(1),
+		id: 100,
+		regionIndex: 0,
+		type: 0,
+		enabled: 1,
+		startingGrids: [],
+		designIndex: 7,
+		district: 2,
+		flags: 0,
+	};
+	const genericRegion: GenericRegion = {
+		box: box(2),
+		id: 200,
+		regionIndex: 1,
+		type: 2,
+		enabled: 1,
+		groupId: 42,
+		cameraCut1: 0,
+		cameraCut2: 0,
+		cameraType1: 0,
+		cameraType2: 0,
+		genericType: 8,
+		isOneWay: 0,
+	};
+	const blackspot: Blackspot = {
+		box: box(3),
+		id: 300,
+		regionIndex: 2,
+		type: 1,
+		enabled: 1,
+		scoreType: 0,
+		scoreAmount: 5000,
+	};
+	const vfxBoxRegion: VFXBoxRegion = {
+		box: box(4),
+		id: 400,
+		regionIndex: 3,
+		type: 3,
+		enabled: 1,
+	};
+	const spawnLocation: SpawnLocation = {
+		position: vec4(10),
+		direction: vec4(20),
+		junkyardId: SPAWN_JUNKYARD_ID,
+		type: 0,
+	};
+	const roamingLocation: RoamingLocation = {
+		position: vec4(30),
+		districtIndex: 4,
+	};
+
+	return {
+		version: 9,
+		size: 1024,
+		playerStartPosition: vec4(0),
+		playerStartDirection: vec4(0),
+		landmarks: [landmark],
+		onlineLandmarkCount: 0,
+		signatureStunts: [],
+		genericRegions: [genericRegion],
+		killzones: [],
+		blackspots: [blackspot],
+		vfxBoxRegions: [vfxBoxRegion],
+		roamingLocations: [roamingLocation],
+		spawnLocations: [spawnLocation],
+	};
+}
+
+describe('exportTriggerDataBulk', () => {
+	it('emits all six kinds in fixed list order regardless of click order', () => {
+		const model = makeModel();
+		// Selection given in deliberately scrambled order.
+		const input: TriggerDataBulkExportInput = {
+			model,
+			selectedEntries: [
+				{ listKey: 'roamingLocations', index: 0 },
+				{ listKey: 'landmarks', index: 0 },
+				{ listKey: 'spawnLocations', index: 0 },
+				{ listKey: 'blackspots', index: 0 },
+				{ listKey: 'vfxBoxRegions', index: 0 },
+				{ listKey: 'genericRegions', index: 0 },
+			],
+		};
+		const env = exportTriggerDataBulk(input);
+		expect(env.items.map((i) => i.listKey)).toEqual([
+			'landmarks',
+			'genericRegions',
+			'blackspots',
+			'vfxBoxRegions',
+			'spawnLocations',
+			'roamingLocations',
+		]);
+	});
+
+	it('sorts by index ascending within a list and records sourceIndex', () => {
+		const model = makeModel();
+		// Three landmarks so within-list index ordering is observable.
+		model.landmarks = [
+			{ ...model.landmarks[0], id: 100 },
+			{ ...model.landmarks[0], id: 101 },
+			{ ...model.landmarks[0], id: 102 },
+		];
+		const env = exportTriggerDataBulk({
+			model,
+			selectedEntries: [
+				{ listKey: 'landmarks', index: 2 },
+				{ listKey: 'landmarks', index: 0 },
+				{ listKey: 'landmarks', index: 1 },
+			],
+		});
+		expect(env.items.map((i) => i.sourceIndex)).toEqual([0, 1, 2]);
+		expect(env.items.map((i) => (i.entry as Landmark).id)).toEqual([
+			100, 101, 102,
+		]);
+	});
+
+	it('produces byte-stable JSON for the same selection in different click orders', () => {
+		const model = makeModel();
+		const selA = exportTriggerDataBulk({
+			model,
+			selectedEntries: [
+				{ listKey: 'spawnLocations', index: 0 },
+				{ listKey: 'landmarks', index: 0 },
+				{ listKey: 'blackspots', index: 0 },
+			],
+		});
+		const selB = exportTriggerDataBulk({
+			model,
+			selectedEntries: [
+				{ listKey: 'blackspots', index: 0 },
+				{ listKey: 'spawnLocations', index: 0 },
+				{ listKey: 'landmarks', index: 0 },
+			],
+		});
+		// Stub the volatile field so only ordering/content differences show.
+		const stamp = (e: typeof selA) => JSON.stringify({ ...e, exportedAt: '' });
+		expect(stamp(selA)).toEqual(stamp(selB));
+	});
+
+	it('dedupes identical (listKey,index) selections', () => {
+		const model = makeModel();
+		const env = exportTriggerDataBulk({
+			model,
+			selectedEntries: [
+				{ listKey: 'landmarks', index: 0 },
+				{ listKey: 'landmarks', index: 0 },
+				{ listKey: 'landmarks', index: 0 },
+			],
+		});
+		expect(env.items).toHaveLength(1);
+	});
+
+	it('skips out-of-range and negative indices', () => {
+		const model = makeModel();
+		const env = exportTriggerDataBulk({
+			model,
+			selectedEntries: [
+				{ listKey: 'landmarks', index: 0 },
+				{ listKey: 'landmarks', index: 5 },
+				{ listKey: 'genericRegions', index: -1 },
+			],
+		});
+		expect(env.items).toHaveLength(1);
+		expect(env.items[0].listKey).toBe('landmarks');
+		expect(env.items[0].sourceIndex).toBe(0);
+	});
+
+	it('emits spawn junkyardId as a round-trippable hex string', () => {
+		const model = makeModel();
+		const env = exportTriggerDataBulk({
+			model,
+			selectedEntries: [{ listKey: 'spawnLocations', index: 0 }],
+		});
+		const wire = env.items[0].entry as WireSpawnLocation;
+		expect(typeof wire.junkyardId).toBe('string');
+		expect(wire.junkyardId).toBe('0x' + SPAWN_JUNKYARD_ID.toString(16));
+		expect(BigInt(wire.junkyardId)).toBe(SPAWN_JUNKYARD_ID);
+	});
+
+	it('survives JSON.stringify (no bigint leaks through)', () => {
+		const model = makeModel();
+		const env = exportTriggerDataBulk({
+			model,
+			selectedEntries: [{ listKey: 'spawnLocations', index: 0 }],
+		});
+		expect(() => JSON.stringify(env)).not.toThrow();
+	});
+
+	it('deep-clones entries so mutating an item never touches the model', () => {
+		const model = makeModel();
+		const env = exportTriggerDataBulk({
+			model,
+			selectedEntries: [
+				{ listKey: 'landmarks', index: 0 },
+				{ listKey: 'spawnLocations', index: 0 },
+			],
+		});
+		const landmarkItem = env.items.find((i) => i.listKey === 'landmarks')!;
+		const lmEntry = landmarkItem.entry as Landmark;
+		lmEntry.designIndex = 999;
+		lmEntry.box.position.x = -1;
+		expect(model.landmarks[0].designIndex).toBe(7);
+		expect(model.landmarks[0].box.position.x).toBe(1);
+
+		// The spawn item's junkyardId is now a string; the model's stays bigint.
+		expect(typeof model.spawnLocations[0].junkyardId).toBe('bigint');
+		expect(model.spawnLocations[0].junkyardId).toBe(SPAWN_JUNKYARD_ID);
+	});
+
+	it('labels profile from the model version and sets resourceKey', () => {
+		const model = makeModel();
+		const env = exportTriggerDataBulk({
+			model,
+			selectedEntries: [{ listKey: 'landmarks', index: 0 }],
+		});
+		expect(env.profile).toBe('9');
+		expect(env.profile).toBe(String(model.version));
+		expect(env.resourceKey).toBe('triggerData');
+		expect(env.kind).toBe('steward.bulk');
+		expect(env.version).toBe(1);
+	});
+
+	it('includes sourceBundle only when a filename is provided', () => {
+		const model = makeModel();
+		const withName = exportTriggerDataBulk({
+			model,
+			selectedEntries: [{ listKey: 'landmarks', index: 0 }],
+			sourceBundleFilename: 'TRK_UNIT01.BNDL',
+		});
+		const withoutName = exportTriggerDataBulk({
+			model,
+			selectedEntries: [{ listKey: 'landmarks', index: 0 }],
+		});
+		expect(withName.sourceBundle).toBe('TRK_UNIT01.BNDL');
+		expect('sourceBundle' in withoutName).toBe(false);
+	});
+});

--- a/src/lib/clipboard/__tests__/triggerDataBulkImport.test.ts
+++ b/src/lib/clipboard/__tests__/triggerDataBulkImport.test.ts
@@ -1,0 +1,461 @@
+// Coverage for the TriggerData bulk-import pipeline.
+
+import { describe, it, expect } from 'vitest';
+import {
+	parseTriggerDataData,
+	writeTriggerDataData,
+	type ParsedTriggerData,
+	type Vector4,
+	type Landmark,
+	type GenericRegion,
+	type Blackspot,
+	type VFXBoxRegion,
+	type SpawnLocation,
+	type RoamingLocation,
+	type BoxRegion,
+} from '@/lib/core/triggerData';
+import { exportTriggerDataBulk } from '../triggerDataBulkExport';
+import type {
+	TriggerDataBulkItem,
+	TriggerDataBulkListKey,
+} from '../triggerDataBulkExport';
+import { importTriggerDataBulk } from '../triggerDataBulkImport';
+import type { BulkEnvelope } from '../bulkEnvelope';
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+const vec4 = (n: number): Vector4 => ({ x: n, y: n + 1, z: n + 2, w: n + 3 });
+
+const box = (n: number): BoxRegion => ({
+	position: { x: n, y: n, z: n },
+	rotation: { x: 0, y: 0, z: 0 },
+	dimensions: { x: 1, y: 1, z: 1 },
+});
+
+function landmark(over: Partial<Landmark> = {}): Landmark {
+	return {
+		box: box(1),
+		id: 100,
+		regionIndex: 0,
+		type: 0,
+		enabled: 1,
+		startingGrids: [],
+		designIndex: 7,
+		district: 2,
+		flags: 0,
+		...over,
+	};
+}
+
+function genericRegion(over: Partial<GenericRegion> = {}): GenericRegion {
+	return {
+		box: box(2),
+		id: 200,
+		regionIndex: 1,
+		type: 2,
+		enabled: 1,
+		groupId: 42,
+		cameraCut1: 0,
+		cameraCut2: 0,
+		cameraType1: 0,
+		cameraType2: 0,
+		genericType: 8,
+		isOneWay: 0,
+		...over,
+	};
+}
+
+function blackspot(over: Partial<Blackspot> = {}): Blackspot {
+	return {
+		box: box(3),
+		id: 300,
+		regionIndex: 2,
+		type: 1,
+		enabled: 1,
+		scoreType: 0,
+		scoreAmount: 5000,
+		...over,
+	};
+}
+
+function vfxBoxRegion(over: Partial<VFXBoxRegion> = {}): VFXBoxRegion {
+	return {
+		box: box(4),
+		id: 400,
+		regionIndex: 3,
+		type: 3,
+		enabled: 1,
+		...over,
+	};
+}
+
+function spawnLocation(over: Partial<SpawnLocation> = {}): SpawnLocation {
+	return {
+		position: vec4(10),
+		direction: vec4(20),
+		junkyardId: 0x1122334455667788n,
+		type: 0,
+		...over,
+	};
+}
+
+function roamingLocation(over: Partial<RoamingLocation> = {}): RoamingLocation {
+	return { position: vec4(30), districtIndex: 4, ...over };
+}
+
+function makeDestination(over: Partial<ParsedTriggerData> = {}): ParsedTriggerData {
+	return {
+		version: 9,
+		size: 1024,
+		playerStartPosition: vec4(0),
+		playerStartDirection: vec4(0),
+		landmarks: [landmark()],
+		onlineLandmarkCount: 1,
+		signatureStunts: [],
+		genericRegions: [genericRegion()],
+		killzones: [],
+		blackspots: [blackspot()],
+		vfxBoxRegions: [vfxBoxRegion()],
+		roamingLocations: [roamingLocation()],
+		spawnLocations: [spawnLocation()],
+		...over,
+	};
+}
+
+/** Build an envelope by exporting the named entries from a source model. */
+function envelopeFrom(
+	source: ParsedTriggerData,
+	selected: ReadonlyArray<{ listKey: TriggerDataBulkListKey; index: number }>,
+): BulkEnvelope<TriggerDataBulkItem> {
+	return exportTriggerDataBulk({ model: source, selectedEntries: selected });
+}
+
+/** Max id / regionIndex across the four box-region lists. */
+function boxMaxes(td: ParsedTriggerData): { id: number; ri: number } {
+	let id = 0;
+	let ri = 0;
+	for (const list of [td.landmarks, td.genericRegions, td.blackspots, td.vfxBoxRegions]) {
+		for (const r of list) {
+			if (r.id > id) id = r.id;
+			if (r.regionIndex > ri) ri = r.regionIndex;
+		}
+	}
+	return { id, ri };
+}
+
+function allBoxRegionIndices(td: ParsedTriggerData): number[] {
+	return [
+		...td.landmarks.map((r) => r.regionIndex),
+		...td.genericRegions.map((r) => r.regionIndex),
+		...td.blackspots.map((r) => r.regionIndex),
+		...td.vfxBoxRegions.map((r) => r.regionIndex),
+	];
+}
+
+function allBoxRegionIds(td: ParsedTriggerData): number[] {
+	return [
+		...td.landmarks.map((r) => r.id),
+		...td.genericRegions.map((r) => r.id),
+		...td.blackspots.map((r) => r.id),
+		...td.vfxBoxRegions.map((r) => r.id),
+	];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('importTriggerDataBulk — error paths', () => {
+	it('throws on a non-triggerData envelope resourceKey', () => {
+		const env: BulkEnvelope<TriggerDataBulkItem> = {
+			kind: 'steward.bulk',
+			version: 1,
+			resourceKey: 'aiSections',
+			profile: '9',
+			exportedAt: new Date().toISOString(),
+			items: [],
+		};
+		expect(() =>
+			importTriggerDataBulk({
+				envelope: env,
+				destination: makeDestination(),
+				mode: 'append',
+			}),
+		).toThrow(/wrong resourceKey/i);
+	});
+});
+
+describe('importTriggerDataBulk — profile mismatch', () => {
+	it('sets profileMismatch and a note when versions differ, without blocking', () => {
+		const source = makeDestination({ version: 7 });
+		const env = envelopeFrom(source, [{ listKey: 'genericRegions', index: 0 }]);
+		expect(env.profile).toBe('7');
+		const out = importTriggerDataBulk({
+			envelope: env,
+			destination: makeDestination({ version: 9 }),
+			mode: 'append',
+		});
+		expect(out.profileMismatch).toBe(true);
+		expect(out.notes.some((n) => /profile/i.test(n))).toBe(true);
+		expect(out.result.genericRegions).toHaveLength(2);
+	});
+
+	it('clears profileMismatch when versions match', () => {
+		const env = envelopeFrom(makeDestination({ version: 9 }), [
+			{ listKey: 'genericRegions', index: 0 },
+		]);
+		const out = importTriggerDataBulk({
+			envelope: env,
+			destination: makeDestination({ version: 9 }),
+			mode: 'append',
+		});
+		expect(out.profileMismatch).toBe(false);
+	});
+});
+
+describe('importTriggerDataBulk — append assigns fresh id + regionIndex', () => {
+	it('assigns ids/indices strictly above the destination maxes, unique across all four box lists', () => {
+		const dest = makeDestination();
+		const before = boxMaxes(dest);
+		// Import one of every box-region kind from a source model.
+		const source = makeDestination();
+		const env = envelopeFrom(source, [
+			{ listKey: 'landmarks', index: 0 },
+			{ listKey: 'genericRegions', index: 0 },
+			{ listKey: 'blackspots', index: 0 },
+			{ listKey: 'vfxBoxRegions', index: 0 },
+		]);
+		const out = importTriggerDataBulk({ envelope: env, destination: dest, mode: 'append' });
+
+		const ids = allBoxRegionIds(out.result);
+		const indices = allBoxRegionIndices(out.result);
+
+		// The four newly-assigned ids/indices are above the original maxes.
+		const newIds = ids.filter((v) => v > before.id);
+		const newIndices = indices.filter((v) => v > before.ri);
+		expect(newIds).toHaveLength(4);
+		expect(newIndices).toHaveLength(4);
+
+		// Unique across the four box lists (writer's region-table sort needs
+		// regionIndex unique; ids must not collide with killzone references).
+		expect(new Set(ids).size).toBe(ids.length);
+		expect(new Set(indices).size).toBe(indices.length);
+
+		// Contiguous range reported.
+		expect(out.assignedIdRange).toEqual({ firstId: before.id + 1, lastId: before.id + 4 });
+		expect(out.assignedRegionIndexRange).toEqual({ first: before.ri + 1, last: before.ri + 4 });
+	});
+
+	it('preserves genericRegion.groupId verbatim', () => {
+		const source = makeDestination();
+		source.genericRegions = [genericRegion({ groupId: 0xdead })];
+		const env = envelopeFrom(source, [{ listKey: 'genericRegions', index: 0 }]);
+		const out = importTriggerDataBulk({
+			envelope: env,
+			destination: makeDestination(),
+			mode: 'append',
+		});
+		const imported = out.result.genericRegions[out.result.genericRegions.length - 1];
+		expect(imported.groupId).toBe(0xdead);
+	});
+
+	it('restores spawn junkyardId as a bigint and leaves it id/index-free', () => {
+		const source = makeDestination();
+		source.spawnLocations = [spawnLocation({ junkyardId: 0xaabbccddeeff0011n })];
+		const env = envelopeFrom(source, [{ listKey: 'spawnLocations', index: 0 }]);
+		const out = importTriggerDataBulk({
+			envelope: env,
+			destination: makeDestination(),
+			mode: 'append',
+		});
+		const imported = out.result.spawnLocations[out.result.spawnLocations.length - 1];
+		expect(typeof imported.junkyardId).toBe('bigint');
+		expect(imported.junkyardId).toBe(0xaabbccddeeff0011n);
+		// Spawn carries no id/regionIndex; importing one does not assign them.
+		expect(out.assignedIdRange).toBeNull();
+		expect(out.assignedRegionIndexRange).toBeNull();
+	});
+
+	it('leaves onlineLandmarkCount unchanged and notes appended landmarks are offline', () => {
+		const dest = makeDestination({ onlineLandmarkCount: 1 });
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'landmarks', index: 0 }]);
+		const out = importTriggerDataBulk({ envelope: env, destination: dest, mode: 'append' });
+		expect(out.result.onlineLandmarkCount).toBe(1);
+		expect(out.notes.some((n) => /offline/i.test(n))).toBe(true);
+	});
+
+	it('tracks perListCounts', () => {
+		const source = makeDestination();
+		const env = envelopeFrom(source, [
+			{ listKey: 'genericRegions', index: 0 },
+			{ listKey: 'blackspots', index: 0 },
+			{ listKey: 'spawnLocations', index: 0 },
+			{ listKey: 'roamingLocations', index: 0 },
+		]);
+		const out = importTriggerDataBulk({
+			envelope: env,
+			destination: makeDestination(),
+			mode: 'append',
+		});
+		expect(out.perListCounts.genericRegions).toBe(1);
+		expect(out.perListCounts.blackspots).toBe(1);
+		expect(out.perListCounts.spawnLocations).toBe(1);
+		expect(out.perListCounts.roamingLocations).toBe(1);
+		expect(out.perListCounts.landmarks).toBe(0);
+		expect(out.perListCounts.vfxBoxRegions).toBe(0);
+	});
+
+	it('does not alias source entries into the destination (deep clone)', () => {
+		const source = makeDestination();
+		const env = envelopeFrom(source, [{ listKey: 'genericRegions', index: 0 }]);
+		const out = importTriggerDataBulk({
+			envelope: env,
+			destination: makeDestination(),
+			mode: 'append',
+		});
+		const imported = out.result.genericRegions[out.result.genericRegions.length - 1];
+		imported.box.position.x = -999;
+		expect(source.genericRegions[0].box.position.x).not.toBe(-999);
+	});
+
+	it('returns null ranges and unchanged lists for an empty envelope', () => {
+		const dest = makeDestination();
+		const env = envelopeFrom(makeDestination(), []);
+		const out = importTriggerDataBulk({ envelope: env, destination: dest, mode: 'append' });
+		expect(out.assignedIdRange).toBeNull();
+		expect(out.assignedRegionIndexRange).toBeNull();
+		expect(out.result.genericRegions).toHaveLength(1);
+		expect(out.result.landmarks).toHaveLength(1);
+	});
+});
+
+describe('importTriggerDataBulk — replace mode', () => {
+	it('empties only the lists present in the envelope, leaving others intact', () => {
+		const dest = makeDestination();
+		// Import only generic regions; everything else must survive.
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'genericRegions', index: 0 }]);
+		const out = importTriggerDataBulk({ envelope: env, destination: dest, mode: 'replace' });
+
+		// genericRegions replaced → only the one imported entry.
+		expect(out.result.genericRegions).toHaveLength(1);
+		// Untouched lists keep the destination's contents.
+		expect(out.result.landmarks).toHaveLength(1);
+		expect(out.result.blackspots).toHaveLength(1);
+		expect(out.result.vfxBoxRegions).toHaveLength(1);
+		expect(out.result.spawnLocations).toHaveLength(1);
+		expect(out.result.roamingLocations).toHaveLength(1);
+	});
+
+	it('reclaims id/index floor from preserved lists, not the emptied one', () => {
+		// Destination genericRegion has the highest regionIndex (50). On replace
+		// it is emptied, but landmarks/blackspots/vfx still cap the floor.
+		const dest = makeDestination({
+			genericRegions: [genericRegion({ id: 999, regionIndex: 50 })],
+			landmarks: [landmark({ id: 100, regionIndex: 10 })],
+			blackspots: [blackspot({ id: 300, regionIndex: 20 })],
+			vfxBoxRegions: [vfxBoxRegion({ id: 400, regionIndex: 30 })],
+		});
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'genericRegions', index: 0 }]);
+		const out = importTriggerDataBulk({ envelope: env, destination: dest, mode: 'replace' });
+		// Highest surviving regionIndex is 30 (vfx); the import takes 31.
+		expect(out.assignedRegionIndexRange).toEqual({ first: 31, last: 31 });
+		// Highest surviving id is 400; the import takes 401.
+		expect(out.assignedIdRange).toEqual({ firstId: 401, lastId: 401 });
+	});
+});
+
+describe('importTriggerDataBulk — i16 overflow guard', () => {
+	it('throws when the next regionIndex would exceed 32767', () => {
+		// Seed the destination with a region already at the i16 max so the next
+		// assigned index (32768) overflows.
+		const dest = makeDestination({
+			genericRegions: [genericRegion({ id: 1, regionIndex: 0x7fff })],
+			landmarks: [],
+			blackspots: [],
+			vfxBoxRegions: [],
+		});
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'blackspots', index: 0 }]);
+		expect(() =>
+			importTriggerDataBulk({ envelope: env, destination: dest, mode: 'append' }),
+		).toThrow(/regionIndex would overflow i16 \(32767\)/);
+	});
+});
+
+describe('importTriggerDataBulk — round-trip through the writer', () => {
+	it('appends a mixed import and survives writeTriggerDataData → parseTriggerDataData', () => {
+		const dest = makeDestination();
+		const before = boxMaxes(dest);
+		const origGenericId = dest.genericRegions[0].id;
+		const origSpawnId = dest.spawnLocations[0].junkyardId;
+
+		// Source carries a distinctive spawn so we can prove its junkyardId
+		// survives the hex-string round-trip.
+		const source = makeDestination();
+		source.spawnLocations = [spawnLocation({ junkyardId: 0x0f0f0f0f0f0f0f0fn })];
+
+		const env = envelopeFrom(source, [
+			{ listKey: 'genericRegions', index: 0 },
+			{ listKey: 'blackspots', index: 0 },
+			{ listKey: 'vfxBoxRegions', index: 0 },
+			{ listKey: 'spawnLocations', index: 0 },
+		]);
+		const out = importTriggerDataBulk({ envelope: env, destination: dest, mode: 'append' });
+
+		// The writer iterates the destination's (empty) killzones/stunts only;
+		// imported generic regions are referenced by nobody, so genericOffsets-
+		// ById.get is never called for a missing id. Must not throw.
+		let bytes: Uint8Array;
+		expect(() => {
+			bytes = writeTriggerDataData(out.result, true);
+		}).not.toThrow();
+
+		const reparsed = parseTriggerDataData(bytes!, true);
+
+		// Appended entries sit at the end of their lists.
+		expect(reparsed.genericRegions).toHaveLength(2);
+		expect(reparsed.blackspots).toHaveLength(2);
+		expect(reparsed.vfxBoxRegions).toHaveLength(2);
+		expect(reparsed.spawnLocations).toHaveLength(2);
+
+		// Existing entries unchanged at the head.
+		expect(reparsed.genericRegions[0].id).toBe(origGenericId);
+		expect(reparsed.spawnLocations[0].junkyardId).toBe(origSpawnId);
+
+		// Imported box-region ids/indices are strictly above the original maxes
+		// and unique across the four box lists, even after the writer's
+		// regionIndex sort + reparse.
+		const ids = allBoxRegionIds(reparsed);
+		const indices = allBoxRegionIndices(reparsed);
+		expect(new Set(ids).size).toBe(ids.length);
+		expect(new Set(indices).size).toBe(indices.length);
+		expect(reparsed.genericRegions[1].regionIndex).toBeGreaterThan(before.ri);
+		expect(reparsed.blackspots[1].regionIndex).toBeGreaterThan(before.ri);
+		expect(reparsed.vfxBoxRegions[1].regionIndex).toBeGreaterThan(before.ri);
+		expect(reparsed.genericRegions[1].id).toBeGreaterThan(before.id);
+
+		// Imported spawn junkyardId restored as the correct bigint after the
+		// full hex-string export → bigint import → u64 write → u64 read cycle.
+		expect(reparsed.spawnLocations[1].junkyardId).toBe(0x0f0f0f0f0f0f0f0fn);
+	});
+
+	it('round-trips cleanly when the destination has a killzone referencing a kept region', () => {
+		// A destination killzone points at the destination's own generic region.
+		// Imported generic regions get fresh ids referenced by nobody — the
+		// writer must still resolve the killzone's pointer without throwing.
+		const keptGeneric = genericRegion({ id: 200, regionIndex: 1 });
+		const dest = makeDestination({
+			genericRegions: [keptGeneric],
+			killzones: [{ triggerIds: [200], regionIds: [] }],
+		});
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'genericRegions', index: 0 }]);
+		const out = importTriggerDataBulk({ envelope: env, destination: dest, mode: 'append' });
+
+		expect(() => writeTriggerDataData(out.result, true)).not.toThrow();
+		const reparsed = parseTriggerDataData(writeTriggerDataData(out.result, true), true);
+		// Killzone still resolves to the kept region's id.
+		expect(reparsed.killzones[0].triggerIds).toEqual([200]);
+		expect(reparsed.genericRegions).toHaveLength(2);
+	});
+});

--- a/src/lib/clipboard/triggerDataBulkExport.ts
+++ b/src/lib/clipboard/triggerDataBulkExport.ts
@@ -1,0 +1,165 @@
+// TriggerData bulk-export pipeline.
+//
+// Slots between the workspace bulk panel's "Export → clipboard / file…"
+// buttons and the resource-agnostic JSON envelope (bulkEnvelope.ts). The
+// TriggerData-specific logic — which of the six bulk-eligible lists an entry
+// belongs to, how to make each entry JSON-safe — lives here.
+//
+// Bigint → hex-string wire conversion (load-bearing, non-obvious):
+//   SpawnLocation.junkyardId is a CgsID, modeled as a JS `bigint`. The
+//   envelope is serialized with `JSON.stringify`, and JSON.stringify THROWS
+//   ("Do not know how to serialize a BigInt") the moment it hits a bigint —
+//   it has no number type wide enough to carry a 64-bit id losslessly. So on
+//   the way out we replace junkyardId with a '0x…' hex string, and the import
+//   side rehydrates it with BigInt(str). Among the six bulk lists, ONLY
+//   spawnLocations carries a bigint — every other field across landmarks /
+//   genericRegions / blackspots / vfxBoxRegions / roamingLocations is a plain
+//   number (or nested {x,y,z(,w)} of numbers) and passes through untouched.
+//
+// Determinism: entries go out in a FIXED listKey order, then by sourceIndex
+// ascending, with duplicate (listKey,index) pairs collapsed. The user's click
+// sequence in the workspace is irrelevant — sorting here makes the JSON
+// byte-stable for the same selection regardless of click order, which matters
+// for diffing two exports of "the same selection".
+
+import type {
+	ParsedTriggerData,
+	Landmark,
+	GenericRegion,
+	Blackspot,
+	VFXBoxRegion,
+	SpawnLocation,
+	RoamingLocation,
+} from '@/lib/core/triggerData';
+import type { BulkEnvelope } from './bulkEnvelope';
+
+/** The six TriggerData lists that participate in bulk transfer. Killzones and
+ *  signatureStunts are excluded — they hold cross-references (region-id
+ *  pointers) that can't be carried entry-by-entry. */
+export type TriggerDataBulkListKey =
+	| 'landmarks'
+	| 'genericRegions'
+	| 'blackspots'
+	| 'vfxBoxRegions'
+	| 'spawnLocations'
+	| 'roamingLocations';
+
+/** SpawnLocation as it travels on the wire: junkyardId is a '0x…' hex string
+ *  because JSON cannot carry a bigint (see file header). */
+export type WireSpawnLocation = Omit<SpawnLocation, 'junkyardId'> & {
+	junkyardId: string;
+};
+
+export type TriggerBulkEntryWire =
+	| Landmark
+	| GenericRegion
+	| Blackspot
+	| VFXBoxRegion
+	| WireSpawnLocation
+	| RoamingLocation;
+
+export type TriggerDataBulkItem = {
+	listKey: TriggerDataBulkListKey;
+	/** Source-bundle index of the entry within its list. */
+	sourceIndex: number;
+	entry: TriggerBulkEntryWire;
+};
+
+export type TriggerDataBulkExportInput = {
+	model: ParsedTriggerData;
+	selectedEntries: ReadonlyArray<{
+		listKey: TriggerDataBulkListKey;
+		index: number;
+	}>;
+	sourceBundleFilename?: string;
+};
+
+const RESOURCE_KEY = 'triggerData';
+
+// Fixed list ordering — anchors deterministic output (see file header). The
+// ranks double as the membership test for "is this a bulk-eligible list".
+const LIST_ORDER: TriggerDataBulkListKey[] = [
+	'landmarks',
+	'genericRegions',
+	'blackspots',
+	'vfxBoxRegions',
+	'spawnLocations',
+	'roamingLocations',
+];
+const LIST_RANK: Record<TriggerDataBulkListKey, number> = {
+	landmarks: 0,
+	genericRegions: 1,
+	blackspots: 2,
+	vfxBoxRegions: 3,
+	spawnLocations: 4,
+	roamingLocations: 5,
+};
+
+function toWireEntry(
+	listKey: TriggerDataBulkListKey,
+	entry: unknown,
+): TriggerBulkEntryWire {
+	// structuredClone severs aliasing so a later mutation of an exported item
+	// can never reach back into the live source model.
+	const cloned = structuredClone(entry);
+	if (listKey === 'spawnLocations') {
+		const spawn = cloned as SpawnLocation;
+		const { junkyardId, ...rest } = spawn;
+		return { ...rest, junkyardId: '0x' + junkyardId.toString(16) };
+	}
+	return cloned as TriggerBulkEntryWire;
+}
+
+/**
+ * Build a JSON envelope from a workspace bulk selection. Entries are emitted
+ * in a fixed list order then by ascending index, with duplicates collapsed
+ * and out-of-range indices skipped.
+ */
+export function exportTriggerDataBulk(
+	input: TriggerDataBulkExportInput,
+): BulkEnvelope<TriggerDataBulkItem> {
+	// Dedupe + deterministic sort. Keyed by "listKey:index" so the same entry
+	// selected twice (different clicks) collapses to one item.
+	const seen = new Set<string>();
+	const ordered = [...input.selectedEntries]
+		.filter((e) => {
+			if (!(e.listKey in LIST_RANK)) return false;
+			if (!Number.isInteger(e.index) || e.index < 0) return false;
+			const key = `${e.listKey}:${e.index}`;
+			if (seen.has(key)) return false;
+			seen.add(key);
+			return true;
+		})
+		.sort((a, b) => {
+			const byList = LIST_RANK[a.listKey] - LIST_RANK[b.listKey];
+			return byList !== 0 ? byList : a.index - b.index;
+		});
+
+	const items: TriggerDataBulkItem[] = [];
+	for (const { listKey, index } of ordered) {
+		const list = input.model[listKey];
+		const entry = list?.[index];
+		if (entry == null) continue;
+		items.push({
+			listKey,
+			sourceIndex: index,
+			entry: toWireEntry(listKey, entry),
+		});
+	}
+
+	return {
+		kind: 'steward.bulk',
+		version: 1,
+		resourceKey: RESOURCE_KEY,
+		profile: String(input.model.version),
+		exportedAt: new Date().toISOString(),
+		items,
+		...(input.sourceBundleFilename != null
+			? { sourceBundle: input.sourceBundleFilename }
+			: {}),
+	};
+}
+
+// Re-exported so the import side / tests can iterate the canonical order
+// without re-declaring it.
+export { LIST_ORDER as TRIGGER_BULK_LIST_ORDER };

--- a/src/lib/clipboard/triggerDataBulkImport.ts
+++ b/src/lib/clipboard/triggerDataBulkImport.ts
@@ -1,0 +1,295 @@
+// TriggerData bulk-import pipeline.
+//
+// Merges a decoded BulkEnvelope (from triggerDataBulkExport.ts) into a
+// destination ParsedTriggerData. Pure function: same input → same output,
+// no clipboard / DOM / network. The mirror image of aiSectionsBulkImport.ts.
+//
+// Why we assign a FRESH id + regionIndex to every appended box-region
+// (landmarks / genericRegions / blackspots / vfxBoxRegions):
+//
+//   The writer (core/triggerData.ts, writeTriggerDataData) builds the
+//   consolidated TriggerRegion offset table by sorting ALL four box-region
+//   kinds together on `regionIndex`. If two regions share a regionIndex the
+//   table ordering is ambiguous and the bundle's index-keyed lookups
+//   (killzone / landmark matching compare index-to-index) break. So every
+//   appended region gets a regionIndex strictly above the destination's
+//   current max, contiguous and collision-free across all four lists —
+//   exactly the dense, unique invariant the writer's sort assumes.
+//
+//   `id` (mId) is the key killzones and signature stunts dereference. The
+//   writer records `genericOffsetsById` and THROWS if a referenced id is
+//   missing. We never import killzones/stunts and never touch the
+//   destination's, so imported regions are referenced by nobody — but they
+//   still must not COLLIDE with an existing id, or a destination killzone
+//   that points at the old id could resolve to the wrong (imported) region.
+//   Fresh ids above the destination max guarantee no collision.
+//
+// regionIndex is i16 on disk (writeI16 in the writer). We guard against
+// overflow past 32767 with a clear error rather than silently wrapping
+// negative — a wrapped index sorts wrong and corrupts the region table.
+//
+// genericRegion.groupId is PRESERVED verbatim. It is the author's
+// intentional grouping (miGroupID — the functional key tying a stunt /
+// killzone cluster together at runtime), NOT a remappable offset/index into
+// any table. Rewriting it would dissolve the author's grouping.
+//
+// Recon risk note (the user has CHOSEN auto-reassign+append regardless):
+//   - SAVE-GAME / RoadRules cross-resource keys: when groupId == 0, a
+//     region's mId is the key into the player save profile (stunt / drive-
+//     thru completion) and into the companion RoadRules resource (road-limit
+//     validity). Reassigning ids divorces a region from any such prior
+//     state. HARMLESS for newly-imported regions: they have no save state in
+//     the destination, and any RoadRules entry that would back an imported
+//     road-limit region does not exist in the destination's RoadRules — that
+//     link is already broken by the import, reassign or not.
+//   - This pipeline imports PLAIN trigger regions only — never killzone /
+//     signatureStunt wrappers. Were that ever added, the reassigned mId
+//     values would have to be propagated into the wrapper's parallel id list
+//     (Killzone.regionIds / SignatureStunt linkage); the pointer arrays
+//     self-heal on re-serialization, the parallel id lists do NOT.
+
+import type {
+	ParsedTriggerData,
+	Landmark,
+	GenericRegion,
+	Blackspot,
+	VFXBoxRegion,
+	SpawnLocation,
+	RoamingLocation,
+} from '@/lib/core/triggerData';
+import type { BulkEnvelope } from './bulkEnvelope';
+import type {
+	TriggerDataBulkItem,
+	TriggerDataBulkListKey,
+	WireSpawnLocation,
+} from './triggerDataBulkExport';
+
+export type TriggerImportMode = 'append' | 'replace';
+
+export type TriggerDataBulkImportInput = {
+	envelope: BulkEnvelope<TriggerDataBulkItem>;
+	destination: ParsedTriggerData;
+	mode: TriggerImportMode;
+};
+
+export type TriggerDataBulkImportResult = {
+	result: ParsedTriggerData;
+	perListCounts: Record<TriggerDataBulkListKey, number>;
+	/** Range of box-region mIds actually assigned (inclusive). null when no
+	 *  box-region was imported. */
+	assignedIdRange: { firstId: number; lastId: number } | null;
+	/** Range of box-region regionIndices actually assigned (inclusive). null
+	 *  when no box-region was imported. */
+	assignedRegionIndexRange: { first: number; last: number } | null;
+	/** True when the envelope profile != String(destination.version). Not a
+	 *  blocker — TriggerData needs no migration across versions — surfaced as
+	 *  a note for the UI. */
+	profileMismatch: boolean;
+	notes: string[];
+};
+
+const RESOURCE_KEY = 'triggerData';
+
+// regionIndex is a signed 16-bit field on disk (writeI16). Past 0x7FFF it
+// wraps negative, which sorts wrong in the writer's region table.
+const MAX_I16 = 0x7fff;
+
+// The four box-region lists — the ones that carry id + regionIndex and feed
+// the consolidated region offset table.
+const BOX_REGION_LISTS: TriggerDataBulkListKey[] = [
+	'landmarks',
+	'genericRegions',
+	'blackspots',
+	'vfxBoxRegions',
+];
+
+/** Largest `id` across the four box-region lists in the working state, or 0
+ *  if all four are empty. */
+function maxBoxRegionId(td: ParsedTriggerData): number {
+	let max = 0;
+	for (const lm of td.landmarks) if (lm.id > max) max = lm.id;
+	for (const gr of td.genericRegions) if (gr.id > max) max = gr.id;
+	for (const bs of td.blackspots) if (bs.id > max) max = bs.id;
+	for (const v of td.vfxBoxRegions) if (v.id > max) max = v.id;
+	return max;
+}
+
+/** Largest `regionIndex` across the four box-region lists in the working
+ *  state, or 0 if all four are empty. */
+function maxBoxRegionIndex(td: ParsedTriggerData): number {
+	let max = 0;
+	for (const lm of td.landmarks) if (lm.regionIndex > max) max = lm.regionIndex;
+	for (const gr of td.genericRegions) if (gr.regionIndex > max) max = gr.regionIndex;
+	for (const bs of td.blackspots) if (bs.regionIndex > max) max = bs.regionIndex;
+	for (const v of td.vfxBoxRegions) if (v.regionIndex > max) max = v.regionIndex;
+	return max;
+}
+
+/** Rehydrate a wire spawn (junkyardId is a '0x…' hex string) back to the
+ *  model shape (junkyardId is a bigint CgsID). */
+function spawnFromWire(wire: WireSpawnLocation): SpawnLocation {
+	const { junkyardId, ...rest } = wire;
+	return { ...rest, junkyardId: BigInt(junkyardId) };
+}
+
+/**
+ * Merge the bulk envelope's items into the destination model.
+ *
+ * mode 'append' — all six working lists start as copies of the destination's
+ * and imported entries are appended.
+ *
+ * mode 'replace' — only the lists that APPEAR in the envelope items start
+ * empty; lists absent from the import are left as copies of the destination's
+ * (replacing nothing the user didn't bring data for).
+ */
+export function importTriggerDataBulk(
+	input: TriggerDataBulkImportInput,
+): TriggerDataBulkImportResult {
+	const { envelope, destination, mode } = input;
+
+	if (envelope.resourceKey !== RESOURCE_KEY) {
+		throw new Error(
+			`importTriggerDataBulk: wrong resourceKey ${JSON.stringify(envelope.resourceKey)}; expected ${JSON.stringify(RESOURCE_KEY)}.`,
+		);
+	}
+
+	const notes: string[] = [];
+	const profileMismatch = envelope.profile !== String(destination.version);
+	if (profileMismatch) {
+		notes.push(
+			`Source profile ${JSON.stringify(envelope.profile)} differs from destination version ${destination.version}; TriggerData needs no migration, importing as-is.`,
+		);
+	}
+
+	// For 'replace', a list starts empty only if the import carries entries
+	// for it. Lists with no imported entries are left untouched.
+	const importedLists = new Set<TriggerDataBulkListKey>(
+		envelope.items.map((it) => it.listKey),
+	);
+	const startEmpty = (key: TriggerDataBulkListKey): boolean =>
+		mode === 'replace' && importedLists.has(key);
+
+	// Build the working state. Each of the six bulk-eligible lists gets a NEW
+	// array so we never alias the destination's arrays into the result.
+	const landmarks: Landmark[] = startEmpty('landmarks')
+		? []
+		: [...destination.landmarks];
+	const genericRegions: GenericRegion[] = startEmpty('genericRegions')
+		? []
+		: [...destination.genericRegions];
+	const blackspots: Blackspot[] = startEmpty('blackspots')
+		? []
+		: [...destination.blackspots];
+	const vfxBoxRegions: VFXBoxRegion[] = startEmpty('vfxBoxRegions')
+		? []
+		: [...destination.vfxBoxRegions];
+	const spawnLocations: SpawnLocation[] = startEmpty('spawnLocations')
+		? []
+		: [...destination.spawnLocations];
+	const roamingLocations: RoamingLocation[] = startEmpty('roamingLocations')
+		? []
+		: [...destination.roamingLocations];
+
+	// Seed counters from the POST-replace working state so 'replace' that
+	// empties a list reclaims those ids/indices, while preserved lists still
+	// constrain the floor.
+	const working: ParsedTriggerData = {
+		...destination,
+		landmarks,
+		genericRegions,
+		blackspots,
+		vfxBoxRegions,
+		spawnLocations,
+		roamingLocations,
+	};
+	let nextId = maxBoxRegionId(working) + 1;
+	let nextRegionIndex = maxBoxRegionIndex(working) + 1;
+
+	const perListCounts: Record<TriggerDataBulkListKey, number> = {
+		landmarks: 0,
+		genericRegions: 0,
+		blackspots: 0,
+		vfxBoxRegions: 0,
+		spawnLocations: 0,
+		roamingLocations: 0,
+	};
+
+	let firstAssignedId: number | null = null;
+	let lastAssignedId: number | null = null;
+	let firstAssignedRegionIndex: number | null = null;
+	let lastAssignedRegionIndex: number | null = null;
+
+	const assignBoxRegion = <T extends { id: number; regionIndex: number }>(
+		entry: T,
+	): T => {
+		if (nextRegionIndex > MAX_I16) {
+			throw new Error(
+				'TriggerData regionIndex would overflow i16 (32767); destination has too many regions to append.',
+			);
+		}
+		entry.id = nextId;
+		entry.regionIndex = nextRegionIndex;
+		if (firstAssignedId === null) firstAssignedId = nextId;
+		lastAssignedId = nextId;
+		if (firstAssignedRegionIndex === null) firstAssignedRegionIndex = nextRegionIndex;
+		lastAssignedRegionIndex = nextRegionIndex;
+		nextId++;
+		nextRegionIndex++;
+		return entry;
+	};
+
+	for (const item of envelope.items) {
+		// structuredClone severs aliasing so the imported entry can never reach
+		// back into the source workspace's model after import.
+		const cloned = structuredClone(item.entry);
+		switch (item.listKey) {
+			case 'spawnLocations':
+				spawnLocations.push(spawnFromWire(cloned as WireSpawnLocation));
+				break;
+			case 'roamingLocations':
+				roamingLocations.push(cloned as RoamingLocation);
+				break;
+			case 'landmarks':
+				landmarks.push(assignBoxRegion(cloned as Landmark));
+				break;
+			case 'genericRegions':
+				// groupId preserved verbatim (author's grouping, not an offset).
+				genericRegions.push(assignBoxRegion(cloned as GenericRegion));
+				break;
+			case 'blackspots':
+				blackspots.push(assignBoxRegion(cloned as Blackspot));
+				break;
+			case 'vfxBoxRegions':
+				vfxBoxRegions.push(assignBoxRegion(cloned as VFXBoxRegion));
+				break;
+		}
+		perListCounts[item.listKey]++;
+	}
+
+	if (perListCounts.landmarks > 0) {
+		// Appended landmarks are OFFLINE by default — onlineLandmarkCount keys
+		// the leading slice of the landmark table that is exposed online, and
+		// appended entries go to the tail, so the count stays as the
+		// destination's.
+		notes.push(
+			'Appended landmarks are offline by default; onlineLandmarkCount left unchanged.',
+		);
+	}
+
+	const result: ParsedTriggerData = working;
+
+	return {
+		result,
+		perListCounts,
+		assignedIdRange:
+			firstAssignedId !== null && lastAssignedId !== null
+				? { firstId: firstAssignedId, lastId: lastAssignedId }
+				: null,
+		assignedRegionIndexRange:
+			firstAssignedRegionIndex !== null && lastAssignedRegionIndex !== null
+				? { first: firstAssignedRegionIndex, last: lastAssignedRegionIndex }
+				: null,
+		profileMismatch,
+		notes,
+	};
+}

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -71,6 +71,7 @@ import { BulkPanelStack } from '@/components/workspace/BulkPanelStack';
 import { BulkTransformGizmoSessionProvider } from '@/components/workspace/BulkTransformGizmoSession';
 import { BulkTransformNumericPanel } from '@/components/workspace/BulkTransformNumericPanel';
 import { BulkImportDialog } from '@/components/workspace/BulkImportDialog';
+import { TriggerDataBulkImportDialog } from '@/components/workspace/TriggerDataBulkImportDialog';
 import { BundleExportValidationDialog } from '@/components/workspace/BundleExportValidationDialog';
 import { findUnresolvedPortals, type UnresolvedPortal } from '@/lib/core/aiSectionsValidate';
 import { BulkEditPanel } from '@/components/polygonSoupList/BulkEditPanel';
@@ -412,6 +413,14 @@ function RightInspector() {
 		selection.index != null &&
 		inspectorBundle != null;
 
+	// TriggerData has a single profile (no v12/v4 split), so the import
+	// affordance is gated only on the resource key — every TriggerData
+	// instance is importable.
+	const showTriggerImport =
+		selection.resourceKey === 'triggerData' &&
+		selection.index != null &&
+		inspectorBundle != null;
+
 	// The inspector gets its own error boundary (the centre viewport already has
 	// one). Without it, any throw while rendering the schema form propagates
 	// uncaught and React 18 unmounts the entire root — which destroys the
@@ -432,6 +441,12 @@ function RightInspector() {
 			>
 				{showAIImport && inspectorBundle && selection.index != null ? (
 					<AIImportInspectorWrapper
+						bundle={inspectorBundle}
+						index={selection.index}
+						setResourceAt={setResourceAt as never}
+					/>
+				) : showTriggerImport && inspectorBundle && selection.index != null ? (
+					<TriggerImportInspectorWrapper
 						bundle={inspectorBundle}
 						index={selection.index}
 						setResourceAt={setResourceAt as never}
@@ -501,6 +516,69 @@ function AIImportInspectorWrapper({
 				bundleId={bundle.id}
 				onConfirm={(result) => {
 					setResourceAt(bundle.id, 'aiSections', index, result);
+				}}
+			/>
+		</div>
+	);
+}
+
+// Inspector wrapper that prepends the "Import bulk JSON" affordance for a
+// TriggerData instance. Mirrors AIImportInspectorWrapper — pulled into its own
+// component so the import dialog state stays attached to the (bundle, index)
+// pair via React keys. TriggerData has one profile, so there's no v12/v4 gate.
+function TriggerImportInspectorWrapper({
+	bundle,
+	index,
+	setResourceAt,
+}: {
+	bundle: EditableBundle;
+	index: number;
+	setResourceAt: <T>(bundleId: string, key: string, index: number, value: T) => void;
+}) {
+	const [importOpen, setImportOpen] = useState(false);
+	const model = bundle.parsedResourcesAll.get('triggerData')?.[index] as
+		| import('@/lib/core/triggerData').ParsedTriggerData
+		| undefined;
+	if (!model) {
+		return <InspectorPanel />;
+	}
+	return (
+		<div className="h-full flex flex-col min-h-0">
+			<div className="shrink-0 border-b bg-card/40 px-3 py-2">
+				<div className="text-[11px] uppercase tracking-wide text-muted-foreground mb-1">
+					Import bulk JSON
+				</div>
+				<div className="flex flex-wrap gap-1.5">
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						className="h-7 text-xs"
+						onClick={() => setImportOpen(true)}
+					>
+						Paste from clipboard
+					</Button>
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						className="h-7 text-xs"
+						onClick={() => setImportOpen(true)}
+					>
+						From file…
+					</Button>
+				</div>
+			</div>
+			<div className="flex-1 min-h-0 overflow-auto">
+				<InspectorPanel />
+			</div>
+			<TriggerDataBulkImportDialog
+				open={importOpen}
+				onOpenChange={setImportOpen}
+				destination={model}
+				bundleId={bundle.id}
+				onConfirm={(result) => {
+					setResourceAt(bundle.id, 'triggerData', index, result);
 				}}
 			/>
 		</div>


### PR DESCRIPTION
## What

Adds the **export-to-file / import-from-file** half of TriggerData bulk, mirroring the AI Sections feature. The TriggerData workspace bulk *selection* already shipped in #63; this fills in the missing transfer half.

**Use case:** two people author triggers independently — one does the main triggers, the other the challenge triggers — and want to merge at the end. Export a bulk selection of triggers to a `steward.bulk` JSON envelope (clipboard or `.json` file), then **Import → Append** it into another bundle's TriggerData. Imported triggers land at the end of their lists, renumbered so they never collide with existing ones, byte-exact on save.

## Scope

All six bulk-eligible lists: `landmarks`, `genericRegions`, `blackspots`, `vfxBoxRegions`, `spawnLocations`, `roamingLocations`. Whatever is in the bulk selection travels.

## How it works

- **Auto-reassign on append.** Each appended box-region (landmark/generic/blackspot/vfx) gets a fresh `id` (mId) and `regionIndex` past the destination's current max, so they can't collide with existing references and land at the end of the consolidated region table (the writer sorts that table by `regionIndex`). `spawnLocations`/`roamingLocations` have no id/regionIndex and just append. `genericRegion.groupId` is preserved verbatim (it's the author's functional grouping key, not a remappable index).
- **bigint wire encoding.** `spawnLocations.junkyardId` is the only bigint among the six lists, and `JSON.stringify` throws on bigint — so it's encoded as a hex string on export and rehydrated via `BigInt()` on import.
- **i16 guard** on `regionIndex` (errors clearly rather than silently overflowing past 32767).

## Files

- `src/lib/clipboard/triggerDataBulkExport.ts` / `triggerDataBulkImport.ts` — pure pipelines (+ full test coverage)
- `src/components/workspace/TriggerDataBulkImportDialog.tsx` (+ `TriggerImportPreviewBlock.tsx`, `triggerDataBulkImportDialog.helpers.ts`) — Append/Replace, paste-or-file, live preview of per-list counts and the id/regionIndex ranges that will be assigned. No "Starting ID" field (unlike AI) since ids auto-assign.
- `bulkPanelExport.helpers.ts` — trigger envelope builders; `exportEnvelopeFilename` generalised to take a resource slug
- `BulkPanelStack.tsx` — filled the stubbed TriggerData export buttons; extracted a shared `<BulkExportButtons>` now used by **both** the AI and trigger panels (behaviourally identical, just hoisted; AI export filenames unchanged)
- `WorkspacePage.tsx` — `showTriggerImport` gate + `TriggerImportInspectorWrapper` (mirrors `AIImportInspectorWrapper`; no profile sub-gate — TriggerData has one profile)

## Domain note (safety of id reassignment)

Outside TriggerData, a region's `mId` (when `groupId == 0`) is the key into the **player save profile** (stunt / drive-thru completion) and the companion **RoadRules** resource (road-limit validity). Reassigning is **safe for newly-imported regions**: they have no prior save state, and any RoadRules entry that would back an imported road-limit region doesn't exist in the destination anyway. In-bundle runtime resolution is pointer/index-based (killzone membership matches by `regionIndex` equality), not mId-based, so reassignment doesn't dissolve groupings.

**Limitation (by design):** `killzones` and `signatureStunts` aren't individually selectable, so they don't travel with an export. If a challenge ever needs its killzone/stunt wrapper ported too, that's a clean follow-up (the wrapper's parallel id-list would need the reassigned ids propagated in).

## Verification

- 290 targeted tests green (`src/lib/clipboard` + `src/components/workspace`), typecheck clean.
- Load-bearing test: `importTriggerDataBulk` → `writeTriggerDataData` → `parseTriggerDataData` round-trips with appended entries intact and references valid.
- Full **real-module browser round-trip** (export → encode → decode → preview → import → write → reparse) against a model with all six kinds, a bigint spawn, and deliberately-colliding ids: collision-reassign, groupId-preserve, bigint-restore, and binary round-trip all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
