### PR TITLE
feat(triggerData): yellow bulk marking in 3D + Starting ID in import dialog

### DIFF
--- a/src/components/schema-editor/viewports/TriggerDataOverlay.tsx
+++ b/src/components/schema-editor/viewports/TriggerDataOverlay.tsx
@@ -26,8 +26,9 @@
 //
 // The BatchedRegionBoxes mesh hosts four kinds on one InstancedMesh, so it
 // can't use the `useInstancedSelection` hook (which is single-kind). Its
-// inline paint loop stays — only the theme imports are migrated. RoamingDots
-// is single-kind and uses the hook.
+// inline paint loop resolves colour via the shared `pickRegionColor` helper so
+// its precedence (primary > hover > bulk > base) can't drift from the hook.
+// RoamingDots is single-kind and uses the hook directly.
 //
 // DOM siblings: marquee bulk-select rides the WorldViewport HTML slot.
 
@@ -51,6 +52,7 @@ import {
 	useInstancedSelection,
 	type Selection,
 } from './selection';
+import { pickRegionColor, pickRegionState } from './triggerOverlayColors';
 import {
 	bulkRotateTriggerBoxes,
 	bulkTranslateTriggerBoxes,
@@ -217,6 +219,9 @@ const hovEdgeMat = new THREE.LineBasicMaterial({ color: '#66aaff' });
 const coneGeo = new THREE.ConeGeometry(3, 8, 8);
 const spawnMat = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.5, metalness: 0.2 });
 const spawnSelMat = new THREE.MeshStandardMaterial({ color: 0xffaa33, roughness: 0.4, metalness: 0.2, emissive: 0x664400, emissiveIntensity: 0.5 });
+// Amber bulk tint — mirrors SELECTION_THEME.bulk (0xffcc66) for cones caught in
+// a multi-select but not the single-selection pick.
+const spawnBulkMat = new THREE.MeshStandardMaterial({ color: 0xffcc66, roughness: 0.4, metalness: 0.2, emissive: 0x554400, emissiveIntensity: 0.4 });
 
 const roamGeo = new THREE.SphereGeometry(2, 8, 6);
 const roamMat = new THREE.MeshStandardMaterial({ roughness: 0.6 });
@@ -231,11 +236,13 @@ const playerConeGeo = new THREE.ConeGeometry(5, 12, 8);
 // ---------------------------------------------------------------------------
 
 function BatchedRegionBoxes({
-	regions, primary, hovered, onPick, onHover,
+	regions, primary, hovered, bulk, onPick, onHover,
 }: {
 	regions: RegionEntry[];
 	primary: Selection | null;
 	hovered: Selection | null;
+	/** Bulk-selected box regions, keyed `${kind}:${index}`. */
+	bulk: ReadonlySet<string>;
 	onPick: (sel: Selection) => void;
 	onHover: (sel: Selection | null) => void;
 }) {
@@ -244,8 +251,9 @@ function BatchedRegionBoxes({
 
 	// Mixed-kind paint loop — one InstancedMesh hosts four selection kinds
 	// (landmark / generic / blackspot / vfx) so the per-kind hook doesn't fit
-	// here without expanding it to take a `kind` per-instance. The codec +
-	// theme migrate cleanly; the loop itself stays inline.
+	// here without expanding it to take a `kind` per-instance. Colour precedence
+	// (primary > hover > bulk > base) lives in `pickRegionColor` so it can't
+	// drift from useInstancedSelection.
 	useUpdateInstancedMesh(
 		meshRef,
 		count,
@@ -258,12 +266,13 @@ function BatchedRegionBoxes({
 				_dummy.updateMatrix();
 				mesh.setMatrixAt(i, _dummy.matrix);
 
-				const isSel = primary?.kind === r.kind && primary.indices[0] === r.index;
-				const isHov = hovered?.kind === r.kind && hovered.indices[0] === r.index;
-				mesh.setColorAt(i, isSel ? SELECTION_THEME.primary : isHov ? SELECTION_THEME.hover : r.color);
+				const isPrimary = primary?.kind === r.kind && primary.indices[0] === r.index;
+				const isHovered = hovered?.kind === r.kind && hovered.indices[0] === r.index;
+				const isBulk = bulk.has(`${r.kind}:${r.index}`);
+				mesh.setColorAt(i, pickRegionColor({ isPrimary, isHovered, isBulk }, r.color, SELECTION_THEME));
 			}
 		},
-		[regions, count, primary, hovered],
+		[regions, count, primary, hovered, bulk],
 	);
 
 	const handleClick = useCallback((e: ThreeEvent<MouseEvent>) => {
@@ -332,10 +341,12 @@ function BoxLabel({ box, label, color }: { box: BoxRegion; label: string; color:
 }
 
 function SpawnArrows({
-	data, primary, onPick,
+	data, primary, bulk, onPick,
 }: {
 	data: ParsedTriggerData;
 	primary: Selection | null;
+	/** Bulk-selected spawn indices. */
+	bulk: ReadonlySet<number>;
 	onPick: (sel: Selection) => void;
 }) {
 	return (
@@ -343,6 +354,10 @@ function SpawnArrows({
 			{data.spawnLocations.map((sp, i) => {
 				const pos: [number, number, number] = [sp.position.x, sp.position.y, sp.position.z];
 				const isSel = primary?.kind === 'spawn' && primary.indices[0] === i;
+				// Cones can't hover-paint (no InstancedMesh hover wiring here), so
+				// hover is always false — precedence still lives in one helper.
+				const state = pickRegionState({ isPrimary: isSel, isHovered: false, isBulk: bulk.has(i) });
+				const coneMat = state === 'primary' ? spawnSelMat : state === 'bulk' ? spawnBulkMat : spawnMat;
 				const dir = new THREE.Vector3(sp.direction.x, sp.direction.y, sp.direction.z);
 				if (dir.lengthSq() > 0.001) dir.normalize();
 				const arrowEnd: [number, number, number] = [
@@ -352,11 +367,11 @@ function SpawnArrows({
 					<group key={`spawn-${i}`}>
 						<mesh
 							geometry={coneGeo}
-							material={isSel ? spawnSelMat : spawnMat}
+							material={coneMat}
 							position={pos}
 							onClick={(e) => { e.stopPropagation(); if (isDragRelease(e.nativeEvent.clientX, e.nativeEvent.clientY)) return; onPick({ kind: 'spawn', indices: [i] }); }}
 						/>
-						<Line points={[pos, arrowEnd]} color={isSel ? '#ffaa33' : '#ffffff'} lineWidth={2} />
+						<Line points={[pos, arrowEnd]} color={isSel ? '#ffaa33' : state === 'bulk' ? '#ffcc66' : '#ffffff'} lineWidth={2} />
 						{isSel && (
 							<Html position={pos} center distanceFactor={200} style={{ pointerEvents: 'none' }}>
 								<div style={{
@@ -652,6 +667,7 @@ export function applyDragToTriggerModel(
 // ---------------------------------------------------------------------------
 
 const EMPTY_BULK: ReadonlySet<string> = new Set();
+const EMPTY_SPAWN_BULK: ReadonlySet<number> = new Set();
 
 type Props = {
 	data: ParsedTriggerData;
@@ -693,11 +709,6 @@ export const TriggerDataOverlay: WorldOverlayComponent<ParsedTriggerData> = ({
 
 	// Translate the bulk path-key set (e.g. `'roamingLocations/3'`) into the
 	// Selection-keyed Set `useInstancedSelection` expects (`'roaming:3'`).
-	// Only the subset the hook cares about (single-kind 'roaming') needs
-	// translation; other entry kinds (landmarks/genericRegions/blackspots/
-	// vfxBoxRegions/spawnLocations) participate in the bulk Set without yet
-	// being painted in 3D — paint will land when the per-kind paint loop is
-	// extended in a follow-up.
 	const roamingBulk = useMemo<ReadonlySet<string>>(() => {
 		const keys = instanceBulk?.bulkPathKeys;
 		if (!keys || keys.size === 0) return EMPTY_BULK;
@@ -706,6 +717,37 @@ export const TriggerDataOverlay: WorldOverlayComponent<ParsedTriggerData> = ({
 			if (!k.startsWith('roamingLocations/')) continue;
 			const idx = Number(k.slice('roamingLocations/'.length));
 			if (Number.isFinite(idx)) out.add(`roaming:${idx}`);
+		}
+		return out;
+	}, [instanceBulk]);
+
+	// Box-region bulk set keyed `${kind}:${index}` so BatchedRegionBoxes can
+	// test membership against the RegionEntry it's painting. The mesh hosts all
+	// four box kinds, so the key carries the kind — mirroring the `RegionEntry`
+	// discriminator, NOT the on-disk list name.
+	const boxRegionBulk = useMemo<ReadonlySet<string>>(() => {
+		const keys = instanceBulk?.bulkPathKeys;
+		if (!keys || keys.size === 0) return EMPTY_BULK;
+		const out = new Set<string>();
+		for (const k of keys) {
+			const ref = bulkKeyToRef(k);
+			if (ref && ref.kind !== 'roaming' && ref.kind !== 'spawn') {
+				out.add(`${ref.kind}:${ref.idx}`);
+			}
+		}
+		return out;
+	}, [instanceBulk]);
+
+	// Spawn bulk set of raw indices (keys `spawnLocations/i`) — SpawnArrows
+	// renders one cone per spawn and just needs `has(i)`.
+	const spawnBulk = useMemo<ReadonlySet<number>>(() => {
+		const keys = instanceBulk?.bulkPathKeys;
+		if (!keys || keys.size === 0) return EMPTY_SPAWN_BULK;
+		const out = new Set<number>();
+		for (const k of keys) {
+			if (!k.startsWith('spawnLocations/')) continue;
+			const idx = Number(k.slice('spawnLocations/'.length));
+			if (Number.isFinite(idx)) out.add(idx);
 		}
 		return out;
 	}, [instanceBulk]);
@@ -943,6 +985,7 @@ export const TriggerDataOverlay: WorldOverlayComponent<ParsedTriggerData> = ({
 				regions={regions}
 				primary={primary}
 				hovered={hovered}
+				bulk={boxRegionBulk}
 				onPick={handlePick}
 				onHover={setHovered}
 			/>
@@ -957,7 +1000,7 @@ export const TriggerDataOverlay: WorldOverlayComponent<ParsedTriggerData> = ({
 				<BoxLabel box={hovEntry.box} label={hovEntry.label} color="#66aaff" />
 			)}
 
-			<SpawnArrows data={data} primary={primary} onPick={handlePick} />
+			<SpawnArrows data={data} primary={primary} bulk={spawnBulk} onPick={handlePick} />
 			<RoamingDots
 				data={data}
 				primary={primary}

--- a/src/components/schema-editor/viewports/__tests__/triggerOverlayColors.test.ts
+++ b/src/components/schema-editor/viewports/__tests__/triggerOverlayColors.test.ts
@@ -1,0 +1,60 @@
+// Colour-precedence resolution for the TriggerData overlay's non-hook meshes.
+//
+// The box InstancedMesh and the spawn cones both resolve their highlight tint
+// through `pickRegionColor` / `pickRegionState`. This spec pins the precedence
+// (primary > hover > bulk > base) so the box paint loop, the spawn material
+// chooser, and useInstancedSelection can't silently diverge.
+
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { SELECTION_THEME } from '../selection/theme';
+import { pickRegionColor, pickRegionState } from '../triggerOverlayColors';
+
+const BASE = new THREE.Color(0x123456);
+
+describe('pickRegionState', () => {
+	it('primary wins over hover and bulk', () => {
+		expect(pickRegionState({ isPrimary: true, isHovered: true, isBulk: true })).toBe('primary');
+		expect(pickRegionState({ isPrimary: true, isHovered: false, isBulk: false })).toBe('primary');
+	});
+
+	it('hover wins over bulk (but not primary)', () => {
+		expect(pickRegionState({ isPrimary: false, isHovered: true, isBulk: true })).toBe('hover');
+		expect(pickRegionState({ isPrimary: false, isHovered: true, isBulk: false })).toBe('hover');
+	});
+
+	it('bulk wins over base', () => {
+		expect(pickRegionState({ isPrimary: false, isHovered: false, isBulk: true })).toBe('bulk');
+	});
+
+	it('base when no flags set', () => {
+		expect(pickRegionState({ isPrimary: false, isHovered: false, isBulk: false })).toBe('base');
+	});
+});
+
+describe('pickRegionColor', () => {
+	it('paints primary tint when primary (beats hover + bulk)', () => {
+		const c = pickRegionColor({ isPrimary: true, isHovered: true, isBulk: true }, BASE, SELECTION_THEME);
+		expect(c).toBe(SELECTION_THEME.primary);
+	});
+
+	it('paints hover tint when hovered but not primary (beats bulk)', () => {
+		const c = pickRegionColor({ isPrimary: false, isHovered: true, isBulk: true }, BASE, SELECTION_THEME);
+		expect(c).toBe(SELECTION_THEME.hover);
+	});
+
+	it('paints bulk tint when only bulk (beats base)', () => {
+		const c = pickRegionColor({ isPrimary: false, isHovered: false, isBulk: true }, BASE, SELECTION_THEME);
+		expect(c).toBe(SELECTION_THEME.bulk);
+	});
+
+	it('paints the base colour when no flag is set', () => {
+		const c = pickRegionColor({ isPrimary: false, isHovered: false, isBulk: false }, BASE, SELECTION_THEME);
+		expect(c).toBe(BASE);
+	});
+
+	it('bulk tint is the amber theme colour, distinct from primary', () => {
+		expect(SELECTION_THEME.bulk.getHex()).toBe(0xffcc66);
+		expect(SELECTION_THEME.bulk.getHex()).not.toBe(SELECTION_THEME.primary.getHex());
+	});
+});

--- a/src/components/schema-editor/viewports/triggerOverlayColors.ts
+++ b/src/components/schema-editor/viewports/triggerOverlayColors.ts
@@ -1,0 +1,57 @@
+// Colour-precedence resolution for the TriggerData overlay's non-hook meshes.
+//
+// The BatchedRegionBoxes InstancedMesh hosts four selection kinds on one mesh
+// and SpawnArrows renders one <mesh> per cone, so neither can lean on
+// useInstancedSelection to decide which highlight tint an entity gets. This
+// module is the single tested home for that decision so the two call sites
+// cannot drift from each other — or from the hook, which resolves the same
+// precedence.
+//
+// Precedence: primary > hover > bulk > base. Hover beats bulk because a hover
+// indicator under the cursor is feedback the user just produced and should
+// stay visible even on a multi-selected entity (matches
+// useInstancedSelection.computeInstanceState).
+
+import type * as THREE from 'three';
+import type { SelectionTheme } from './selection/theme';
+
+/** The three flags that select a highlight tint, resolved against the base. */
+export type RegionSelectionFlags = {
+	isPrimary: boolean;
+	isHovered: boolean;
+	isBulk: boolean;
+};
+
+/** Which paint bucket an entity lands in after precedence resolution. */
+export type RegionColorState = 'primary' | 'hover' | 'bulk' | 'base';
+
+/**
+ * Pure precedence decision — returns the bucket an entity paints in.
+ * Exported so both the colour picker and the spawn-material chooser share
+ * one implementation (and one set of tests).
+ */
+export function pickRegionState({ isPrimary, isHovered, isBulk }: RegionSelectionFlags): RegionColorState {
+	if (isPrimary) return 'primary';
+	if (isHovered) return 'hover';
+	if (isBulk) return 'bulk';
+	return 'base';
+}
+
+/**
+ * Resolve the THREE.Color an entity should paint. `baseColor` is the entity's
+ * own resting tint (region kind colour). The theme supplies the three
+ * highlight tints. Returns a reference to the theme colour or `baseColor` —
+ * callers must not mutate the result (they feed it straight to setColorAt).
+ */
+export function pickRegionColor(
+	flags: RegionSelectionFlags,
+	baseColor: THREE.Color,
+	theme: SelectionTheme,
+): THREE.Color {
+	switch (pickRegionState(flags)) {
+		case 'primary': return theme.primary;
+		case 'hover': return theme.hover;
+		case 'bulk': return theme.bulk;
+		case 'base': return baseColor;
+	}
+}

--- a/src/components/workspace/TriggerDataBulkImportDialog.tsx
+++ b/src/components/workspace/TriggerDataBulkImportDialog.tsx
@@ -2,15 +2,13 @@
 // envelope onto a TriggerData destination.
 //
 // Mirrors BulkImportDialog (AI Sections) but is typed to ParsedTriggerData and
-// drives the TriggerData import pipeline. Two differences from the AI dialog:
+// drives the TriggerData import pipeline. One difference from the AI dialog:
 //
-//   - No "Starting ID" field. TriggerData box-region ids + regionIndices are
-//     auto-assigned by importTriggerDataBulk above the destination's current
-//     max (the writer's consolidated region table requires dense, unique
-//     regionIndices — the user can't pick them). The preview shows the ranges
-//     that WILL be assigned so there's no surprise.
 //   - Six heterogeneous lists, so the preview is a per-list count breakdown
-//     rather than a single section count.
+//     rather than a single section count. The "Starting ID" field controls the
+//     box-region mId base only — regionIndex still auto-assigns above the
+//     destination max (it is the writer's dense/unique region-table sort key,
+//     not a user-tracked id).
 //
 // The preview never re-derives assignment math — buildTriggerImportPreview runs
 // the real import so what's shown is exactly what Confirm produces.
@@ -37,8 +35,13 @@ import {
 import {
 	decodeTriggerEnvelope,
 	buildTriggerImportPreview,
+	defaultTriggerStartId,
+	detectTriggerIdCollisions,
+	parseStartingId,
+	previewBoxRegionCount,
 } from './triggerDataBulkImportDialog.helpers';
 import { TriggerImportPreviewBlock } from './TriggerImportPreviewBlock';
+import { TriggerStartIdField } from './TriggerStartIdField';
 import type { TriggerDataBulkItem } from '@/lib/clipboard/triggerDataBulkExport';
 import type { BulkEnvelope } from '@/lib/clipboard/bulkEnvelope';
 import type { ParsedTriggerData } from '@/lib/core/triggerData';
@@ -66,20 +69,38 @@ export function TriggerDataBulkImportDialog({
 	const [envelopeState, setEnvelopeState] = useState<EnvelopeState>({ kind: 'idle' });
 	const [pasteText, setPasteText] = useState('');
 	const [mode, setMode] = useState<TriggerImportMode>('append');
+	const defaultStart = useMemo(() => defaultTriggerStartId(destination), [destination]);
+	const [startIdInput, setStartIdInput] = useState<string>(() => formatIdInputDefault(defaultStart));
 	const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+	// Blank / unparseable falls back to the default so the preview + confirm stay
+	// live while the user edits — the field never blocks the import.
+	const resolvedStartId = useMemo(() => {
+		const parsed = parseStartingId(startIdInput);
+		return parsed ?? defaultStart;
+	}, [startIdInput, defaultStart]);
 
 	const preview = useMemo(
 		() =>
 			envelopeState.kind === 'ready'
-				? buildTriggerImportPreview(envelopeState.envelope, destination, mode)
+				? buildTriggerImportPreview(envelopeState.envelope, destination, mode, resolvedStartId)
 				: null,
-		[envelopeState, destination, mode],
+		[envelopeState, destination, mode, resolvedStartId],
+	);
+
+	const collisions = useMemo(
+		() =>
+			preview && !preview.error
+				? detectTriggerIdCollisions(destination, resolvedStartId, previewBoxRegionCount(preview))
+				: [],
+		[preview, destination, resolvedStartId],
 	);
 
 	const reset = () => {
 		setEnvelopeState({ kind: 'idle' });
 		setPasteText('');
 		setMode('append');
+		setStartIdInput(formatIdInputDefault(defaultStart));
 	};
 
 	const handleClose = (next: boolean) => {
@@ -124,6 +145,7 @@ export function TriggerDataBulkImportDialog({
 			envelope: envelopeState.envelope,
 			destination,
 			mode,
+			startId: resolvedStartId,
 		});
 		onConfirm(out.result);
 		const counts = preview.perList
@@ -245,6 +267,13 @@ export function TriggerDataBulkImportDialog({
 							</p>
 						</div>
 
+						<TriggerStartIdField
+							value={startIdInput}
+							onChange={setStartIdInput}
+							placeholder={formatIdInputDefault(defaultStart)}
+							collisions={collisions}
+						/>
+
 						{preview && <TriggerImportPreviewBlock preview={preview} mode={mode} />}
 					</div>
 				)}
@@ -262,4 +291,10 @@ export function TriggerDataBulkImportDialog({
 			</DialogContent>
 		</Dialog>
 	);
+}
+
+// Hex form (no decimal suffix) for the input's pre-filled value / placeholder —
+// mirrors the AI dialog so the two Starting-ID fields read the same.
+function formatIdInputDefault(id: number): string {
+	return `0x${(id >>> 0).toString(16).toUpperCase()}`;
 }

--- a/src/components/workspace/TriggerStartIdField.tsx
+++ b/src/components/workspace/TriggerStartIdField.tsx
@@ -1,0 +1,56 @@
+// "Starting ID" field for TriggerDataBulkImportDialog. Split out of the dialog
+// so the dialog stays under the file-size soft cap and this owns the input +
+// non-blocking collision warning.
+//
+// The field controls the box-region mId base ONLY. regionIndex still
+// auto-assigns above the destination max (it is the writer's dense/unique
+// region-table sort key, not a user-tracked id), so this field never mentions
+// it. Blank / unparseable input falls back to the default upstream — the field
+// never blocks the import, mirroring the AI Sections dialog.
+
+import { AlertTriangle } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { formatTriggerIdLabel } from './triggerDataBulkImportDialog.helpers';
+
+export function TriggerStartIdField({
+	value,
+	onChange,
+	placeholder,
+	collisions,
+}: {
+	value: string;
+	onChange: (next: string) => void;
+	placeholder: string;
+	collisions: number[];
+}) {
+	return (
+		<div className="space-y-2">
+			<Label htmlFor="trigger-import-startid">Starting ID</Label>
+			<Input
+				id="trigger-import-startid"
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				placeholder={placeholder}
+			/>
+			<p className="text-[11px] text-muted-foreground">
+				Base mId for the first appended region — decimal or hex with <code>0x</code> prefix.
+				Usually you want this high; collisions with the GameDB will crash the game. The
+				pre-filled value is a safe-above-the-current-max suggestion. Region indices are always
+				assigned automatically. Leave blank to use the default.
+			</p>
+			{collisions.length > 0 && (
+				<div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-2 text-[11px]">
+					<div className="flex items-center gap-1.5 font-medium text-amber-700 dark:text-amber-400">
+						<AlertTriangle className="h-3 w-3" />
+						{collisions.length} collision{collisions.length === 1 ? '' : 's'} with existing destination IDs
+					</div>
+					<div className="mt-1 font-mono text-muted-foreground">
+						{collisions.slice(0, 5).map(formatTriggerIdLabel).join(', ')}
+						{collisions.length > 5 ? ` … +${collisions.length - 5} more` : ''}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/workspace/__tests__/triggerDataBulkImportDialog.helpers.test.ts
+++ b/src/components/workspace/__tests__/triggerDataBulkImportDialog.helpers.test.ts
@@ -5,8 +5,13 @@ import {
 	decodeTriggerEnvelope,
 	buildTriggerImportPreview,
 	formatTriggerIdLabel,
+	defaultTriggerStartId,
+	detectTriggerIdCollisions,
+	previewBoxRegionCount,
+	parseStartingId,
 	TRIGGER_PREVIEW_LIST_ORDER,
 } from '../triggerDataBulkImportDialog.helpers';
+import { parseStartingId as aiParseStartingId } from '../bulkImportDialog.helpers';
 import { exportTriggerDataBulk } from '@/lib/clipboard/triggerDataBulkExport';
 import type {
 	TriggerDataBulkItem,
@@ -256,6 +261,24 @@ describe('buildTriggerImportPreview', () => {
 		expect(preview.profileMismatch).toBe(false);
 	});
 
+	it('seeds the previewed assignedIdRange from a supplied startId', () => {
+		const env = envelopeFrom(makeDestination(), [
+			{ listKey: 'genericRegions', index: 0 },
+			{ listKey: 'blackspots', index: 0 },
+		]);
+		const preview = buildTriggerImportPreview(env, makeDestination(), 'append', 0x90000000);
+		expect(preview.assignedIdRange).toEqual({ firstId: 0x90000000, lastId: 0x90000001 });
+		// regionIndex stays on the auto path (dest max 3 → 4..5), unaffected by startId.
+		expect(preview.assignedRegionIndexRange).toEqual({ first: 4, last: 5 });
+	});
+
+	it('falls back to the default id range when startId is omitted', () => {
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'genericRegions', index: 0 }]);
+		const withStart = buildTriggerImportPreview(env, makeDestination(), 'append');
+		// Dest box max id is 400 → default base 401.
+		expect(withStart.assignedIdRange).toEqual({ firstId: 401, lastId: 401 });
+	});
+
 	it('captures the i16 overflow as an error instead of throwing', () => {
 		const dest = makeDestination({
 			genericRegions: [genericRegion({ id: 1, regionIndex: 0x7fff })],
@@ -267,6 +290,133 @@ describe('buildTriggerImportPreview', () => {
 		const preview = buildTriggerImportPreview(env, dest, 'append');
 		expect(preview.error).toMatch(/regionIndex would overflow i16/);
 		expect(preview.assignedIdRange).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// parseStartingId (re-exported from the AI dialog — one shared parser)
+// ---------------------------------------------------------------------------
+
+describe('parseStartingId re-export', () => {
+	it('is the SAME function the AI dialog uses', () => {
+		expect(parseStartingId).toBe(aiParseStartingId);
+	});
+
+	it('parses decimal and 0x hex, returning null on garbage', () => {
+		expect(parseStartingId('12345')).toBe(12345);
+		expect(parseStartingId('0x90000000')).toBe(0x90000000);
+		expect(parseStartingId('  0xFF  ')).toBe(0xff);
+		expect(parseStartingId('')).toBeNull();
+		expect(parseStartingId('nope')).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// defaultTriggerStartId
+// ---------------------------------------------------------------------------
+
+describe('defaultTriggerStartId', () => {
+	it('returns max box-region id + 1 across all four box lists', () => {
+		// makeDestination box ids: 100 / 200 / 300 / 400 → default 401.
+		expect(defaultTriggerStartId(makeDestination())).toBe(401);
+	});
+
+	it('picks the max from whichever box list holds it', () => {
+		const dest = makeDestination({
+			landmarks: [landmark({ id: 9999 })],
+			genericRegions: [genericRegion({ id: 200 })],
+			blackspots: [blackspot({ id: 300 })],
+			vfxBoxRegions: [vfxBoxRegion({ id: 400 })],
+		});
+		expect(defaultTriggerStartId(dest)).toBe(10000);
+	});
+
+	it('returns 0 when the destination has no box regions', () => {
+		const dest = makeDestination({
+			landmarks: [],
+			genericRegions: [],
+			blackspots: [],
+			vfxBoxRegions: [],
+		});
+		expect(defaultTriggerStartId(dest)).toBe(0);
+	});
+
+	it('ignores spawn / roaming lists (they carry no mId)', () => {
+		const dest = makeDestination({
+			landmarks: [],
+			genericRegions: [],
+			blackspots: [],
+			vfxBoxRegions: [],
+			spawnLocations: [spawnLocation(), spawnLocation()],
+			roamingLocations: [roamingLocation()],
+		});
+		expect(defaultTriggerStartId(dest)).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// detectTriggerIdCollisions
+// ---------------------------------------------------------------------------
+
+describe('detectTriggerIdCollisions', () => {
+	it('returns box-region ids in [startId, startId+count-1] that already exist, sorted asc', () => {
+		// Box ids present: 100 / 200 / 300 / 400. Range [200, 202] hits 200 only.
+		expect(detectTriggerIdCollisions(makeDestination(), 200, 3)).toEqual([200]);
+		// Range [98, 102] hits 100.
+		expect(detectTriggerIdCollisions(makeDestination(), 98, 5)).toEqual([100]);
+	});
+
+	it('detects multiple collisions across the four box lists', () => {
+		const dest = makeDestination({
+			landmarks: [landmark({ id: 10 })],
+			genericRegions: [genericRegion({ id: 11 })],
+			blackspots: [blackspot({ id: 12 })],
+			vfxBoxRegions: [vfxBoxRegion({ id: 20 })],
+		});
+		expect(detectTriggerIdCollisions(dest, 10, 11)).toEqual([10, 11, 12, 20]);
+	});
+
+	it('returns [] when the range clears every existing id', () => {
+		expect(detectTriggerIdCollisions(makeDestination(), 0x90000000, 4)).toEqual([]);
+	});
+
+	it('returns [] for a zero box-region count', () => {
+		expect(detectTriggerIdCollisions(makeDestination(), 100, 0)).toEqual([]);
+	});
+
+	it('does not treat spawn / roaming entries as id collisions', () => {
+		// spawn / roaming carry no mId; a starting id in their range never collides.
+		const dest = makeDestination({
+			landmarks: [],
+			genericRegions: [],
+			blackspots: [],
+			vfxBoxRegions: [],
+		});
+		expect(detectTriggerIdCollisions(dest, 0, 100)).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// previewBoxRegionCount
+// ---------------------------------------------------------------------------
+
+describe('previewBoxRegionCount', () => {
+	it('sums only the four box-region lists, excluding spawn / roaming', () => {
+		const env = envelopeFrom(makeDestination(), [
+			{ listKey: 'landmarks', index: 0 },
+			{ listKey: 'genericRegions', index: 0 },
+			{ listKey: 'spawnLocations', index: 0 },
+			{ listKey: 'roamingLocations', index: 0 },
+		]);
+		const preview = buildTriggerImportPreview(env, makeDestination(), 'append');
+		// 2 box regions (landmark + generic); spawn + roaming excluded.
+		expect(previewBoxRegionCount(preview)).toBe(2);
+	});
+
+	it('is 0 for a spawn-only import', () => {
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'spawnLocations', index: 0 }]);
+		const preview = buildTriggerImportPreview(env, makeDestination(), 'append');
+		expect(previewBoxRegionCount(preview)).toBe(0);
 	});
 });
 

--- a/src/components/workspace/triggerDataBulkImportDialog.helpers.ts
+++ b/src/components/workspace/triggerDataBulkImportDialog.helpers.ts
@@ -26,6 +26,12 @@ import type {
 	TriggerDataBulkListKey,
 } from '@/lib/clipboard/triggerDataBulkExport';
 import type { ParsedTriggerData } from '@/lib/core/triggerData';
+import { parseStartingId } from './bulkImportDialog.helpers';
+
+// The Starting-ID parser is resource-agnostic (decimal / 0x hex → u32 | null).
+// Re-export the AI dialog's implementation so both import dialogs share ONE
+// parser rather than drifting.
+export { parseStartingId };
 
 const RESOURCE_KEY = 'triggerData';
 
@@ -39,6 +45,26 @@ export const TRIGGER_PREVIEW_LIST_ORDER: readonly TriggerDataBulkListKey[] = [
 	'spawnLocations',
 	'roamingLocations',
 ];
+
+/** The lists that carry a box-region mId — the only imported entries that
+ *  consume ids and can collide with a starting id. spawn / roaming carry no
+ *  mId and are excluded. */
+export const BOX_REGION_LIST_KEYS: readonly TriggerDataBulkListKey[] = [
+	'landmarks',
+	'genericRegions',
+	'blackspots',
+	'vfxBoxRegions',
+];
+
+/** Sum the four box-region list counts in a preview — the number of mIds the
+ *  import will consume, for collision detection against the starting id. */
+export function previewBoxRegionCount(preview: TriggerImportPreview): number {
+	const boxKeys = new Set<TriggerDataBulkListKey>(BOX_REGION_LIST_KEYS);
+	return preview.perList.reduce(
+		(sum, l) => (boxKeys.has(l.listKey) ? sum + l.count : sum),
+		0,
+	);
+}
 
 // Each branch carries a field absent on the other (`reason?: undefined` /
 // `envelope?: undefined`) so narrowing on `ok` works under the project's
@@ -107,15 +133,17 @@ export type TriggerImportPreview = {
 /**
  * Build the live preview for a decoded envelope against a destination + mode.
  * Runs the real import so the displayed ranges are EXACTLY what Confirm will
- * assign — no parallel math to drift out of sync.
+ * assign — no parallel math to drift out of sync. `startId`, when provided,
+ * seeds the previewed assignedIdRange to the user's chosen base mId.
  */
 export function buildTriggerImportPreview(
 	envelope: BulkEnvelope<TriggerDataBulkItem>,
 	destination: ParsedTriggerData,
 	mode: TriggerImportMode,
+	startId?: number,
 ): TriggerImportPreview {
 	try {
-		const out = importTriggerDataBulk({ envelope, destination, mode });
+		const out = importTriggerDataBulk({ envelope, destination, mode, startId });
 		const perList: TriggerPreviewListCount[] = TRIGGER_PREVIEW_LIST_ORDER.map(
 			(listKey) => ({ listKey, count: out.perListCounts[listKey] }),
 		);
@@ -140,6 +168,49 @@ export function buildTriggerImportPreview(
 			error: err instanceof Error ? err.message : String(err),
 		};
 	}
+}
+
+/** The four box-region lists that carry an mId. Only these consume mIds —
+ *  spawn / roaming locations do not, so they never collide with a starting id. */
+function boxRegionIds(destination: ParsedTriggerData): number[] {
+	return [
+		...destination.landmarks.map((r) => r.id),
+		...destination.genericRegions.map((r) => r.id),
+		...destination.blackspots.map((r) => r.id),
+		...destination.vfxBoxRegions.map((r) => r.id),
+	];
+}
+
+/** Suggest a starting mId high enough to sit above every box-region id already
+ *  in the destination: `max(existing box-region id) + 1`, or 0 when the
+ *  destination carries no box regions. Mirrors the AI dialog's default. */
+export function defaultTriggerStartId(destination: ParsedTriggerData): number {
+	let max = -1;
+	for (const id of boxRegionIds(destination)) {
+		if (id > max) max = id;
+	}
+	return (max + 1) >>> 0;
+}
+
+/** Ids in `[startId, startId + boxRegionCount - 1]` that already exist among the
+ *  destination's four box-region lists, sorted ascending. Only box regions
+ *  consume mIds, so spawn / roaming counts must be excluded from
+ *  `boxRegionCount` by the caller. */
+export function detectTriggerIdCollisions(
+	destination: ParsedTriggerData,
+	startId: number,
+	boxRegionCount: number,
+): number[] {
+	if (boxRegionCount <= 0) return [];
+	const lo = startId >>> 0;
+	const hi = (startId + boxRegionCount - 1) >>> 0;
+	const existing = new Set<number>();
+	for (const id of boxRegionIds(destination)) existing.add(id >>> 0);
+	const out: number[] = [];
+	for (let i = lo; i <= hi; i++) {
+		if (existing.has(i)) out.push(i);
+	}
+	return out;
 }
 
 /** Format a box-region id / index as a decimal+hex paired string

--- a/src/lib/clipboard/__tests__/triggerDataBulkImport.test.ts
+++ b/src/lib/clipboard/__tests__/triggerDataBulkImport.test.ts
@@ -331,6 +331,106 @@ describe('importTriggerDataBulk — append assigns fresh id + regionIndex', () =
 	});
 });
 
+describe('importTriggerDataBulk — startId override (mId base only)', () => {
+	it('seeds the first assigned mId from startId instead of the destination max', () => {
+		const dest = makeDestination();
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'genericRegions', index: 0 }]);
+		const out = importTriggerDataBulk({
+			envelope: env,
+			destination: dest,
+			mode: 'append',
+			startId: 0x90000000,
+		});
+		const imported = out.result.genericRegions[out.result.genericRegions.length - 1];
+		expect(imported.id).toBe(0x90000000);
+		expect(out.assignedIdRange).toEqual({ firstId: 0x90000000, lastId: 0x90000000 });
+	});
+
+	it('assigns sequential mIds counting up from startId across box lists', () => {
+		const dest = makeDestination();
+		const env = envelopeFrom(makeDestination(), [
+			{ listKey: 'landmarks', index: 0 },
+			{ listKey: 'genericRegions', index: 0 },
+			{ listKey: 'blackspots', index: 0 },
+			{ listKey: 'vfxBoxRegions', index: 0 },
+		]);
+		const out = importTriggerDataBulk({
+			envelope: env,
+			destination: dest,
+			mode: 'append',
+			startId: 5000,
+		});
+		expect(out.assignedIdRange).toEqual({ firstId: 5000, lastId: 5003 });
+		const importedIds = [
+			out.result.landmarks[out.result.landmarks.length - 1].id,
+			out.result.genericRegions[out.result.genericRegions.length - 1].id,
+			out.result.blackspots[out.result.blackspots.length - 1].id,
+			out.result.vfxBoxRegions[out.result.vfxBoxRegions.length - 1].id,
+		];
+		expect(importedIds).toEqual([5000, 5001, 5002, 5003]);
+	});
+
+	it('leaves regionIndex on the auto path (above the destination max) regardless of startId', () => {
+		// Destination box maxes: regionIndex 3 (vfx). startId is a huge mId, but
+		// regionIndex must still take max+1 = 4.
+		const dest = makeDestination();
+		const before = boxMaxes(dest);
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'blackspots', index: 0 }]);
+		const out = importTriggerDataBulk({
+			envelope: env,
+			destination: dest,
+			mode: 'append',
+			startId: 0x90000000,
+		});
+		const imported = out.result.blackspots[out.result.blackspots.length - 1];
+		expect(imported.regionIndex).toBe(before.ri + 1);
+		expect(out.assignedRegionIndexRange).toEqual({ first: before.ri + 1, last: before.ri + 1 });
+	});
+
+	it('is byte-identical to the default when startId is omitted', () => {
+		const dest = makeDestination();
+		const env = envelopeFrom(makeDestination(), [
+			{ listKey: 'genericRegions', index: 0 },
+			{ listKey: 'blackspots', index: 0 },
+		]);
+		const omitted = importTriggerDataBulk({ envelope: env, destination: dest, mode: 'append' });
+		const explicit = importTriggerDataBulk({
+			envelope: env,
+			destination: dest,
+			mode: 'append',
+			startId: boxMaxes(dest).id + 1,
+		});
+		expect(explicit.assignedIdRange).toEqual(omitted.assignedIdRange);
+		expect(allBoxRegionIds(explicit.result)).toEqual(allBoxRegionIds(omitted.result));
+	});
+
+	it('ignores a non-finite startId, falling back to the default base', () => {
+		const dest = makeDestination();
+		const before = boxMaxes(dest);
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'genericRegions', index: 0 }]);
+		const out = importTriggerDataBulk({
+			envelope: env,
+			destination: dest,
+			mode: 'append',
+			startId: Number.NaN,
+		});
+		expect(out.assignedIdRange).toEqual({ firstId: before.id + 1, lastId: before.id + 1 });
+	});
+
+	it('leaves ranges null for a spawn-only import even with a startId', () => {
+		const dest = makeDestination();
+		const env = envelopeFrom(makeDestination(), [{ listKey: 'spawnLocations', index: 0 }]);
+		const out = importTriggerDataBulk({
+			envelope: env,
+			destination: dest,
+			mode: 'append',
+			startId: 5000,
+		});
+		expect(out.assignedIdRange).toBeNull();
+		expect(out.assignedRegionIndexRange).toBeNull();
+	});
+});
+
 describe('importTriggerDataBulk — replace mode', () => {
 	it('empties only the lists present in the envelope, leaving others intact', () => {
 		const dest = makeDestination();

--- a/src/lib/clipboard/triggerDataBulkImport.ts
+++ b/src/lib/clipboard/triggerDataBulkImport.ts
@@ -24,6 +24,13 @@
 //   that points at the old id could resolve to the wrong (imported) region.
 //   Fresh ids above the destination max guarantee no collision.
 //
+// An optional `startId` overrides the base mId of the first appended box
+// region only; subsequent regions increment from there. regionIndex is NOT
+// affected — it stays auto-assigned above the destination's current max
+// because it is the writer's consolidated-region-table sort key (dense +
+// unique across all four box lists), not a user-tracked id. Omitting startId
+// keeps the historical behaviour (mId base = destination max + 1).
+//
 // regionIndex is i16 on disk (writeI16 in the writer). We guard against
 // overflow past 32767 with a clear error rather than silently wrapping
 // negative — a wrapped index sorts wrong and corrupts the region table.
@@ -70,6 +77,11 @@ export type TriggerDataBulkImportInput = {
 	envelope: BulkEnvelope<TriggerDataBulkItem>;
 	destination: ParsedTriggerData;
 	mode: TriggerImportMode;
+	/** Base mId for the first appended box region. When provided and finite,
+	 *  overrides the default (destination box-region max + 1) for the mId only;
+	 *  regionIndex still auto-assigns above the destination max. Omitted →
+	 *  historical behaviour. */
+	startId?: number;
 };
 
 export type TriggerDataBulkImportResult = {
@@ -145,7 +157,7 @@ function spawnFromWire(wire: WireSpawnLocation): SpawnLocation {
 export function importTriggerDataBulk(
 	input: TriggerDataBulkImportInput,
 ): TriggerDataBulkImportResult {
-	const { envelope, destination, mode } = input;
+	const { envelope, destination, mode, startId } = input;
 
 	if (envelope.resourceKey !== RESOURCE_KEY) {
 		throw new Error(
@@ -202,7 +214,13 @@ export function importTriggerDataBulk(
 		spawnLocations,
 		roamingLocations,
 	};
-	let nextId = maxBoxRegionId(working) + 1;
+	// startId overrides the mId base only; regionIndex stays auto-assigned above
+	// the destination max (it is the writer's region-table sort key, not a
+	// user-tracked id).
+	let nextId =
+		startId !== undefined && Number.isFinite(startId)
+			? startId >>> 0
+			: maxBoxRegionId(working) + 1;
 	let nextRegionIndex = maxBoxRegionIndex(working) + 1;
 
 	const perListCounts: Record<TriggerDataBulkListKey, number> = {


### PR DESCRIPTION
Two follow-ups from feedback on the TriggerData bulk feature (#142).

## 1. Yellow bulk marking for trigger boxes & spawns

Bulk-selected triggers now show the yellow highlight in the 3D viewport. Previously only **roaming dots** painted it (they use `useInstancedSelection`); the four box kinds (landmarks / generic / blackspots / VFX) and spawn cones never read the bulk set — so a bulk selection of boxes looked unmarked.

- `BatchedRegionBoxes` and `SpawnArrows` now colour bulk members `SELECTION_THEME.bulk`, precedence **primary > hover > bulk > base** (matching the hook + AI Sections).
- The precedence decision is extracted to a pure, fully unit-tested helper (`triggerOverlayColors.ts`) shared by the box paint loop and the spawn material chooser, so they can't drift from each other or from `useInstancedSelection`.
- Closes the 3D-paint gap for these kinds (tracked in #69).

## 2. Starting ID field in the import dialog

Mirrors the AI Sections import dialog. When pasting a bulk into a new file, the user can now set the base **mId** assigned to appended box-regions:

- Decimal or `0x` hex input, defaulted to `max existing id + 1`, with a **non-blocking collision warning** when the chosen range overlaps existing ids.
- `regionIndex` keeps auto-assigning above the destination max — it's the internal region-table sort key, not a user-tracked id, so it stays out of the UI. One field, matching AI's single Starting-ID.

Implementation:
- `triggerDataBulkImport.ts` — optional `startId` seeds the mId base; omitting it is byte-identical to the previous behaviour.
- `triggerDataBulkImportDialog.helpers.ts` — `parseStartingId` (reused from the AI helper — one shared parser), `defaultTriggerStartId`, `detectTriggerIdCollisions`; `startId` threaded through `buildTriggerImportPreview` so the live preview's assigned-id range reflects the choice.
- `TriggerDataBulkImportDialog.tsx` + new `TriggerStartIdField.tsx` sub-block.

## Verification

77 TriggerData tests green (9 new colour-precedence tests + extended `startId` pipeline/helper coverage), typecheck clean. The colour helper and the `startId` assignment math are pure and fully covered; the viewport paint and dialog wiring follow the existing spec-test convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
