### PR TITLE
feat(triggerData): amber bulk marking + count badge on trigger rows in the hierarchy tree

### DIFF
--- a/src/components/workspace/WorkspaceHierarchy.helpers.ts
+++ b/src/components/workspace/WorkspaceHierarchy.helpers.ts
@@ -696,3 +696,53 @@ export function buildWorkspaceFlat({
 
 	return out;
 }
+
+// ---------------------------------------------------------------------------
+// Bulk-row accent resolution
+// ---------------------------------------------------------------------------
+
+// True when `schemaPath` sits at or strictly underneath any bulk-member key.
+// aiSections and triggerData normalise a clicked sub-path (a portal row, a
+// box.position row) to its containing entry when it enters the bulk Set, so a
+// sub-row must inherit the parent entry's amber accent via prefix match —
+// otherwise only the (often-collapsed) top-level entry row would light up.
+export function isPathInsideBulkMember(
+	schemaPath: NodePath,
+	bulkKeys: ReadonlySet<string>,
+): boolean {
+	for (const key of bulkKeys) {
+		const parts = key.split('/');
+		if (parts.length > schemaPath.length) continue;
+		let prefixOk = true;
+		for (let i = 0; i < parts.length; i++) {
+			// Bulk keys store numeric indices stringified, so compare via String.
+			if (String(schemaPath[i]) !== parts[i]) {
+				prefixOk = false;
+				break;
+			}
+		}
+		if (prefixOk) return true;
+	}
+	return false;
+}
+
+// Whether a schema row should wear the bulk (amber) accent. Direct path-key
+// match applies to every bulk-eligible resource; the prefix match additionally
+// covers aiSections / triggerData, whose sub-paths collapse to a containing
+// entry in the bulk Set. PSL polygons are leaves (no sub-paths) → direct match
+// only.
+export function rowIsInBulk(
+	resourceKey: string,
+	schemaPath: NodePath,
+	activeBulkKeys: ReadonlySet<string> | null,
+): boolean {
+	if (!activeBulkKeys) return false;
+	if (activeBulkKeys.has(schemaPath.join('/'))) return true;
+	if (
+		(resourceKey === 'aiSections' || resourceKey === 'triggerData') &&
+		isPathInsideBulkMember(schemaPath, activeBulkKeys)
+	) {
+		return true;
+	}
+	return false;
+}

--- a/src/components/workspace/WorkspaceHierarchy.tsx
+++ b/src/components/workspace/WorkspaceHierarchy.tsx
@@ -37,6 +37,7 @@ import type { NodePath } from '@/lib/schema/walk';
 import {
 	bundleKey,
 	buildWorkspaceFlat,
+	rowIsInBulk,
 	type BundleFlatNode,
 	type FlatNode,
 	type InstanceFlatNode,
@@ -61,33 +62,6 @@ function selectionAnchorPath(
 	if (!selection) return [];
 	if (selection.resourceKey !== resourceKey) return [];
 	return selection.path ?? [];
-}
-
-// True when `schemaPath` lives strictly underneath any bulk-member section
-// path in `bulkKeys`. Used so a sub-row of a bulk-member section (a portal
-// row, a no-go-line row) inherits the amber tint — without this the only
-// row painted amber would be the top-level `Sec N` row, which is rarely
-// visible since users tend to expand into the section they care about.
-function isPathInsideBulkSection(
-	schemaPath: NodePath,
-	bulkKeys: ReadonlySet<string>,
-): boolean {
-	for (const key of bulkKeys) {
-		const parts = key.split('/');
-		if (parts.length > schemaPath.length) continue;
-		let prefixOk = true;
-		for (let i = 0; i < parts.length; i++) {
-			const ours = schemaPath[i];
-			// Bulk keys store numbers as their stringified form; equality
-			// must compare via toString to match either side.
-			if (String(ours) !== parts[i]) {
-				prefixOk = false;
-				break;
-			}
-		}
-		if (prefixOk) return true;
-	}
-	return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -433,6 +407,8 @@ export function WorkspaceHierarchy({ onAddBundle }: WorkspaceHierarchyProps) {
 									pslBulkPathKeys={bulk?.bulkPathKeys ?? null}
 									aiBulkGetPathKeys={aiBulk?.getPathKeys ?? null}
 									aiBulkGetCount={aiBulk?.getCount ?? null}
+									triggerBulkGetPathKeys={triggerBulk?.getPathKeys ?? null}
+									triggerBulkGetCount={triggerBulk?.getCount ?? null}
 									dragSource={dragSource}
 									dropTarget={dropTarget}
 									onReorderDragStart={onReorderDragStart}
@@ -496,6 +472,14 @@ type HierarchyRowProps = {
 	/** Cheap count lookup for the resource-type-row Badge. Same null-vs-fn
 	 *  contract as `aiBulkGetPathKeys`. */
 	aiBulkGetCount: ((bundleId: string, index: number) => number) | null;
+	/** TriggerData bulk path-key lookup for `(bundleId, index)` — drives the
+	 *  amber tint on trigger schema rows. Same null-vs-fn contract as
+	 *  `aiBulkGetPathKeys`. */
+	triggerBulkGetPathKeys:
+		| ((bundleId: string, index: number) => ReadonlySet<string> | null)
+		| null;
+	/** Cheap count lookup for the trigger resource-type-row Badge. */
+	triggerBulkGetCount: ((bundleId: string, index: number) => number) | null;
 	// ---- Drag-to-reorder (record-list instance rows only) ----
 	/** The currently-dragged list item, or null when no drag is in flight.
 	 *  A row consults this to decide whether it's a valid drop target. */
@@ -632,16 +616,20 @@ function ResourceTypeRow({
 	onToggleExpansion,
 	onSelectResourceType,
 	aiBulkGetCount,
+	triggerBulkGetCount,
 }: HierarchyRowProps & { node: ResourceTypeFlatNode }) {
-	// Per-resource bulk badge. AI Sections is single-instance so the count
-	// reads directly off (bundleId, 0) — no fan-out across instances needed
-	// today. When a future resource grows multi-instance bulk support
-	// (e.g. PSL retrofitted onto the panel stack) this badge will need to
-	// sum over indices, but Slice 1 doesn't.
-	const aiCount =
-		node.resourceKey === 'aiSections' && aiBulkGetCount && !node.isMultiInstance
+	// Per-resource bulk badge. AI Sections and TriggerData are single-instance
+	// so the count reads directly off (bundleId, 0) — no fan-out across
+	// instances needed today. When a future resource grows multi-instance bulk
+	// support (e.g. PSL retrofitted onto the panel stack) this badge will need
+	// to sum over indices, but that isn't the case yet.
+	const bulkCount = node.isMultiInstance
+		? 0
+		: node.resourceKey === 'aiSections' && aiBulkGetCount
 			? aiBulkGetCount(node.bundleId, 0)
-			: 0;
+			: node.resourceKey === 'triggerData' && triggerBulkGetCount
+				? triggerBulkGetCount(node.bundleId, 0)
+				: 0;
 
 	return (
 		<div
@@ -683,13 +671,13 @@ function ResourceTypeRow({
 					<span className="text-[10px] opacity-70"> ({node.count})</span>
 				)}
 			</span>
-			{aiCount > 0 && (
+			{bulkCount > 0 && (
 				<Badge
 					variant="outline"
 					className="h-4 px-1 text-[10px] tabular-nums shrink-0 border-amber-500/60 text-amber-700"
-					title={`${aiCount} section${aiCount === 1 ? '' : 's'} in bulk`}
+					title={`${bulkCount} in bulk`}
 				>
-					{aiCount}
+					{bulkCount}
 				</Badge>
 			)}
 			{node.showVisibility && (
@@ -768,6 +756,7 @@ function SchemaRow({
 	onSelectSchema,
 	pslBulkPathKeys,
 	aiBulkGetPathKeys,
+	triggerBulkGetPathKeys,
 	dragSource,
 	dropTarget,
 	onReorderDragStart,
@@ -798,31 +787,25 @@ function SchemaRow({
 	const dropEdge =
 		dropTarget?.pathKey === node.pathKey ? dropTarget.edge : null;
 	// Resolve the right bulk-path-key set for THIS row's resource. PSL is a
-	// single global Set today (one bulk active at a time); AI sections is
-	// per-(bundleId, index) so the same row in two different bundles can be
-	// in or out of bulk independently.
+	// single global Set today (one bulk active at a time); AI sections and
+	// TriggerData are per-(bundleId, index) so the same row in two different
+	// bundles can be in or out of bulk independently.
 	const activeBulkKeys: ReadonlySet<string> | null =
 		node.resourceKey === 'polygonSoupList'
 			? pslBulkPathKeys
 			: node.resourceKey === 'aiSections' && aiBulkGetPathKeys
 				? aiBulkGetPathKeys(node.bundleId, node.index)
-				: null;
+				: node.resourceKey === 'triggerData' && triggerBulkGetPathKeys
+					? triggerBulkGetPathKeys(node.bundleId, node.index)
+					: null;
 
 	// Schema rows whose schema path is in the active bulk wear an amber
-	// border + faint amber tint — same accent as the legacy schema
-	// HierarchyTree so users coming from the per-resource page see the
-	// same cue. AI sections sub-paths normalise to their containing
-	// section path inside `onBulkToggle`, so e.g. clicking a portal row
-	// adds the section's path and the section's row goes amber — drilling
-	// deeper into the same section wears the amber too via prefix match.
-	const isInBulk =
-		activeBulkKeys != null &&
-		(activeBulkKeys.has(node.schemaPath.join('/')) ||
-			// Sub-paths inside a bulk-member section (e.g. clicking 'portals'
-			// under section 5) inherit the amber tint so the user sees the
-			// path THROUGH the bulk member, not just its top.
-			(node.resourceKey === 'aiSections' &&
-				isPathInsideBulkSection(node.schemaPath, activeBulkKeys)));
+	// border + faint amber tint — same accent as the 3D overlay's bulk
+	// colour so a curated multi-selection reads the same in the tree and the
+	// viewport. AI sections + TriggerData sub-paths normalise to their
+	// containing entry inside `onBulkToggle`, so a sub-row inherits the tint
+	// via prefix match (see rowIsInBulk).
+	const isInBulk = rowIsInBulk(node.resourceKey, node.schemaPath, activeBulkKeys);
 	return (
 		<div
 			className={cn(

--- a/src/components/workspace/__tests__/WorkspaceHierarchy.bulkMarking.test.ts
+++ b/src/components/workspace/__tests__/WorkspaceHierarchy.bulkMarking.test.ts
@@ -1,0 +1,102 @@
+// Covers the pure bulk-row accent resolution that drives the amber tint /
+// count badge on hierarchy rows. The precedence itself is trivial; the
+// load-bearing behaviour is the per-resource prefix rule: aiSections and
+// triggerData collapse a clicked sub-path to its containing entry, so a
+// sub-row must inherit the tint via prefix — while PSL polygons are leaves
+// and match by exact path only.
+
+import { describe, it, expect } from 'vitest';
+import {
+	isPathInsideBulkMember,
+	rowIsInBulk,
+} from '../WorkspaceHierarchy.helpers';
+
+describe('isPathInsideBulkMember', () => {
+	it('matches an exact entry path', () => {
+		expect(
+			isPathInsideBulkMember(['genericRegions', 3], new Set(['genericRegions/3'])),
+		).toBe(true);
+	});
+
+	it('matches a sub-path of a bulk-member entry (prefix)', () => {
+		expect(
+			isPathInsideBulkMember(
+				['genericRegions', 3, 'box', 'position', 'x'],
+				new Set(['genericRegions/3']),
+			),
+		).toBe(true);
+	});
+
+	it('does not match a sibling index', () => {
+		expect(
+			isPathInsideBulkMember(['genericRegions', 4], new Set(['genericRegions/3'])),
+		).toBe(false);
+	});
+
+	it('does not match across lists', () => {
+		expect(
+			isPathInsideBulkMember(['landmarks', 3], new Set(['genericRegions/3'])),
+		).toBe(false);
+	});
+
+	it('never treats a longer key as a prefix of a shorter path', () => {
+		expect(
+			isPathInsideBulkMember(['genericRegions'], new Set(['genericRegions/3'])),
+		).toBe(false);
+	});
+});
+
+describe('rowIsInBulk', () => {
+	it('returns false when there is no active bulk', () => {
+		expect(rowIsInBulk('triggerData', ['genericRegions', 3], null)).toBe(false);
+	});
+
+	it('tints a triggerData entry row on a direct match', () => {
+		expect(
+			rowIsInBulk('triggerData', ['genericRegions', 3], new Set(['genericRegions/3'])),
+		).toBe(true);
+	});
+
+	it('tints a triggerData sub-row via prefix (box field under a bulk entry)', () => {
+		expect(
+			rowIsInBulk(
+				'triggerData',
+				['genericRegions', 3, 'box', 'dimensions'],
+				new Set(['genericRegions/3']),
+			),
+		).toBe(true);
+	});
+
+	it('tints trigger entries across every bulk-eligible list', () => {
+		const keys = new Set([
+			'landmarks/0',
+			'blackspots/1',
+			'vfxBoxRegions/2',
+			'spawnLocations/3',
+			'roamingLocations/4',
+		]);
+		expect(rowIsInBulk('triggerData', ['landmarks', 0], keys)).toBe(true);
+		expect(rowIsInBulk('triggerData', ['blackspots', 1], keys)).toBe(true);
+		expect(rowIsInBulk('triggerData', ['vfxBoxRegions', 2], keys)).toBe(true);
+		expect(rowIsInBulk('triggerData', ['spawnLocations', 3], keys)).toBe(true);
+		expect(rowIsInBulk('triggerData', ['roamingLocations', 4], keys)).toBe(true);
+	});
+
+	it('does not tint a non-selected trigger row', () => {
+		expect(
+			rowIsInBulk('triggerData', ['genericRegions', 9], new Set(['genericRegions/3'])),
+		).toBe(false);
+	});
+
+	it('preserves the aiSections prefix behaviour (portal row under a bulk section)', () => {
+		expect(
+			rowIsInBulk('aiSections', ['sections', 5, 'portals', 0], new Set(['sections/5'])),
+		).toBe(true);
+	});
+
+	it('keeps PSL to exact-match only (a poly sub-row does NOT inherit the tint)', () => {
+		const keys = new Set(['polys/2']);
+		expect(rowIsInBulk('polygonSoupList', ['polys', 2], keys)).toBe(true);
+		expect(rowIsInBulk('polygonSoupList', ['polys', 2, 'verts', 0], keys)).toBe(false);
+	});
+});


### PR DESCRIPTION
Follow-up from feedback: _"starting ID is there, but my bad, meant yellow marking in the **list** of triggers."_

The bulk-selection highlight the user wanted is the amber row accent in the **hierarchy tree** (the trigger list), not the 3D viewport. AI Sections and PolygonSoupList rows already wear the amber border + faint tint (and the resource-type row shows a count badge) when they're in a bulk — but TriggerData rows didn't, because the tree's per-row bulk resolution had no `triggerData` branch. (The tree-row Ctrl/Shift toggling and the provider's `getPathKeys`/`getCount` were already wired — only the visual decoration was missing.)

## Changes

- **Extracted the row bulk-accent decision into pure helpers** in `WorkspaceHierarchy.helpers.ts`:
  - `isPathInsideBulkMember` (moved out of the `.tsx`) — prefix match for sub-rows.
  - `rowIsInBulk(resourceKey, schemaPath, activeBulkKeys)` — direct path-key match for every bulk-eligible resource; prefix match **additionally** for `aiSections`/`triggerData`, whose sub-paths collapse to a containing entry (so drilling into a bulk entry keeps the tint). PSL polygons stay exact-match only.
  - Fully unit-tested (12 cases) — the first coverage of this logic, which was previously inline and untested.
- **`WorkspaceHierarchy.tsx`**: thread `triggerBulk` `getPathKeys`/`getCount` into the rows; add the `triggerData` branch to `activeBulkKeys`; drive `isInBulk` through `rowIsInBulk`; generalise the resource-type-row count badge to cover trigger bulks.

The amber uses the same accent as AI/PSL rows, so a curated multi-selection reads consistently across the tree and the 3D overlay.

## Verification

64 hierarchy tests green (12 new bulk-marking + 32 existing `WorkspaceHierarchy` + reorder), typecheck clean on touched files, and `vite dev` compiles + serves the `/workspace` route (edited module transforms without import/parse errors). The amber CSS classes are the exact ones AI/PSL rows already use — this change just routes trigger rows through the same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
