### PR TITLE
Add crash-deformation MVP rigging tools

### DIFF
--- a/docs/deform-rig-tool.md
+++ b/docs/deform-rig-tool.md
@@ -1,0 +1,77 @@
+# Crash-deformation rigging tools
+
+Three `scripts/` tools for working with per-vehicle crash deformation
+(`DeformationSpec`, resource type `0x1001C`) and its companion graphics layout
+(`GraphicsSpec`, `0x10006`). They exist to give a **single-mesh vehicle** — a
+custom car whose body is one welded mesh plus wheels, with no separate panels —
+a working crash rig without re-modelling it.
+
+## Why single-mesh cars need special handling
+
+A normal Burnout car crumples because its body is split into ~26 separate
+graphics parts (bonnet, doors, bumpers, wings, …), each driven by its own IK
+part in the DeformationSpec: a hinge that bends and, past a threshold, detaches.
+A one-piece body has nothing to hinge, so grafting a paneled car's spec onto it
+drives the *wrong* meshes — panels fly off, a frame hovers, and FX locators land
+in empty space. The fix is a **minimal rig** that any body can carry: root + one
+soft body-shell + four wheels, no hinged panels and no glass. The whole body
+then dents as a single soft skin and never disintegrates.
+
+## The partType slot convention
+
+Across every retail vehicle spec, `IKPart.partType` is a stable slot id. The
+ones this toolset relies on:
+
+| partType | slot | notes |
+|---|---|---|
+| `999` | root / handling body | one per car, no graphics part |
+| `46` | body shell | carries the bulk of the soft-body tag points, no hinge |
+| `48` / `49` / `50` / `51` | wheels FL/FR/RL/RR | fixed IK parts; wheels detach via the wheel system, not an IK hinge |
+| `1`/`2`, `3`, `4`, `8`/`10`, `26`–`29`, … | bumpers, bonnet, boot, doors, wings | hinged, detachable panels |
+
+`scripts/parts-taxonomy.ts` derives the full table (position, hinge axis, fold
+angle, detach behaviour) empirically from a whole `VEHICLES/` folder.
+
+## Tools
+
+### `parts-taxonomy.ts` — learn the part template
+Joins every car's DeformationSpec IK parts to its real GraphicsSpec part
+positions and aggregates per-partType statistics.
+```
+npx tsx scripts/parts-taxonomy.ts --veh <VEHICLES dir> [--out parts-taxonomy.json]
+```
+
+### `deform-rig-mvp.ts` — auto-rig a single-mesh car
+Takes a **donor** car's spec (any normal car), keeps only the 6 IK parts above,
+deletes every panel and all glass, then box→box remaps every point (sensors, tag
+points, driven points, and the FX/camera/light locators) from the donor body
+extent onto the **target**'s real graphics-body AABB (decoded from its `_GR`).
+Wheels are placed at the target's real wheel-locator positions. The new spec is
+written into the target's own `_AT` bundle wrapper, so the target keeps its
+attribs/audio resources. Writes only to `--out`; never touches the game folder.
+```
+npx tsx scripts/deform-rig-mvp.ts \
+  --donor <normalCar_AT.BIN> --target-gr <target_GR.BIN> \
+  --target-at <target_AT.BIN> --out <out_AT.BIN> [--corners 0,1,21,22]
+```
+`--corners` names the gfx-part indices of the four wheels; omit it to
+auto-detect (the parts whose locator sits off the body origin). The script
+re-parses its own output and asserts the intended 6-part, no-glass, no-joint,
+all-points-inside-the-body rig before finishing.
+
+### `preview-deform.ts` — see whether a spec fits a body
+Renders a car body (GraphicsSpec-driven, LOD0, part-tinted) with every sensor
+(red) and tag point (cyan) drawn as a marker in the body's own model space, so a
+mis-aligned spec is visible as markers floating off the bodywork. Needs
+`headless-gl` (as `render-car.ts` does) and must run under node 22:
+```
+fnm exec --using=22 node node_modules/tsx/dist/cli.mjs scripts/preview-deform.ts \
+  --gr <_GR.BIN> --at <_AT.BIN> --tex <VEHICLETEX.BIN> --out <dir> [--size WxH]
+```
+
+## Scope
+
+This is an MVP: soft whole-body denting plus wheels, no detachable panels. Giving
+a single-mesh car *real* crumpling panels needs the body split into separate
+graphics parts first, which requires a GraphicsSpec/renderable writer that the
+codebase does not yet have.

--- a/scripts/deform-rig-mvp.ts
+++ b/scripts/deform-rig-mvp.ts
@@ -306,19 +306,35 @@ function main() {
 		else console.warn(`[wheels] no target locator for header wheel ${i}; keeping donor position`);
 	}
 
-	// No glass; handling box from the target; real gfx-part count.
+	// Write the new spec into the TARGET's own bundle wrapper (keeps its
+	// attribs/audio) AND adopt the target's own physics-positioning fields.
+	const targetAtAb = abOf(TARGET_AT!);
+	const targetAtBundle = parseBundle(targetAtAb);
+	const targetDsRes = targetAtBundle.resources.find((r) => r.resourceTypeId === DEFORMATION_SPEC_TYPE_ID);
+	if (!targetDsRes) throw new Error('target _AT has no DeformationSpec slot to overwrite');
+	const targetSpec = parseDeformationSpecData(extractResourceRaw(targetAtAb, targetAtBundle, targetDsRes));
+
+	// Preserve the TARGET's physics config: the handling-body box, the
+	// COM/mesh/rigid-body/collision offsets, the inertia tensor and the
+	// model->handling transform. These set the car's rest height and collision
+	// and are tuned per vehicle — using the donor's would sink or float a
+	// differently-proportioned body (an over-tall handling box sinks the car
+	// into the road). Only the deformation content (IK parts, tags, sensors)
+	// comes from the donor; the graphics AABB is used only to place those points.
+	model.handlingBodyDimensions = targetSpec.handlingBodyDimensions;
+	model.currentCOMOffset = targetSpec.currentCOMOffset;
+	model.meshOffset = targetSpec.meshOffset;
+	model.rigidBodyOffset = targetSpec.rigidBodyOffset;
+	model.collisionOffset = targetSpec.collisionOffset;
+	model.inertiaTensor = targetSpec.inertiaTensor;
+	model.carModelSpaceToHandlingBodySpace = targetSpec.carModelSpaceToHandlingBodySpace;
+
+	// No glass; real gfx-part count.
 	model.glassPanes = [];
-	model.handlingBodyDimensions = [tHalf[0], tHalf[1], tHalf[2], donor.handlingBodyDimensions[3]] as Vec4;
 	model.numGraphicsParts = geom.numGfxParts;
 	model.numVehicleBodies = 1;
 	model.numDeformationSensors = 20;
 
-	// Write the new spec into the TARGET's own bundle wrapper (keeps its attribs/audio).
-	const targetAtAb = abOf(TARGET_AT!);
-	const targetAtBundle = parseBundle(targetAtAb);
-	if (!targetAtBundle.resources.some((r) => r.resourceTypeId === DEFORMATION_SPEC_TYPE_ID)) {
-		throw new Error('target _AT has no DeformationSpec slot to overwrite');
-	}
 	const newSpecBytes = writeDeformationSpecData(model);
 	const outAb = writeBundleFresh(targetAtBundle, targetAtAb, { overrides: { resources: { [DEFORMATION_SPEC_TYPE_ID]: newSpecBytes } } });
 	fs.writeFileSync(OUT!, Buffer.from(outAb));

--- a/scripts/deform-rig-mvp.ts
+++ b/scripts/deform-rig-mvp.ts
@@ -1,0 +1,374 @@
+// Minimal crash-deformation auto-rigger (MVP).
+//
+// PURPOSE: give a single-mesh vehicle (e.g. a custom mod whose body is one
+// welded mesh + wheels, with no separate panels) a working, non-broken crash
+// rig, WITHOUT re-modelling it. A full paneled car crumples by hinging ~30
+// separate body parts; a one-piece body has nothing to hinge, so grafting a
+// paneled car's DeformationSpec drives the wrong meshes (panels fly off / a
+// frame hovers). This tool instead builds a MINIMAL rig that any body can carry:
+//   root + one soft body-shell + four wheels — no hinged panels, no glass.
+// The whole body then dents as a single soft skin and never disintegrates.
+//
+// HOW: take a DONOR car's DeformationSpec (any normal car carries the standard
+// part set), keep only 6 IK parts by partType — 999 (root), 46 (body shell),
+// 48/49/50/51 (wheels) — delete every hinged panel and all glass, then box->box
+// remap every point (sensors, tag points, driven points, and the FX/camera/light
+// locators) from the donor's body extent into the TARGET's real graphics-body
+// AABB (decoded from its _GR bundle). Wheels are placed at the target's real
+// wheel-locator positions. The new spec is written into the target's own _AT
+// bundle wrapper, preserving the target's attribs/audio resources.
+//
+// The DeformationSpec partType meaning (999 root, 46 body shell with the bulk of
+// the soft-body tag points, 48-51 wheels) is a stable slot convention observed
+// across every retail vehicle spec — see scripts/parts-taxonomy.ts.
+//
+// Run (pure parse/write, no GL — plain node/tsx is fine):
+//   npx tsx scripts/deform-rig-mvp.ts \
+//     --donor     <VEH_<donorCar>_AT.BIN>   (a normal car's rig, e.g. a coupe) \
+//     --target-gr <VEH_<target>_GR.BIN>     (the single-mesh car's geometry) \
+//     --target-at <VEH_<target>_AT.BIN>     (the target's own _AT; its attribs/audio are kept) \
+//     --out       <out_AT.BIN> \
+//     [--corners 0,1,21,22]   (gfx part indices of the 4 wheels; default: auto-detect non-origin parts)
+//
+// Never writes to the game folder — only to --out.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as THREE from 'three';
+import { parseBundle, writeBundleFresh } from '../src/lib/core/bundle';
+import { extractResourceRaw } from '../src/lib/core/registry';
+import {
+	parseDeformationSpecData,
+	writeDeformationSpecData,
+	DEFORMATION_SPEC_TYPE_ID,
+	type ParsedDeformationSpec,
+	type IKPart,
+	type TagPointSpec,
+	type DrivenPoint,
+	type Vec3,
+	type Vec4,
+} from '../src/lib/core/deformationSpec';
+import { parseGraphicsSpecData, resolveGraphicsSpecParts, GRAPHICS_SPEC_TYPE_ID } from '../src/lib/core/graphicsSpec';
+import { decodeAllRenderables, locatorToMatrix4 } from '../src/lib/core/renderableDecode';
+
+// --- args -------------------------------------------------------------------
+function arg(name: string): string | undefined {
+	const i = process.argv.indexOf(`--${name}`);
+	return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : undefined;
+}
+const DONOR = arg('donor');
+const TARGET_GR = arg('target-gr');
+const TARGET_AT = arg('target-at');
+const OUT = arg('out');
+const CORNERS_ARG = arg('corners');
+if (!DONOR || !TARGET_GR || !TARGET_AT || !OUT) {
+	throw new Error(
+		'usage: --donor <_AT.BIN> --target-gr <_GR.BIN> --target-at <_AT.BIN> --out <_AT.BIN> [--corners a,b,c,d]',
+	);
+}
+
+// The 6 IK part types the MVP keeps (stable partType slots; see parts-taxonomy.ts).
+const ROOT = 999, BODY_SHELL = 46;
+const WHEEL_TYPES = [48, 49, 50, 51]; // FL, FR, RL, RR
+const KEEP_TYPES = new Set([ROOT, BODY_SHELL, ...WHEEL_TYPES]);
+const NEVER_DETACH = 9995; // runtime sentinel: a tag point at/above this never detaches
+const CORNER_EPS = 0.1;    // a gfx part this far off the body origin counts as a wheel/corner
+
+function abOf(p: string): ArrayBuffer {
+	const b = fs.readFileSync(p);
+	// A Node Buffer views a shared pool — slice out this file's own bytes.
+	return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
+}
+
+type Vec3T = { x: number; y: number; z: number };
+
+// =============================================================================
+// Decode the target body geometry from its _GR bundle.
+// =============================================================================
+
+type TargetGeom = {
+	min: Vec3T; max: Vec3T; center: Vec3T; half: Vec3T;
+	bodyIdx: number;                          // gfx index of the largest body part
+	wheelSlotToGfx: Record<number, number>;   // partType(48/49/50/51) -> gfx idx
+	wheelSlotToPos: Record<number, Vec3>;     // partType -> [x,y,z] locator translation
+	numGfxParts: number;
+	corners: Set<number>;
+};
+
+function decodeTargetGeometry(grPath: string): TargetGeom {
+	const ab = abOf(grPath);
+	const bundle = parseBundle(ab);
+
+	const gsRes = bundle.resources.find((r) => r.resourceTypeId === GRAPHICS_SPEC_TYPE_ID);
+	if (!gsRes) throw new Error('target _GR has no GraphicsSpec (0x10006)');
+	const gs = parseGraphicsSpecData(extractResourceRaw(ab, bundle, gsRes));
+	const parts = resolveGraphicsSpecParts(ab, bundle, gs); // index == gfx index
+	const numGfxParts = parts.length;
+	console.log(`[geom] GraphicsSpec parts: ${numGfxParts}`);
+
+	// Corners (wheels) = explicit --corners, else auto: parts whose locator sits
+	// off the body origin. A single-mesh body keeps every panel at the origin, so
+	// the only non-origin parts are the wheels.
+	const corners = new Set<number>();
+	if (CORNERS_ARG) {
+		for (const s of CORNERS_ARG.split(',')) corners.add(Number(s.trim()));
+	} else {
+		for (let i = 0; i < numGfxParts; i++) {
+			const l = parts[i].locator;
+			if (Math.hypot(l[12], l[13], l[14]) > CORNER_EPS) corners.add(i);
+		}
+	}
+	console.log(`[geom] corner/wheel gfx parts: {${[...corners].sort((a, b) => a - b).join(', ')}}`);
+	if (corners.size !== 4) console.warn(`[geom] WARNING: expected 4 wheel/corner parts, found ${corners.size}`);
+
+	const { renderables } = decodeAllRenderables(ab, bundle, new Map(), false, 'graphics');
+	const byRid = new Map<bigint, (typeof renderables)[number]>();
+	for (const d of renderables) byRid.set(d.resourceId, d);
+
+	const partBox = (i: number): THREE.Box3 | null => {
+		const part = parts[i];
+		if (part.renderableId == null) return null;
+		const d = byRid.get(part.renderableId);
+		if (!d || d.meshes.length === 0) return null;
+		const m = locatorToMatrix4(part.locator);
+		const box = new THREE.Box3();
+		let any = false;
+		for (const mesh of d.meshes) {
+			if (!mesh.geometry.boundingBox) mesh.geometry.computeBoundingBox();
+			const bb = mesh.geometry.boundingBox;
+			if (!bb) continue;
+			box.union(bb.clone().applyMatrix4(m));
+			any = true;
+		}
+		return any ? box : null;
+	};
+
+	// Body AABB = union over all NON-corner parts; bodyIdx = the largest of them.
+	const bodyBox = new THREE.Box3();
+	let bodyBoxHasAny = false, bodyIdx = -1, bestVol = -1;
+	for (let i = 0; i < numGfxParts; i++) {
+		if (corners.has(i)) continue;
+		const b = partBox(i);
+		if (!b) continue;
+		bodyBox.union(b);
+		bodyBoxHasAny = true;
+		const size = b.getSize(new THREE.Vector3());
+		const vol = size.x * size.y * size.z;
+		if (vol > bestVol) { bestVol = vol; bodyIdx = i; }
+	}
+	if (!bodyBoxHasAny) throw new Error('no body meshes decoded for target');
+
+	const mn = bodyBox.min, mx = bodyBox.max;
+	const center: Vec3T = { x: (mn.x + mx.x) / 2, y: (mn.y + mx.y) / 2, z: (mn.z + mx.z) / 2 };
+	const half: Vec3T = { x: (mx.x - mn.x) / 2, y: (mx.y - mn.y) / 2, z: (mx.z - mn.z) / 2 };
+
+	// Corner parts -> wheel slot by sign of locator translation:
+	//   x<0,z>0 = 48 FL   x>0,z>0 = 49 FR   x<0,z<0 = 50 RL   x>0,z<0 = 51 RR
+	const wheelSlotToGfx: Record<number, number> = {};
+	const wheelSlotToPos: Record<number, Vec3> = {};
+	for (const i of corners) {
+		if (i >= numGfxParts) continue;
+		const l = parts[i].locator;
+		const x = l[12], y = l[13], z = l[14];
+		const slot = x < 0 && z > 0 ? 48 : x > 0 && z > 0 ? 49 : x < 0 && z < 0 ? 50 : 51;
+		wheelSlotToGfx[slot] = i;
+		wheelSlotToPos[slot] = [x, y, z];
+	}
+	console.log(`[geom] bodyIdx=${bodyIdx} center=${JSON.stringify(center)} half=${JSON.stringify(half)}`);
+
+	return {
+		min: { x: mn.x, y: mn.y, z: mn.z }, max: { x: mx.x, y: mx.y, z: mx.z },
+		center, half, bodyIdx, wheelSlotToGfx, wheelSlotToPos, numGfxParts, corners,
+	};
+}
+
+// =============================================================================
+// Rig
+// =============================================================================
+
+function main() {
+	fs.mkdirSync(path.dirname(OUT!), { recursive: true });
+
+	// Donor DeformationSpec.
+	const donorAb = abOf(DONOR!);
+	const donorBundle = parseBundle(donorAb);
+	const donorRes = donorBundle.resources.find((r) => r.resourceTypeId === DEFORMATION_SPEC_TYPE_ID);
+	if (!donorRes) throw new Error('donor _AT has no DeformationSpec (0x1001C)');
+	const donor = parseDeformationSpecData(extractResourceRaw(donorAb, donorBundle, donorRes));
+	console.log(`[donor] ik=${donor.ikParts.length} tag=${donor.tagPoints.length} glass=${donor.glassPanes.length} `
+		+ `partTypes=[${donor.ikParts.map((p) => p.partType).join(',')}]`);
+
+	// Donor body box (over its tag points) for the remap source extent.
+	const p12min: Vec3 = [Infinity, Infinity, Infinity];
+	const p12max: Vec3 = [-Infinity, -Infinity, -Infinity];
+	for (const t of donor.tagPoints) for (let k = 0; k < 3; k++) {
+		p12min[k] = Math.min(p12min[k], t.initialPosition[k]);
+		p12max[k] = Math.max(p12max[k], t.initialPosition[k]);
+	}
+	const dCenter: Vec3 = [(p12min[0] + p12max[0]) / 2, (p12min[1] + p12max[1]) / 2, (p12min[2] + p12max[2]) / 2];
+	const dHalf: Vec3 = [(p12max[0] - p12min[0]) / 2, (p12max[1] - p12min[1]) / 2, (p12max[2] - p12min[2]) / 2];
+
+	// Target geometry + box->box remap.
+	const geom = decodeTargetGeometry(TARGET_GR!);
+	const tCenter: Vec3 = [geom.center.x, geom.center.y, geom.center.z];
+	const tHalf: Vec3 = [geom.half.x, geom.half.y, geom.half.z];
+	const scale: Vec3 = [0, 1, 2].map((k) => (Math.abs(dHalf[k]) < 1e-4 ? 1 : tHalf[k] / dHalf[k])) as Vec3;
+	console.log(`[remap] scale=${scale.map((v) => v.toFixed(3))}`);
+	const R = (p: Vec3): Vec3 => [
+		tCenter[0] + (p[0] - dCenter[0]) * scale[0],
+		tCenter[1] + (p[1] - dCenter[1]) * scale[1],
+		tCenter[2] + (p[2] - dCenter[2]) * scale[2],
+	];
+
+	const model: ParsedDeformationSpec = JSON.parse(JSON.stringify(donor));
+
+	// Keep only the 6 IK parts (first occurrence per type, donor order).
+	const kept: IKPart[] = [];
+	const seen = new Set<number>();
+	const oldPartIndexOfKept: number[] = [];
+	model.ikParts.forEach((p, i) => {
+		if (KEEP_TYPES.has(p.partType) && !seen.has(p.partType)) {
+			seen.add(p.partType); kept.push(p); oldPartIndexOfKept.push(i);
+		}
+	});
+	for (const t of KEEP_TYPES) if (!seen.has(t)) throw new Error(`donor missing required IK partType ${t}`);
+	const oldToNewPart = new Map<number, number>();
+	oldPartIndexOfKept.forEach((oldIdx, newIdx) => oldToNewPart.set(oldIdx, newIdx));
+	const newBodyShellPartIdx = kept.findIndex((p) => p.partType === BODY_SHELL);
+
+	// Rebuild global tagPoints / drivenPoints from the kept parts' slices.
+	const newTagPoints: TagPointSpec[] = [];
+	const oldToNewTag = new Map<number, number>();
+	let tagCursor = 0;
+	for (const part of kept) {
+		const s = part.startIndexOfTagPoints, n = part.numberOfTagPoints;
+		part.startIndexOfTagPoints = tagCursor;
+		for (let k = 0; k < n; k++) { oldToNewTag.set(s + k, tagCursor); newTagPoints.push(donor.tagPoints[s + k]); tagCursor++; }
+	}
+	const newDrivenPoints: DrivenPoint[] = [];
+	let drivenCursor = 0, danglingDriven = 0;
+	for (const part of kept) {
+		const s = part.startIndexOfDrivenPoints, n = part.numberOfDrivenPoints;
+		part.startIndexOfDrivenPoints = drivenCursor;
+		for (let k = 0; k < n; k++) {
+			const dp: DrivenPoint = JSON.parse(JSON.stringify(donor.drivenPoints[s + k]));
+			const mapIdx = (idx: number) => { if (idx < 0) return idx; const nn = oldToNewTag.get(idx); if (nn === undefined) { danglingDriven++; return -1; } return nn; };
+			dp.tagPointIndexA = mapIdx(dp.tagPointIndexA);
+			dp.tagPointIndexB = mapIdx(dp.tagPointIndexB);
+			newDrivenPoints.push(dp); drivenCursor++;
+		}
+	}
+	if (danglingDriven) console.warn(`[rig] ${danglingDriven} driven-point tag refs pointed at deleted parts -> -1`);
+
+	// Remap every point onto the target body: sensors first (they feed tag offsets),
+	// then tag points (recomputing offsetFromA/B), driven points, and the
+	// transform-tag locator translations (FX / camera / light locators).
+	for (const ssr of model.sensors) ssr.initialOffset = R(ssr.initialOffset as Vec3);
+	for (const t of newTagPoints) {
+		t.initialPosition = R(t.initialPosition as Vec3);
+		const a = t.deformationSensorA, b = t.deformationSensorB;
+		if (a >= 0 && a < model.sensors.length) { const so = model.sensors[a].initialOffset; t.offsetFromA = [t.initialPosition[0] - so[0], t.initialPosition[1] - so[1], t.initialPosition[2] - so[2]]; }
+		if (b >= 0 && b < model.sensors.length) { const so = model.sensors[b].initialOffset; t.offsetFromB = [t.initialPosition[0] - so[0], t.initialPosition[1] - so[1], t.initialPosition[2] - so[2]]; }
+	}
+	for (const d of newDrivenPoints) d.initialPos = R(d.initialPos as Vec3);
+	for (const arr of [model.genericTags, model.cameraTags, model.lightTags]) for (const tag of arr) {
+		const tr = R([tag.locator[3][0], tag.locator[3][1], tag.locator[3][2]]);
+		tag.locator[3][0] = tr[0]; tag.locator[3][1] = tr[1]; tag.locator[3][2] = tr[2];
+		// Keep transform-tag ikPartIndex in-bounds after deletion: remap to the kept
+		// part, else re-anchor to the body shell so the locator binds to a live part.
+		if (tag.ikPartIndex >= 0) { const nn = oldToNewPart.get(tag.ikPartIndex); tag.ikPartIndex = nn !== undefined ? nn : newBodyShellPartIdx; }
+	}
+
+	// Fix up kept parts: no joints anywhere; body shell -> target body gfx +
+	// never-detach; wheels -> matching corner gfx; root -> -1.
+	for (const part of kept) {
+		part.jointSpecs = [];
+		if (part.partType === ROOT) {
+			part.partGraphics = -1;
+		} else if (part.partType === BODY_SHELL) {
+			part.partGraphics = geom.bodyIdx;
+			const s = part.startIndexOfTagPoints, n = part.numberOfTagPoints;
+			for (let k = 0; k < n; k++) { const t = newTagPoints[s + k]; t.detachThreshold = NEVER_DETACH; t.fDetachThresholdSquared = NEVER_DETACH * NEVER_DETACH; }
+		} else {
+			const g = geom.wheelSlotToGfx[part.partType];
+			part.partGraphics = g !== undefined ? g : -1;
+		}
+	}
+	model.ikParts = kept;
+	model.tagPoints = newTagPoints;
+	model.drivenPoints = newDrivenPoints;
+
+	// Header wheel mounts (order FR,FL,RR,RL) -> target wheel positions.
+	const headerOrder = [49, 48, 51, 50];
+	for (let i = 0; i < 4; i++) {
+		const pos = geom.wheelSlotToPos[headerOrder[i]];
+		if (pos) model.wheels[i].position = [pos[0], pos[1], pos[2], 1] as Vec4;
+		else console.warn(`[wheels] no target locator for header wheel ${i}; keeping donor position`);
+	}
+
+	// No glass; handling box from the target; real gfx-part count.
+	model.glassPanes = [];
+	model.handlingBodyDimensions = [tHalf[0], tHalf[1], tHalf[2], donor.handlingBodyDimensions[3]] as Vec4;
+	model.numGraphicsParts = geom.numGfxParts;
+	model.numVehicleBodies = 1;
+	model.numDeformationSensors = 20;
+
+	// Write the new spec into the TARGET's own bundle wrapper (keeps its attribs/audio).
+	const targetAtAb = abOf(TARGET_AT!);
+	const targetAtBundle = parseBundle(targetAtAb);
+	if (!targetAtBundle.resources.some((r) => r.resourceTypeId === DEFORMATION_SPEC_TYPE_ID)) {
+		throw new Error('target _AT has no DeformationSpec slot to overwrite');
+	}
+	const newSpecBytes = writeDeformationSpecData(model);
+	const outAb = writeBundleFresh(targetAtBundle, targetAtAb, { overrides: { resources: { [DEFORMATION_SPEC_TYPE_ID]: newSpecBytes } } });
+	fs.writeFileSync(OUT!, Buffer.from(outAb));
+	console.log(`[write] spec ${newSpecBytes.length} B -> bundle ${outAb.byteLength} B -> ${OUT}`);
+
+	verifyOutput(geom, tHalf);
+}
+
+// =============================================================================
+// Verify the written bundle re-parses to the intended minimal rig.
+// =============================================================================
+
+function inside(p: Vec3, mn: Vec3T, mx: Vec3T, margin: Vec3): boolean {
+	return p[0] >= mn.x - margin[0] && p[0] <= mx.x + margin[0]
+		&& p[1] >= mn.y - margin[1] && p[1] <= mx.y + margin[1]
+		&& p[2] >= mn.z - margin[2] && p[2] <= mx.z + margin[2];
+}
+
+function verifyOutput(geom: TargetGeom, tHalf: Vec3) {
+	const ab = abOf(OUT!);
+	const bundle = parseBundle(ab);
+	const res = bundle.resources.find((r) => r.resourceTypeId === DEFORMATION_SPEC_TYPE_ID)!;
+	const m = parseDeformationSpecData(extractResourceRaw(ab, bundle, res));
+
+	const partTypes = m.ikParts.map((p) => p.partType).sort((a, b) => a - b);
+	const allowedGfx = new Set<number>([geom.bodyIdx, ...geom.corners, -1]);
+	const margin: Vec3 = [Math.max(0.25, tHalf[0] * 0.2), Math.max(0.25, tHalf[1] * 0.2), Math.max(0.25, tHalf[2] * 0.2)];
+	const sensorsInside = m.sensors.filter((s) => inside(s.initialOffset as Vec3, geom.min, geom.max, margin)).length;
+	const tagsInside = m.tagPoints.filter((t) => inside(t.initialPosition as Vec3, geom.min, geom.max, margin)).length;
+
+	const v = {
+		numIKParts: m.ikParts.length,
+		partTypes,
+		partTypesOk: m.ikParts.length === 6 && JSON.stringify(partTypes) === JSON.stringify([46, 48, 49, 50, 51, 999]),
+		numGlass: m.glassPanes.length,
+		numSensors: m.sensors.length,
+		numWheels: m.wheels.length,
+		numTagPoints: m.tagPoints.length,
+		allPartGraphicsOk: m.ikParts.every((p) => allowedGfx.has(p.partGraphics)),
+		anyJointSpecs: m.ikParts.some((p) => p.jointSpecs.length > 0),
+		allSensorsInsideAABB: sensorsInside === m.sensors.length,
+		allTagsInsideAABB: tagsInside === m.tagPoints.length,
+		wheelPos: m.wheels.map((w) => (w.position as Vec4).map((x) => +x.toFixed(3))),
+	};
+	const pass = v.partTypesOk && v.numGlass === 0 && v.numSensors === 20 && v.numWheels === 4
+		&& v.allPartGraphicsOk && !v.anyJointSpecs && v.allSensorsInsideAABB && v.allTagsInsideAABB;
+	console.log('\n===== VERIFICATION =====');
+	console.log(JSON.stringify({ ...v, allChecksPass: pass }, null, 2));
+	if (!pass) throw new Error('verification FAILED');
+	console.log('all checks pass');
+}
+
+main();

--- a/scripts/parts-taxonomy.ts
+++ b/scripts/parts-taxonomy.ts
@@ -1,0 +1,105 @@
+// Build the canonical vehicle-part taxonomy across a whole VEHICLES/ folder by
+// joining every car's DeformationSpec IK parts (0x1001C) to its real GraphicsSpec
+// part locators (0x10006). For each partType it aggregates presence, position
+// centroid, hinge axis, fold angle, detach behaviour and tag/joint counts — the
+// template the deform-rig-mvp.ts auto-rigger relies on (which partType is the
+// root, the body shell, the wheels, etc.). Writes a JSON summary + per-car rows.
+//
+// Run:  npx tsx scripts/parts-taxonomy.ts --veh <VEHICLES dir> [--out parts-taxonomy.json]
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { parseBundle } from '../src/lib/core/bundle';
+import { extractResourceRaw } from '../src/lib/core/registry';
+import { parseGraphicsSpecData } from '../src/lib/core/graphicsSpec';
+import { parseDeformationSpecData, DEFORMATION_SPEC_TYPE_ID } from '../src/lib/core/deformationSpec';
+
+const arg = (name: string): string | undefined => {
+	const i = process.argv.indexOf(`--${name}`);
+	return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : undefined;
+};
+const VEH = arg('veh');
+const OUT = arg('out') ?? 'parts-taxonomy.json';
+if (!VEH) throw new Error('usage: --veh <VEHICLES dir> [--out parts-taxonomy.json]');
+const GSPEC = 0x10006;
+
+function abOf(p: string) { const b = fs.readFileSync(p); return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength); }
+function gspecParts(id: string): { pos: number[] }[] | null {
+  try {
+    const ab = abOf(path.join(VEH, `VEH_${id}_GR.BIN`));
+    const b = parseBundle(ab);
+    const res = b.resources.find((r) => r.resourceTypeId === GSPEC);
+    if (!res) return null;
+    const gs = parseGraphicsSpecData(extractResourceRaw(ab, b, res));
+    return gs.parts.map((p) => ({ pos: [p.locator[12], p.locator[13], p.locator[14]] }));
+  } catch { return null; }
+}
+
+type PartRow = { partType: number; gfx: number; pos: number[] | null; joints: number; axis: number[] | null; maxAngle: number | null; detach: number | null; tags: number; driven: number };
+const perCar: { id: string; ik: PartRow[]; glassPartTypes: number[]; nGfxReal: number | null }[] = [];
+
+const files = fs.readdirSync(VEH).filter((f) => /^VEH_.*_AT\.BIN$/i.test(f));
+let joinable = 0;
+for (const f of files) {
+  const id = f.replace(/^VEH_/i, '').replace(/_AT\.BIN$/i, '');
+  try {
+    const ab = abOf(path.join(VEH, f));
+    const b = parseBundle(ab);
+    const res = b.resources.find((r) => r.resourceTypeId === DEFORMATION_SPEC_TYPE_ID)!;
+    const d = parseDeformationSpecData(extractResourceRaw(ab, b, res));
+    const gp = gspecParts(id);
+    if (gp) joinable++;
+    const ik: PartRow[] = d.ikParts.map((p) => {
+      const j0 = p.jointSpecs[0];
+      const pos = gp && p.partGraphics >= 0 && p.partGraphics < gp.length ? gp[p.partGraphics].pos : null;
+      return {
+        partType: p.partType, gfx: p.partGraphics, pos,
+        joints: p.jointSpecs.length,
+        axis: j0 ? j0.axis.slice(0, 3) : null,
+        maxAngle: j0 ? j0.maxJointAngle : null,
+        detach: j0 ? j0.jointDetachThreshold : null,
+        tags: p.numberOfTagPoints, driven: p.numberOfDrivenPoints,
+      };
+    });
+    perCar.push({ id, ik, glassPartTypes: d.glassPanes.map((g) => g.partType), nGfxReal: gp ? gp.length : null });
+  } catch { /* skip */ }
+}
+
+// ---- aggregate by partType ----
+const byType: Record<number, { cars: Set<string>; n: number; pos: number[][]; axis: number[][]; maxA: number[]; det: number[]; tags: number[]; driven: number[]; joints: number[] }> = {};
+for (const car of perCar) for (const p of car.ik) {
+  const t = (byType[p.partType] ??= { cars: new Set(), n: 0, pos: [], axis: [], maxA: [], det: [], tags: [], driven: [], joints: [] });
+  t.cars.add(car.id); t.n++;
+  if (p.pos) t.pos.push(p.pos);
+  if (p.axis) t.axis.push(p.axis);
+  if (p.maxAngle != null) t.maxA.push(p.maxAngle);
+  if (p.detach != null) t.det.push(p.detach);
+  t.tags.push(p.tags); t.driven.push(p.driven); t.joints.push(p.joints);
+}
+const mean = (a: number[]) => a.length ? a.reduce((s, x) => s + x, 0) / a.length : null;
+const med = (a: number[]) => { if (!a.length) return null; const s = [...a].sort((x, y) => x - y); return s[Math.floor(s.length / 2)]; };
+const cen = (v: number[][]) => v.length ? [0, 1, 2].map((i) => +(mean(v.map((p) => p[i]))!).toFixed(2)) : null;
+const spread = (v: number[][]) => { if (!v.length) return null; const c = cen(v)!; return +(mean(v.map((p) => Math.hypot(p[0] - c[0], p[1] - c[1], p[2] - c[2])))!).toFixed(2); };
+
+const nCars = perCar.length;
+const template = Object.entries(byType).map(([t, s]) => ({
+  partType: +t,
+  inCars: s.cars.size, pctCars: +(100 * s.cars.size / nCars).toFixed(0),
+  instances: s.n, avgPerCar: +(s.n / s.cars.size).toFixed(2),
+  posCentroid: cen(s.pos), posSpread: spread(s.pos), posSamples: s.pos.length,
+  axisCentroid: cen(s.axis),
+  maxAngleDeg: s.maxA.length ? { med: +(med(s.maxA)! * 57.2958).toFixed(1), max: +(Math.max(...s.maxA) * 57.2958).toFixed(1) } : null,
+  detach: s.det.length ? { med: +med(s.det)!.toFixed(2), pctUnbreakable: +(100 * s.det.filter((x) => x <= -0.9).length / s.det.length).toFixed(0) } : null,
+  medTags: med(s.tags), medDriven: med(s.driven), medJoints: med(s.joints),
+})).sort((a, b) => b.pctCars - a.pctCars);
+
+const ikCounts = perCar.map((c) => c.ik.length).sort((a, b) => a - b);
+const summary = {
+  cars: nCars, joinableWithGraphicsSpec: joinable,
+  ikPartCount: { min: ikCounts[0], max: ikCounts[ikCounts.length - 1], median: ikCounts[Math.floor(ikCounts.length / 2)] },
+  // the "standard" part set = partTypes present in >=80% of cars
+  standardPartTypes: template.filter((t) => t.pctCars >= 80).map((t) => t.partType),
+  distinctPartTypes: template.length,
+  template,
+};
+fs.writeFileSync(OUT, JSON.stringify({ summary, perCar }, null, 1));
+console.log(JSON.stringify(summary, null, 1));

--- a/scripts/preview-deform.ts
+++ b/scripts/preview-deform.ts
@@ -1,0 +1,276 @@
+// Headless deformation-spec overlay previewer.
+//
+// PURPOSE: let a text agent SEE whether a DeformationSpec's sensor / tag points
+// actually sit on the car's real body. It decodes the vehicle body the same way
+// the workspace viewport does (GraphicsSpec-driven, LOD0), renders it under a
+// simple lambert rig, then OVERLAYS small emissive sphere markers at every
+// deformation-sensor `initialOffset` (red) and every tag-point `initialPosition`
+// (cyan), in the same body-local model space the meshes assemble in. If the spec
+// is well-aligned the markers hug the bodywork; if a bundle is mis-rigged (e.g.
+// a P12-positioned spec dropped onto an Alien body) the markers float off in
+// empty space — which is exactly what this tool makes visible.
+//
+// Each GraphicsSpec part is tinted a distinct golden-angle HSL colour so the
+// part breakdown stays legible without textures (textures are deliberately OFF
+// here — this is a geometry/alignment check, not a paint check).
+//
+// Like render-car.ts this needs headless-gl built for the node-22 ABI and MUST
+// run under node 22 (system node 16 can't load gl):
+//
+//   fnm exec --using=22 node node_modules/tsx/dist/cli.mjs scripts/preview-deform.ts \
+//     --gr  D:/.../VEHICLES/VEH_ALIEN_GR.BIN \
+//     --at  D:/.../VEHICLES/VEH_ALIEN_AT.BIN \
+//     --tex D:/.../VEHICLES/VEHICLETEX.BIN \
+//     --out /tmp/alien-deform --size 900x600
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { deflateSync } from 'node:zlib';
+import createGL from 'gl';
+import * as THREE from 'three';
+import { parseBundle } from '../src/lib/core/bundle/index';
+import { parseDebugDataFromBuffer, parseDebugDataFromXml } from '../src/lib/core/bundle/debugData';
+import type { TextureSourceBundle } from '../src/lib/core/materialChain';
+import { decodeAllRenderables, locatorToMatrix4, type DecodedMesh } from '../src/lib/core/renderableDecode';
+import { extractResourceRaw } from '../src/lib/core/registry/extract';
+import { parseDeformationSpecData, DEFORMATION_SPEC_TYPE_ID, type Vec3 } from '../src/lib/core/deformationSpec';
+import type { ParsedBundle } from '../src/lib/core/types';
+
+// --- args -------------------------------------------------------------------
+function arg(name: string, def?: string): string | undefined {
+	const i = process.argv.indexOf(`--${name}`);
+	return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : def;
+}
+const GR = arg('gr')!;
+const AT = arg('at')!;
+const TEX = arg('tex')!;
+const OUT = arg('out', '/tmp/deform')!;
+const [W, H] = (arg('size', '900x600')!).split('x').map(Number);
+if (!GR || !AT || !TEX) {
+	throw new Error('usage: --gr <_GR.BIN> --at <_AT.BIN> --tex <VEHICLETEX.BIN> --out <dir> [--size WxH]');
+}
+mkdirSync(OUT, { recursive: true });
+
+type Src = { bundle: ParsedBundle; arrayBuffer: ArrayBuffer; debug: ReturnType<typeof parseDebugDataFromXml> };
+function load(path: string): Src {
+	const buf = readFileSync(path);
+	const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+	const bundle = parseBundle(ab);
+	let debug: ReturnType<typeof parseDebugDataFromXml> = [];
+	try { const xml = parseDebugDataFromBuffer(ab, bundle.header); if (xml) debug = parseDebugDataFromXml(xml); } catch { /* */ }
+	return { bundle, arrayBuffer: ab, debug };
+}
+
+// --- minimal RGBA → PNG (single IDAT, filter 0 per scanline) ----------------
+function crc32(buf: Uint8Array): number {
+	let c = ~0;
+	for (let i = 0; i < buf.length; i++) { c ^= buf[i]; for (let k = 0; k < 8; k++) c = (c >>> 1) ^ (0xEDB88320 & -(c & 1)); }
+	return ~c >>> 0;
+}
+function chunk(type: string, data: Uint8Array): Uint8Array {
+	const out = new Uint8Array(12 + data.length);
+	const dv = new DataView(out.buffer);
+	dv.setUint32(0, data.length);
+	for (let i = 0; i < 4; i++) out[4 + i] = type.charCodeAt(i);
+	out.set(data, 8);
+	dv.setUint32(8 + data.length, crc32(out.subarray(4, 8 + data.length)));
+	return out;
+}
+function encodePng(rgba: Uint8Array, w: number, h: number): Uint8Array {
+	const sig = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+	const ihdr = new Uint8Array(13);
+	const dv = new DataView(ihdr.buffer);
+	dv.setUint32(0, w); dv.setUint32(4, h); ihdr[8] = 8; ihdr[9] = 6;
+	const raw = new Uint8Array(h * (w * 4 + 1));
+	for (let y = 0; y < h; y++) { raw[y * (w * 4 + 1)] = 0; raw.set(rgba.subarray(y * w * 4, (y + 1) * w * 4), y * (w * 4 + 1) + 1); }
+	const idat = deflateSync(Buffer.from(raw));
+	const parts = [sig, chunk('IHDR', ihdr), chunk('IDAT', new Uint8Array(idat)), chunk('IEND', new Uint8Array(0))];
+	const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+	let off = 0; for (const p of parts) { out.set(p, off); off += p.length; }
+	return out;
+}
+
+// --- colour helpers ---------------------------------------------------------
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+	h = ((h % 360) + 360) % 360 / 360;
+	const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+	const p = 2 * l - q;
+	const hue = (t: number) => {
+		if (t < 0) t += 1; if (t > 1) t -= 1;
+		if (t < 1 / 6) return p + (q - p) * 6 * t;
+		if (t < 1 / 2) return q;
+		if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+		return p;
+	};
+	return [hue(h + 1 / 3), hue(h), hue(h - 1 / 3)];
+}
+const toHex = (c: [number, number, number]) =>
+	'#' + c.map((v) => Math.round(v * 255).toString(16).padStart(2, '0')).join('');
+
+// --- lambert + emissive ES1 shader -----------------------------------------
+// uEmissive=1 flattens the lighting (markers glow at their own tint); uEmissive=0
+// keeps the 0.55 ambient + diffuse lambert term so body shape stays readable.
+const VS = `
+precision highp float;
+attribute vec3 position; attribute vec3 normal;
+uniform mat4 uMVP; uniform mat4 uModel;
+varying vec3 vN;
+void main(){ vN = mat3(uModel) * normal; gl_Position = uMVP * vec4(position, 1.0); }`;
+const FS = `
+precision highp float;
+varying vec3 vN;
+uniform vec3 uTint; uniform float uAlpha; uniform float uEmissive;
+void main(){
+	vec3 N = normalize(vN);
+	vec3 L1 = normalize(vec3(0.5, 0.8, 0.4)), L2 = normalize(vec3(-0.6, 0.3, -0.7));
+	float d = 0.55 + 0.7 * max(dot(N, L1), 0.0) + 0.3 * max(dot(N, L2), 0.0);
+	float lit = mix(d, 1.0, uEmissive);
+	gl_FragColor = vec4(uTint * lit, uAlpha);
+}`;
+
+function main() {
+	// ---- Body decode (GraphicsSpec-driven, LOD0, textures resolved but unused) ----
+	const primary = load(GR);
+	const tex = load(TEX);
+	const debugNames = new Map<string, string>();
+	const norm = (s: string) => s.toLowerCase().replace(/^0x/, '').replace(/^0+(?=.)/, '');
+	for (const d of primary.debug) if (d.id && d.name) debugNames.set(norm(d.id), d.name);
+	const textureBundles: TextureSourceBundle[] = [{ buffer: tex.arrayBuffer, bundle: tex.bundle }];
+	const decoded = decodeAllRenderables(primary.arrayBuffer, primary.bundle, debugNames, false, 'graphics', textureBundles, null);
+	console.log(`decoded ${decoded.renderables.length} GraphicsSpec parts, ${decoded.totalMeshes} meshes, ${decoded.failed} failed`);
+
+	// ---- DeformationSpec overlay points (parsed from the _AT bundle) ----
+	const at = load(AT);
+	const dsResource = at.bundle.resources.find((r) => r.resourceTypeId === DEFORMATION_SPEC_TYPE_ID);
+	if (!dsResource) throw new Error(`no DeformationSpec (0x${DEFORMATION_SPEC_TYPE_ID.toString(16)}) resource in ${AT}`);
+	const dsRaw = extractResourceRaw(at.arrayBuffer, at.bundle, dsResource);
+	const ds = parseDeformationSpecData(dsRaw, true);
+	const sensorPts: Vec3[] = ds.sensors.map((s) => s.initialOffset);
+	const tagPts: Vec3[] = ds.tagPoints.map((t) => t.initialPosition);
+	console.log(`deformation spec: ${sensorPts.length} sensors, ${tagPts.length} tag points`);
+
+	// ---- GL setup ----
+	const gl = createGL(W, H, { preserveDrawingBuffer: true });
+	gl.enable(gl.DEPTH_TEST); gl.disable(gl.CULL_FACE); gl.viewport(0, 0, W, H);
+	const sh = (t: number, s: string) => { const o = gl.createShader(t)!; gl.shaderSource(o, s); gl.compileShader(o); if (!gl.getShaderParameter(o, gl.COMPILE_STATUS)) throw new Error(gl.getShaderInfoLog(o) || 'compile'); return o; };
+	const prog = gl.createProgram()!; gl.attachShader(prog, sh(gl.VERTEX_SHADER, VS)); gl.attachShader(prog, sh(gl.FRAGMENT_SHADER, FS)); gl.linkProgram(prog);
+	if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) throw new Error(gl.getProgramInfoLog(prog) || 'link');
+	gl.useProgram(prog);
+	const loc = (n: string) => gl.getUniformLocation(prog, n);
+	const aPos = gl.getAttribLocation(prog, 'position'), aNrm = gl.getAttribLocation(prog, 'normal');
+	const mkBuf = (data: ArrayBufferView, target = gl.ARRAY_BUFFER) => { const b = gl.createBuffer()!; gl.bindBuffer(target, b); gl.bufferData(target, data, gl.STATIC_DRAW); return b; };
+
+	type Draw = { pos: WebGLBuffer; nrm: WebGLBuffer | null; idx: WebGLBuffer; n: number; tint: [number, number, number]; alpha: number; emissive: number; world: THREE.Matrix4 };
+	const draws: Draw[] = [];
+	// framing inputs: {center, radius} in world space over body meshes + markers
+	const frames: { c: THREE.Vector3; r: number }[] = [];
+
+	// ---- Body parts: golden-angle tint per GraphicsSpec part ----
+	const legend: { idx: number; name: string; hex: string }[] = [];
+	for (let i = 0; i < decoded.renderables.length; i++) {
+		const r = decoded.renderables[i];
+		const world = r.partLocator ? locatorToMatrix4(r.partLocator) : new THREE.Matrix4();
+		const tint = hslToRgb(i * 137.508, 0.62, 0.55);
+		legend.push({ idx: i, name: r.debugName ?? '(unnamed)', hex: toHex(tint) });
+		for (const m of r.meshes) {
+			const g = m.geometry;
+			draws.push({
+				pos: mkBuf(g.getAttribute('position').array as Float32Array),
+				nrm: g.getAttribute('normal') ? mkBuf(g.getAttribute('normal').array as Float32Array) : null,
+				idx: mkBuf(g.getIndex()!.array as Uint16Array, gl.ELEMENT_ARRAY_BUFFER),
+				n: g.getIndex()!.count, tint, alpha: 1.0, emissive: 0, world,
+			});
+			g.computeBoundingSphere();
+			const bs = g.boundingSphere!;
+			frames.push({ c: bs.center.clone().applyMatrix4(world), r: bs.radius });
+		}
+	}
+
+	// ---- Body AABB (world space) for the inside-body fraction ----
+	// Built from each part's world-space bounding sphere extents (frames). This
+	// is a loose box (sphere-padded), so "inside" means "within the body's gross
+	// bounding volume" — good enough to flag markers that float clean off it.
+	const bodyBox = new THREE.Box3();
+	for (const f of frames) {
+		bodyBox.expandByPoint(f.c.clone().subScalar(f.r));
+		bodyBox.expandByPoint(f.c.clone().addScalar(f.r));
+	}
+
+	// ---- Marker geometry (one shared unit sphere, translated per point) ----
+	const bodySize = bodyBox.getSize(new THREE.Vector3());
+	const markerR = Math.max(bodySize.length() * 0.010, 0.02);
+	const sphere = new THREE.SphereGeometry(markerR, 12, 8);
+	const sPos = mkBuf(sphere.getAttribute('position').array as Float32Array);
+	const sNrm = mkBuf(sphere.getAttribute('normal').array as Float32Array);
+	const sIdxArr = new Uint16Array(sphere.getIndex()!.array as ArrayLike<number>);
+	const sIdx = mkBuf(sIdxArr, gl.ELEMENT_ARRAY_BUFFER);
+	const sN = sIdxArr.length;
+	const RED: [number, number, number] = [0.95, 0.15, 0.15];
+	const CYAN: [number, number, number] = [0.15, 0.85, 0.95];
+	const addMarker = (p: Vec3, tint: [number, number, number]) => {
+		const world = new THREE.Matrix4().makeTranslation(p[0], p[1], p[2]);
+		draws.push({ pos: sPos, nrm: sNrm, idx: sIdx, n: sN, tint, alpha: 1.0, emissive: 1.0, world });
+		frames.push({ c: new THREE.Vector3(p[0], p[1], p[2]), r: markerR });
+	};
+	for (const p of sensorPts) addMarker(p, RED);
+	for (const p of tagPts) addMarker(p, CYAN);
+
+	// ---- Inside-body fraction ----
+	const allMarkers = [...sensorPts, ...tagPts];
+	let inside = 0;
+	for (const p of allMarkers) if (bodyBox.containsPoint(new THREE.Vector3(p[0], p[1], p[2]))) inside++;
+	const fracInside = allMarkers.length ? inside / allMarkers.length : 0;
+
+	// ---- Robust framing: median-center, keep 90% nearest, box those ----
+	const med = (xs: number[]) => xs.slice().sort((a, b) => a - b)[Math.floor(xs.length / 2)];
+	const mc = new THREE.Vector3(med(frames.map((i) => i.c.x)), med(frames.map((i) => i.c.y)), med(frames.map((i) => i.c.z)));
+	const keep = frames.map((i) => ({ ...i, d: i.c.distanceTo(mc) })).sort((a, b) => a.d - b.d).slice(0, Math.max(1, Math.floor(frames.length * 0.9)));
+	const worldBox = new THREE.Box3();
+	for (const k of keep) { worldBox.expandByPoint(k.c.clone().subScalar(k.r)); worldBox.expandByPoint(k.c.clone().addScalar(k.r)); }
+	const center = worldBox.getCenter(new THREE.Vector3());
+	const radius = Math.max(worldBox.getSize(new THREE.Vector3()).length() * 0.5, 0.5);
+
+	// ---- Render the four canonical angles ----
+	const camera = new THREE.PerspectiveCamera(45, W / H, radius * 0.02, radius * 40);
+	const mvp = new THREE.Matrix4(), vp = new THREE.Matrix4();
+	const angles = [
+		{ name: 'front34', az: 35, el: 16 }, { name: 'side', az: 90, el: 6 },
+		{ name: 'rear34', az: 215, el: 16 }, { name: 'top', az: 40, el: 62 },
+	];
+	const px = new Uint8Array(W * H * 4), flip = new Uint8Array(W * H * 4);
+	const pngPaths: string[] = [];
+	for (const a of angles) {
+		const az = (a.az * Math.PI) / 180, el = (a.el * Math.PI) / 180, dist = radius * 1.6;
+		camera.position.set(center.x + dist * Math.cos(el) * Math.sin(az), center.y + dist * Math.sin(el), center.z + dist * Math.cos(el) * Math.cos(az));
+		camera.up.set(0, 1, 0); camera.lookAt(center); camera.updateProjectionMatrix(); camera.updateMatrixWorld(true);
+		camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
+		vp.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse);
+		gl.clearColor(0.102, 0.114, 0.137, 1); gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+		for (const d of draws) {
+			mvp.multiplyMatrices(vp, d.world);
+			gl.uniformMatrix4fv(loc('uMVP'), false, mvp.elements);
+			gl.uniformMatrix4fv(loc('uModel'), false, d.world.elements);
+			gl.uniform3f(loc('uTint'), d.tint[0], d.tint[1], d.tint[2]);
+			gl.uniform1f(loc('uAlpha'), d.alpha);
+			gl.uniform1f(loc('uEmissive'), d.emissive);
+			gl.bindBuffer(gl.ARRAY_BUFFER, d.pos); gl.enableVertexAttribArray(aPos); gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 0, 0);
+			if (d.nrm) { gl.bindBuffer(gl.ARRAY_BUFFER, d.nrm); gl.enableVertexAttribArray(aNrm); gl.vertexAttribPointer(aNrm, 3, gl.FLOAT, false, 0, 0); }
+			else { gl.disableVertexAttribArray(aNrm); (gl.vertexAttrib4f as (i: number, x: number, y: number, z: number, w: number) => void)(aNrm, 0, 0, 1, 0); }
+			gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, d.idx); gl.drawElements(gl.TRIANGLES, d.n, gl.UNSIGNED_SHORT, 0);
+		}
+		gl.readPixels(0, 0, W, H, gl.RGBA, gl.UNSIGNED_BYTE, px);
+		for (let y = 0; y < H; y++) flip.set(px.subarray(y * W * 4, (y + 1) * W * 4), (H - 1 - y) * W * 4);
+		const file = `${OUT}/${a.name}.png`; writeFileSync(file, encodePng(flip, W, H));
+		pngPaths.push(file);
+		console.log(`wrote ${file}`);
+	}
+
+	// ---- Legend + summary ----
+	console.log('\n--- part legend (idx -> debugName -> colour) ---');
+	for (const l of legend) console.log(`  [${String(l.idx).padStart(2)}] ${l.hex}  ${l.name}`);
+	console.log('\n--- overlay summary ---');
+	console.log(`markers: ${allMarkers.length} total (${sensorPts.length} sensors red, ${tagPts.length} tag points cyan)`);
+	console.log(`body AABB (world): min=(${bodyBox.min.x.toFixed(2)},${bodyBox.min.y.toFixed(2)},${bodyBox.min.z.toFixed(2)}) max=(${bodyBox.max.x.toFixed(2)},${bodyBox.max.y.toFixed(2)},${bodyBox.max.z.toFixed(2)})`);
+	console.log(`markers inside body AABB: ${inside}/${allMarkers.length} = ${(fracInside * 100).toFixed(1)}%`);
+	console.log('done');
+}
+main();


### PR DESCRIPTION
## What

Adds three `scripts/` tools for the vehicle crash-deformation format (`DeformationSpec` `0x1001C`) and its graphics layout (`GraphicsSpec` `0x10006`):

- **`parts-taxonomy.ts`** — joins every car's DeformationSpec IK parts to its real GraphicsSpec part positions and aggregates a per-`partType` template (position, hinge axis, fold angle, detach behaviour).
- **`deform-rig-mvp.ts`** — auto-rigs a **single-mesh** vehicle (a mod whose body is one welded mesh + wheels, with no separate panels). It keeps only 6 IK parts — root, body shell, 4 wheels — deletes every hinged panel and all glass, and box→box remaps every sensor / tag / driven point and the FX/camera/light locators from a donor car onto the target's real graphics-body AABB. The body then dents as one soft skin; nothing flies off in the wrong place.
- **`preview-deform.ts`** — a headless preview (like `render-car.ts`) that draws a body part-tinted and overlays a spec's sensor (red) and tag (cyan) points, so a mis-aligned spec shows up as markers floating off the bodywork.

## Why

Grafting a paneled car's deformation spec onto a one-piece modded body drives the wrong meshes — panels detach, a frame hovers, FX locators land in empty space. These tools produce a minimal rig any body can carry, plus a way to verify the fit before testing in-game.

## Notes

- Pure `scripts/` tools alongside the existing `render-car.ts` / `survey-*` / `investigate-*` scripts; no `src/lib` changes.
- `deform-rig-mvp.ts` and `parts-taxonomy.ts` run under plain `npx tsx`; `preview-deform.ts` needs `headless-gl` under node 22 (same as `render-car.ts`).
- `deform-rig-mvp.ts` self-verifies its output (6 parts, no glass, no joints, all sensor/tag points inside the body AABB) and errors if any check fails.
- Scope is an MVP: soft whole-body denting + wheels, not detachable panels — that needs a GraphicsSpec/renderable writer the codebase doesn't have yet (noted in `docs/deform-rig-tool.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
